### PR TITLE
Handle dummy positions

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -205,16 +205,20 @@ let location_of_merlin_loc uri = function
   | `Not_found _
   | `Not_in_env _ ->
     None
-  | `Found (path, lex_position) ->
-    let position = Position.of_lexical_position lex_position in
-    let range = { Range.start = position; end_ = position } in
-    let uri =
-      match path with
-      | None -> uri
-      | Some path -> Lsp.Uri.of_path path
-    in
-    let locs = [ { Location.uri = Lsp.Uri.to_string uri; range } ] in
-    Some (`Location locs)
+  | `Found (path, lex_position) -> (
+    match Position.of_lexical_position lex_position with
+    | None ->
+      log ~title:Logger.Title.Warning "merlin returned dummy position";
+      None
+    | Some position ->
+      let range = { Range.start = position; end_ = position } in
+      let uri =
+        match path with
+        | None -> uri
+        | Some path -> Lsp.Uri.of_path path
+      in
+      let locs = [ { Location.uri = Lsp.Uri.to_string uri; range } ] in
+      Some (`Location locs) )
 
 let on_request :
     type resp.

--- a/ocaml-lsp-server/src/position.ml
+++ b/ocaml-lsp-server/src/position.ml
@@ -1,10 +1,19 @@
 open Import
 include Lsp.Types.Position
 
-let of_lexical_position (lex_position : Lexing.position) : t =
-  let line = lex_position.pos_lnum - 1 in
-  let character = lex_position.pos_cnum - lex_position.pos_bol in
-  { line; character }
+let is_dummy (lp : Lexing.position) =
+  lp.pos_lnum = Lexing.dummy_pos.pos_lnum
+  && lp.pos_cnum = Lexing.dummy_pos.pos_cnum
+
+let of_lexical_position (lex_position : Lexing.position) : t option =
+  if is_dummy lex_position then
+    None
+  else
+    let line = lex_position.pos_lnum - 1 in
+    let character = lex_position.pos_cnum - lex_position.pos_bol in
+    assert (line >= 0);
+    assert (character >= 0);
+    Some { line; character }
 
 let ( - ) ({ line; character } : t) (t : t) : t =
   { line = line - t.line; character = character - t.character }

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -10,4 +10,4 @@ val compare : t -> t -> Ordering.t
 
 val logical : t -> [> `Logical of int * int ]
 
-val of_lexical_position : Lexing.position -> t
+val of_lexical_position : Lexing.position -> t option

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -8,7 +8,14 @@ let compare_size (x : t) (y : t) =
   Stdune.Tuple.T2.compare Int.compare Int.compare (dx.line, dy.line)
     (dx.character, dy.character)
 
+let first_line =
+  let start = { Position.line = 1; character = 0 } in
+  let end_ = { Position.line = 2; character = 0 } in
+  { start; end_ }
+
 let of_loc (loc : Loc.t) : t =
-  { start = Position.of_lexical_position loc.loc_start
-  ; end_ = Position.of_lexical_position loc.loc_end
-  }
+  (let open Option.O in
+  let* start = Position.of_lexical_position loc.loc_start in
+  let+ end_ = Position.of_lexical_position loc.loc_end in
+  { start; end_ })
+  |> Option.value ~default:first_line


### PR DESCRIPTION
Dummy positions are now turned into ranges that span the first line of
the file.

There's also a warning if merlin returns a dummy position as the
definition source.