### PR TITLE
Test support of ocamlformat-ignore

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
@@ -110,5 +110,38 @@ maybeDescribe("textDocument/formatting", () => {
         },
       ]);
     });
+
+    it("does not format ignored files", async () => {
+      languageServer = await LanguageServer.startAndInitialize();
+
+      let tmpdir = setupOcamlFormat(ocamlFormat);
+
+      let ocamlFormatIgnore = path.join(tmpdir, ".ocamlformat-ignore");
+      fs.writeFileSync(ocamlFormatIgnore, "test.ml\n");
+
+      let name = path.join(tmpdir, "test.ml");
+
+      await openDocument(
+        languageServer,
+        "let rec gcd a b = match (a, b) with\n" +
+        "  | 0, n\n" +
+        "  | n, 0 ->\n" +
+        "    n\n" +
+        "  | _, _ -> gcd a (b mod a)\n",
+        name,
+      );
+
+      let result = await query(languageServer, name);
+      expect(result).toMatchObject([
+        {
+          newText:
+            "let rec gcd a b = match (a, b) with\n" +
+            "  | 0, n\n" +
+            "  | n, 0 ->\n" +
+            "    n\n" +
+            "  | _, _ -> gcd a (b mod a)\n",
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
In the process of trying to reproduce https://github.com/ocamllabs/vscode-ocaml-platform/issues/223 I wrote this test. Apparently the problem was on my side. But you might want to keep the test.