### PR TITLE
LSP - Code Actions

### DIFF
--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -8424,3 +8424,424 @@ module FoldingRange = struct
 
   let yojson_of_result r = `List (List.map ~f:yojson_of_t r)
 end
+
+module CodeActionContext = struct
+  type t =
+    { diagnostics : PublishDiagnostics.diagnostic list
+    ; only : CodeActionKind.t list [@default []]
+    }
+  [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    ( let _tp_loc = "lsp/src/protocol.ml.CodeActionContext.t" in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let diagnostics_field = ref None
+        and only_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "diagnostics" -> (
+              match Ppx_yojson_conv_lib.( ! ) diagnostics_field with
+              | None ->
+                let fvalue =
+                  list_of_yojson PublishDiagnostics.diagnostic_of_yojson
+                    _field_yojson
+                in
+                diagnostics_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "only" -> (
+              match Ppx_yojson_conv_lib.( ! ) only_field with
+              | None ->
+                let fvalue =
+                  list_of_yojson CodeActionKind.t_of_yojson _field_yojson
+                in
+                only_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match
+              ( Ppx_yojson_conv_lib.( ! ) diagnostics_field
+              , Ppx_yojson_conv_lib.( ! ) only_field )
+            with
+            | Some diagnostics_value, only_value ->
+              { diagnostics = diagnostics_value
+              ; only =
+                  ( match only_value with
+                  | None -> []
+                  | Some v -> v )
+              }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) diagnostics_field)
+                      None
+                  , "diagnostics" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    ( function
+      | { diagnostics = v_diagnostics; only = v_only } ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg = yojson_of_list CodeActionKind.yojson_of_t v_only in
+          ("only", arg) :: bnds
+        in
+        let bnds =
+          let arg =
+            yojson_of_list PublishDiagnostics.yojson_of_diagnostic v_diagnostics
+          in
+          ("diagnostics", arg) :: bnds
+        in
+        `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
+module CodeActionParams = struct
+  type t =
+    { textDocument : TextDocumentIdentifier.t
+    ; range : range
+    ; context : CodeActionContext.t
+    }
+  [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    ( let _tp_loc = "lsp/src/protocol.ml.CodeActionParams.t" in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let textDocument_field = ref None
+        and range_field = ref None
+        and context_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "textDocument" -> (
+              match Ppx_yojson_conv_lib.( ! ) textDocument_field with
+              | None ->
+                let fvalue = TextDocumentIdentifier.t_of_yojson _field_yojson in
+                textDocument_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "range" -> (
+              match Ppx_yojson_conv_lib.( ! ) range_field with
+              | None ->
+                let fvalue = range_of_yojson _field_yojson in
+                range_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "context" -> (
+              match Ppx_yojson_conv_lib.( ! ) context_field with
+              | None ->
+                let fvalue = CodeActionContext.t_of_yojson _field_yojson in
+                context_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match
+              ( Ppx_yojson_conv_lib.( ! ) textDocument_field
+              , Ppx_yojson_conv_lib.( ! ) range_field
+              , Ppx_yojson_conv_lib.( ! ) context_field )
+            with
+            | Some textDocument_value, Some range_value, Some context_value ->
+              { textDocument = textDocument_value
+              ; range = range_value
+              ; context = context_value
+              }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) textDocument_field)
+                      None
+                  , "textDocument" )
+                ; ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) range_field)
+                      None
+                  , "range" )
+                ; ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) context_field)
+                      None
+                  , "context" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    ( function
+      | { textDocument = v_textDocument; range = v_range; context = v_context }
+        ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg = CodeActionContext.yojson_of_t v_context in
+          ("context", arg) :: bnds
+        in
+        let bnds =
+          let arg = yojson_of_range v_range in
+          ("range", arg) :: bnds
+        in
+        let bnds =
+          let arg = TextDocumentIdentifier.yojson_of_t v_textDocument in
+          ("textDocument", arg) :: bnds
+        in
+        `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
+module CodeAction = struct
+  type t =
+    { title : string
+    ; kind : CodeActionKind.t option [@yojson.option]
+    ; diagnostics : PublishDiagnostics.diagnostic list [@default []]
+    ; edit : WorkspaceEdit.t option [@yojson.option]
+    ; command : Command.t option [@yojson.option]
+    }
+  [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    ( let _tp_loc = "lsp/src/protocol.ml.CodeAction.t" in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let title_field = ref None
+        and kind_field = ref None
+        and diagnostics_field = ref None
+        and edit_field = ref None
+        and command_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "title" -> (
+              match Ppx_yojson_conv_lib.( ! ) title_field with
+              | None ->
+                let fvalue = string_of_yojson _field_yojson in
+                title_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "kind" -> (
+              match Ppx_yojson_conv_lib.( ! ) kind_field with
+              | None ->
+                let fvalue = CodeActionKind.t_of_yojson _field_yojson in
+                kind_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "diagnostics" -> (
+              match Ppx_yojson_conv_lib.( ! ) diagnostics_field with
+              | None ->
+                let fvalue =
+                  list_of_yojson PublishDiagnostics.diagnostic_of_yojson
+                    _field_yojson
+                in
+                diagnostics_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "edit" -> (
+              match Ppx_yojson_conv_lib.( ! ) edit_field with
+              | None ->
+                let fvalue = WorkspaceEdit.t_of_yojson _field_yojson in
+                edit_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "command" -> (
+              match Ppx_yojson_conv_lib.( ! ) command_field with
+              | None ->
+                let fvalue = Command.t_of_yojson _field_yojson in
+                command_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match
+              ( Ppx_yojson_conv_lib.( ! ) title_field
+              , Ppx_yojson_conv_lib.( ! ) kind_field
+              , Ppx_yojson_conv_lib.( ! ) diagnostics_field
+              , Ppx_yojson_conv_lib.( ! ) edit_field
+              , Ppx_yojson_conv_lib.( ! ) command_field )
+            with
+            | ( Some title_value
+              , kind_value
+              , diagnostics_value
+              , edit_value
+              , command_value ) ->
+              { title = title_value
+              ; kind = kind_value
+              ; diagnostics =
+                  ( match diagnostics_value with
+                  | None -> []
+                  | Some v -> v )
+              ; edit = edit_value
+              ; command = command_value
+              }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) title_field)
+                      None
+                  , "title" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    ( function
+      | { title = v_title
+        ; kind = v_kind
+        ; diagnostics = v_diagnostics
+        ; edit = v_edit
+        ; command = v_command
+        } ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          match v_command with
+          | None -> bnds
+          | Some v ->
+            let arg = Command.yojson_of_t v in
+            let bnd = ("command", arg) in
+            bnd :: bnds
+        in
+        let bnds =
+          match v_edit with
+          | None -> bnds
+          | Some v ->
+            let arg = WorkspaceEdit.yojson_of_t v in
+            let bnd = ("edit", arg) in
+            bnd :: bnds
+        in
+        let bnds =
+          let arg =
+            yojson_of_list PublishDiagnostics.yojson_of_diagnostic v_diagnostics
+          in
+          ("diagnostics", arg) :: bnds
+        in
+        let bnds =
+          match v_kind with
+          | None -> bnds
+          | Some v ->
+            let arg = CodeActionKind.yojson_of_t v in
+            let bnd = ("kind", arg) in
+            bnd :: bnds
+        in
+        let bnds =
+          let arg = yojson_of_string v_title in
+          ("title", arg) :: bnds
+        in
+        `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end

--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -4557,9 +4557,95 @@ module Initialize = struct
   let hover_empty = { contentFormat = [ Plaintext ] }
 
   type codeAction =
-    { dynamicRegistration : bool Or_bool.t
-    ; codeActionLiteralSupport : CodeActionLiteralSupport.t option
-    }
+    { codeActionLiteralSupport : CodeActionLiteralSupport.t option }
+  [@@deriving_inline yojson]
+
+  let _ = fun (_ : codeAction) -> ()
+
+  let codeAction_of_yojson =
+    ( let _tp_loc = "lsp/src/protocol.ml.Initialize.codeAction" in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let codeActionLiteralSupport_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "codeActionLiteralSupport" -> (
+              match
+                Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field
+              with
+              | None ->
+                let fvalue =
+                  option_of_yojson CodeActionLiteralSupport.t_of_yojson
+                    _field_yojson
+                in
+                codeActionLiteralSupport_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field with
+            | Some codeActionLiteralSupport_value ->
+              { codeActionLiteralSupport = codeActionLiteralSupport_value }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field)
+                      None
+                  , "codeActionLiteralSupport" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> codeAction )
+
+  let _ = codeAction_of_yojson
+
+  let yojson_of_codeAction =
+    ( function
+      | { codeActionLiteralSupport = v_codeActionLiteralSupport } ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg =
+            yojson_of_option CodeActionLiteralSupport.yojson_of_t
+              v_codeActionLiteralSupport
+          in
+          ("codeActionLiteralSupport", arg) :: bnds
+        in
+        `Assoc bnds
+      : codeAction -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_codeAction
+
+  [@@@end]
+
+  let codeAction_empty = { codeActionLiteralSupport = None }
 
   type documentSymbol =
     { hierarchicalDocumentSymbolSupport : bool [@default false] }
@@ -4799,6 +4885,7 @@ module Initialize = struct
     ; synchronization = synchronization_empty
     ; hover = hover_empty
     ; documentSymbol = documentSymbol_empty
+    ; codeAction = codeAction_empty
     }
 
   type workspaceEdit =
@@ -8864,126 +8951,9 @@ module CodeAction = struct
     ; edit : WorkspaceEdit.t option [@yojson.option]
     ; command : Command.t option [@yojson.option]
     }
-  [@@deriving_inline yojson]
+  [@@deriving_inline yojson_of]
 
   let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    ( let _tp_loc = "lsp/src/protocol.ml.CodeAction.t" in
-      function
-      | `Assoc field_yojsons as yojson -> (
-        let title_field = ref None
-        and kind_field = ref None
-        and diagnostics_field = ref None
-        and edit_field = ref None
-        and command_field = ref None
-        and duplicates = ref []
-        and extra = ref [] in
-        let rec iter = function
-          | (field_name, _field_yojson) :: tail ->
-            ( match field_name with
-            | "title" -> (
-              match Ppx_yojson_conv_lib.( ! ) title_field with
-              | None ->
-                let fvalue = string_of_yojson _field_yojson in
-                title_field := Some fvalue
-              | Some _ ->
-                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
-              )
-            | "kind" -> (
-              match Ppx_yojson_conv_lib.( ! ) kind_field with
-              | None ->
-                let fvalue = CodeActionKind.t_of_yojson _field_yojson in
-                kind_field := Some fvalue
-              | Some _ ->
-                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
-              )
-            | "diagnostics" -> (
-              match Ppx_yojson_conv_lib.( ! ) diagnostics_field with
-              | None ->
-                let fvalue =
-                  list_of_yojson PublishDiagnostics.diagnostic_of_yojson
-                    _field_yojson
-                in
-                diagnostics_field := Some fvalue
-              | Some _ ->
-                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
-              )
-            | "edit" -> (
-              match Ppx_yojson_conv_lib.( ! ) edit_field with
-              | None ->
-                let fvalue = WorkspaceEdit.t_of_yojson _field_yojson in
-                edit_field := Some fvalue
-              | Some _ ->
-                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
-              )
-            | "command" -> (
-              match Ppx_yojson_conv_lib.( ! ) command_field with
-              | None ->
-                let fvalue = Command.t_of_yojson _field_yojson in
-                command_field := Some fvalue
-              | Some _ ->
-                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
-              )
-            | _ ->
-              if
-                Ppx_yojson_conv_lib.( ! )
-                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
-              then
-                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
-              else
-                () );
-            iter tail
-          | [] -> ()
-        in
-        iter field_yojsons;
-        match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] -> (
-          match Ppx_yojson_conv_lib.( ! ) extra with
-          | _ :: _ ->
-            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
-              (Ppx_yojson_conv_lib.( ! ) extra)
-              yojson
-          | [] -> (
-            match
-              ( Ppx_yojson_conv_lib.( ! ) title_field
-              , Ppx_yojson_conv_lib.( ! ) kind_field
-              , Ppx_yojson_conv_lib.( ! ) diagnostics_field
-              , Ppx_yojson_conv_lib.( ! ) edit_field
-              , Ppx_yojson_conv_lib.( ! ) command_field )
-            with
-            | ( Some title_value
-              , kind_value
-              , diagnostics_value
-              , edit_value
-              , command_value ) ->
-              { title = title_value
-              ; kind = kind_value
-              ; diagnostics =
-                  ( match diagnostics_value with
-                  | None -> []
-                  | Some v -> v )
-              ; edit = edit_value
-              ; command = command_value
-              }
-            | _ ->
-              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                _tp_loc yojson
-                [ ( Ppx_yojson_conv_lib.poly_equal
-                      (Ppx_yojson_conv_lib.( ! ) title_field)
-                      None
-                  , "title" )
-                ] ) ) )
-      | _ as yojson ->
-        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
-          yojson
-      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
-
-  let _ = t_of_yojson
 
   let yojson_of_t =
     ( function

--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -4001,6 +4001,170 @@ module CodeActionOptions = struct
   [@@@end]
 end
 
+module CodeActionLiteralSupport = struct
+  type codeActionKind = { valueSet : CodeActionKind.t list }
+  [@@deriving_inline yojson]
+
+  let _ = fun (_ : codeActionKind) -> ()
+
+  let codeActionKind_of_yojson =
+    ( let _tp_loc =
+        "lsp/src/protocol.ml.CodeActionLiteralSupport.codeActionKind"
+      in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let valueSet_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "valueSet" -> (
+              match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+              | None ->
+                let fvalue =
+                  list_of_yojson CodeActionKind.t_of_yojson _field_yojson
+                in
+                valueSet_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+            | Some valueSet_value -> { valueSet = valueSet_value }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) valueSet_field)
+                      None
+                  , "valueSet" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> codeActionKind )
+
+  let _ = codeActionKind_of_yojson
+
+  let yojson_of_codeActionKind =
+    ( function
+      | { valueSet = v_valueSet } ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg = yojson_of_list CodeActionKind.yojson_of_t v_valueSet in
+          ("valueSet", arg) :: bnds
+        in
+        `Assoc bnds
+      : codeActionKind -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_codeActionKind
+
+  [@@@end]
+
+  type t = { codeActionKind : codeActionKind } [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    ( let _tp_loc = "lsp/src/protocol.ml.CodeActionLiteralSupport.t" in
+      function
+      | `Assoc field_yojsons as yojson -> (
+        let codeActionKind_field = ref None
+        and duplicates = ref []
+        and extra = ref [] in
+        let rec iter = function
+          | (field_name, _field_yojson) :: tail ->
+            ( match field_name with
+            | "codeActionKind" -> (
+              match Ppx_yojson_conv_lib.( ! ) codeActionKind_field with
+              | None ->
+                let fvalue = codeActionKind_of_yojson _field_yojson in
+                codeActionKind_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | _ ->
+              if
+                Ppx_yojson_conv_lib.( ! )
+                  Ppx_yojson_conv_lib.Yojson_conv.record_check_extra_fields
+              then
+                extra := field_name :: Ppx_yojson_conv_lib.( ! ) extra
+              else
+                () );
+            iter tail
+          | [] -> ()
+        in
+        iter field_yojsons;
+        match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] -> (
+          match Ppx_yojson_conv_lib.( ! ) extra with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) extra)
+              yojson
+          | [] -> (
+            match Ppx_yojson_conv_lib.( ! ) codeActionKind_field with
+            | Some codeActionKind_value ->
+              { codeActionKind = codeActionKind_value }
+            | _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                _tp_loc yojson
+                [ ( Ppx_yojson_conv_lib.poly_equal
+                      (Ppx_yojson_conv_lib.( ! ) codeActionKind_field)
+                      None
+                  , "codeActionKind" )
+                ] ) ) )
+      | _ as yojson ->
+        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+          yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    ( function
+      | { codeActionKind = v_codeActionKind } ->
+        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg = yojson_of_codeActionKind v_codeActionKind in
+          ("codeActionKind", arg) :: bnds
+        in
+        `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
 (* Initialize request, method="initialize" *)
 module Initialize = struct
   type trace =
@@ -4088,6 +4252,14 @@ module Initialize = struct
               | None ->
                 let fvalue = bool_of_yojson _field_yojson in
                 didSave_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "codeAction" -> (
+              match Ppx_yojson_conv_lib.( ! ) codeAction_field with
+              | None ->
+                let fvalue = codeAction_of_yojson _field_yojson in
+                codeAction_field := Some fvalue
               | Some _ ->
                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
               )
@@ -4384,6 +4556,11 @@ module Initialize = struct
 
   let hover_empty = { contentFormat = [ Plaintext ] }
 
+  type codeAction =
+    { dynamicRegistration : bool Or_bool.t
+    ; codeActionLiteralSupport : CodeActionLiteralSupport.t option
+    }
+
   type documentSymbol =
     { hierarchicalDocumentSymbolSupport : bool [@default false] }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -4469,8 +4646,9 @@ module Initialize = struct
           (** textDocument/documentSymbol *)
     ; documentSymbol : documentSymbol [@default documentSymbol_empty]
           (** textDocument/hover *)
-    ; hover : hover [@default hover_empty]
-          (* omitted: dynamic-registration fields *)
+    ; hover : hover
+          [@default hover_empty] (* omitted: dynamic-registration fields *)
+    ; codeAction : codeAction [@default codeAction_empty]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -4486,6 +4664,7 @@ module Initialize = struct
         and completion_field = ref None
         and documentSymbol_field = ref None
         and hover_field = ref None
+        and codeAction_field = ref None
         and duplicates = ref []
         and extra = ref [] in
         let rec iter = function
@@ -4543,11 +4722,13 @@ module Initialize = struct
             let ( synchronization_value
                 , completion_value
                 , documentSymbol_value
-                , hover_value ) =
+                , hover_value
+                , codeAction_value ) =
               ( Ppx_yojson_conv_lib.( ! ) synchronization_field
               , Ppx_yojson_conv_lib.( ! ) completion_field
               , Ppx_yojson_conv_lib.( ! ) documentSymbol_field
-              , Ppx_yojson_conv_lib.( ! ) hover_field )
+              , Ppx_yojson_conv_lib.( ! ) hover_field
+              , Ppx_yojson_conv_lib.( ! ) codeAction_field )
             in
             { synchronization =
                 ( match synchronization_value with
@@ -4565,6 +4746,10 @@ module Initialize = struct
                 ( match hover_value with
                 | None -> hover_empty
                 | Some v -> v )
+            ; codeAction =
+                ( match codeAction_value with
+                | None -> codeAction_empty
+                | Some v -> v )
             } ) )
       | _ as yojson ->
         Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
@@ -4579,8 +4764,13 @@ module Initialize = struct
         ; completion = v_completion
         ; documentSymbol = v_documentSymbol
         ; hover = v_hover
+        ; codeAction = v_codeAction
         } ->
         let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg = yojson_of_codeAction v_codeAction in
+          ("codeAction", arg) :: bnds
+        in
         let bnds =
           let arg = yojson_of_hover v_hover in
           ("hover", arg) :: bnds

--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -4557,7 +4557,9 @@ module Initialize = struct
   let hover_empty = { contentFormat = [ Plaintext ] }
 
   type codeAction =
-    { codeActionLiteralSupport : CodeActionLiteralSupport.t option }
+    { codeActionLiteralSupport : CodeActionLiteralSupport.t option
+          [@yojson.option]
+    }
   [@@deriving_inline yojson]
 
   let _ = fun (_ : codeAction) -> ()
@@ -4578,8 +4580,7 @@ module Initialize = struct
               with
               | None ->
                 let fvalue =
-                  option_of_yojson CodeActionLiteralSupport.t_of_yojson
-                    _field_yojson
+                  CodeActionLiteralSupport.t_of_yojson _field_yojson
                 in
                 codeActionLiteralSupport_field := Some fvalue
               | Some _ ->
@@ -4608,18 +4609,11 @@ module Initialize = struct
             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
               (Ppx_yojson_conv_lib.( ! ) extra)
               yojson
-          | [] -> (
-            match Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field with
-            | Some codeActionLiteralSupport_value ->
-              { codeActionLiteralSupport = codeActionLiteralSupport_value }
-            | _ ->
-              Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                _tp_loc yojson
-                [ ( Ppx_yojson_conv_lib.poly_equal
-                      (Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field)
-                      None
-                  , "codeActionLiteralSupport" )
-                ] ) ) )
+          | [] ->
+            let codeActionLiteralSupport_value =
+              Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field
+            in
+            { codeActionLiteralSupport = codeActionLiteralSupport_value } ) )
       | _ as yojson ->
         Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
           yojson
@@ -4632,11 +4626,12 @@ module Initialize = struct
       | { codeActionLiteralSupport = v_codeActionLiteralSupport } ->
         let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
         let bnds =
-          let arg =
-            yojson_of_option CodeActionLiteralSupport.yojson_of_t
-              v_codeActionLiteralSupport
-          in
-          ("codeActionLiteralSupport", arg) :: bnds
+          match v_codeActionLiteralSupport with
+          | None -> bnds
+          | Some v ->
+            let arg = CodeActionLiteralSupport.yojson_of_t v in
+            let bnd = ("codeActionLiteralSupport", arg) in
+            bnd :: bnds
         in
         `Assoc bnds
       : codeAction -> Ppx_yojson_conv_lib.Yojson.Safe.t )
@@ -4785,6 +4780,14 @@ module Initialize = struct
               | None ->
                 let fvalue = hover_of_yojson _field_yojson in
                 hover_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
+            | "codeAction" -> (
+              match Ppx_yojson_conv_lib.( ! ) codeAction_field with
+              | None ->
+                let fvalue = codeAction_of_yojson _field_yojson in
+                codeAction_field := Some fvalue
               | Some _ ->
                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
               )

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -21,7 +21,7 @@ let initializeInfo : Lsp.Protocol.Initialize.result =
       ; documentHighlightProvider = true
       ; documentSymbolProvider = true
       ; workspaceSymbolProvider = false
-      ; codeActionProvider = false
+      ; codeActionProvider = Bool false
       ; codeLensProvider = Some { codelens_resolveProvider = false }
       ; documentFormattingProvider = false
       ; documentRangeFormattingProvider = false


### PR DESCRIPTION
In this PR I'd like to add support for code actions in LSP:

- [x] CodeActionKind
- [x] CodeActionParams
- [x] TextDocumentClientCapabilities/codeAction
- [x] CodeActionOptions
- [x] ServerCapabilities/codeActionProvider
- [x] CodeActionContext
- [x] CodeAction
- [ ] CodeActionRegistrationOptions