### PR TITLE
Always return something on request

### DIFF
--- a/lsp/src/rpc.mli
+++ b/lsp/src/rpc.mli
@@ -12,7 +12,8 @@ type 'state handler =
       -> ('state * Initialize.Result.t, string) result
   ; on_request :
       'res.    t -> 'state -> Initialize.ClientCapabilities.t
-      -> 'res Client_request.t -> ('state * 'res, string) result
+      -> 'res Client_request.t
+      -> ('state * 'res, Jsonrpc.Response.Error.t) result
   ; on_notification :
       t -> 'state -> Client_notification.t -> ('state, string) result
   }

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -13,7 +13,11 @@ let get store uri =
   match Table.find store uri with
   | Some doc -> Ok doc
   | None ->
-    Lsp.Import.Result.errorf "no document found with uri: %a" Lsp.Uri.pp uri
+    Error
+      (Lsp.Jsonrpc.Response.Error.make ~code:InvalidRequest
+         ~message:
+           (Format.asprintf "no document found with uri: %a" Lsp.Uri.pp uri)
+         ())
 
 let remove_document store uri =
   Table.filter_map_inplace

--- a/ocaml-lsp-server/src/document_store.mli
+++ b/ocaml-lsp-server/src/document_store.mli
@@ -4,7 +4,10 @@ val make : unit -> t
 
 val put : t -> Document.t -> unit
 
-val get : t -> Lsp.Protocol.documentUri -> (Document.t, string) result
+val get :
+     t
+  -> Lsp.Protocol.documentUri
+  -> (Document.t, Lsp.Jsonrpc.Response.Error.t) result
 
 val get_opt : t -> Lsp.Protocol.documentUri -> Document.t option
 


### PR DESCRIPTION
Changed the signature of request to return either a success (store * resp) or a Response.Error
The server should always answer requests, even in case of error, it should return an error response.