### PR TITLE
Try and recover on InternalError

### DIFF
--- a/lsp/src/jsonrpc.ml
+++ b/lsp/src/jsonrpc.ml
@@ -271,6 +271,10 @@ module Response = struct
     [@@@end]
 
     let make ?data ~code ~message () = { data; code; message }
+
+    let of_exn exn =
+      let message = Printexc.to_string exn in
+      make ~code:InternalError ~message ()
   end
 
   type t =

--- a/lsp/src/jsonrpc.mli
+++ b/lsp/src/jsonrpc.mli
@@ -44,6 +44,8 @@ module Response : sig
       }
 
     val make : ?data:Json.t -> code:Code.t -> message:string -> unit -> t
+
+    val of_exn : Exn.t -> t
   end
 
   type t =

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -160,13 +160,10 @@ let start init_state handler ic oc =
             | Message.Request (id, E req) -> (
               ( try handler.on_request rpc state client_capabilities req
                 with exn ->
-                  let message = Printexc.to_string exn in
-                  let error =
-                    Jsonrpc.Response.Error.make ~code:InternalError ~message ()
-                  in
+                  let error = Jsonrpc.Response.Error.of_exn exn in
                   let response = Jsonrpc.Response.error id error in
                   send_response rpc response;
-                  Error message )
+                  Error error.message )
               >>= fun (next_state, result) ->
               match Client_request.yojson_of_result req result with
               | None -> Ok next_state

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -154,17 +154,27 @@ let start init_state handler ic oc =
             | Message.Client_notification (Exit as notif) ->
               rpc.state <- Closed;
               handler.on_notification rpc state notif
-            | Message.Client_notification notif ->
-              handler.on_notification rpc state notif
+            | Message.Client_notification notif -> (
+              try handler.on_notification rpc state notif
+              with exn -> Error (Printexc.to_string exn) )
             | Message.Request (id, E req) -> (
-              handler.on_request rpc state client_capabilities req
-              >>= fun (next_state, result) ->
-              match Client_request.yojson_of_result req result with
-              | None -> Ok next_state
-              | Some response ->
-                let response = Jsonrpc.Response.ok id response in
+              try
+                handler.on_request rpc state client_capabilities req
+                >>= fun (next_state, result) ->
+                match Client_request.yojson_of_result req result with
+                | None -> Ok next_state
+                | Some response ->
+                  let response = Jsonrpc.Response.ok id response in
+                  send_response rpc response;
+                  Ok next_state
+              with exn ->
+                let message = Printexc.to_string exn in
+                let error =
+                  Jsonrpc.Response.Error.make ~code:InternalError ~message ()
+                in
+                let response = Jsonrpc.Response.error id error in
                 send_response rpc response;
-                Ok next_state ))
+                Error message ))
       in
       Logger.log_flush ();
       loop rpc next_state


### PR DESCRIPTION
Fixes #101 

However, I am not entirely sure that this is the right answer.
For example when handling client requests, should I only try and catch the exceptions in the handler or in the whole process of responding. Meaning, should the `try..with` be surrounding the whole block (like what I did) or just the 
```ocaml
handler.on_request rpc state client_capabilities req
```
What if the exception arises after a response has already been sent ? Right now this can't really happen, but if we ever add things to do after the `send_response`...

But then, if I only surround the handler, I don't know what I should return by default.

Conclusion : I think this is the right answer, but there may be slightly different choices to make