### PR TITLE
Response of types of requests aren't optional

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -63,7 +63,7 @@ type _ t =
   | TextDocumentColor : DocumentColorParams.t -> ColorInformation.t list t
   | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list t
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
-  | UnknownRequest : string * Json.t option -> unit t
+  | UnknownRequest : string * Json.t option -> Json.t t
 
 let yojson_of_DocumentSymbol ds : Json.t =
   Json.Option.yojson_of_t
@@ -81,63 +81,54 @@ let yojson_of_Completion ds : Json.t =
 
 let yojson_of_result (type a) (req : a t) (result : a) =
   match (req, result) with
-  | Shutdown, () -> None
-  | Initialize _, result -> Some (InitializeResult.yojson_of_t result)
+  | Shutdown, () -> `Null
+  | Initialize _, result -> InitializeResult.yojson_of_t result
   | TextDocumentDeclaration _, result ->
-    Some (Json.Conv.yojson_of_option Locations.yojson_of_t result)
+    Json.Conv.yojson_of_option Locations.yojson_of_t result
   | TextDocumentHover _, result ->
-    Some (Json.Option.yojson_of_t Hover.yojson_of_t result)
+    Json.Option.yojson_of_t Hover.yojson_of_t result
   | TextDocumentDefinition _, result ->
-    Some (Json.Option.yojson_of_t Locations.yojson_of_t result)
+    Json.Option.yojson_of_t Locations.yojson_of_t result
   | TextDocumentTypeDefinition _, result ->
-    Some (Json.Option.yojson_of_t Locations.yojson_of_t result)
-  | TextDocumentCompletion _, result -> Some (yojson_of_Completion result)
-  | TextDocumentCodeLens _, result ->
-    Some (Json.To.list CodeLens.yojson_of_t result)
-  | TextDocumentCodeLensResolve _, result -> Some (CodeLens.yojson_of_t result)
+    Json.Option.yojson_of_t Locations.yojson_of_t result
+  | TextDocumentCompletion _, result -> yojson_of_Completion result
+  | TextDocumentCodeLens _, result -> Json.To.list CodeLens.yojson_of_t result
+  | TextDocumentCodeLensResolve _, result -> CodeLens.yojson_of_t result
   | TextDocumentPrepareRename _, result ->
-    Some (Json.Option.yojson_of_t Range.yojson_of_t result)
-  | TextDocumentRename _, result -> Some (WorkspaceEdit.yojson_of_t result)
-  | DocumentSymbol _, result -> Some (yojson_of_DocumentSymbol result)
-  | DebugEcho _, result -> Some (DebugEcho.Result.yojson_of_t result)
+    Json.Option.yojson_of_t Range.yojson_of_t result
+  | TextDocumentRename _, result -> WorkspaceEdit.yojson_of_t result
+  | DocumentSymbol _, result -> yojson_of_DocumentSymbol result
+  | DebugEcho _, result -> DebugEcho.Result.yojson_of_t result
   | DebugTextDocumentGet _, result ->
-    Some (DebugTextDocumentGet.Result.yojson_of_t result)
+    DebugTextDocumentGet.Result.yojson_of_t result
   | TextDocumentReferences _, result ->
-    Some (Json.Option.yojson_of_t (Json.To.list Location.yojson_of_t) result)
+    Json.Option.yojson_of_t (Json.To.list Location.yojson_of_t) result
   | TextDocumentHighlight _, result ->
-    Some
-      (Json.Option.yojson_of_t
-         (Json.To.list DocumentHighlight.yojson_of_t)
-         result)
+    Json.Option.yojson_of_t (Json.To.list DocumentHighlight.yojson_of_t) result
   | TextDocumentFoldingRange _, result ->
-    Some
-      (Json.Option.yojson_of_t (Json.To.list FoldingRange.yojson_of_t) result)
-  | SignatureHelp _, result -> Some (SignatureHelp.yojson_of_t result)
-  | CodeAction _, result -> Some (CodeActionResult.yojson_of_t result)
-  | CompletionItemResolve _, result -> Some (CompletionItem.yojson_of_t result)
+    Json.Option.yojson_of_t (Json.To.list FoldingRange.yojson_of_t) result
+  | SignatureHelp _, result -> SignatureHelp.yojson_of_t result
+  | CodeAction _, result -> CodeActionResult.yojson_of_t result
+  | CompletionItemResolve _, result -> CompletionItem.yojson_of_t result
   | WillSaveWaitUntilTextDocument _, result ->
-    Some (Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result)
+    Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
   | TextDocumentOnTypeFormatting _, result ->
-    Some (Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result)
+    Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
   | TextDocumentFormatting _, result ->
-    Some (Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result)
+    Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
   | TextDocumentLink _, result ->
-    Some
-      (Json.Option.yojson_of_t (Json.To.list DocumentLink.yojson_of_t) result)
-  | TextDocumentLinkResolve _, result -> Some (DocumentLink.yojson_of_t result)
+    Json.Option.yojson_of_t (Json.To.list DocumentLink.yojson_of_t) result
+  | TextDocumentLinkResolve _, result -> DocumentLink.yojson_of_t result
   | WorkspaceSymbol _, result ->
-    Some
-      (Json.Option.yojson_of_t
-         (Json.To.list SymbolInformation.yojson_of_t)
-         result)
+    Json.Option.yojson_of_t (Json.To.list SymbolInformation.yojson_of_t) result
   | TextDocumentColorPresentation _, result ->
-    Some (Json.To.list ColorPresentation.yojson_of_t result)
+    Json.To.list ColorPresentation.yojson_of_t result
   | TextDocumentColor _, result ->
-    Some (Json.To.list ColorInformation.yojson_of_t result)
+    Json.To.list ColorInformation.yojson_of_t result
   | SelectionRange _, result ->
-    Some (Json.yojson_of_list SelectionRange.yojson_of_t result)
-  | ExecuteCommand _, result -> Some result
-  | UnknownRequest _, _resp -> None
+    Json.yojson_of_list SelectionRange.yojson_of_t result
+  | ExecuteCommand _, result -> result
+  | UnknownRequest _, resp -> resp
 
 type packed = E : 'r t -> packed
 

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -63,9 +63,9 @@ type _ t =
   | TextDocumentColor : DocumentColorParams.t -> ColorInformation.t list t
   | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list t
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
-  | UnknownRequest : string * Json.t option -> unit t
+  | UnknownRequest : string * Json.t option -> Json.t t
 
-val yojson_of_result : 'a t -> 'a -> Json.t option
+val yojson_of_result : 'a t -> 'a -> Json.t
 
 type packed = E : 'r t -> packed
 

--- a/lsp/src/rpc.ml
+++ b/lsp/src/rpc.ml
@@ -95,7 +95,7 @@ module type Request_intf = sig
 
   val of_jsonrpc : Jsonrpc.Message.request -> (packed, string) result
 
-  val yojson_of_result : 'a t -> 'a -> Json.t option
+  val yojson_of_result : 'a t -> 'a -> Json.t
 
   val to_jsonrpc_request : 'a t -> id:Id.t -> Jsonrpc.Message.request
 
@@ -192,8 +192,7 @@ struct
         | Error e -> (Response.error req.id e, state)
         | Ok (response, state) ->
           let json = In_request.yojson_of_result r response in
-          let result = Option.value_exn json in
-          let response = Response.ok req.id result in
+          let response = Response.ok req.id json in
           (response, state) )
     in
     let on_notification ctx : (Notify.t * state) Fiber.t =

--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -12,7 +12,7 @@ type _ t =
   | ShowMessageRequest :
       ShowMessageRequestParams.t
       -> MessageActionItem.t option t
-  | UnknownRequest : string * Json.t option -> unit t
+  | UnknownRequest : string * Json.t option -> Json.t t
 
 type packed = E : 'r t -> packed
 
@@ -63,18 +63,18 @@ let of_jsonrpc (r : Jsonrpc.Message.request) : (packed, string) Result.t =
     E (ShowMessageRequest params)
   | m -> Ok (E (UnknownRequest (m, r.params)))
 
-let yojson_of_result (type a) (t : a t) (r : a) : Json.t option =
+let yojson_of_result (type a) (t : a t) (r : a) : Json.t =
   match (t, r) with
-  | WorkspaceApplyEdit _, r -> Some (ApplyWorkspaceEditResponse.yojson_of_t r)
+  | WorkspaceApplyEdit _, r -> ApplyWorkspaceEditResponse.yojson_of_t r
   | WorkspaceFolders, r ->
-    Some (Json.Conv.yojson_of_list WorkspaceFolder.yojson_of_t r)
-  | WorkspaceConfiguration _, r ->
-    Some (Json.Conv.yojson_of_list (fun x -> x) r)
-  | ClientRegisterCapability _, () -> None
-  | ClientUnregisterCapability _, () -> None
-  | ShowMessageRequest _, None -> None
-  | ShowMessageRequest _, Some r -> Some (MessageActionItem.yojson_of_t r)
-  | UnknownRequest (_, _), _ -> None
+    Json.Conv.yojson_of_list WorkspaceFolder.yojson_of_t r
+  | WorkspaceConfiguration _, r -> Json.Conv.yojson_of_list (fun x -> x) r
+  | ClientRegisterCapability _, () -> `Null
+  | ClientUnregisterCapability _, () -> `Null
+  | ShowMessageRequest _, None -> `Null
+  | ShowMessageRequest _, r ->
+    Json.Conv.yojson_of_option MessageActionItem.yojson_of_t r
+  | UnknownRequest (_, _), json -> json
 
 let response_of_json (type a) (t : a t) (json : Json.t) : a =
   let open Json.Conv in
@@ -85,4 +85,4 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   | ClientRegisterCapability _ -> unit_of_yojson json
   | ClientUnregisterCapability _ -> unit_of_yojson json
   | ShowMessageRequest _ -> option_of_yojson MessageActionItem.t_of_yojson json
-  | UnknownRequest (_, _) -> unit_of_yojson json
+  | UnknownRequest (_, _) -> json

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -12,11 +12,11 @@ type _ t =
   | ShowMessageRequest :
       ShowMessageRequestParams.t
       -> MessageActionItem.t option t
-  | UnknownRequest : string * Json.t option -> unit t
+  | UnknownRequest : string * Json.t option -> Json.t t
 
 type packed = E : 'r t -> packed
 
-val yojson_of_result : 'a t -> 'a -> Json.t option
+val yojson_of_result : 'a t -> 'a -> Json.t
 
 val to_jsonrpc_request : _ t -> id:Jsonrpc.Id.t -> Jsonrpc.Message.request
 


### PR DESCRIPTION
The signature of yojson_of_result was:

val yojson_of_result : 'a t -> 'a -> Json.t option

This isn't correct because the result cannot be None.

This PR makes the return type Json.t and returns null for previous None
values.