### PR TITLE
Add binary version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -45,6 +45,7 @@ possible and does not make any assumptions about IO.
   stdlib-shims
   menhir
   ppx_yojson_conv_lib
+  dune-build-info
   (ocamlformat :with-test)
   (ocamlfind (>= 1.5.2))
   (ocaml (>= 4.06))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -20,6 +20,7 @@ depends: [
   "stdlib-shims"
   "menhir"
   "ppx_yojson_conv_lib"
+  "dune-build-info"
   "ocamlformat" {with-test}
   "ocamlfind" {>= "1.5.2"}
   "ocaml" {>= "4.06"}

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -6,4 +6,4 @@
  (libraries stdune merlin.specific merlin.analysis merlin.kernel
    merlin.merlin_utils merlin.parsing merlin.query_protocol lsp merlin.typing
    merlin.utils merlin.query_commands result yojson ppx_yojson_conv_lib
-   cmdliner fiber))
+   cmdliner fiber dune-build-info))

--- a/ocaml-lsp-server/src/main.ml
+++ b/ocaml-lsp-server/src/main.ml
@@ -13,8 +13,9 @@ let () =
 
   let cmd =
     let doc = "Start OCaml LSP server (only stdio transport is supported)" in
+    let version = Version.get () in
     ( Term.(const run $ log_file)
-    , Term.info "ocamllsp" ~doc ~exits:Term.default_exits )
+    , Term.info "ocamllsp" ~version ~doc ~exits:Term.default_exits )
   in
 
   Term.(exit @@ eval cmd)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -45,8 +45,8 @@ let initializeInfo : InitializeResult.t =
       ~experimental ~renameProvider ()
   in
   let serverInfo =
-    (* TODO use actual version *)
-    InitializeResult.create_serverInfo ~name:"ocamllsp" ()
+    let version = Version.get () in
+    InitializeResult.create_serverInfo ~name:"ocamllsp" ~version ()
   in
   InitializeResult.create ~capabilities ~serverInfo ()
 

--- a/ocaml-lsp-server/src/version.ml
+++ b/ocaml-lsp-server/src/version.ml
@@ -1,0 +1,4 @@
+let get () =
+  match Build_info.V1.version () with
+  | None -> "dev"
+  | Some v -> Build_info.V1.Version.to_string v

--- a/ocaml-lsp-server/src/version.mli
+++ b/ocaml-lsp-server/src/version.mli
@@ -1,0 +1,1 @@
+val get : unit -> string


### PR DESCRIPTION
The version is accessible in two different ways:
* traditionally via the ocmmandline `$ ocamllsp --version`
* inside the initialize result sent by the server