### PR TITLE
Fix #206: Select markdown language id based on document syntax

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,8 +46,6 @@ jobs:
 
       - run: opam exec -- make
 
-      - run: yarn global add reason-cli
-
       - run: yarn --frozen-lockfile
         working-directory: ocaml-lsp-server/test/e2e
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
 
       - run: opam exec -- make
 
-      - run: yarn add -g reason-cli
+      - run: yarn global add reason-cli
 
       - run: yarn --frozen-lockfile
         working-directory: ocaml-lsp-server/test/e2e

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,6 +46,8 @@ jobs:
 
       - run: opam exec -- make
 
+      - run: yarn add -g reason-cli
+
       - run: yarn --frozen-lockfile
         working-directory: ocaml-lsp-server/test/e2e
 

--- a/dune-project
+++ b/dune-project
@@ -48,6 +48,7 @@ possible and does not make any assumptions about IO.
   ppx_yojson_conv_lib
   dune-build-info
   (ocamlformat :with-test)
+  (reason :with-test)
   (ocamlfind (>= 1.5.2))
   (ocaml (>= 4.06))
   (dune (>= 2.5.0))))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -22,6 +22,7 @@ depends: [
   "ppx_yojson_conv_lib"
   "dune-build-info"
   "ocamlformat" {with-test}
+  "reason" {with-test}
   "ocamlfind" {>= "1.5.2"}
   "ocaml" {>= "4.06"}
   "dune" {>= "2.5.0"}

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -26,6 +26,10 @@ module Syntax = struct
     | "ocaml" -> Ocaml
     | "reason" -> Reason
     | id -> failwith ("Unexpected language id " ^ id)
+
+  let to_language_id = function
+  | Ocaml -> "ocaml"
+  | Reason -> "reason"
 end
 
 type t =

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -6,6 +6,8 @@ module Syntax : sig
   type t =
     | Ocaml
     | Reason
+
+  val to_language_id : t -> string
 end
 
 module Kind : sig

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -261,7 +261,12 @@ let on_request :
       | _ -> None
     in
 
-    let format_contents ~as_markdown ~typ ~doc =
+    let format_contents ~syntax ~as_markdown ~typ ~doc =
+      let languageId = 
+        match syntax with
+        | Document.Syntax.Ocaml -> "ocaml"
+        | Document.Syntax.Reason -> "reason"
+      in
       let doc =
         match doc with
         | None -> ""
@@ -269,7 +274,7 @@ let on_request :
       in
       `MarkupContent
         ( if as_markdown then
-          { MarkupContent.value = Printf.sprintf "```ocaml\n%s%s\n```" typ doc
+          { MarkupContent.value = Printf.sprintf "```%s\n%s%s\n```" languageId typ doc
           ; kind = MarkupKind.Markdown
           }
         else
@@ -284,6 +289,7 @@ let on_request :
     match query_type doc pos with
     | None -> Ok (store, None)
     | Some (loc, typ) ->
+      let syntax = Document.syntax doc in
       let doc = query_doc doc pos in
       let as_markdown =
         match client_capabilities.textDocument with
@@ -293,7 +299,7 @@ let on_request :
             ~set:(Option.value contentFormat ~default:[ Markdown ])
         | _ -> false
       in
-      let contents = format_contents ~as_markdown ~typ ~doc in
+      let contents = format_contents ~syntax ~as_markdown ~typ ~doc in
       let range = Range.of_loc loc in
       let resp = Hover.create ~contents ~range () in
       Ok (store, Some resp) )

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -262,11 +262,7 @@ let on_request :
     in
 
     let format_contents ~syntax ~as_markdown ~typ ~doc =
-      let languageId = 
-        match syntax with
-        | Document.Syntax.Ocaml -> "ocaml"
-        | Document.Syntax.Reason -> "reason"
-      in
+      let languageId = Document.Syntax.to_language_id syntax in
       let doc =
         match doc with
         | None -> ""

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -67,6 +67,38 @@ describe("textDocument/hover", () => {
     });
   });
 
+  it("returns correct syntax for reason (markdown formatting)", async () => {
+    languageServer = await LanguageServer.startAndInitialize({
+      textDocument: {
+        hover: {
+          dynamicRegistration: true,
+          contentFormat: ["markdown", "plaintext"],
+        },
+      },
+    });
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.re",
+        "reason",
+        0,
+        "let x = 1;\n",
+      ),
+    });
+
+    let result = await languageServer.sendRequest("textDocument/hover", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.re"),
+      position: Types.Position.create(0, 4),
+    });
+
+    expect(result).toMatchObject({
+      contents: { kind: "markdown", value: "```reason\nint\n```" },
+      range: {
+        end: { character: 5, line: 0 },
+        start: { character: 4, line: 0 },
+      },
+    });
+  });
+
   it("returns type inferred under cursor with documentation", async () => {
     languageServer = await LanguageServer.startAndInitialize({
       textDocument: {


### PR DESCRIPTION
The `hover` request is hard-coded to always specify a language type of `ocaml`, but it's actually sending Reason code over in the Reason case - but the language specifier is always `ocaml`.

This selects the language id conditionally based on the syntax of the document.

Fixes #206 