### PR TITLE
Use Lsp.Logger

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -597,4 +597,4 @@ let () =
     | exception Not_found -> None
     | file -> Some file
   in
-  Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main
+  Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main


### PR DESCRIPTION
Before that this used merlin's `Logger` module while `lsp` used
`Lsp.Logger` and thus we didn't see `lsp` section when running server.