### PR TITLE
Logging through LSP

### DIFF
--- a/lsp/src/logger.mli
+++ b/lsp/src/logger.mli
@@ -29,8 +29,23 @@
     according to a * section and a verbosity level. * * 2. Allow to setup a
     destination for these log messages. * **)
 
+module Title : sig
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Debug
+    | LocalDebug
+    | Notify
+    | Custom of string
+
+  val to_string : t -> string
+end
+
+val register_consumer : (string * Title.t * string -> unit) -> unit
+
 val log :
-  section:string -> title:string -> ('b, unit, string, unit) format4 -> 'b
+  section:string -> title:Title.t -> ('b, unit, string, unit) format4 -> 'b
 
 val fmt : unit -> (Format.formatter -> unit) -> string
 
@@ -51,7 +66,7 @@ val with_notifications : notification list ref -> (unit -> 'a) -> 'a
 
 val with_log_file : string option -> ?sections:string list -> (unit -> 'a) -> 'a
 
-type 'a printf = title:string -> ('a, unit, string, unit) format4 -> 'a
+type 'a printf = title:Title.t -> ('a, unit, string, unit) format4 -> 'a
 
 type logger = { log : 'a. 'a printf }
 

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -15,7 +15,7 @@ and state =
 let { Logger.log } = Logger.for_section "lsp"
 
 let send rpc json =
-  log ~title:"debug" "send: %a"
+  log ~title:Logger.Title.LocalDebug "send: %a"
     (fun () -> Yojson.Safe.pretty_to_string ~std:false)
     json;
   let data = Yojson.Safe.to_string json in
@@ -44,7 +44,7 @@ let read rpc =
   let parse_json content =
     match Yojson.Safe.from_string content with
     | json ->
-      log ~title:"debug" "recv: %a"
+      log ~title:Logger.Title.LocalDebug "recv: %a"
         (fun () -> Yojson.Safe.pretty_to_string ~std:false)
         json;
       Ok json
@@ -101,11 +101,12 @@ let start init_state handler ic oc =
     let start = Unix.gettimeofday () in
     let next_state = f () in
     let ellapsed = (Unix.gettimeofday () -. start) /. 1000.0 in
-    log ~title:"debug" "time elapsed processing message: %fs" ellapsed;
+    log ~title:Logger.Title.LocalDebug "time elapsed processing message: %fs"
+      ellapsed;
     match next_state with
     | Ok next_state -> next_state
     | Error msg ->
-      log ~title:"error" "%s" msg;
+      log ~title:Logger.Title.Error "%s" msg;
       prev_state
   in
 

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -51,7 +51,7 @@ let make ?(version = 0) ~uri ~text () =
 let update_text ?version change doc =
   let tdoc = Lsp.Text_document.apply_content_change ?version change doc.tdoc in
   let text = Lsp.Text_document.text tdoc in
-  log ~title:"debug" "TEXT\n%s" text;
+  log ~title:Logger.Title.Debug "TEXT\n%s" text;
   let config = make_config (Lsp.Text_document.documentUri tdoc) in
   let source = Msource.make text in
   let pipeline = Mpipeline.make config source in


### PR DESCRIPTION
This PR makes the server to send log outputs to client through `window/logMessage`.

This will make debugging far easier within VSCode or other editors.

To match [the LSP spec](https://microsoft.github.io/language-server-protocol/specification#window_showMessage) and avoid an infinite loop [while logging about request sending/receiving](https://github.com/ocaml/ocaml-lsp/blob/master/lsp/src/rpc.ml#L18), this PR also introduces a type `Logger.Title.t`.