### PR TITLE
Plaintext hover result: separate docs from type

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -225,7 +225,7 @@ let on_request :
         ; kind = Lsp.Protocol.MarkupKind.Markdown
         }
       else
-        { Lsp.Protocol.MarkupContent.value = Printf.sprintf "%s%s" doc typ
+        { Lsp.Protocol.MarkupContent.value = Printf.sprintf "%s%s" typ doc
         ; kind = Lsp.Protocol.MarkupKind.Plaintext
         }
     in


### PR DESCRIPTION
In the plaintext hover result the docs come first, and nothing separates
it from the type.
This is visible when used through Vim/ALE in a terminal, where you'd get
something like this:
```
(**  [String.map f s] applies function [f] in turn to all the
    characters of [s] (in increasing index order) and stores the
    results in a new string that is returned.
    @since 4.00.0  *)(char -> char) -> string -> string
```

Put the doc last: this is consistent with the markdown format, and has a newline when not empty.