### PR TITLE
Set ocaml-lsp as source of diagnostics

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -53,6 +53,7 @@ let initializeInfo : InitializeResult.t =
 let ocamlmerlin_reason = "ocamlmerlin-reason"
 
 let send_diagnostics rpc doc =
+  let diagnostic_create = Diagnostic.create ~source:"ocamllsp" in
   let reason_merlin_available =
     match Document.syntax doc with
     | Ocaml -> true
@@ -71,7 +72,7 @@ let send_diagnostics rpc doc =
           let pos = Position.create ~line:1 ~character:1 in
           Range.create ~start:pos ~end_:pos
         in
-        [ Diagnostic.create ~range ~message () ]
+        [ diagnostic_create ~range ~message () ]
       in
       Lsp.Server_notification.PublishDiagnostics
         (PublishDiagnosticsParams.create ~uri ~diagnostics ())
@@ -96,7 +97,7 @@ let send_diagnostics rpc doc =
             Loc.print_main Format.str_formatter error;
             String.trim (Format.flush_str_formatter ())
           in
-          Diagnostic.create ~range ~message ~severity ())
+          diagnostic_create ~range ~message ~severity ())
     in
 
     let notif =


### PR DESCRIPTION
Set `ocaml-lsp` as the source of the diagnostics. It is convenient when multiple tools can provide diagnostics. For example if I have a build task in addition to the lsp server. With this addition I can see which errors are coming from ocamllsp and which are coming from my build task.

![image](https://user-images.githubusercontent.com/974142/82735752-91f93c80-9d56-11ea-9ccb-0ac6fa80b6d5.png)
