### PR TITLE
[WIP] Batched document changes

### DIFF
--- a/lsp/src/dune
+++ b/lsp/src/dune
@@ -3,7 +3,7 @@
 (library
  (name lsp)
  (public_name lsp)
- (libraries stdune yojson threads.posix ppx_yojson_conv_lib)
+ (libraries stdune yojson threads.posix ppx_yojson_conv_lib fiber)
  (preprocess future_syntax)
  (flags :standard "-open" "Ppx_yojson_conv_lib" "-open" "Yojson_conv")
  (lint

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -265,7 +265,7 @@ let start init_state handler ic oc =
   set_binary_mode_in ic true;
   set_binary_mode_out oc true;
   let fd = Unix.descr_of_in_channel stdin in
-  let rpc = { ic; oc; fd; state = Ready; queue = Event_queue.create 1000 } in
+  let rpc = { ic; oc; fd; state = Ready; queue = Event_queue.create 100 } in
   reader_thread rpc |> ignore;
   loop rpc init_state
 

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -17,20 +17,10 @@ let { Logger.log } = Logger.for_section "lsp"
 
 let threaded f x =
   let open Fiber.O in
-  let mutex = Mutex.create () in
   let var = ref None in
-  Thread.create
-    (fun x ->
-      Mutex.lock mutex;
-      var := Some (f x);
-      Mutex.unlock mutex)
-    x
-  |> ignore;
-
+  Thread.create (fun x -> var := Some (f x)) x |> ignore;
   let rec loop () =
-    Mutex.lock mutex;
     let v = !var in
-    Mutex.unlock mutex;
     match v with
     | Some v -> Fiber.return v
     | None -> Fiber.yield () >>= fun () -> loop ()

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -1,10 +1,67 @@
 open Import
 open Types
 
+module Event_queue = struct
+  type 'a t =
+    { queue : 'a Queue.t
+    ; empty : Condition.t
+    ; full : Condition.t
+    ; mutex : Mutex.t
+    ; max : int
+    }
+
+  let create max =
+    { queue = Queue.create ()
+    ; empty = Condition.create ()
+    ; full = Condition.create ()
+    ; mutex = Mutex.create ()
+    ; max
+    }
+
+  let add q v =
+    Mutex.lock q.mutex;
+    while Queue.length q.queue = q.max do
+      Condition.wait q.empty q.mutex
+    done;
+    Queue.add v q.queue;
+    Condition.signal q.full;
+    Mutex.unlock q.mutex
+
+  let take q =
+    Mutex.lock q.mutex;
+    while Queue.length q.queue = 0 do
+      Condition.wait q.full q.mutex
+    done;
+    let ret = Queue.take q.queue in
+    Condition.signal q.empty;
+    Mutex.unlock q.mutex;
+    ret
+end
+
+module Message = struct
+  type t =
+    | Request of Jsonrpc.Id.t * Client_request.packed
+    | Client_notification of Client_notification.t
+
+  let of_jsonrpc (packet : Jsonrpc.Request.t) =
+    let open Result.O in
+    match packet.id with
+    | None ->
+      Client_notification.of_jsonrpc packet >>| fun cn -> Client_notification cn
+    | Some id -> Client_request.of_jsonrpc packet >>| fun r -> Request (id, r)
+end
+
+module Event = struct
+  type t =
+    | Message of (Message.t, string) result
+    | Notification of Server_notification.t
+end
+
 type t =
   { ic : in_channel
   ; oc : out_channel
   ; fd : Unix.file_descr
+  ; queue : Event.t Event_queue.t
   ; mutable state : state
   }
 
@@ -14,18 +71,6 @@ and state =
   | Closed
 
 let { Logger.log } = Logger.for_section "lsp"
-
-let threaded f x =
-  let open Fiber.O in
-  let var = ref None in
-  Thread.create (fun x -> var := Some (f x)) x |> ignore;
-  let rec loop () =
-    let v = !var in
-    match v with
-    | Some v -> Fiber.return v
-    | None -> Fiber.yield () >>= fun () -> loop ()
-  in
-  loop ()
 
 let send rpc json =
   log ~title:Logger.Title.LocalDebug "send: %a"
@@ -70,29 +115,12 @@ let read rpc =
   | r -> Ok r
   | exception _exn -> Error "Unexpected packet"
 
-let read rpc = threaded read rpc
-
 let send_response rpc (response : Jsonrpc.Response.t) =
   let json = Jsonrpc.Response.yojson_of_t response in
   send rpc json
 
 let send_notification rpc notif =
-  let response = Server_notification.to_jsonrpc_request notif in
-  let json = Jsonrpc.Request.yojson_of_t response in
-  send rpc json
-
-module Message = struct
-  type t =
-    | Request of Jsonrpc.Id.t * Client_request.packed
-    | Client_notification of Client_notification.t
-
-  let of_jsonrpc (packet : Jsonrpc.Request.t) =
-    let open Result.O in
-    match packet.id with
-    | None ->
-      Client_notification.of_jsonrpc packet >>| fun cn -> Client_notification cn
-    | Some id -> Client_request.of_jsonrpc packet >>| fun r -> Request (id, r)
-end
+  Event_queue.add rpc.queue (Event.Notification notif)
 
 open Types
 
@@ -101,119 +129,144 @@ type 'state handler =
          t
       -> 'state
       -> InitializeParams.t
-      -> ('state * InitializeResult.t, string) result Fiber.t
+      -> ('state * InitializeResult.t, string) result
   ; on_request :
       'res.    t -> 'state -> ClientCapabilities.t -> 'res Client_request.t
-      -> ('state * 'res, Jsonrpc.Response.Error.t) result Fiber.t
+      -> ('state * 'res, Jsonrpc.Response.Error.t) result
   ; on_notification :
-      t -> 'state -> Client_notification.t -> ('state, string) result Fiber.t
+      t -> 'state -> Client_notification.t -> ('state, string) result
   }
+
+let handle_message prev_state f =
+  let start = Unix.gettimeofday () in
+  let next_state = f () in
+  let ellapsed = (Unix.gettimeofday () -. start) /. 1000.0 in
+  log ~title:Logger.Title.LocalDebug "time elapsed processing message: %fs"
+    ellapsed;
+  match next_state with
+  | Ok next_state -> next_state
+  | Error msg ->
+    log ~title:Logger.Title.Error "%s" msg;
+    prev_state
+
+let is_stopped rpc =
+  match rpc.state with
+  | Closed -> true
+  | _ -> false
 
 let start init_state handler ic oc =
   let open Result.O in
-  let read_message rpc =
-    Fiber.map (read rpc) ~f:(fun m -> m >>= Message.of_jsonrpc)
+  let on_message_when_ready rpc state msg =
+    handle_message state @@ fun () ->
+    let open Client_request in
+    match msg with
+    | Ok (Message.Request (id, E (Initialize params))) ->
+      let* next_state, result = handler.on_initialize rpc state params in
+      let json = InitializeResult.yojson_of_t result in
+      let response = Jsonrpc.Response.ok id json in
+      rpc.state <- Initialized params.capabilities;
+      send_response rpc response;
+      Ok next_state
+    | Ok (Message.Client_notification Exit) ->
+      rpc.state <- Closed;
+      Ok state
+    | Ok (Message.Client_notification _) ->
+      (* we drop all notifications per protocol before we initialized *)
+      Ok state
+    | Ok (Message.Request (id, _)) ->
+      (* we response with -32002 per protocol before we initialized *)
+      let response =
+        let error =
+          Jsonrpc.Response.Error.make ~code:ServerNotInitialized
+            ~message:"not initialized" ()
+        in
+        Jsonrpc.Response.error id error
+      in
+      send_response rpc response;
+      Ok state
+    | Error err -> Error err
   in
 
-  let handle_message prev_state f =
-    let open Fiber.O in
-    let start = Unix.gettimeofday () in
-    let+ next_state = f () in
-    let ellapsed = (Unix.gettimeofday () -. start) /. 1000.0 in
-    log ~title:Logger.Title.LocalDebug "time elapsed processing message: %fs"
-      ellapsed;
-    match next_state with
-    | Ok next_state -> next_state
-    | Error msg ->
-      log ~title:Logger.Title.Error "%s" msg;
-      prev_state
+  let on_message_when_initialized rpc state client_capabilities msg =
+    handle_message state @@ fun () ->
+    let open Client_request in
+    match msg with
+    | Ok (Message.Request (_id, E (Initialize _))) ->
+      Error "received another initialize request"
+    | Ok (Message.Client_notification (Exit as notif)) ->
+      rpc.state <- Closed;
+      handler.on_notification rpc state notif
+    | Ok (Message.Client_notification notif) -> (
+      try handler.on_notification rpc state notif
+      with exn -> Error (Printexc.to_string exn) )
+    | Ok (Message.Request (id, E req)) -> (
+      let handled =
+        try handler.on_request rpc state client_capabilities req
+        with exn -> Error (Jsonrpc.Response.Error.of_exn exn)
+      in
+      match handled with
+      | Ok (next_state, result) ->
+        let yojson_result =
+          match Client_request.yojson_of_result req result with
+          | None -> `Null
+          | Some res -> res
+        in
+        let response = Jsonrpc.Response.ok id yojson_result in
+        send_response rpc response;
+        Ok next_state
+      | Error e ->
+        let response = Jsonrpc.Response.error id e in
+        send_response rpc response;
+        Error e.message )
+    | Error err -> Error err
+  in
+
+  let on_message rpc state msg =
+    let next_state =
+      match rpc.state with
+      | Closed -> exit 0
+      | Ready -> Some (on_message_when_ready rpc state msg)
+      | Initialized client_capabilities ->
+        Some (on_message_when_initialized rpc state client_capabilities msg)
+    in
+    Logger.log_flush ();
+    next_state
+  in
+
+  let on_notification rpc notif =
+    let response = Server_notification.to_jsonrpc_request notif in
+    let json = Jsonrpc.Request.yojson_of_t response in
+    send rpc json
   in
 
   let rec loop rpc state =
-    let open Result.O in
-    let ( let*: ) = Fiber.O.( let* ) in
-    let ( let+: ) = Fiber.O.( let+ ) in
-    match rpc.state with
-    | Closed -> Fiber.return ()
-    | Ready ->
-      let*: next_state =
-        handle_message state @@ fun () ->
-        let*: msg = read_message rpc in
-        let open Client_request in
-        match msg with
-        | Ok (Message.Request (id, E (Initialize params))) ->
-          let+: init = handler.on_initialize rpc state params in
-          let* next_state, result = init in
-          let json = InitializeResult.yojson_of_t result in
-          let response = Jsonrpc.Response.ok id json in
-          rpc.state <- Initialized params.capabilities;
-          send_response rpc response;
-          Ok next_state
-        | Ok (Message.Client_notification Exit) ->
-          rpc.state <- Closed;
-          Fiber.return @@ Ok state
-        | Ok (Message.Client_notification _) ->
-          (* we drop all notifications per protocol before we initialized *)
-          Fiber.return @@ Ok state
-        | Ok (Message.Request (id, _)) ->
-          (* we response with -32002 per protocol before we initialized *)
-          let response =
-            let error =
-              Jsonrpc.Response.Error.make ~code:ServerNotInitialized
-                ~message:"not initialized" ()
-            in
-            Jsonrpc.Response.error id error
-          in
-          send_response rpc response;
-          Fiber.return @@ Ok state
-        | Error err -> Fiber.return (Error err)
+    if not (is_stopped rpc) then
+      let event = Event_queue.take rpc.queue in
+      let next_state =
+        match event with
+        | Event.Message msg -> on_message rpc state msg
+        | Notification msg ->
+          on_notification rpc msg;
+          Some state
       in
-      Logger.log_flush ();
-      loop rpc next_state
-    | Initialized client_capabilities ->
-      let*: next_state =
-        handle_message state @@ fun () ->
-        let*: msg = read_message rpc in
-        let open Client_request in
-        match msg with
-        | Ok (Message.Request (_id, E (Initialize _))) ->
-          Fiber.return @@ Error "received another initialize request"
-        | Ok (Message.Client_notification (Exit as notif)) ->
-          rpc.state <- Closed;
-          handler.on_notification rpc state notif
-        | Ok (Message.Client_notification notif) -> (
-          try handler.on_notification rpc state notif
-          with exn -> Fiber.return @@ Error (Printexc.to_string exn) )
-        | Ok (Message.Request (id, E req)) -> (
-          let+: handled =
-            try handler.on_request rpc state client_capabilities req
-            with exn ->
-              Fiber.return @@ Error (Jsonrpc.Response.Error.of_exn exn)
-          in
-          match handled with
-          | Ok (next_state, result) ->
-            let yojson_result =
-              match Client_request.yojson_of_result req result with
-              | None -> `Null
-              | Some res -> res
-            in
-            let response = Jsonrpc.Response.ok id yojson_result in
-            send_response rpc response;
-            Ok next_state
-          | Error e ->
-            let response = Jsonrpc.Response.error id e in
-            send_response rpc response;
-            Error e.message )
-        | Error err -> Fiber.return @@ Error err
-      in
-      Logger.log_flush ();
-      loop rpc next_state
+      Option.iter next_state ~f:(loop rpc)
+  in
+
+  let reader_thread =
+    Thread.create (fun rpc ->
+        let rec loop () =
+          let msg = Event.Message (read rpc >>= Message.of_jsonrpc) in
+          Event_queue.add rpc.queue msg;
+          loop ()
+        in
+        loop ())
   in
 
   set_binary_mode_in ic true;
   set_binary_mode_out oc true;
   let fd = Unix.descr_of_in_channel stdin in
-  let rpc = { ic; oc; fd; state = Ready } in
+  let rpc = { ic; oc; fd; state = Ready; queue = Event_queue.create 1000 } in
+  reader_thread rpc |> ignore;
   loop rpc init_state
 
 let stop (rpc : t) = rpc.state <- Closed

--- a/lsp/src/rpc.mli
+++ b/lsp/src/rpc.mli
@@ -18,7 +18,8 @@ type 'state handler =
       t -> 'state -> Client_notification.t -> ('state, string) result
   }
 
-val start : 'state -> 'state handler -> in_channel -> out_channel -> unit
+val start :
+  'state -> 'state handler -> in_channel -> out_channel -> unit Fiber.t
 
 val stop : t -> unit
 

--- a/lsp/src/rpc.mli
+++ b/lsp/src/rpc.mli
@@ -10,17 +10,18 @@ type 'state handler =
          t
       -> 'state
       -> InitializeParams.t
-      -> ('state * InitializeResult.t, string) result Fiber.t
+      -> ('state * InitializeResult.t, string) result
   ; on_request :
       'res.    t -> 'state -> ClientCapabilities.t -> 'res Client_request.t
-      -> ('state * 'res, Jsonrpc.Response.Error.t) result Fiber.t
+      -> ('state * 'res, Jsonrpc.Response.Error.t) result
   ; on_notification :
-      t -> 'state -> Client_notification.t -> ('state, string) result Fiber.t
+      t -> 'state -> Client_notification.t -> ('state, string) result
   }
 
-val start :
-  'state -> 'state handler -> in_channel -> out_channel -> unit Fiber.t
+val start : 'state -> 'state handler -> in_channel -> out_channel -> unit
 
 val stop : t -> unit
+
+val is_stopped : t -> bool
 
 val send_notification : t -> Server_notification.t -> unit

--- a/lsp/src/rpc.mli
+++ b/lsp/src/rpc.mli
@@ -10,12 +10,12 @@ type 'state handler =
          t
       -> 'state
       -> InitializeParams.t
-      -> ('state * InitializeResult.t, string) result
+      -> ('state * InitializeResult.t, string) result Fiber.t
   ; on_request :
       'res.    t -> 'state -> ClientCapabilities.t -> 'res Client_request.t
-      -> ('state * 'res, Jsonrpc.Response.Error.t) result
+      -> ('state * 'res, Jsonrpc.Response.Error.t) result Fiber.t
   ; on_notification :
-      t -> 'state -> Client_notification.t -> ('state, string) result
+      t -> 'state -> Client_notification.t -> ('state, string) result Fiber.t
   }
 
 val start :

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -1,17 +1,28 @@
 open! Import
 module Table = Hashtbl.Make (Lsp.Uri)
 
-type t = Document.t Table.t
+type value =
+  { document : Document.t
+  ; last_update : float
+  }
+
+type t = value Table.t
 
 let make () = Table.create 50
 
-let put store doc = Table.replace store ~key:(Document.uri doc) ~data:doc
+let put store doc =
+  Table.replace store ~key:(Document.uri doc)
+    ~data:{ document = doc; last_update = Unix.time () }
 
-let get_opt store = Table.find store
+let get_opt store uri =
+  Table.find store uri |> Option.map ~f:(fun v -> v.document)
+
+let get_full_opt store uri =
+  Table.find store uri |> Option.map ~f:(fun v -> (v.document, v.last_update))
 
 let get store uri =
   match Table.find store uri with
-  | Some doc -> Ok doc
+  | Some doc -> Ok doc.document
   | None ->
     Error
       (Lsp.Jsonrpc.Response.Error.make ~code:InvalidRequest

--- a/ocaml-lsp-server/src/document_store.mli
+++ b/ocaml-lsp-server/src/document_store.mli
@@ -8,6 +8,8 @@ val get : t -> Lsp.Uri.t -> (Document.t, Lsp.Jsonrpc.Response.Error.t) result
 
 val get_opt : t -> Lsp.Uri.t -> Document.t option
 
+val get_full_opt : t -> Lsp.Uri.t -> (Document.t * float) option
+
 val remove_document : t -> Lsp.Uri.t -> unit
 
 val get_size : t -> int

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -6,4 +6,4 @@
  (libraries stdune merlin.specific merlin.analysis merlin.kernel
    merlin.merlin_utils merlin.parsing merlin.query_protocol lsp merlin.typing
    merlin.utils merlin.query_commands result yojson ppx_yojson_conv_lib
-   cmdliner))
+   cmdliner fiber))

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -6,4 +6,4 @@
  (libraries stdune merlin.specific merlin.analysis merlin.kernel
    merlin.merlin_utils merlin.parsing merlin.query_protocol lsp merlin.typing
    merlin.utils merlin.query_commands result yojson ppx_yojson_conv_lib
-   cmdliner core_kernel threads.posix))
+   cmdliner threads.posix))

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -6,4 +6,4 @@
  (libraries stdune merlin.specific merlin.analysis merlin.kernel
    merlin.merlin_utils merlin.parsing merlin.query_protocol lsp merlin.typing
    merlin.utils merlin.query_commands result yojson ppx_yojson_conv_lib
-   cmdliner fiber))
+   cmdliner core_kernel threads.posix))

--- a/ocaml-lsp-server/src/main.ml
+++ b/ocaml-lsp-server/src/main.ml
@@ -1,4 +1,4 @@
-let run log_file = Ocaml_lsp_server.run ~log_file
+let run log_file delay = Ocaml_lsp_server.run ~log_file ~delay
 
 let () =
   let open Cmdliner in
@@ -11,9 +11,15 @@ let () =
     value & opt (some string) None & info [ "log-file" ] ~docv:"FILE" ~doc ~env
   in
 
+  let delay =
+    let open Arg in
+    let doc = "Delay between updating a file and receiving diagnostics" in
+    value & opt float 0.75 & info [ "delay" ] ~docv:"FILE" ~doc
+  in
+
   let cmd =
     let doc = "Start OCaml LSP server (only stdio transport is supported)" in
-    ( Term.(const run $ log_file)
+    ( Term.(const run $ log_file $ delay)
     , Term.info "ocamllsp" ~doc ~exits:Term.default_exits )
   in
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -114,7 +114,7 @@ module Diagnostics = struct
               None
             ) else (
               ( match !next_time with
-              | Some t -> next_time := Some (Float.min t scheduled)
+              | Some t -> next_time := Some (min t scheduled)
               | None -> next_time := Some scheduled );
               Some scheduled
             ));

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -612,7 +612,8 @@ let start () =
     prepare_and_run Lsp.Jsonrpc.Response.Error.of_exn @@ fun () ->
     on_request rpc state caps req
   in
-  Lsp.Rpc.start docs { on_initialize; on_request; on_notification } stdin stdout;
+  Lsp.Rpc.start docs { on_initialize; on_request; on_notification } stdin stdout
+  |> Fiber.run;
   log ~title:Logger.Title.Info "exiting"
 
 let run ~log_file =

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -1,3 +1,3 @@
 (* intentionally blank *)
 
-val run : log_file:string option -> unit
+val run : log_file:string option -> delay:float -> unit


### PR DESCRIPTION
Quick implementation of batching diagnostics after a document changes (#116). 

The current code will wait 2 seconds after a change before running `send_diagnostics`. If another change occurs in that time, the timer resets. The goal is to avoid running Merlin on every change to improve performance.

This code isn't ready to merge, because it busy waits for reads and for updates, but maybe it'll be a starting point for this feature.