### PR TITLE
More completion related fields in LSP

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -451,6 +451,7 @@ let on_request :
       ; insertTextFormat = None
       ; textEdit
       ; additionalTextEdits = []
+      ; commitCharacters = []
       }
     in
 


### PR DESCRIPTION
* Add triggerCharacter field to completionContext
* commitCharacters field to result

@andreypopp I see that we're using `[@default None]` for these optional fields.
What's the difference between this and `[@yojson.option]`?