### PR TITLE
Implement textDocument/selectionRange

### DIFF
--- a/lsp/src/initialize.ml
+++ b/lsp/src/initialize.ml
@@ -3573,6 +3573,7 @@ module ServerCapabilities = struct
     ; executeCommandProvider : ExecuteCommandOptions.t option [@yojson.option]
     ; typeCoverageProvider : bool
     ; foldingRangeProvider : Void.t Or_bool.t
+    ; selectionRangeProvider : Void.t Or_bool.t
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -3602,6 +3603,7 @@ module ServerCapabilities = struct
         and executeCommandProvider_field = ref None
         and typeCoverageProvider_field = ref None
         and foldingRangeProvider_field = ref None
+        and selectionRangeProvider_field = ref None
         and duplicates = ref []
         and extra = ref [] in
         let rec iter = function
@@ -3784,6 +3786,16 @@ module ServerCapabilities = struct
               | Some _ ->
                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
               )
+            | "selectionRangeProvider" -> (
+              match Ppx_yojson_conv_lib.( ! ) selectionRangeProvider_field with
+              | None ->
+                let fvalue =
+                  Or_bool.t_of_yojson Void.t_of_yojson _field_yojson
+                in
+                selectionRangeProvider_field := Some fvalue
+              | Some _ ->
+                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates
+              )
             | _ -> () );
             iter tail
           | [] -> ()
@@ -3821,7 +3833,8 @@ module ServerCapabilities = struct
               , Ppx_yojson_conv_lib.( ! ) documentLinkProvider_field
               , Ppx_yojson_conv_lib.( ! ) executeCommandProvider_field
               , Ppx_yojson_conv_lib.( ! ) typeCoverageProvider_field
-              , Ppx_yojson_conv_lib.( ! ) foldingRangeProvider_field )
+              , Ppx_yojson_conv_lib.( ! ) foldingRangeProvider_field
+              , Ppx_yojson_conv_lib.( ! ) selectionRangeProvider_field )
             with
             | ( Some textDocumentSync_value
               , Some hoverProvider_value
@@ -3842,7 +3855,8 @@ module ServerCapabilities = struct
               , documentLinkProvider_value
               , executeCommandProvider_value
               , Some typeCoverageProvider_value
-              , Some foldingRangeProvider_value ) ->
+              , Some foldingRangeProvider_value
+              , Some selectionRangeProvider_value ) ->
               { textDocumentSync = textDocumentSync_value
               ; hoverProvider = hoverProvider_value
               ; completionProvider = completionProvider_value
@@ -3865,6 +3879,7 @@ module ServerCapabilities = struct
               ; executeCommandProvider = executeCommandProvider_value
               ; typeCoverageProvider = typeCoverageProvider_value
               ; foldingRangeProvider = foldingRangeProvider_value
+              ; selectionRangeProvider = selectionRangeProvider_value
               }
             | _ ->
               Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
@@ -3958,8 +3973,15 @@ module ServerCapabilities = struct
         ; executeCommandProvider = v_executeCommandProvider
         ; typeCoverageProvider = v_typeCoverageProvider
         ; foldingRangeProvider = v_foldingRangeProvider
+        ; selectionRangeProvider = v_selectionRangeProvider
         } ->
         let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+        let bnds =
+          let arg =
+            Or_bool.yojson_of_t Void.yojson_of_t v_selectionRangeProvider
+          in
+          ("selectionRangeProvider", arg) :: bnds
+        in
         let bnds =
           let arg =
             Or_bool.yojson_of_t Void.yojson_of_t v_foldingRangeProvider
@@ -4097,6 +4119,7 @@ module ServerCapabilities = struct
     ; executeCommandProvider = None
     ; typeCoverageProvider = false
     ; foldingRangeProvider = Bool false
+    ; selectionRangeProvider = Bool false
     }
 end
 

--- a/lsp/src/initialize.mli
+++ b/lsp/src/initialize.mli
@@ -276,6 +276,7 @@ module ServerCapabilities : sig
     ; executeCommandProvider : ExecuteCommandOptions.t option
     ; typeCoverageProvider : bool
     ; foldingRangeProvider : Void.t Or_bool.t
+    ; selectionRangeProvider : Void.t Or_bool.t
     }
 
   val default : t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -72,6 +72,7 @@ let initializeInfo : Lsp.Initialize.Result.t =
       ; executeCommandProvider = None
       ; typeCoverageProvider = false
       ; foldingRangeProvider = Bool true
+      ; selectionRangeProvider = Bool true
       ; signatureHelpProvider = None
       }
   }

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
@@ -1,0 +1,61 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/selectionRange", () => {
+  let languageServer = null;
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        source,
+      ),
+    });
+  }
+
+  async function selectionRange(positions) {
+    return await languageServer.sendRequest("textDocument/selectionRange", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      positions: positions,
+    });
+  }
+
+  it("returns a selection range for modules", async () => {
+    await openDocument(outdent`
+      let foo a b =
+        let min_ab = min a b in
+        let max_ab = max a b in
+        min_ab * max_ab
+        `);
+
+    let result = await selectionRange([Types.Position.create(1, 17)]);
+    expect(result).toMatchObject([
+      {
+        range: {
+          start: {
+            line: 1,
+            character: 15,
+          },
+          end: {
+            line: 1,
+            character: 18,
+          },
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #100.

This PR implements `textDocument/selectionRange`.

This is still WIP:
- [x] Find the desired way to flatten Merlin's `Shape` into LSP's `SelectionRange`
- [x] Change the server's capabilities
- [x] Write some tests