### PR TITLE
Logging improvements

### DIFF
--- a/lsp/src/logger.ml
+++ b/lsp/src/logger.ml
@@ -59,7 +59,8 @@ let log ~section ~title fmt =
         if str <> "" then (
           output_string oc str;
           if str.[String.length str - 1] <> '\n' then output_char oc '\n'
-        ))
+        );
+        flush oc)
       fmt
   | None
   | Some _ ->

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -621,9 +621,14 @@ let () =
     | exception Not_found -> None
     | file -> Some file
   in
-  match List.tl (Array.to_list Sys.argv) with
-  | ("-help" | "--help" | "-h") :: _ ->
-    Printf.eprintf
-      "Usage: %s\nStart merlin LSP server (only stdio transport is supported)\n"
+  let args = Arg.align [
+  ] in
+  let anon_fun _ =
+    raise (Arg.Bad "arguments are not supported")
+  in
+  let usage_msg =
+    Printf.sprintf "Usage: %s\nStart merlin LSP server (only stdio transport is supported)"
       Sys.argv.(0)
-  | _ -> Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main
+  in
+  Arg.parse args anon_fun usage_msg;
+  Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -631,7 +631,7 @@ let () =
   let log_file =
     match !log_file with
     | None -> (
-      match Sys.getenv "MERLIN_LOG" with
+      match Sys.getenv "OCAML_LSP_SERVER_LOG" with
       | exception Not_found -> None
       | file -> Some file)
     | Some f -> Some f

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -612,12 +612,7 @@ let start () =
 let main () =
   (* Setup env for extensions *)
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
-  match List.tl (Array.to_list Sys.argv) with
-  | ("-help" | "--help" | "-h") :: _ ->
-    Printf.eprintf
-      "Usage: %s\nStart merlin LSP server (only stdio transport is supported)\n"
-      Sys.argv.(0)
-  | _ -> start ()
+  start ()
 
 let () =
   Printexc.record_backtrace true;
@@ -626,4 +621,9 @@ let () =
     | exception Not_found -> None
     | file -> Some file
   in
-  Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main
+  match List.tl (Array.to_list Sys.argv) with
+  | ("-help" | "--help" | "-h") :: _ ->
+    Printf.eprintf
+      "Usage: %s\nStart merlin LSP server (only stdio transport is supported)\n"
+      Sys.argv.(0)
+  | _ -> Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -616,12 +616,9 @@ let main () =
 
 let () =
   Printexc.record_backtrace true;
-  let log_file =
-    match Sys.getenv "MERLIN_LOG" with
-    | exception Not_found -> None
-    | file -> Some file
-  in
+  let log_file = ref None in
   let args = Arg.align [
+    ("--log-file", String (fun f -> log_file := Some f), "FILE" ^ " " ^ "Enable logging to file");
   ] in
   let anon_fun _ =
     raise (Arg.Bad "arguments are not supported")
@@ -631,4 +628,12 @@ let () =
       Sys.argv.(0)
   in
   Arg.parse args anon_fun usage_msg;
+  let log_file =
+    match !log_file with
+    | None -> (
+      match Sys.getenv "MERLIN_LOG" with
+      | exception Not_found -> None
+      | file -> Some file)
+    | Some f -> Some f
+  in
   Lsp.Logger.with_log_file ~sections:[ "ocamlmerlin-lsp"; "lsp" ] log_file main

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -38,7 +38,7 @@ export const toURI = s => {
 
 export const start = (opts?: cp.SpawnOptions) => {
   opts = opts || {
-    env: { ...process.env, MERLIN_LOG: "-" },
+    env: { ...process.env, OCAML_LSP_SERVER_LOG: "-" },
   };
   let childProcess = cp.spawn(serverPath, [], opts);
 


### PR DESCRIPTION
This patch series:
- improves the way command line arguments are handled (using `Arg`)
- add an option to specify the file (better than the environment variable)
- make sure the logging output is flushed