### PR TITLE
Remove foldingRangeProvider server capability

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -48,7 +48,7 @@ let initialize_info : InitializeResult.t =
       ~referencesProvider:(`Bool true) ~documentHighlightProvider:(`Bool true)
       ~documentFormattingProvider:(`Bool true)
       ~selectionRangeProvider:(`Bool true) ~documentSymbolProvider:(`Bool true)
-      ~foldingRangeProvider:(`Bool true) ~experimental ~renameProvider ()
+      ~experimental ~renameProvider ()
   in
   let serverInfo =
     let version = Version.get () in


### PR DESCRIPTION
If the lsp server doesn't have `foldingRange` capability, vs code (and maybe other editors?) provides more granular folding ranges (based on indentation perhaps). 

| ocaml-lsp folding ranges | vs code folding ranges|
|---  | ---   |
| ![image](https://user-images.githubusercontent.com/16353531/87312695-314ddb00-c521-11ea-94ae-822f67dcee58.png) | ![image](https://user-images.githubusercontent.com/16353531/87312396-cac8bd00-c520-11ea-93f2-d2db5633df23.png)|


With this initial state of the PR people can try which version works best for them. 

#### Actions based on feedback

- if the folding is better without this server capability on all editors, we can go on and remove all folding range handling code.
- if this only works for vs code users, we can either create a PR to vscode-ocaml-platform extension removing this client capability or add client-based logic to ocaml-lsp