### PR TITLE
LSP: executeCommand

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -53,6 +53,7 @@ type _ t =
       -> ColorPresentation.t list t
   | TextDocumentColor : DocumentColor.Params.t -> DocumentColor.Result.t t
   | SelectionRange : SelectionRange.Params.t -> SelectionRange.t list t
+  | ExecuteCommand : ExecuteCommand.Params.t -> ExecuteCommand.Result.t t
   | UnknownRequest : string * Json.t option -> unit t
 
 let yojson_of_result (type a) (req : a t) (result : a) =
@@ -104,6 +105,7 @@ let yojson_of_result (type a) (req : a t) (result : a) =
     Some (DocumentColor.Result.yojson_of_t result)
   | SelectionRange _, result ->
     Some (Json.yojson_of_list SelectionRange.yojson_of_t result)
+  | ExecuteCommand _, result -> Some (ExecuteCommand.Result.yojson_of_t result)
   | UnknownRequest _, _resp -> None
 
 type packed = E : 'r t -> packed
@@ -178,4 +180,7 @@ let of_jsonrpc (r : Jsonrpc.Request.t) =
   | "textDocument/selectionRange" ->
     parse SelectionRange.Params.t_of_yojson >>| fun params ->
     E (SelectionRange params)
+  | "workspace/executeCommand" ->
+    parse ExecuteCommand.Params.t_of_yojson >>| fun params ->
+    E (ExecuteCommand params)
   | m -> Ok (E (UnknownRequest (m, r.params)))

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -51,6 +51,7 @@ type _ t =
       -> ColorPresentation.t list t
   | TextDocumentColor : DocumentColor.Params.t -> DocumentColor.Result.t t
   | SelectionRange : SelectionRange.Params.t -> SelectionRange.t list t
+  | ExecuteCommand : ExecuteCommand.Params.t -> ExecuteCommand.Result.t t
   | UnknownRequest : string * Json.t option -> unit t
 
 val yojson_of_result : 'a t -> 'a -> Json.t option

--- a/lsp/src/codeAction.ml
+++ b/lsp/src/codeAction.ml
@@ -298,42 +298,60 @@ type t =
 let _ = fun (_ : t) -> ()
 
 let yojson_of_t =
-  (function
-   | { title = v_title; kind = v_kind; diagnostics = v_diagnostics;
-       edit = v_edit; command = v_command; isPreferred = v_isPreferred } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_bool v_isPreferred in ("isPreferred", arg) ::
-           bnds in
-       let bnds =
-         match v_command with
-         | None -> bnds
-         | Some v ->
-             let arg = Command.yojson_of_t v in
-             let bnd = ("command", arg) in bnd :: bnds in
-       let bnds =
-         match v_edit with
-         | None -> bnds
-         | Some v ->
-             let arg = WorkspaceEdit.yojson_of_t v in
-             let bnd = ("edit", arg) in bnd :: bnds in
-       let bnds =
-         if [] = v_diagnostics
-         then bnds
-         else
-           (let arg =
-              (yojson_of_list PublishDiagnostics.yojson_of_diagnostic)
-                v_diagnostics in
-            let bnd = ("diagnostics", arg) in bnd :: bnds) in
-       let bnds =
-         match v_kind with
-         | None -> bnds
-         | Some v ->
-             let arg = Kind.yojson_of_t v in
-             let bnd = ("kind", arg) in bnd :: bnds in
-       let bnds =
-         let arg = yojson_of_string v_title in ("title", arg) :: bnds in
-       `Assoc bnds : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ( function
+    | { title = v_title
+      ; kind = v_kind
+      ; diagnostics = v_diagnostics
+      ; edit = v_edit
+      ; command = v_command
+      ; isPreferred = v_isPreferred
+      } ->
+      let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+      let bnds =
+        let arg = yojson_of_bool v_isPreferred in
+        ("isPreferred", arg) :: bnds
+      in
+      let bnds =
+        match v_command with
+        | None -> bnds
+        | Some v ->
+          let arg = Command.yojson_of_t v in
+          let bnd = ("command", arg) in
+          bnd :: bnds
+      in
+      let bnds =
+        match v_edit with
+        | None -> bnds
+        | Some v ->
+          let arg = WorkspaceEdit.yojson_of_t v in
+          let bnd = ("edit", arg) in
+          bnd :: bnds
+      in
+      let bnds =
+        if [] = v_diagnostics then
+          bnds
+        else
+          let arg =
+            (yojson_of_list PublishDiagnostics.yojson_of_diagnostic)
+              v_diagnostics
+          in
+          let bnd = ("diagnostics", arg) in
+          bnd :: bnds
+      in
+      let bnds =
+        match v_kind with
+        | None -> bnds
+        | Some v ->
+          let arg = Kind.yojson_of_t v in
+          let bnd = ("kind", arg) in
+          bnd :: bnds
+      in
+      let bnds =
+        let arg = yojson_of_string v_title in
+        ("title", arg) :: bnds
+      in
+      `Assoc bnds
+    : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
 
 let _ = yojson_of_t
 

--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -8775,3 +8775,125 @@ module SelectionRange = struct
 
   [@@@end]
 end
+
+module ExecuteCommand = struct
+  module Params = struct
+    type t =
+      { command : string
+      ; arguments : Json.t list option [@yojson.option]
+      }
+    [@@yojson.allow_extra_fields] [@@deriving_inline yojson]
+
+    let _ = fun (_ : t) -> ()
+
+    let t_of_yojson =
+      ( let _tp_loc = "lsp/src/protocol.ml.ExecuteCommand.Params.t" in
+        function
+        | `Assoc field_yojsons as yojson -> (
+          let command_field = ref None
+          and arguments_field = ref None
+          and duplicates = ref []
+          and extra = ref [] in
+          let rec iter = function
+            | (field_name, _field_yojson) :: tail ->
+              ( match field_name with
+              | "command" -> (
+                match Ppx_yojson_conv_lib.( ! ) command_field with
+                | None ->
+                  let fvalue = string_of_yojson _field_yojson in
+                  command_field := Some fvalue
+                | Some _ ->
+                  duplicates :=
+                    field_name :: Ppx_yojson_conv_lib.( ! ) duplicates )
+              | "arguments" -> (
+                match Ppx_yojson_conv_lib.( ! ) arguments_field with
+                | None ->
+                  let fvalue = list_of_yojson Json.t_of_yojson _field_yojson in
+                  arguments_field := Some fvalue
+                | Some _ ->
+                  duplicates :=
+                    field_name :: Ppx_yojson_conv_lib.( ! ) duplicates )
+              | _ -> () );
+              iter tail
+            | [] -> ()
+          in
+          iter field_yojsons;
+          match Ppx_yojson_conv_lib.( ! ) duplicates with
+          | _ :: _ ->
+            Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+              _tp_loc
+              (Ppx_yojson_conv_lib.( ! ) duplicates)
+              yojson
+          | [] -> (
+            match Ppx_yojson_conv_lib.( ! ) extra with
+            | _ :: _ ->
+              Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields _tp_loc
+                (Ppx_yojson_conv_lib.( ! ) extra)
+                yojson
+            | [] -> (
+              match
+                ( Ppx_yojson_conv_lib.( ! ) command_field
+                , Ppx_yojson_conv_lib.( ! ) arguments_field )
+              with
+              | Some command_value, arguments_value ->
+                { command = command_value; arguments = arguments_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) command_field)
+                        None
+                    , "command" )
+                  ] ) ) )
+        | _ as yojson ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc
+            yojson
+        : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+    let _ = t_of_yojson
+
+    let yojson_of_t =
+      ( function
+        | { command = v_command; arguments = v_arguments } ->
+          let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+          let bnds =
+            match v_arguments with
+            | None -> bnds
+            | Some v ->
+              let arg = yojson_of_list Json.yojson_of_t v in
+              let bnd = ("arguments", arg) in
+              bnd :: bnds
+          in
+          let bnds =
+            let arg = yojson_of_string v_command in
+            ("command", arg) :: bnds
+          in
+          `Assoc bnds
+        : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+    let _ = yojson_of_t
+
+    [@@@end]
+  end
+
+  module Result = struct
+    type t = (Json.t option[@yojson.option]) [@@deriving_inline yojson]
+
+    let _ = fun (_ : t) -> ()
+
+    let t_of_yojson =
+      ( let _tp_loc = "lsp/src/protocol.ml.ExecuteCommand.Result.t" in
+        fun t -> option_of_yojson Json.t_of_yojson t
+        : Ppx_yojson_conv_lib.Yojson.Safe.t -> t )
+
+    let _ = t_of_yojson
+
+    let yojson_of_t =
+      ( fun v -> yojson_of_option Json.yojson_of_t v
+        : t -> Ppx_yojson_conv_lib.Yojson.Safe.t )
+
+    let _ = yojson_of_t
+
+    [@@@end]
+  end
+end

--- a/lsp/src/protocol.mli
+++ b/lsp/src/protocol.mli
@@ -934,3 +934,20 @@ module SelectionRange : sig
 
   include Json.Jsonable.S with type t := t
 end
+
+module ExecuteCommand : sig
+  module Params : sig
+    type t =
+      { command : string
+      ; arguments : Json.t list option
+      }
+
+    include Json.Jsonable.S with type t := t
+  end
+
+  module Result : sig
+    type t = Json.t option
+
+    include Json.Jsonable.S with type t := t
+  end
+end

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -634,6 +634,7 @@ let on_request :
     in
     Ok (store, folds)
   | Lsp.Client_request.SignatureHelp _ -> not_supported ()
+  | Lsp.Client_request.ExecuteCommand _ -> not_supported ()
   | Lsp.Client_request.TextDocumentLinkResolve l -> Ok (store, l)
   | Lsp.Client_request.TextDocumentLink _ -> Ok (store, [])
   | Lsp.Client_request.WillSaveWaitUntilTextDocument _ -> Ok (store, [])


### PR DESCRIPTION
Simply adds `workspace/executeCommand` to the lsp lib.

Also formats the part of codeAction.ml using `make fmt`