### PR TITLE
Implement textDocument/formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The server supports the following queries:
 - [x] `textDocument/references`
 - [ ] `textDocument/documentColor`
 - [ ] `textDocument/colorPresentation`
-- [ ] `textDocument/formatting`
+- [x] `textDocument/formatting`
 - [ ] `textDocument/rangeFormatting`
 - [ ] `textDocument/onTypeFormatting`
 - [ ] `textDocument/prepareRename`

--- a/dune-project
+++ b/dune-project
@@ -41,6 +41,7 @@ possible and does not make any assumptions about IO.
   stdlib-shims
   menhir
   ppx_yojson_conv_lib
+  (ocamlformat :with-test)
   (ocamlfind (>= 1.5.2))
   (ocaml (>= 4.06))
   (dune (>= 1.11))))

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -6,6 +6,9 @@ module Int = Stdune.Int
 module Dyn = Stdune.Dyn
 module Ordering = Stdune.Ordering
 module Exn = Stdune.Exn
+module Bin = Stdune.Bin
+module Unix_env = Stdune.Env
+module Fpath = Stdune.Path
 
 module String = struct
   include Stdune.String

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -18,6 +18,7 @@ depends: [
   "stdlib-shims"
   "menhir"
   "ppx_yojson_conv_lib"
+  "ocamlformat" {with-test}
   "ocamlfind" {>= "1.5.2"}
   "ocaml" {>= "4.06"}
   "dune" {>= "1.11"}

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -649,7 +649,7 @@ let on_request :
     let fileName = Document.uri doc |> Lsp.Uri.to_path in
     let result =
       Ocamlformat.format_file
-        (Ocamlformat.Input.Stdin (src, Ocamlformat.FileType.Name fileName))
+        (Ocamlformat.Input.Stdin (src, Ocamlformat.File_type.Name fileName))
         Ocamlformat.Output.Stdout Ocamlformat.Options.default
     in
     match result with

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -731,7 +731,6 @@ let start () =
   let on_request rpc state caps req =
     prepare_and_run @@ fun () -> on_request rpc state caps req
   in
-  log ~title:"info" "starting";
   Lsp.Rpc.start docs { on_initialize; on_request; on_notification } stdin stdout;
   log ~title:"info" "exiting"
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -642,7 +642,11 @@ let on_request :
   | Lsp.Client_request.WillSaveWaitUntilTextDocument _ -> Ok (store, [])
   | Lsp.Client_request.CodeAction params -> code_action store params
   | Lsp.Client_request.CompletionItemResolve compl -> Ok (store, compl)
-  | Lsp.Client_request.TextDocumentFormatting _ -> Ok (store, [])
+  | Lsp.Client_request.TextDocumentFormatting
+      { textDocument = { uri }; options } ->
+    Document_store.get store uri >>= fun doc ->
+    
+    Ok (store, [])
   | Lsp.Client_request.TextDocumentOnTypeFormatting _ -> Ok (store, [])
   | Lsp.Client_request.SelectionRange _ -> Ok (store, [])
   | Lsp.Client_request.UnknownRequest _ -> Error "got unknown request"

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -60,7 +60,7 @@ let initializeInfo : Lsp.Initialize.Result.t =
       ; workspaceSymbolProvider = false
       ; codeActionProvider = Value codeActionProvider
       ; codeLensProvider = Some { resolveProvider = false }
-      ; documentFormattingProvider = false
+      ; documentFormattingProvider = true
       ; documentRangeFormattingProvider = false
       ; documentOnTypeFormattingProvider = None
       ; renameProvider = true

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -646,10 +646,10 @@ let on_request :
       { textDocument = { uri }; options = _ } -> (
     Document_store.get store uri >>= fun doc ->
     let src = Document.source doc |> Msource.text in
-    let fileName = Document.uri doc |> Lsp.Uri.to_path in
+    let file_name = Document.uri doc |> Lsp.Uri.to_path in
     let result =
       Ocamlformat.format_file
-        (Ocamlformat.Input.Stdin (src, Ocamlformat.File_type.Name fileName))
+        (Ocamlformat.Input.Stdin (src, Ocamlformat.File_type.Name file_name))
         Ocamlformat.Output.Stdout Ocamlformat.Options.default
     in
     match result with
@@ -657,11 +657,11 @@ let on_request :
     | Result.Ok result ->
       let pos line col = { Lsp.Protocol.Position.character = col; line } in
       let range =
-        let startPos = pos 0 0 in
+        let start_pos = pos 0 0 in
         match Msource.get_logical (Document.source doc) `End with
         | `Logical (l, c) ->
-          let endPos = pos l c in
-          { Lsp.Protocol.Range.start_ = startPos; end_ = endPos }
+          let end_pos = pos l c in
+          { Lsp.Protocol.Range.start_ = start_pos; end_ = end_pos }
       in
       let change = { Lsp.Protocol.TextEdit.newText = result; range } in
       Ok (store, [ change ]) )

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -648,7 +648,8 @@ let on_request :
     let src = Document.source doc |> Msource.text in
     let edits =
       begin match Ocamlformat.exec src [] with
-      | Result.Error _ -> begin
+      | Result.Error e -> begin
+        Lsp.Logger.log ~title:"error" ~section:"textDocument_formatting" "%s" e;
         []
         end
       | Result.Ok result -> begin

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -1,11 +1,15 @@
 open Import
 
 module FileType = struct
-  type t = Impl | Intf | Name of string
+  type t =
+    | Impl
+    | Intf
+    | Name of string
+
   let to_cmdline_args = function
-    | Impl -> ["--impl"]
-    | Intf -> ["--intf"]
-    | Name n -> [Printf.sprintf "--name=%s" n]
+    | Impl -> [ "--impl" ]
+    | Intf -> [ "--intf" ]
+    | Name n -> [ Printf.sprintf "--name=%s" n ]
 end
 
 module Input = struct
@@ -16,42 +20,67 @@ end
 
 module Output = struct
   type _ t =
-    | File: string -> unit t
-    | Stdout: string t
-  let to_cmdline_args: type o. o t -> string list =
-    function
-    | File s -> [Printf.sprintf "--output=%s" s]
+    | File : string -> unit t
+    | Stdout : string t
+
+  let to_cmdline_args : type o. o t -> string list = function
+    | File s -> [ Printf.sprintf "--output=%s" s ]
     | Stdout -> []
 end
 
 module Config = struct
   type t = (string * string) list
 
-  let to_comma_separated_list (conf: t) : string =
+  let to_comma_separated_list (conf : t) : string =
     List.map conf ~f:(fun (k, v) -> Printf.sprintf "%s=%s" k v)
     |> String.concat ~sep:","
 
-  let of_comma_separated_list (s: string) : t option =
+  let of_comma_separated_list (s : string) : t option =
     String.split_on_char s ~sep:','
     |> List.fold_right ~init:(Some []) ~f:(fun s state ->
-      match state with
-      | None -> None
-      | Some acc -> begin
-        match String.split_on_char s ~sep:'=' with
-        | k :: v :: _ -> Some ((k, v) :: acc)
-        | _ -> None
-        end
-    )
+           match state with
+           | None -> None
+           | Some acc -> (
+             match String.split_on_char s ~sep:'=' with
+             | k :: v :: _ -> Some ((k, v) :: acc)
+             | _ -> None ))
+
+  let of_print_config_output (s : string) : t option =
+    String.split_lines s
+    |> List.fold_right ~init:(Some []) ~f:(fun s state ->
+           match state with
+           | None -> None
+           | Some acc -> (
+             match String.split_on_char s ~sep:' ' with
+             | [ x ]
+             | x :: "(file" :: _ -> (
+               match String.split_on_char x ~sep:'=' with
+               | [ key; value ] -> Some ((key, value) :: acc)
+               | _ -> None )
+             | _ -> None ))
 end
 
 let append_if flag value xs =
-  if flag then value :: xs else xs
+  if flag then
+    value :: xs
+  else
+    xs
+
 let append_opt opt f xs =
-  match opt with None -> xs | Some x -> f x :: xs
+  match opt with
+  | None -> xs
+  | Some x -> f x :: xs
 
 module Options = struct
   module Profile = struct
-    type t = Conventional|Default|Compact|Sparse|Ocamlformat|Janestreet
+    type t =
+      | Conventional
+      | Default
+      | Compact
+      | Sparse
+      | Ocamlformat
+      | Janestreet
+
     let to_string = function
       | Conventional -> "conventional"
       | Default -> "default"
@@ -60,57 +89,64 @@ module Options = struct
       | Ocamlformat -> "ocamlformat"
       | Janestreet -> "janestreet"
   end
+
   type t =
-    {
-      config: Config.t option;
-      commentCheck: bool option;
-      disableConfAttrs: bool;
-      disableConfLines: bool;
-      enableOutsideDetectedProject: bool;
-      ignoreInvalidOption: bool;
-      maxIters: int option;
-      noVersionCheck: bool;
-      ocpIndentConfig: bool;
-      profile: Profile.t option;
-      quiet: bool option;
-      root: string option;
+    { config : Config.t option
+    ; commentCheck : bool option
+    ; disableConfAttrs : bool
+    ; disableConfLines : bool
+    ; enableOutsideDetectedProject : bool
+    ; ignoreInvalidOption : bool
+    ; maxIters : int option
+    ; noVersionCheck : bool
+    ; ocpIndentConfig : bool
+    ; profile : Profile.t option
+    ; quiet : bool option
+    ; root : string option
     }
+
   let default =
-    {
-      config = None;
-      commentCheck = None;
-      disableConfAttrs = false;
-      disableConfLines = false;
-      enableOutsideDetectedProject = false;
-      ignoreInvalidOption = false;
-      maxIters = None;
-      noVersionCheck = false;
-      ocpIndentConfig = false;
-      profile = None;
-      quiet = None;
-      root = None
+    { config = None
+    ; commentCheck = None
+    ; disableConfAttrs = false
+    ; disableConfLines = false
+    ; enableOutsideDetectedProject = false
+    ; ignoreInvalidOption = false
+    ; maxIters = None
+    ; noVersionCheck = false
+    ; ocpIndentConfig = false
+    ; profile = None
+    ; quiet = None
+    ; root = None
     }
-  let to_cmdline_args (opt: t) : string list =
-    [] |> append_opt opt.root (Printf.sprintf "--root=%s")
-       |> append_opt opt.quiet (function true -> "--quiet" | _ -> "--no-quiet")
-       |> append_opt opt.profile Profile.to_string
-       |> append_if  opt.ocpIndentConfig "--ocp-indent-config"
-       |> append_if  opt.noVersionCheck "--no-version-check"
-       |> append_opt opt.maxIters (Printf.sprintf "--max-iters:%d")
-       |> append_if  opt.ignoreInvalidOption "--ignore-invalid-option"
-       |> append_if  opt.enableOutsideDetectedProject "--enable-outside-detected-project"
-       |> append_if  opt.disableConfLines "-disable-conf-lines"
-       |> append_if  opt.disableConfAttrs "-disable-conf-attrs"
-       |> append_opt opt.commentCheck (function true -> "--comment-check" | _ -> "--no-comment-check")
-       |> append_opt opt.config (Config.to_comma_separated_list)
+
+  let to_cmdline_args (opt : t) : string list =
+    []
+    |> append_opt opt.root (Printf.sprintf "--root=%s")
+    |> append_opt opt.quiet (function
+         | true -> "--quiet"
+         | _ -> "--no-quiet")
+    |> append_opt opt.profile Profile.to_string
+    |> append_if opt.ocpIndentConfig "--ocp-indent-config"
+    |> append_if opt.noVersionCheck "--no-version-check"
+    |> append_opt opt.maxIters (Printf.sprintf "--max-iters:%d")
+    |> append_if opt.ignoreInvalidOption "--ignore-invalid-option"
+    |> append_if opt.enableOutsideDetectedProject
+         "--enable-outside-detected-project"
+    |> append_if opt.disableConfLines "-disable-conf-lines"
+    |> append_if opt.disableConfAttrs "-disable-conf-attrs"
+    |> append_opt opt.commentCheck (function
+         | true -> "--comment-check"
+         | _ -> "--no-comment-check")
+    |> append_opt opt.config Config.to_comma_separated_list
 end
 
 type 'result command =
-  | FormatFile: Input.t * 'result Output.t -> 'result command
-  | FormatFilesInPlace: string list -> unit command
-  | Check: Input.t -> bool command
+  | FormatFile : Input.t * 'result Output.t -> 'result command
+  | FormatFilesInPlace : string list -> unit command
+  | Check : Input.t -> bool command
 
-let read_to_end ?(hint=0) (inChan: in_channel) : string =
+let read_to_end ?(hint = 0) (inChan : in_channel) : string =
   let buf = Buffer.create hint in
   let rec go () =
     try
@@ -118,15 +154,14 @@ let read_to_end ?(hint=0) (inChan: in_channel) : string =
       Buffer.add_string buf line;
       Buffer.add_char buf '\n';
       go ()
-    with End_of_file ->
-      Buffer.contents buf
-  in go ()
+    with End_of_file -> Buffer.contents buf
+  in
+  go ()
 
 type command_result =
-  {
-    stdout: string;
-    stderr: string;
-    status: Unix.process_status
+  { stdout : string
+  ; stderr : string
+  ; status : Unix.process_status
   }
 
 let run_command command ?stdin_value args : command_result =
@@ -135,7 +170,8 @@ let run_command command ?stdin_value args : command_result =
     | [] -> command
     | _ -> Printf.sprintf "%s %s" command (String.concat ~sep:" " args)
   in
-  let inChan, outChan, errChan = Unix.open_process_full command [||] in
+  let env = Unix.environment () in
+  let inChan, outChan, errChan = Unix.open_process_full command env in
   let f stdin =
     output_string outChan stdin;
     close_out outChan
@@ -146,36 +182,58 @@ let run_command command ?stdin_value args : command_result =
   let status = Unix.close_process_full (inChan, outChan, errChan) in
   { stdout; stderr; status }
 
-let exec: type r. r command -> Options.t -> (r, string) Result.t =
-  fun cmd opts ->
-    let args, stdin_value =
-      let optArgs = Options.to_cmdline_args opts in
-      begin match cmd with
-      | FormatFile (i, o) ->
-        let args = optArgs @ Output.to_cmdline_args o in
-        begin match i with
-        | Input.File f -> args @ [f], None
-        | Input.Stdin (v, f) -> args @ FileType.to_cmdline_args f, Some v
-        end
-      | FormatFilesInPlace fs ->
-        optArgs @ ("--inplace" :: fs), None
-      | Check i ->
-        match i with
-        | Input.File f -> optArgs @ [f], None
-        | Input.Stdin (v, f) -> optArgs @ FileType.to_cmdline_args f, Some v
-      end
-    in
-    let res = run_command "ocamlformat" ?stdin_value args in
-    begin match res.status with
-    | Unix.WEXITED i ->
-      begin match cmd with
-      | FormatFile (_, o) ->
-        begin match o with
-        | Output.File _ -> Result.Ok ()
-        | Output.Stdout -> Result.Ok res.stdout
-        end
-      | FormatFilesInPlace _ -> Result.Ok ()
-      | Check _ -> Result.Ok (i = 0)
-      end
-    | _ -> Result.Error res.stderr
-    end
+let build_args : type r. r command -> Options.t -> string list * string option =
+ fun cmd opts ->
+  let optArgs = Options.to_cmdline_args opts in
+  match cmd with
+  | FormatFile (i, o) -> (
+    let args = optArgs @ Output.to_cmdline_args o in
+    match i with
+    | Input.File f -> (args @ [ f ], None)
+    | Input.Stdin (v, f) -> (args @ FileType.to_cmdline_args f @ [ "-" ], Some v)
+    )
+  | FormatFilesInPlace fs -> (optArgs @ ("--inplace" :: fs), None)
+  | Check i -> (
+    match i with
+    | Input.File f -> (optArgs @ [ f ], None)
+    | Input.Stdin (v, f) ->
+      (optArgs @ FileType.to_cmdline_args f @ [ "-" ], Some v) )
+
+let exec : type r. r command -> Options.t -> (r, string) Result.t =
+ fun cmd opts ->
+  let args, stdin_value = build_args cmd opts in
+  let res = run_command "ocamlformat" ?stdin_value args in
+  match res.status with
+  | Unix.WEXITED i -> (
+    match cmd with
+    | Check _ -> Result.Ok (i = 0)
+    | _ when i <> 0 -> Result.Error res.stderr
+    | FormatFile (_, o) -> (
+      match o with
+      | Output.File _ -> Result.Ok ()
+      | Output.Stdout -> Result.Ok res.stdout )
+    | FormatFilesInPlace _ -> Result.Ok () )
+  | _ -> Result.Error res.stderr
+
+let get_config : type r. r command -> Options.t -> (Config.t, string) Result.t =
+ fun cmd opts ->
+  let args, stdin_value = build_args cmd opts in
+  let args = "--print-config" :: args in
+  let res = run_command "ocamlformat" ?stdin_value args in
+  match res.status with
+  | Unix.WEXITED 0 -> (
+    match Config.of_print_config_output res.stdout with
+    | None -> Result.Error "get_config: parse error"
+    | Some c -> Result.Ok c )
+  | _ -> Result.Error res.stderr
+
+let format_file :
+    type r. Input.t -> r Output.t -> Options.t -> (r, string) Result.t =
+ fun input output opts -> exec (FormatFile (input, output)) opts
+
+let format_files_in_place (files : string list) (opts : Options.t) :
+    (unit, string) Result.t =
+  exec (FormatFilesInPlace files) opts
+
+let check (input : Input.t) (opts : Options.t) : (bool, string) Result.t =
+  exec (Check input) opts

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -1,26 +1,114 @@
 open Import
 
-module Options = struct
-  type t = (string * string option) list
-
-  let to_string_array (opts: t) : string array =
-    List.map opts ~f:(fun (k, vo) ->
-      let buf = Buffer.create 0 in
-      let bar, sep =
-        if String.length k = 1 then "-", " "
-        else "--", "="
-      in
-      begin
-        Buffer.add_string buf bar; Buffer.add_string buf k;
-        match vo with
-        | None -> ()
-        | Some v -> begin
-          Buffer.add_string buf sep; Buffer.add_string buf v
-        end;
-      end;
-      Buffer.contents buf
-    ) |> Array.of_list
+module FileType = struct
+  type t = Impl | Intf | Name of string
+  let to_cmdline_args = function
+    | Impl -> ["--impl"]
+    | Intf -> ["--intf"]
+    | Name n -> [Printf.sprintf "--name=%s" n]
 end
+
+module Input = struct
+  type t =
+    | Stdin of string * FileType.t
+    | File of string
+end
+
+module Output = struct
+  type _ t =
+    | File: string -> unit t
+    | Stdout: string t
+  let to_cmdline_args: type o. o t -> string list =
+    function
+    | File s -> [Printf.sprintf "--output=%s" s]
+    | Stdout -> []
+end
+
+module Config = struct
+  type t = (string * string) list
+
+  let to_comma_separated_list (conf: t) : string =
+    List.map conf ~f:(fun (k, v) -> Printf.sprintf "%s=%s" k v)
+    |> String.concat ~sep:","
+
+  let of_comma_separated_list (s: string) : t option =
+    String.split_on_char s ~sep:','
+    |> List.fold_right ~init:(Some []) ~f:(fun s state ->
+      match state with
+      | None -> None
+      | Some acc -> begin
+        match String.split_on_char s ~sep:'=' with
+        | k :: v :: _ -> Some ((k, v) :: acc)
+        | _ -> None
+        end
+    )
+end
+
+let append_if flag value xs =
+  if flag then value :: xs else xs
+let append_opt opt f xs =
+  match opt with None -> xs | Some x -> f x :: xs
+
+module Options = struct
+  module Profile = struct
+    type t = Conventional|Default|Compact|Sparse|Ocamlformat|Janestreet
+    let to_string = function
+      | Conventional -> "conventional"
+      | Default -> "default"
+      | Compact -> "compact"
+      | Sparse -> "sparse"
+      | Ocamlformat -> "ocamlformat"
+      | Janestreet -> "janestreet"
+  end
+  type t =
+    {
+      config: Config.t option;
+      commentCheck: bool option;
+      disableConfAttrs: bool;
+      disableConfLines: bool;
+      enableOutsideDetectedProject: bool;
+      ignoreInvalidOption: bool;
+      maxIters: int option;
+      noVersionCheck: bool;
+      ocpIndentConfig: bool;
+      profile: Profile.t option;
+      quiet: bool option;
+      root: string option;
+    }
+  let default =
+    {
+      config = None;
+      commentCheck = None;
+      disableConfAttrs = false;
+      disableConfLines = false;
+      enableOutsideDetectedProject = false;
+      ignoreInvalidOption = false;
+      maxIters = None;
+      noVersionCheck = false;
+      ocpIndentConfig = false;
+      profile = None;
+      quiet = None;
+      root = None
+    }
+  let to_cmdline_args (opt: t) : string list =
+    [] |> append_opt opt.root (Printf.sprintf "--root=%s")
+       |> append_opt opt.quiet (function true -> "--quiet" | _ -> "--no-quiet")
+       |> append_opt opt.profile Profile.to_string
+       |> append_if  opt.ocpIndentConfig "--ocp-indent-config"
+       |> append_if  opt.noVersionCheck "--no-version-check"
+       |> append_opt opt.maxIters (Printf.sprintf "--max-iters:%d")
+       |> append_if  opt.ignoreInvalidOption "--ignore-invalid-option"
+       |> append_if  opt.enableOutsideDetectedProject "--enable-outside-detected-project"
+       |> append_if  opt.disableConfLines "-disable-conf-lines"
+       |> append_if  opt.disableConfAttrs "-disable-conf-attrs"
+       |> append_opt opt.commentCheck (function true -> "--comment-check" | _ -> "--no-comment-check")
+       |> append_opt opt.config (Config.to_comma_separated_list)
+end
+
+type 'result command =
+  | FormatFile: Input.t * 'result Output.t -> 'result command
+  | FormatFilesInPlace: string list -> unit command
+  | Check: Input.t -> bool command
 
 let read_to_end ?(hint=0) (inChan: in_channel) : string =
   let buf = Buffer.create hint in
@@ -34,19 +122,60 @@ let read_to_end ?(hint=0) (inChan: in_channel) : string =
       Buffer.contents buf
   in go ()
 
-let run_command command args input : (string, string) Result.t =
-  let inChan, outChan, errChan = Unix.open_process_args_full command args [||] in
-  output_string outChan input;
-  close_out outChan;
-  let result = read_to_end ~hint:(String.length input) inChan in
-  let error = read_to_end errChan in
-  match Unix.close_process_full (inChan, outChan, errChan) with
-  | Unix.WEXITED 0 -> Result.Ok result
-  | _ -> Result.Error error
+type command_result =
+  {
+    stdout: string;
+    stderr: string;
+    status: Unix.process_status
+  }
 
-let exec (src: string) (opts: Options.t) : (string, string) Result.t =
-  let default_opts = [|
-    "--quiet";
-    (* read from stdin *) "-"
-  |] in
-  run_command "ocamlformat" (Array.append (Options.to_string_array opts) default_opts) src
+let run_command command ?stdin_value args : command_result =
+  let command =
+    match args with
+    | [] -> command
+    | _ -> Printf.sprintf "%s %s" command (String.concat ~sep:" " args)
+  in
+  let inChan, outChan, errChan = Unix.open_process_full command [||] in
+  let f stdin =
+    output_string outChan stdin;
+    close_out outChan
+  in
+  Option.iter stdin_value ~f;
+  let stdout = read_to_end inChan in
+  let stderr = read_to_end errChan in
+  let status = Unix.close_process_full (inChan, outChan, errChan) in
+  { stdout; stderr; status }
+
+let exec: type r. r command -> Options.t -> (r, string) Result.t =
+  fun cmd opts ->
+    let args, stdin_value =
+      let optArgs = Options.to_cmdline_args opts in
+      begin match cmd with
+      | FormatFile (i, o) ->
+        let args = optArgs @ Output.to_cmdline_args o in
+        begin match i with
+        | Input.File f -> args @ [f], None
+        | Input.Stdin (v, f) -> args @ FileType.to_cmdline_args f, Some v
+        end
+      | FormatFilesInPlace fs ->
+        optArgs @ ("--inplace" :: fs), None
+      | Check i ->
+        match i with
+        | Input.File f -> optArgs @ [f], None
+        | Input.Stdin (v, f) -> optArgs @ FileType.to_cmdline_args f, Some v
+      end
+    in
+    let res = run_command "ocamlformat" ?stdin_value args in
+    begin match res.status with
+    | Unix.WEXITED i ->
+      begin match cmd with
+      | FormatFile (_, o) ->
+        begin match o with
+        | Output.File _ -> Result.Ok ()
+        | Output.Stdout -> Result.Ok res.stdout
+        end
+      | FormatFilesInPlace _ -> Result.Ok ()
+      | Check _ -> Result.Ok (i = 0)
+      end
+    | _ -> Result.Error res.stderr
+    end

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -45,13 +45,10 @@ let read_to_end (in_chan : in_channel) : string =
   let chunk = Bytes.create chunk_size in
   let rec go pos =
     let actual_len = input in_chan chunk pos chunk_size in
-    if actual_len = 0 then
-      (* EOF *)
-      ()
-    else (
+    if actual_len > 0 then begin
       Buffer.add_subbytes buf chunk 0 actual_len;
       go pos
-    )
+    end
   in
   go 0;
   Buffer.contents buf

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -39,17 +39,6 @@ type 'result command =
   | Format_files_in_place : string list -> unit command
   | Check : Input.t -> bool command
 
-let read_to_end ?(hint = 0) (in_chan : in_channel) : string =
-  let buf = Buffer.create hint in
-  let rec go () =
-    let line = input_line in_chan in
-    Buffer.add_string buf line;
-    Buffer.add_char buf '\n';
-    go ()
-  in
-  (try go () with End_of_file -> ());
-  Buffer.contents buf
-
 type command_result =
   { stdout : string
   ; stderr : string
@@ -69,8 +58,8 @@ let run_command command ?stdin_value args : command_result =
     close_out out_chan
   in
   Option.iter stdin_value ~f;
-  let stdout = read_to_end in_chan in
-  let stderr = read_to_end err_chan in
+  let stdout = Stdune.Io.read_all in_chan in
+  let stderr = Stdune.Io.read_all err_chan in
   let status = Unix.close_process_full (in_chan, out_chan, err_chan) in
   { stdout; stderr; status }
 

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -1,0 +1,50 @@
+open Import
+
+type opts = (string * string option) list
+
+let read_to_end ?(hint=0) (inChan: in_channel) : string =
+  let buf = Buffer.create hint in
+  let rec go () =
+    try
+      let line = input_line inChan in
+      Buffer.add_string buf line;
+      Buffer.add_char buf '\n';
+      go ()
+    with End_of_file ->
+      Buffer.contents buf
+  in go ()
+
+let run_command command args input : (string, string) Result.t =
+  let inChan, outChan, errChan = Unix.open_process_args_full command args [||] in
+  output_string outChan input;
+  close_out outChan;
+  let result = read_to_end ~hint:(String.length input) inChan in
+  let error = read_to_end errChan in
+  match Unix.close_process_full (inChan, outChan, errChan) with
+  | Unix.WEXITED 0 -> Result.Ok result
+  | _ -> Result.Error error
+
+let opts_to_string_array (opts: opts) : string array =
+  List.map opts ~f:(fun (k, vo) ->
+    let buf = Buffer.create 0 in
+    let bar, sep =
+      if String.length k = 1 then "-", " "
+      else "--", "="
+    in
+    begin
+      Buffer.add_string buf bar; Buffer.add_string buf k;
+      match vo with
+      | None -> ()
+      | Some v -> begin
+        Buffer.add_string buf sep; Buffer.add_string buf v
+      end;
+    end;
+    Buffer.contents buf
+  ) |> Array.of_list
+
+let exec (src: string) (opts: opts) : (string, string) Result.t =
+  let default_opts = [|
+    "--quiet";
+    (* read from stdin *) "-"
+  |] in
+  run_command "ocamlformat" (Array.append (opts_to_string_array opts) default_opts) src

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,77 +1,73 @@
 open Import
 
-module File: sig
-  type t = Impl | Intf | Name of string
+module FileType : sig
+  type t =
+    | Impl
+    | Intf
+    | Name of string
 end
 
-module Input: sig
+module Input : sig
   type t =
-    | Stdin of string * File.t
+    | Stdin of string * FileType.t
     | File of string
 end
 
-module Output: sig
+module Output : sig
   type _ t =
-    | File: string -> unit t
-    | Stdout: string t
+    | File : string -> unit t
+    | Stdout : string t
 end
 
-module Config: sig
+module Config : sig
   type t = (string * string) list
-  val to_comma_separated_list: t -> string
-  val of_comma_separated_list: string -> t option
+
+  val to_comma_separated_list : t -> string
+
+  val of_comma_separated_list : string -> t option
 end
 
-module Options: sig
-  module Profile: sig
-    type t = Conventional|Default|Compact|Sparse|Ocamlformat|Janestreet
+module Options : sig
+  module Profile : sig
+    type t =
+      | Conventional
+      | Default
+      | Compact
+      | Sparse
+      | Ocamlformat
+      | Janestreet
   end
+
   type t =
-    {
-      config: Config.t option;
-      commentCheck: bool;
-      disableConfAttrs: bool;
-      disableConfLines: bool;
-      enableOutsideDetectedProject: bool;
-      ignoreInvalidOption: bool;
-      maxIters: int;
-      noCommentCheck: bool;
-      noVersionCheck: bool;
-      ocpIndentConfig: bool;
-      profile: Profile.t;
-      quiet: bool;
-      root: string option;
+    { config : Config.t option
+    ; commentCheck : bool option
+    ; disableConfAttrs : bool
+    ; disableConfLines : bool
+    ; enableOutsideDetectedProject : bool
+    ; ignoreInvalidOption : bool
+    ; maxIters : int option
+    ; noVersionCheck : bool
+    ; ocpIndentConfig : bool
+    ; profile : Profile.t option
+    ; quiet : bool option
+    ; root : string option
     }
-  val default: t
+
+  val default : t
 end
 
 type 'result command =
-  | FormatFile: Input.t * 'result Output.t -> 'result command
-  | FormatFilesInPlace: string list -> unit command
-  | Check: Input.t -> bool command
+  | FormatFile : Input.t * 'result Output.t -> 'result command
+  | FormatFilesInPlace : string list -> unit command
+  | Check : Input.t -> bool command
 
-val exec:
-     'result command
-  -> Options.t
-  -> ('result, string) Result.t
+val exec : 'result command -> Options.t -> ('result, string) Result.t
 
-val getConfig:
-      _ command
-  -> Options.t
-  -> (Config.t, string) Result.t
+val get_config : _ command -> Options.t -> (Config.t, string) Result.t
 
-val formatFile:
-     Input.t
-  -> 'result Output.t
-  -> Options.t
-  -> ('result, string) Result.t
+val format_file :
+  Input.t -> 'result Output.t -> Options.t -> ('result, string) Result.t
 
-val formatFilesInPlace:
-     string list
-  -> Options.t
-  -> (unit, string) Result.t
+val format_files_in_place : string list -> Options.t -> (unit, string) Result.t
 
-val check:
-     Input.t
-  -> Options.t
-  -> (bool, string) Result.t
+val check : Input.t -> Options.t -> (bool, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,8 +1,77 @@
 open Import
 
-module Options: sig
-  type t = (string * string option) list
-  val to_string_array: t -> string array
+module File: sig
+  type t = Impl | Intf | Name of string
 end
 
-val exec: string -> Options.t -> (string, string) Result.t
+module Input: sig
+  type t =
+    | Stdin of string * File.t
+    | File of string
+end
+
+module Output: sig
+  type _ t =
+    | File: string -> unit t
+    | Stdout: string t
+end
+
+module Config: sig
+  type t = (string * string) list
+  val to_comma_separated_list: t -> string
+  val of_comma_separated_list: string -> t option
+end
+
+module Options: sig
+  module Profile: sig
+    type t = Conventional|Default|Compact|Sparse|Ocamlformat|Janestreet
+  end
+  type t =
+    {
+      config: Config.t option;
+      commentCheck: bool;
+      disableConfAttrs: bool;
+      disableConfLines: bool;
+      enableOutsideDetectedProject: bool;
+      ignoreInvalidOption: bool;
+      maxIters: int;
+      noCommentCheck: bool;
+      noVersionCheck: bool;
+      ocpIndentConfig: bool;
+      profile: Profile.t;
+      quiet: bool;
+      root: string option;
+    }
+  val default: t
+end
+
+type 'result command =
+  | FormatFile: Input.t * 'result Output.t -> 'result command
+  | FormatFilesInPlace: string list -> unit command
+  | Check: Input.t -> bool command
+
+val exec:
+     'result command
+  -> Options.t
+  -> ('result, string) Result.t
+
+val getConfig:
+      _ command
+  -> Options.t
+  -> (Config.t, string) Result.t
+
+val formatFile:
+     Input.t
+  -> 'result Output.t
+  -> Options.t
+  -> ('result, string) Result.t
+
+val formatFilesInPlace:
+     string list
+  -> Options.t
+  -> (unit, string) Result.t
+
+val check:
+     Input.t
+  -> Options.t
+  -> (bool, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,0 +1,5 @@
+open Import
+
+type opts = (string * string option) list
+
+val exec: string -> opts -> (string, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -26,8 +26,8 @@ module Options : sig
 end
 
 type 'result command =
-  | FormatFile : Input.t * 'result Output.t -> 'result command
-  | FormatFilesInPlace : string list -> unit command
+  | Format_file : Input.t * 'result Output.t -> 'result command
+  | Format_files_in_place : string list -> unit command
   | Check : Input.t -> bool command
 
 val exec : 'result command -> Options.t -> ('result, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,6 +1,6 @@
 open Import
 
-module FileType : sig
+module File_type : sig
   type t =
     | Impl
     | Intf
@@ -9,7 +9,7 @@ end
 
 module Input : sig
   type t =
-    | Stdin of string * FileType.t
+    | Stdin of string * File_type.t
     | File of string
 end
 
@@ -19,39 +19,8 @@ module Output : sig
     | Stdout : string t
 end
 
-module Config : sig
-  type t = (string * string) list
-
-  val to_comma_separated_list : t -> string
-
-  val of_comma_separated_list : string -> t option
-end
-
 module Options : sig
-  module Profile : sig
-    type t =
-      | Conventional
-      | Default
-      | Compact
-      | Sparse
-      | Ocamlformat
-      | Janestreet
-  end
-
-  type t =
-    { config : Config.t option
-    ; commentCheck : bool option
-    ; disableConfAttrs : bool
-    ; disableConfLines : bool
-    ; enableOutsideDetectedProject : bool
-    ; ignoreInvalidOption : bool
-    ; maxIters : int option
-    ; noVersionCheck : bool
-    ; ocpIndentConfig : bool
-    ; profile : Profile.t option
-    ; quiet : bool option
-    ; root : string option
-    }
+  type t = string list
 
   val default : t
 end
@@ -62,8 +31,6 @@ type 'result command =
   | Check : Input.t -> bool command
 
 val exec : 'result command -> Options.t -> ('result, string) Result.t
-
-val get_config : _ command -> Options.t -> (Config.t, string) Result.t
 
 val format_file :
   Input.t -> 'result Output.t -> Options.t -> ('result, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,5 +1,8 @@
 open Import
 
-type opts = (string * string option) list
+module Options: sig
+  type t = (string * string option) list
+  val to_string_array: t -> string array
+end
 
-val exec: string -> opts -> (string, string) Result.t
+val exec: string -> Options.t -> (string, string) Result.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -30,11 +30,15 @@ type 'result command =
   | Format_files_in_place : string list -> unit command
   | Check : Input.t -> bool command
 
-val exec : 'result command -> Options.t -> ('result, string) Result.t
+type error =
+  | Missing_binary
+  | Message of string
+
+val exec : 'result command -> Options.t -> ('result, error) Result.t
 
 val format_file :
-  Input.t -> 'result Output.t -> Options.t -> ('result, string) Result.t
+  Input.t -> 'result Output.t -> Options.t -> ('result, error) Result.t
 
-val format_files_in_place : string list -> Options.t -> (unit, string) Result.t
+val format_files_in_place : string list -> Options.t -> (unit, error) Result.t
 
-val check : Input.t -> Options.t -> (bool, string) Result.t
+val check : Input.t -> Options.t -> (bool, error) Result.t

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
@@ -3,24 +3,47 @@ import * as LanguageServer from "../src/LanguageServer";
 
 import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const ocamlFormat = `
+break-cases=all
+break-separators=before
+break-sequences=true
+cases-exp-indent=2
+doc-comments=before
+dock-collection-brackets=false
+field-space=loose
+if-then-else=k-r
+indicate-nested-or-patterns=unsafe-no
+let-and=sparse
+sequence-style=terminator
+space-around-arrays
+space-around-lists
+space-around-records
+type-decl=sparse
+wrap-comments=true
+`;
+
+function setupOcamlFormat(ocamlFormat: string) {
+  let tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "ocamllsp-test-"));
+  fs.writeFileSync(path.join(tmpdir, ".ocamlformat"), ocamlFormat);
+  return tmpdir;
+}
 
 describe("textDocument/formatting", () => {
   let languageServer = null;
 
-  async function openDocument(source) {
+  async function openDocument(source, name) {
     await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "txt",
-        0,
-        source,
-      ),
+      textDocument: Types.TextDocumentItem.create(name, "txt", 0, source),
     });
   }
 
-  async function query() {
+  async function query(name) {
     return await languageServer.sendRequest("textDocument/formatting", {
-      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      textDocument: Types.TextDocumentIdentifier.create(name),
       options: Types.FormattingOptions.create(2, true),
     });
   }
@@ -30,23 +53,62 @@ describe("textDocument/formatting", () => {
     languageServer = null;
   });
 
-  it("is a dummy test", async () => {
-    languageServer = await LanguageServer.startAndInitialize({
-      workspace: { workspaceEdit: { documentChanges: false } },
-    });
+  it("can format an ocaml impl file", async () => {
+    languageServer = await LanguageServer.startAndInitialize();
 
-    console.log(process.cwd());
+    let name = path.join(setupOcamlFormat(ocamlFormat), "test.ml");
 
-    await openDocument(outdent`
+    await openDocument(
+      outdent`
       let rec gcd a b =
         begin match a, b with
           | 0, n | n, 0 -> n
           | _, _ ->
             gcd a (b mod a)
         end
-    `);
+    `,
+      name,
+    );
 
-    let result = await query();
-    console.log(result);
+    let result = await query(name);
+    expect(result).toMatchObject([
+      {
+        newText:
+          "let rec gcd a b =\n" +
+          "  match (a, b) with\n" +
+          "  | 0, n\n" +
+          "  | n, 0 ->\n" +
+          "    n\n" +
+          "  | _, _ -> gcd a (b mod a)\n",
+      },
+    ]);
+  });
+
+  it("can format an ocaml intf file", async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+
+    let name = path.join(setupOcamlFormat(ocamlFormat), "test.mli");
+
+    await openDocument(
+      outdent`
+      module Test:
+        sig
+          type t =
+            Foo
+          | Bar
+          | Baz
+        end
+    `,
+      name,
+    );
+
+    let result = await query(name);
+
+    expect(result).toMatchObject([
+      {
+        newText:
+          "module Test : sig\n  type t =\n    | Foo\n    | Bar\n    | Baz\nend\n",
+      },
+    ]);
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
@@ -1,0 +1,52 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/formatting", () => {
+  let languageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        source,
+      ),
+    });
+  }
+
+  async function query() {
+    return await languageServer.sendRequest("textDocument/formatting", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      options: Types.FormattingOptions.create(2, true),
+    });
+  }
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("is a dummy test", async () => {
+    languageServer = await LanguageServer.startAndInitialize({
+      workspace: { workspaceEdit: { documentChanges: false } },
+    });
+
+    console.log(process.cwd());
+
+    await openDocument(outdent`
+      let rec gcd a b =
+        begin match a, b with
+          | 0, n | n, 0 -> n
+          | _, _ ->
+            gcd a (b mod a)
+        end
+    `);
+
+    let result = await query();
+    console.log(result);
+  });
+});


### PR DESCRIPTION
This PR implements `textDocument/formatting` with a wrapper module to `ocamlformat`.

It finds `ocamlformat` from the current PATH and runs it at the current directory `ocamllsp` is running. Note that I didn't add any facility to find the nearest `.ocamlformat`.

`textDocument/{rangeFormatting, onTypeFormatting}` is not yet implemented. Once https://github.com/ocaml-ppx/ocamlformat/pull/1188 comes into reality, we can easily extend this implementation to support them.