### PR TITLE
Add support for ocamllex/menhir syntax

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -232,3 +232,37 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   | Initialize _ -> InitializeResult.t_of_yojson json
   | ExecuteCommand _ -> json
   | _ -> assert false
+
+let text_document (type a) (t : a t) : TextDocumentIdentifier.t option =
+  match t with
+  | CompletionItemResolve _ -> None
+  | TextDocumentLinkResolve _ -> None
+  | ExecuteCommand _ -> None
+  | TextDocumentCodeLensResolve _ -> None
+  | WorkspaceSymbol _ -> None
+  | DebugEcho _ -> None
+  | Shutdown -> None
+  | Initialize _ -> None
+  | TextDocumentHover r -> Some r.textDocument
+  | TextDocumentDefinition r -> Some r.textDocument
+  | TextDocumentDeclaration r -> Some r.textDocument
+  | TextDocumentTypeDefinition r -> Some r.textDocument
+  | TextDocumentCompletion r -> Some r.textDocument
+  | TextDocumentCodeLens r -> Some r.textDocument
+  | TextDocumentPrepareRename r -> Some r.textDocument
+  | TextDocumentRename r -> Some r.textDocument
+  | TextDocumentLink r -> Some r.textDocument
+  | DocumentSymbol r -> Some r.textDocument
+  | DebugTextDocumentGet r -> Some r.textDocument
+  | TextDocumentReferences r -> Some r.textDocument
+  | TextDocumentHighlight r -> Some r.textDocument
+  | TextDocumentFoldingRange r -> Some r.textDocument
+  | SignatureHelp r -> Some r.textDocument
+  | CodeAction r -> Some r.textDocument
+  | WillSaveWaitUntilTextDocument r -> Some r.textDocument
+  | TextDocumentFormatting r -> Some r.textDocument
+  | TextDocumentOnTypeFormatting r -> Some r.textDocument
+  | TextDocumentColorPresentation r -> Some r.textDocument
+  | TextDocumentColor r -> Some r.textDocument
+  | SelectionRange r -> Some r.textDocument
+  | UnknownRequest _ -> None

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -74,3 +74,5 @@ val of_jsonrpc : Jsonrpc.Message.request -> (packed, string) Result.t
 val to_jsonrpc_request : _ t -> id:Jsonrpc.Id.t -> Jsonrpc.Message.request
 
 val response_of_json : 'a t -> Json.t -> 'a
+
+val text_document : _ t -> TextDocumentIdentifier.t option

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -63,7 +63,11 @@ type _ t =
   | TextDocumentColor : DocumentColorParams.t -> ColorInformation.t list t
   | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list t
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
-  | UnknownRequest : string * Json.t option -> Json.t t
+  | UnknownRequest :
+      { meth : string
+      ; params : Json.t option
+      }
+      -> Json.t t
 
 val yojson_of_result : 'a t -> 'a -> Json.t
 
@@ -75,4 +79,7 @@ val to_jsonrpc_request : _ t -> id:Jsonrpc.Id.t -> Jsonrpc.Message.request
 
 val response_of_json : 'a t -> Json.t -> 'a
 
-val text_document : _ t -> TextDocumentIdentifier.t option
+val text_document :
+     _ t
+  -> (meth:string -> params:Json.t option -> TextDocumentIdentifier.t option)
+  -> TextDocumentIdentifier.t option

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -20,16 +20,31 @@ module Syntax = struct
   type t =
     | Ocaml
     | Reason
+    | Ocamllex
+    | Menhir
 
-  let of_language_id = function
-    | "ocaml.interface" -> Ocaml
-    | "ocaml" -> Ocaml
-    | "reason" -> Reason
-    | id -> failwith ("Unexpected language id " ^ id)
+  let human_name = function
+    | Ocaml -> "OCaml"
+    | Reason -> "Reason"
+    | Ocamllex -> "OCamllex"
+    | Menhir -> "Menhir/ocamlyacc"
 
-  let to_language_id = function
-    | Ocaml -> "ocaml"
-    | Reason -> "reason"
+  let all =
+    [ ("ocaml.interface", Ocaml)
+    ; ("ocaml", Ocaml)
+    ; ("reason", Reason)
+    ; ("ocaml.ocamllex", Ocamllex)
+    ; ("ocaml.menhir", Menhir)
+    ]
+
+  let of_language_id id =
+    match List.assoc all id with
+    | Some id -> id
+    | None -> Code_error.raise "invalid language id" [ ("id", String id) ]
+
+  let to_language_id x =
+    List.find_map all ~f:(fun (k, v) -> Option.some_if (v = x) k)
+    |> Option.value_exn
 end
 
 type t =

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -37,10 +37,12 @@ module Syntax = struct
     ; ("ocaml.menhir", Menhir)
     ]
 
-  let of_language_id id =
-    match List.assoc all id with
+  let of_language_id language_id =
+    match List.assoc all language_id with
     | Some id -> id
-    | None -> Code_error.raise "invalid language id" [ ("id", String id) ]
+    | None ->
+      Code_error.raise "invalid language id"
+        [ ("language_id", String language_id) ]
 
   let to_language_id x =
     List.find_map all ~f:(fun (k, v) -> Option.some_if (v = x) k)

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -45,6 +45,11 @@ module Syntax = struct
   let to_language_id x =
     List.find_map all ~f:(fun (k, v) -> Option.some_if (v = x) k)
     |> Option.value_exn
+
+  let markdown_name = function
+    | Ocaml -> "ocaml"
+    | Reason -> "reason"
+    | s -> to_language_id s
 end
 
 type t =

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -6,6 +6,10 @@ module Syntax : sig
   type t =
     | Ocaml
     | Reason
+    | Ocamllex
+    | Menhir
+
+  val human_name : t -> string
 
   val to_language_id : t -> string
 end

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -11,7 +11,7 @@ module Syntax : sig
 
   val human_name : t -> string
 
-  val to_language_id : t -> string
+  val markdown_name : t -> string
 end
 
 module Kind : sig

--- a/ocaml-lsp-server/src/fmt.ml
+++ b/ocaml-lsp-server/src/fmt.ml
@@ -38,11 +38,15 @@ let run_command command stdin_value args : command_result =
   { stdout; stderr; status }
 
 type error =
+  | Unsupported_syntax of Document.Syntax.t
   | Missing_binary of { binary : string }
   | Unexpected_result of { message : string }
   | Unknown_extension of Lsp.Uri.t
 
 let message = function
+  | Unsupported_syntax syntax ->
+    sprintf "formatting %s files is not supported"
+      (Document.Syntax.human_name syntax)
   | Missing_binary { binary } ->
     sprintf
       "Unable to find %s binary. You need to install %s manually to use the \
@@ -79,6 +83,7 @@ let binary t =
 
 let formatter doc =
   match Document.syntax doc with
+  | (Ocamllex | Menhir) as s -> Error (Unsupported_syntax s)
   | Ocaml -> Ok (Ocaml (Document.uri doc))
   | Reason -> Ok (Reason (Document.kind doc))
 

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -5,6 +5,7 @@ open Import
     Relies on [ocamlformat] for OCaml and [refmt] for reason *)
 
 type error =
+  | Unsupported_syntax of Document.Syntax.t
   | Missing_binary of { binary : string }
   | Unexpected_result of { message : string }
   | Unknown_extension of Lsp.Uri.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -53,5 +53,6 @@ module RenameParams = Lsp.Types.RenameParams
 module CodeLensParams = Lsp.Types.CodeLensParams
 module FoldingRangeParams = Lsp.Types.FoldingRangeParams
 module ReferenceParams = Lsp.Types.ReferenceParams
+module Uri = Lsp.Uri
 
 let { Logger.log } = Logger.for_section "ocaml-lsp-server"

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -59,6 +59,7 @@ let initialize_info : InitializeResult.t =
 let ocamlmerlin_reason = "ocamlmerlin-reason"
 
 let send_diagnostics rpc doc =
+  (* TODO this work is done too eagerly. it should be under schedule *)
   let diagnostic_create = Diagnostic.create ~source:"ocamllsp" in
   let reason_merlin_available =
     match Document.syntax doc with
@@ -265,19 +266,21 @@ let location_of_merlin_loc uri = function
       Some (`Location locs) )
 
 let format_contents ~syntax ~markdown ~typ ~doc =
-  let language_id = Document.Syntax.to_language_id syntax in
+  (* TODO for vscode, we should just use the language id. But that will not work
+     for all editors *)
+  let markdown_name = Document.Syntax.markdown_name syntax in
   `MarkupContent
     ( if markdown then
       let value =
         match doc with
-        | None -> sprintf "```%s\n%s\n```" language_id typ
+        | None -> sprintf "```%s\n%s\n```" markdown_name typ
         | Some s ->
           let doc =
             match Doc_to_md.translate s with
             | Raw d -> sprintf "(** %s *)" d
             | Markdown d -> d
           in
-          sprintf "```%s\n%s\n```\n---\n%s" language_id typ doc
+          sprintf "```%s\n%s\n```\n---\n%s" markdown_name typ doc
       in
       { MarkupContent.value; kind = MarkupKind.Markdown }
     else


### PR DESCRIPTION
We don't actually support any functionality, it's just a new language type. This
is a pre-req for ml/mli switching however.