### PR TITLE
Implements "completionItem/resolve"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For an example of usage of the server in a VSCode extension, see [here](https://
 The server supports the following queries:
 
 - [x] `textDocument/completion`
-- [ ] `completionItem/resolve`
+- [x] `completionItem/resolve`
 - [x] `textdocument/hover`
 - [ ] `textDocument/signatureHelp`
 - [ ] `textDocument/declaration`

--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -146,6 +146,9 @@ let of_jsonrpc (r : Jsonrpc.Message.request) =
   | "textDocument/completion" ->
     parse CompletionParams.t_of_yojson >>| fun params ->
     E (TextDocumentCompletion params)
+  | "completionItem/resolve" ->
+    parse CompletionItem.t_of_yojson >>| fun params ->
+    E (CompletionItemResolve params)
   | "textDocument/documentSymbol" ->
     parse DocumentSymbolParams.t_of_yojson >>| fun params ->
     E (DocumentSymbol params)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -96,7 +96,7 @@ let complete doc position ~markdown =
   let completion =
     let complete =
       Query_protocol.Complete_prefix
-        (prefix, position, completion_kinds, true, true)
+        (prefix, position, completion_kinds, false, true)
     in
     Query_commands.dispatch pipeline complete
   in

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -1,5 +1,22 @@
 open Import
 
+module Resolve = struct
+  type t = CompletionParams.t
+
+  let uri (t : t) = Uri.t_of_yojson (`String t.textDocument.uri)
+
+  let yojson_of_t = CompletionParams.yojson_of_t
+
+  let t_of_yojson = CompletionParams.t_of_yojson
+
+  let of_completion_item (ci : CompletionItem.t) =
+    match ci.data with
+    | Some json -> t_of_yojson json
+    | None ->
+      Code_error.raise
+        "client did not pass additional data to completion resolve" []
+end
+
 let completion_kind kind : CompletionItemKind.t option =
   match kind with
   | `Value -> Some Value
@@ -16,7 +33,15 @@ let make_string chars =
   let chars = Array.of_list chars in
   String.init (Array.length chars) ~f:(Array.get chars)
 
-let prefix_of_position source position =
+(** [prefix_of_position ~short_path source position] computes prefix before
+    given [position].
+
+    @param short_path determines whether we want full prefix or cut at ["."],
+    e.g. [List.m<cursor>] returns ["m"] when [short_path] is set vs ["List.m"]
+    when not.
+
+    @return prefix of [position] in [source] and its length *)
+let prefix_of_position ~short_path source position =
   match Msource.text source with
   | "" -> ""
   | text ->
@@ -34,15 +59,44 @@ let prefix_of_position source position =
         | 'a' .. 'z'
         | 'A' .. 'Z'
         | '0' .. '9'
-        | '.'
         | '\''
         | '_' ->
           find (ch :: prefix) (i - 1)
+        | '.' ->
+          if short_path then
+            make_string prefix
+          else
+            find (ch :: prefix) (i - 1)
         | _ -> make_string prefix
     in
 
     let (`Offset index) = Msource.get_offset source position in
     find [] (index - 1)
+
+let suffix_of_position source position =
+  match Msource.text source with
+  | "" -> ""
+  | text ->
+    let len = String.length text in
+
+    let rec find suffix i =
+      if i >= len then
+        suffix
+      else
+        let ch = text.[i] in
+        (* The characters for an infix function are missing *)
+        match ch with
+        | 'a' .. 'z'
+        | 'A' .. 'Z'
+        | '0' .. '9'
+        | '\''
+        | '_' ->
+          find (ch :: suffix) (i + 1)
+        | _ -> suffix
+    in
+
+    let (`Offset index) = Msource.get_offset source position in
+    make_string (List.rev @@ find [] index)
 
 let range_prefix (lsp_position : Position.t) prefix : Range.t =
   let start =
@@ -52,16 +106,7 @@ let range_prefix (lsp_position : Position.t) prefix : Range.t =
   in
   { Range.start; end_ = lsp_position }
 
-let format_doc ~markdown doc =
-  match markdown with
-  | false -> `String doc
-  | true ->
-    `MarkupContent
-      ( match Doc_to_md.translate doc with
-      | Markdown value -> { kind = MarkupKind.Markdown; MarkupContent.value }
-      | Raw value -> { kind = MarkupKind.PlainText; MarkupContent.value } )
-
-let item index entry ~markdown =
+let item index entry ~compl_info =
   let prefix, (entry : Query_protocol.Compl.entry) =
     match entry with
     | `Keep entry -> (`Keep, entry)
@@ -79,17 +124,17 @@ let item index entry ~markdown =
       (* Without this field the client is not forced to respect the order
          provided by merlin. *)
     ~sortText:(Printf.sprintf "%04d" index)
-    ~documentation:(format_doc ~markdown entry.info)
-    ?textEdit ()
+    ~data:compl_info ?textEdit ()
 
 let completion_kinds =
   [ `Constructor; `Labels; `Modules; `Modules_type; `Types; `Values; `Variants ]
 
-let complete doc position ~markdown =
-  let lsp_position = position in
-  let position = Position.logical position in
+let complete doc lsp_position =
+  let position = Position.logical lsp_position in
 
-  let prefix = prefix_of_position (Document.source doc) position in
+  let prefix =
+    prefix_of_position ~short_path:false (Document.source doc) position
+  in
   log ~title:Logger.Title.Debug "completion prefix: |%s|" prefix;
 
   Document.with_pipeline_exn doc @@ fun pipeline ->
@@ -128,5 +173,50 @@ let complete doc position ~markdown =
       let range = range_prefix lsp_position prefix in
       List.map ~f:(fun entry -> `Replace (range, entry)) entries
   in
-  let items = List.mapi ~f:(item ~markdown) items in
+  let textDocument =
+    TextDocumentIdentifier.create ~uri:(Document.uri doc |> Lsp.Uri.to_string)
+  in
+  let compl_info =
+    CompletionParams.create ~textDocument ~position:lsp_position ()
+    |> CompletionParams.yojson_of_t
+  in
+  let items = List.mapi ~f:(item ~compl_info) items in
   Ok (`CompletionList { CompletionList.isIncomplete = false; items })
+
+let format_doc ~markdown doc =
+  match markdown with
+  | false -> `String doc
+  | true ->
+    `MarkupContent
+      ( match Doc_to_md.translate doc with
+      | Markdown value -> { kind = MarkupKind.Markdown; MarkupContent.value }
+      | Raw value -> { kind = MarkupKind.PlainText; MarkupContent.value } )
+
+let resolve doc (compl : CompletionItem.t) (resolve : Resolve.t) query_doc
+    ~markdown =
+  (* Due to merlin's API, we create a version of the given document with the
+     applied completion item and pass it to merlin to get the docs for the
+     [compl.label] *)
+  let position : Position.t = resolve.position in
+  let complete =
+    let logical_position = Position.logical position in
+    let start =
+      let prefix =
+        prefix_of_position ~short_path:true (Document.source doc)
+          logical_position
+      in
+      { position with character = position.character - String.length prefix }
+    in
+    let end_ =
+      let suffix = suffix_of_position (Document.source doc) logical_position in
+      { position with character = position.character + String.length suffix }
+    in
+    let range = Range.create ~start ~end_ in
+    TextDocumentContentChangeEvent.create ~range ~text:compl.label ()
+  in
+  let doc = Document.update_text complete doc in
+  let open Fiber.O in
+  let* documentation = query_doc doc @@ Position.logical position in
+  let documentation = Option.map ~f:(format_doc ~markdown) documentation in
+  let compl = { compl with documentation; data = None } in
+  Fiber.return @@ Ok compl

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -1,8 +1,28 @@
 open Import
 
+module Resolve : sig
+  type t
+
+  val uri : t -> Uri.t
+
+  val of_completion_item : CompletionItem.t -> t
+
+  val yojson_of_t : t -> Json.t
+
+  val t_of_yojson : Json.t -> t
+end
+
 val complete :
      Document.t
   -> Position.t
-  -> markdown:bool
   -> ([> `CompletionList of CompletionList.t ], Jsonrpc.Response.Error.t) result
      Fiber.t
+
+(** creates a server response for ["completionItem/resolve"] *)
+val resolve :
+     Document.t
+  -> CompletionItem.t
+  -> Resolve.t
+  -> (Document.t -> [> `Logical of int * int ] -> string option Fiber.t)
+  -> markdown:bool
+  -> (CompletionItem.t, Jsonrpc.Response.Error.t) result Fiber.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -41,6 +41,7 @@ module DocumentSymbol = DocumentSymbol
 module SymbolInformation = SymbolInformation
 module CompletionItem = CompletionItem
 module CompletionList = CompletionList
+module CompletionParams = CompletionParams
 module VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier
 module TextDocumentEdit = TextDocumentEdit
 module FoldingRange = FoldingRange

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -582,16 +582,7 @@ let ocaml_on_request :
     let uri = Uri.t_of_yojson (`String uri) in
     let open Fiber.Result.O in
     let* doc = Fiber.return (Document_store.get store uri) in
-    let+ resp =
-      let markdown =
-        markdown_support (client_capabilities state) ~field:(fun d ->
-            let open Option.O in
-            let+ completion = d.completion in
-            let* completion_item = completion.completionItem in
-            completion_item.documentationFormat)
-      in
-      Compl.complete doc position ~markdown
-    in
+    let+ resp = Compl.complete doc position in
     (Some resp, state)
   | Client_request.TextDocumentPrepareRename
       { textDocument = { uri }; position } ->
@@ -618,7 +609,21 @@ let ocaml_on_request :
   | Client_request.WillSaveWaitUntilTextDocument _ ->
     Fiber.return @@ Ok (None, state)
   | Client_request.CodeAction params -> code_action rpc params
-  | Client_request.CompletionItemResolve compl ->
+  | Client_request.CompletionItemResolve ci ->
+    let markdown =
+      markdown_support (client_capabilities state) ~field:(fun d ->
+          let open Option.O in
+          let+ completion = d.completion in
+          let* completion_item = completion.completionItem in
+          completion_item.documentationFormat)
+    in
+    let open Fiber.Result.O in
+    let resolve = Compl.Resolve.of_completion_item ci in
+    let* doc =
+      let uri = Compl.Resolve.uri resolve in
+      Fiber.return (Document_store.get state.store uri)
+    in
+    let* compl = Compl.resolve doc ci resolve query_doc ~markdown in
     Fiber.return @@ Ok (compl, state)
   | Client_request.TextDocumentFormatting
       { textDocument = { uri }; options = _ } ->

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -32,7 +32,7 @@ let initialize_info : InitializeResult.t =
     (* TODO even if this re-enabled in general, it should stay disabled for
        emacs. It makes completion too slow *)
     CompletionOptions.create ~triggerCharacters:[ "."; "#" ]
-      ~resolveProvider:false ()
+      ~resolveProvider:true ()
   in
   let renameProvider =
     `RenameOptions (RenameOptions.create ~prepareProvider:true ())

--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -1,0 +1,99 @@
+import outdent from "outdent";
+import * as LanguageServer from "./../src/LanguageServer";
+
+import * as Types from "vscode-languageserver-types";
+
+xdescribe("textDocument/completion", () => {
+  let languageServer: LanguageServer.LanguageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "ocaml",
+        0,
+        source,
+      ),
+    });
+  }
+
+  async function queryCompletionItemResolve(
+    label: string,
+    position: Types.Position,
+  ) {
+    let response = await languageServer.sendRequest("completionItem/resolve", {
+      label: label,
+      data: {
+        textDocument: {
+          uri: "file:///test.ml",
+        },
+        position: position,
+      },
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("can get documentation for the end of document", async () => {
+    openDocument(outdent`
+      List.ma
+    `);
+
+    let response = await queryCompletionItemResolve(
+      "map2",
+      Types.Position.create(0, 5),
+    );
+
+    expect(response).toMatchObject({
+      documentation: {
+        kind: "markdown",
+        value:
+          "`List.map2 f [a1; ...; an] [b1; ...; bn]` is\n`[f a1 b1; ...; f an bn]`.\nRaise `Invalid_argument` if the two lists are determined\nto have different lengths. Not tail-recursive.",
+      },
+    });
+  });
+
+  it("can get documentation at arbitrary position", async () => {
+    openDocument(outdent`
+      List.fld((=) 0) [1; 2; 3]
+    `);
+
+    let response = await queryCompletionItemResolve(
+      "find_all",
+      Types.Position.create(0, 5),
+    );
+
+    expect(response).toMatchObject({
+      documentation: {
+        kind: "markdown",
+        value: "`find_all` is another name for `List.filter`.",
+      },
+    });
+  });
+
+  it("can get documentation at arbitrary position (before dot)", async () => {
+    openDocument(outdent`
+    Stdlib.LargeFil.in_channel_length
+    `);
+
+    let response = await queryCompletionItemResolve(
+      "find_all",
+      Types.Position.create(0, 15),
+    );
+
+    expect(response).toMatchObject({
+      documentation: {
+        kind: "markdown",
+        value:
+          "Operations on large files.\nThis sub-module provides 64-bit variants of the channel functions\nthat manipulate file positions and file sizes. By representing\npositions and sizes by 64-bit integers \\(type `int64`\\) instead of\nregular integers \\(type `int`\\), these alternate functions allow\noperating on files whose sizes are greater than `max_int`.",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Implements `completionItem/resolve` for lazy fetch of docs on code completion.

`textDocument/completion` seems to take now 2-4 times less time. 

Due to the merlin's API, we need to provide it with a document and a position for it to be able to fetch docs. I modify the given document to "fake" the completion. (is there a simpler/cheaper solution?)

I will rebase when we settle on the solution. 

The PR also seems to fix (merlin's?) bug: currently, ocaml-lsp on `Hashtbl.Make<cursor>` shows an empty documentation, but with the new implementation there is documentation. 

