### PR TITLE
Preview of fiber based scheduler

### DIFF
--- a/lsp/src/scheduler.ml
+++ b/lsp/src/scheduler.ml
@@ -210,7 +210,7 @@ let wake_loop t =
   loop ()
 
 let create () =
-  let rec t =
+  let t =
     { events_pending = 0
     ; events = Queue.create ()
     ; mutex = Mutex.create ()
@@ -311,7 +311,6 @@ let schedule (type a) (timer : timer) (f : unit -> a Fiber.t) :
     (a, [ `Cancelled ]) result Fiber.t =
   let scheduled = Unix.gettimeofday () in
   Mutex.lock timer.timer_scheduler.time_mutex;
-  let open Fiber.O in
   let ivar =
     match Table.find timer.timer_scheduler.timers timer.timer_id with
     | Some active ->

--- a/lsp/src/scheduler.ml
+++ b/lsp/src/scheduler.ml
@@ -143,8 +143,8 @@ and timer =
   }
 
 and 'a active_timer =
-  { mutable scheduled : float
-  ; mutable ivar : ('a, [ `Cancelled ]) result Fiber.Ivar.t
+  { scheduled : float
+  ; ivar : ('a, [ `Cancelled ]) result Fiber.Ivar.t
   ; action : unit -> 'a Fiber.t
   ; parent : timer
   }

--- a/lsp/src/scheduler.ml
+++ b/lsp/src/scheduler.ml
@@ -1,0 +1,224 @@
+open Import
+
+module Worker : sig
+  type 'work t
+  (** Simple queue that is consumed by its own thread *)
+
+  val create : do_:('a -> unit) -> 'a t
+
+  val add_work : 'a t -> 'a -> unit
+
+  val stop : 'a -> unit
+end = struct
+  type state =
+    | Running of Thread.t
+    | Stopped of Thread.t
+    | Finished
+
+  type 'a t =
+    { work : 'a Queue.t
+    ; mutable state : state
+    ; mutex : Mutex.t
+    ; work_available : Condition.t
+    }
+
+  let is_running t =
+    match t.state with
+    | Running _ -> true
+    | _ -> false
+
+  let run (f, t) =
+    Mutex.lock t.mutex;
+    let rec loop () =
+      while Queue.is_empty t.work && is_running t do
+        Condition.wait t.work_available t.mutex
+      done;
+      while not (Queue.is_empty t.work) do
+        f (Queue.pop t.work)
+      done;
+      match t.state with
+      | Stopped _ ->
+        assert (Queue.is_empty t.work);
+        t.state <- Finished
+      | Finished -> assert false
+      | Running _ -> loop ()
+    in
+    loop ()
+
+  let create ~do_ =
+    let t =
+      { work = Queue.create ()
+      ; state = Finished
+      ; mutex = Mutex.create ()
+      ; work_available = Condition.create ()
+      }
+    in
+    t.state <- Running (Thread.create run (do_, t));
+    t
+
+  let add_work t w =
+    ( match t.state with
+    | Running _ -> ()
+    | _ -> Code_error.raise "invalid state" [] );
+    Mutex.lock t.mutex;
+    Queue.add w t.work;
+    Condition.signal t.work_available;
+    Mutex.unlock t.mutex
+
+  let stop _ = assert false
+end
+
+module Timer_id = Id.Make ()
+
+type t =
+  { mutable jobs_pending : int
+  ; jobs_completed : event Queue.t
+  ; mutex : Mutex.t
+  ; job_completed : Condition.t
+  ; timer_available : Condition.t
+  ; mutable threads : thread list
+  ; timers : (Timer_id.t, active_timer) Table.t
+  }
+
+and event =
+  | Job_completed : 'a * 'a Fiber.Ivar.t -> event
+  | Scheduled of active_timer
+
+and job = Pending : (unit -> 'a) * 'a Or_exn.t Fiber.Ivar.t -> job
+
+and thread =
+  { scheduler : t
+  ; jobs : job Queue.t
+  ; job_available : Condition.t
+  ; thread : Thread.t Lazy.t
+  ; th_mutex : Mutex.t
+  ; mutable stopped : bool
+  }
+
+and timer =
+  { delay : float
+  ; timer_scheduler : t
+  ; timer_id : Timer_id.t
+  }
+
+and active_timer =
+  { mutable scheduled : float
+  ; action : unit -> unit
+  ; parent : timer
+  }
+
+let create () =
+  { jobs_pending = 0
+  ; jobs_completed = Queue.create ()
+  ; mutex = Mutex.create ()
+  ; job_completed = Condition.create ()
+  ; threads = []
+  ; timer_available = Condition.create ()
+  ; timers = Table.create (module Timer_id) 10
+  }
+
+let consume_queue q ~f =
+  while not (Queue.is_empty q) do
+    f (Queue.pop q)
+  done
+
+let run_thread (t : thread) =
+  Mutex.lock t.th_mutex;
+  let rec loop () =
+    while Queue.is_empty t.jobs && not t.stopped do
+      Condition.wait t.job_available t.th_mutex
+    done;
+    consume_queue t.jobs ~f:(fun (Pending (f, ivar)) ->
+        Mutex.unlock t.th_mutex;
+        let res = Result.try_with f in
+        Mutex.lock t.scheduler.mutex;
+        Queue.add (Job_completed (res, ivar)) t.scheduler.jobs_completed;
+        Condition.signal t.scheduler.job_completed;
+        Mutex.unlock t.scheduler.mutex);
+    if not t.stopped then loop ()
+  in
+  if not t.stopped then loop ();
+  Mutex.unlock t.th_mutex
+
+let create_thread scheduler =
+  let rec t : thread =
+    { scheduler
+    ; thread = lazy (Thread.create run_thread t)
+    ; jobs = Queue.create ()
+    ; job_available = Condition.create ()
+    ; th_mutex = Mutex.create ()
+    ; stopped = false
+    }
+  in
+  scheduler.threads <- t :: scheduler.threads;
+  t
+
+let async (t : thread) f =
+  if t.stopped then
+    Code_error.raise "Cannot enqueue jobs after thread is stopped" [];
+  let (_ : Thread.t) = Lazy.force t.thread in
+  Mutex.lock t.scheduler.mutex;
+  t.scheduler.jobs_pending <- t.scheduler.jobs_pending + 1;
+  Mutex.unlock t.scheduler.mutex;
+  let ivar = Fiber.Ivar.create () in
+  Mutex.lock t.th_mutex;
+  Queue.add (Pending (f, ivar)) t.jobs;
+  Condition.signal t.job_available;
+  Mutex.unlock t.th_mutex;
+  Fiber.Ivar.read ivar
+
+let stop (t : thread) =
+  Mutex.lock t.th_mutex;
+  t.stopped <- true;
+  Condition.signal t.job_available;
+  Mutex.unlock t.th_mutex
+
+let rec pump_events (t : t) =
+  let open Fiber.O in
+  let* () = Fiber.yield () in
+  if t.jobs_pending = 0 then
+    Fiber.return (List.iter t.threads ~f:stop)
+  else (
+    Mutex.lock t.mutex;
+    while Queue.is_empty t.jobs_completed do
+      Condition.wait t.job_completed t.mutex
+    done;
+    let* () =
+      match Queue.pop t.jobs_completed with
+      | Job_completed (a, ivar) ->
+        Mutex.unlock t.mutex;
+        t.jobs_pending <- t.jobs_pending - 1;
+        Fiber.Ivar.fill ivar a
+      | Scheduled active_timer ->
+        Mutex.unlock t.mutex;
+        active_timer.action ();
+        Fiber.return ()
+    in
+    pump_events t
+  )
+
+let run t f =
+  let open Fiber.O in
+  match
+    Fiber.run
+      (let* user_action_result = Fiber.fork (fun () -> f) in
+       let* pump_events_result = pump_events t in
+       Fiber.return (pump_events_result, user_action_result))
+  with
+  | exception Fiber.Never ->
+    Code_error.raise "[Scheduler.pump_events] got stuck somehow" []
+  | (), b -> Fiber.run (Fiber.Future.wait b)
+
+let create_timer t ~delay =
+  { timer_scheduler = t; delay; timer_id = Timer_id.gen () }
+
+let schedule (timer : timer) f =
+  Mutex.lock timer.timer_scheduler.mutex;
+  let scheduled = Unix.gettimeofday () in
+  ( match Table.find timer.timer_scheduler.timers timer.timer_id with
+  | Some active -> active.scheduled <- scheduled
+  | None ->
+    Table.add_exn timer.timer_scheduler.timers timer.timer_id
+      { scheduled; action = f; parent = timer } );
+  Condition.signal timer.timer_scheduler.timer_available;
+  Mutex.unlock timer.timer_scheduler.mutex

--- a/lsp/src/scheduler.mli
+++ b/lsp/src/scheduler.mli
@@ -18,4 +18,5 @@ type timer
 
 val create_timer : t -> delay:float -> timer
 
-val schedule : timer -> (unit -> unit) -> unit
+val schedule :
+  timer -> (unit -> 'a Fiber.t) -> ('a, [ `Cancelled ]) result Fiber.t

--- a/lsp/src/scheduler.mli
+++ b/lsp/src/scheduler.mli
@@ -1,0 +1,21 @@
+open Import
+
+type t
+
+val create : unit -> t
+
+val run : t -> 'a Fiber.t -> 'a
+
+type thread
+
+val create_thread : t -> thread
+
+val async : thread -> (unit -> 'a) -> 'a Or_exn.t Fiber.t
+
+val stop : thread -> unit
+
+type timer
+
+val create_timer : t -> delay:float -> timer
+
+val schedule : timer -> (unit -> unit) -> unit

--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -16,4 +16,5 @@
 
 (rule
  (alias test)
- (action (run ./fiber_thread_test.exe)))
+ (action
+  (run ./fiber_thread_test.exe)))

--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -1,0 +1,19 @@
+; (executable
+;  (name server_test)
+;  (libraries stdune lsp fiber threads.posix)
+;  (preprocess future_syntax))
+
+; we cannot use the normal test alias because cinaps overtakes it
+
+; (rule
+;  (alias test)
+;  (action
+;   (run ./server_test.exe)))
+
+(executable
+ (name fiber_thread_test)
+ (libraries stdune lsp fiber threads.posix))
+
+(rule
+ (alias test)
+ (action (run ./fiber_thread_test.exe)))

--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -12,6 +12,7 @@
 
 (executable
  (name fiber_thread_test)
+ (preprocess future_syntax)
  (libraries stdune lsp fiber threads.posix))
 
 (rule

--- a/lsp/test/fiber_thread_test.ml
+++ b/lsp/test/fiber_thread_test.ml
@@ -1,0 +1,14 @@
+open! Stdune
+open Lsp
+
+let s = Scheduler.create ()
+
+let worker = Scheduler.create_thread s
+
+let fb = Scheduler.async worker (fun () -> Thread.delay 1.0; print_endline "finit")
+
+let () =
+  let res = Scheduler.run s fb in
+  match res with
+  | Ok () -> print_endline "finished"
+  | Error _ -> Code_error.raise "unexpected error" []

--- a/lsp/test/fiber_thread_test.ml
+++ b/lsp/test/fiber_thread_test.ml
@@ -5,10 +5,41 @@ let s = Scheduler.create ()
 
 let worker = Scheduler.create_thread s
 
-let fb = Scheduler.async worker (fun () -> Thread.delay 1.0; print_endline "finit")
+let fb () =
+  Scheduler.async worker (fun () ->
+      Thread.delay 1.0;
+      print_endline "pre epmtive thread finished")
+
+let _ =
+  Thread.create
+    (fun () ->
+      Thread.delay 3.0;
+      print_endline "unexpected termination";
+      exit 1)
+    ()
 
 let () =
-  let res = Scheduler.run s fb in
+  let open Fiber.O in
+  let timers_finished () =
+    let timer = Scheduler.create_timer s ~delay:1.0 in
+    let now = Unix.gettimeofday () in
+    let diff () = Unix.gettimeofday () -. now in
+    let first =
+      Scheduler.schedule timer (fun () -> Fiber.return (false, diff ()))
+    in
+    let last =
+      Scheduler.schedule timer (fun () -> Fiber.return (true, diff ()))
+    in
+    let+ res = Fiber.fork_and_join (fun () -> first) (fun () -> last) in
+    match res with
+    | Error `Cancelled, Ok (true, diff) ->
+      Format.eprintf "first scheduled cancelled. second one ran after %f@.%!"
+        diff;
+      Ok ()
+    | _, _ -> Error ()
+  in
+  let all = Fiber.fork_and_join fb timers_finished in
+  let res = Scheduler.run s all in
   match res with
-  | Ok () -> print_endline "finished"
-  | Error _ -> Code_error.raise "unexpected error" []
+  | Ok (), Ok () -> print_endline "finished successfully"
+  | _, _ -> Code_error.raise "unexpected error" []

--- a/lsp/test/server_test.ml
+++ b/lsp/test/server_test.ml
@@ -1,0 +1,83 @@
+open Lsp
+open! Import
+
+module Client = struct
+  let on_request _ _ =
+    let code = Jsonrpc.Response.Error.Code.InternalError in
+    let message = "Request not supported" in
+    Fiber.return (Error (Jsonrpc.Response.Error.make ~code ~message ()))
+
+  let on_notification _ _notif = Format.eprintf "Received notification@.%!"
+
+  let handler = { Client.on_request; on_notification }
+
+  let run in_ out =
+    let initialize =
+      let capabilities = Types.ClientCapabilities.create () in
+      Types.InitializeParams.create ~capabilities ()
+    in
+    let client = Client.create handler in_ out initialize in
+    let start () =
+      let _start = Client.start client in
+      let open Fiber.O in
+      let+ (_ : Types.InitializeResult.t) = Client.initialized client in
+      Format.eprintf "initialized"
+    in
+    Thread.create start ()
+end
+
+module Server = struct
+  type state =
+    | Started
+    | Initialized
+
+  let on_initialize _ s _ =
+    assert (s = Started);
+    let ir =
+      let capabilities = Types.ServerCapabilities.create () in
+      Types.InitializeResult.create ~capabilities ()
+    in
+    Format.eprintf "initialized server@.%!";
+    Fiber.return (Ok (Initialized, ir))
+
+  let on_request _ state _ _ =
+    assert (state = Initialized);
+    let code = Jsonrpc.Response.Error.Code.InternalError in
+    let message = "Request not supported" in
+    Fiber.return (Error (Jsonrpc.Response.Error.make ~code ~message ()))
+
+  let on_notification _ state _notif =
+    assert (state = Initialized);
+    Format.eprintf "Received notification@.%!";
+    Fiber.return (Ok state)
+
+  let handler = { Server.on_initialize; on_request; on_notification }
+
+  let run in_ out =
+    let loop () = Server.start Started handler in_ out |> Fiber.run in
+    Thread.create loop ()
+end
+
+let () =
+  let client_in, server_out = Unix.pipe () in
+  let server_in, client_out = Unix.pipe () in
+  let server_thread =
+    let in_ = Unix.in_channel_of_descr server_in in
+    let out = Unix.out_channel_of_descr server_out in
+    Server.run in_ out
+  in
+  let client_thread =
+    let in_ = Unix.in_channel_of_descr client_in in
+    let out = Unix.out_channel_of_descr client_out in
+    Client.run in_ out
+  in
+  let (_ : Thread.t) =
+    Thread.create
+      (fun () ->
+        Thread.delay 5.0;
+        Format.eprintf "Test failed to terminate before 5 seconds";
+        exit 1)
+      ()
+  in
+  Thread.join server_thread;
+  Thread.join client_thread


### PR DESCRIPTION
@jfeser @giltho, this is a preview of the scheduler required to make #151 work with fibers.

In particular, it contains two comoponents:

* A way to run computations in separate threads. We will be using this for async
  IO

* A timer mechanism to implement batched updates. This implementation slightly
  differs with #151 by having the "waker" run in a separate thread. Otherwise, this
  snippet:

```ocaml
 Option.iter !next_time ~f:(fun t ->
   Thread.delay (t -. Unix.gettimeofday ()));
```

 is problematic. What happens when a new timer that's due before `!next_time` is scheduled?

Some initial review would be helpful.