### PR TITLE
Add documentFormattingProvider to server capabilities

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -100,6 +100,7 @@ let initializeInfo : InitializeResult.t =
       ~definitionProvider:(`Bool true) ~typeDefinitionProvider:(`Bool true)
       ~completionProvider ~codeActionProvider ~referencesProvider:(`Bool true)
       ~documentHighlightProvider:(`Bool true)
+      ~documentFormattingProvider:(`Bool true)
       ~selectionRangeProvider:(`Bool true) ~documentSymbolProvider:(`Bool true)
       ~renameProvider:(`Bool true) ()
   in


### PR DESCRIPTION
Looks like this was (accidentally?) removed in
7860a87689b5bdd3309445831227e32995c1d8b5.

Fixes #124.