### PR TITLE
Allow setting line width for refmt

### DIFF
--- a/ocaml-lsp-server/src/fmt.ml
+++ b/ocaml-lsp-server/src/fmt.ml
@@ -57,10 +57,11 @@ type formatter =
   | Reason of Document.Kind.t
   | Ocaml of Lsp.Uri.t
 
-let args = function
+let args ~refmt_width t =
+  match t with
   | Ocaml uri -> [ sprintf "--name=%s" (Lsp.Uri.to_path uri); "-" ]
   | Reason kind -> (
-    [ "--parse"; "re"; "--print"; "re" ]
+    [ "--parse"; "re"; "--print"; "re"; "--print-width"; string_of_int refmt_width ]
     @
     match kind with
     | Impl -> []
@@ -89,10 +90,10 @@ let exec bin args stdin =
   | Unix.WEXITED 0 -> Result.Ok res.stdout
   | _ -> Result.Error (Unexpected_result { message = res.stderr })
 
-let run doc =
+let run ~refmt_width doc =
   let open Result.O in
   let* formatter = formatter doc in
-  let args = args formatter in
+  let args = args ~refmt_width formatter in
   let* binary = binary formatter in
   let contents = Document.source doc |> Msource.text in
   exec binary args contents

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -11,4 +11,4 @@ type error =
 
 val message : error -> string
 
-val run : Document.t -> (string, error) Result.t
+val run : refmt_width:int -> Document.t -> (string, error) Result.t

--- a/ocaml-lsp-server/src/main.ml
+++ b/ocaml-lsp-server/src/main.ml
@@ -1,4 +1,4 @@
-let run log_file _refmt_width = Ocaml_lsp_server.run ~log_file
+let run log_file refmt_width = Ocaml_lsp_server.run ~log_file ~refmt_width
 
 let default_refmt_width = 80
 

--- a/ocaml-lsp-server/src/main.ml
+++ b/ocaml-lsp-server/src/main.ml
@@ -1,4 +1,6 @@
-let run log_file = Ocaml_lsp_server.run ~log_file
+let run log_file _refmt_width = Ocaml_lsp_server.run ~log_file
+
+let default_refmt_width = 80
 
 let () =
   let open Cmdliner in
@@ -11,9 +13,15 @@ let () =
     value & opt (some string) None & info [ "log-file" ] ~docv:"FILE" ~doc ~env
   in
 
+  let refmt_width =
+    let open Arg in
+    let doc = "refmt wrapping width" in
+    value & opt int default_refmt_width & info ["w"; "refmt-width"] ~docv:"WIDTH" ~doc
+  in
+
   let cmd =
     let doc = "Start OCaml LSP server (only stdio transport is supported)" in
-    ( Term.(const run $ log_file)
+    ( Term.(const run $ log_file $ refmt_width)
     , Term.info "ocamllsp" ~doc ~exits:Term.default_exits )
   in
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -1,1 +1,1 @@
-val run : log_file:string option -> unit
+val run : log_file:string option -> refmt_width:int -> unit


### PR DESCRIPTION
There is currently no way of setting up line width for `refmt` other than passing flag to the command. 

While we at this point, I am suggesting to introduce `--refmt-width` argument to `ocamllsp` and pass it to `refmt`. On editor extension side a setting for refmt can be introduced and passed to `ocamllsp` instance: https://github.com/ocamllabs/vscode-ocaml-platform/pull/184

Related issue in reason repo: https://github.com/facebook/reason/issues/2567