### PR TITLE
Per document timer

### DIFF
--- a/lsp/src/scheduler.ml
+++ b/lsp/src/scheduler.ml
@@ -293,7 +293,7 @@ let await_no_cancel task =
   | Error `Canceled -> assert false
   | Error (`Exn exn) -> Error exn
 
-let cancel task =
+let cancel_task task =
   let open Fiber.O in
   let* status = Fiber.Ivar.peek task.ivar in
   match status with
@@ -481,6 +481,10 @@ let schedule (type a) (timer : timer) (f : unit -> a Fiber.t) :
           active_timer.ivar)
   in
   Fiber.Ivar.read ivar
+
+let cancel_timer (timer : timer) =
+  with_mutex timer.timer_scheduler.time_mutex ~f:(fun () ->
+      Table.remove timer.timer_scheduler.timers timer.timer_id)
 
 let detach ?name t f =
   let task () =

--- a/lsp/src/scheduler.mli
+++ b/lsp/src/scheduler.mli
@@ -16,7 +16,7 @@ val await : 'a task -> ('a, [ `Exn of Exn.t | `Canceled ]) result Fiber.t
 
 val await_no_cancel : 'a task -> 'a Or_exn.t Fiber.t
 
-val cancel : 'a task -> unit Fiber.t
+val cancel_task : 'a task -> unit Fiber.t
 
 val async : thread -> (unit -> 'a) -> 'a task
 
@@ -32,6 +32,8 @@ val detach : ?name:string -> t -> (unit -> unit Fiber.t) -> unit Fiber.t
 
 val schedule :
   timer -> (unit -> 'a Fiber.t) -> ('a, [ `Cancelled ]) result Fiber.t
+
+val cancel_timer : timer -> unit
 
 val scheduler : unit -> t
 

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -1,4 +1,4 @@
-open Lsp.Types
+open Import
 
 type t
 
@@ -20,7 +20,10 @@ val kind : t -> Kind.t
 
 val syntax : t -> Syntax.t
 
-val make : Lsp.Scheduler.thread -> DidOpenTextDocumentParams.t -> t
+val make :
+  Scheduler.timer -> Scheduler.thread -> DidOpenTextDocumentParams.t -> t
+
+val timer : t -> Scheduler.timer
 
 val uri : t -> Lsp.Uri.t
 

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -18,6 +18,12 @@ let get store uri =
            (Format.asprintf "no document found with uri: %a" Lsp.Uri.pp uri)
          ())
 
-let remove_document store uri = Table.remove store uri
+let remove_document store uri =
+  match Table.find store uri with
+  | None -> ()
+  | Some doc ->
+    let timer = Document.timer doc in
+    Scheduler.cancel_timer timer;
+    Table.remove store uri
 
 let get_size store = Table.length store

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -1,6 +1,7 @@
 include Lsp.Import
 module Logger = Lsp.Logger
 module Loc = Location
+module Scheduler = Lsp.Scheduler
 open Lsp.Types
 module CompletionItemKind = CompletionItemKind
 module SymbolKind = SymbolKind
@@ -39,5 +40,7 @@ module VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier
 module TextDocumentEdit = TextDocumentEdit
 module FoldingRange = FoldingRange
 module SelectionRange = SelectionRange
+module DidOpenTextDocumentParams = DidOpenTextDocumentParams
+module TextDocumentContentChangeEvent = TextDocumentContentChangeEvent
 
 let { Logger.log } = Logger.for_section "ocaml-lsp-server"


### PR DESCRIPTION
This PR introduces an individual timer for every document. The advantage
of this are twofold:

* It allows us to configure the delay per document.
* When we close a document, we can cancel outstanding timed tasks.