### PR TITLE
Fix incorrect type for workspace/applyEdit request

### DIFF
--- a/lsp/src/protocol.ml
+++ b/lsp/src/protocol.ml
@@ -4745,7 +4745,7 @@ module ApplyWorkspaceEdit = struct
   module Params = struct
     type t =
       { label : string option [@yojson.option]
-      ; edit : WorkspaceEdit.t list
+      ; edit : WorkspaceEdit.t
       }
     [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -4773,9 +4773,7 @@ module ApplyWorkspaceEdit = struct
               | "edit" -> (
                 match Ppx_yojson_conv_lib.( ! ) edit_field with
                 | None ->
-                  let fvalue =
-                    list_of_yojson WorkspaceEdit.t_of_yojson _field_yojson
-                  in
+                  let fvalue = WorkspaceEdit.t_of_yojson _field_yojson in
                   edit_field := Some fvalue
                 | Some _ ->
                   duplicates :=
@@ -4824,7 +4822,7 @@ module ApplyWorkspaceEdit = struct
         | { label = v_label; edit = v_edit } ->
           let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
           let bnds =
-            let arg = yojson_of_list WorkspaceEdit.yojson_of_t v_edit in
+            let arg = WorkspaceEdit.yojson_of_t v_edit in
             ("edit", arg) :: bnds
           in
           let bnds =

--- a/lsp/src/protocol.mli
+++ b/lsp/src/protocol.mli
@@ -514,7 +514,7 @@ module ApplyWorkspaceEdit : sig
   module Params : sig
     type t =
       { label : string option
-      ; edit : WorkspaceEdit.t list
+      ; edit : WorkspaceEdit.t
       }
 
     include Json.Jsonable.S with type t := t


### PR DESCRIPTION
[The specification][spec] states that only a single edit should be supplied. Multiple edits can be embedded inside `WorkspaceEdit.t`.

I realise that the lsp package doesn't currently have support for server requests, so fixing this may not be a high priority. I had a quick play around with bodging in support locally, and found this bug as a result.

[spec]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#workspace_applyEdit