### PR TITLE
fix Infix completion

### DIFF
--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -46,7 +46,8 @@
 (library
  (name lsp_expect_tests)
  (modules lsp_expect_tests fiber_stream_tests)
- (enabled_if (>= %{ocaml_version} 4.08))
+ (enabled_if
+  (>= %{ocaml_version} 4.08))
  (inline_tests)
  (libraries
   fiber

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -175,13 +175,14 @@ let complete doc lsp_position =
     | `Application { Query_protocol.Compl.labels; argument_type = _ } ->
       items
       @ List.map labels ~f:(fun (name, typ) ->
-            `Keep
+            `Replace
+              (short_range,
               { Query_protocol.Compl.name
               ; kind = `Label
               ; desc = typ
               ; info = ""
               ; deprecated = false (* TODO this is wrong *)
-              })
+              }))
   in
   let items =
     match items with

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -54,13 +54,14 @@ let prefix_of_position ~short_path source position =
         find prefix (i - 1)
       else
         let ch = text.[i] in
-        (* The characters for an infix function are missing *)
         match ch with
         | 'a' .. 'z'
         | 'A' .. 'Z'
         | '0' .. '9'
         | '\''
-        | '_' ->
+        | '_'
+        (* Infix function characters *)
+        | '$' |  '&' |  '*' |  '+' |  '-' |  '/' |  '=' |  '>' |  '@' |  '^' | '!' | '?' | '%' | '<' | ':' | '~' | '#' ->
           find (ch :: prefix) (i - 1)
         | '.' ->
           if short_path then

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -146,7 +146,8 @@ let complete doc lsp_position =
     in
     Query_commands.dispatch pipeline complete
   in
-  let items = completion.entries |> List.map ~f:(fun entry -> `Keep entry) in
+  let range = range_prefix lsp_position prefix in
+  let items = completion.entries |> List.map ~f:(fun entry -> `Replace  (range,entry)) in
   let items =
     match completion.context with
     | `Unknown -> items

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -61,7 +61,23 @@ let prefix_of_position ~short_path source position =
         | '\''
         | '_'
         (* Infix function characters *)
-        | '$' |  '&' |  '*' |  '+' |  '-' |  '/' |  '=' |  '>' |  '@' |  '^' | '!' | '?' | '%' | '<' | ':' | '~' | '#' ->
+        | '$'
+        | '&'
+        | '*'
+        | '+'
+        | '-'
+        | '/'
+        | '='
+        | '>'
+        | '@'
+        | '^'
+        | '!'
+        | '?'
+        | '%'
+        | '<'
+        | ':'
+        | '~'
+        | '#' ->
           find (ch :: prefix) (i - 1)
         | '.' ->
           if short_path then
@@ -147,7 +163,9 @@ let complete doc lsp_position =
     Query_commands.dispatch pipeline complete
   in
   let range = range_prefix lsp_position prefix in
-  let items = completion.entries |> List.map ~f:(fun entry -> `Replace  (range,entry)) in
+  let items =
+    completion.entries |> List.map ~f:(fun entry -> `Replace (range, entry))
+  in
   let items =
     match completion.context with
     | `Unknown -> items

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -162,9 +162,12 @@ let complete doc lsp_position =
     in
     Query_commands.dispatch pipeline complete
   in
-  let range = range_prefix lsp_position prefix in
+  let short_range =
+    range_prefix lsp_position
+      (prefix_of_position ~short_path:true (Document.source doc) position)
+  in
   let items =
-    completion.entries |> List.map ~f:(fun entry -> `Replace (range, entry))
+    completion.entries |> List.map ~f:(fun entry -> `Replace (short_range, entry))
   in
   let items =
     match completion.context with

--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -3,7 +3,7 @@ import * as LanguageServer from "./../src/LanguageServer";
 
 import * as Types from "vscode-languageserver-types";
 
-xdescribe("textDocument/completion", () => {
+describe("textDocument/completion", () => {
   let languageServer: LanguageServer.LanguageServer = null;
 
   async function openDocument(source) {
@@ -21,7 +21,7 @@ xdescribe("textDocument/completion", () => {
     label: string,
     position: Types.Position,
   ) {
-    let response = await languageServer.sendRequest("completionItem/resolve", {
+    return languageServer.sendRequest("completionItem/resolve", {
       label: label,
       data: {
         textDocument: {
@@ -51,13 +51,15 @@ xdescribe("textDocument/completion", () => {
       Types.Position.create(0, 5),
     );
 
-    expect(response).toMatchObject({
-      documentation: {
-        kind: "markdown",
-        value:
-          "`List.map2 f [a1; ...; an] [b1; ...; bn]` is\n`[f a1 b1; ...; f an bn]`.\nRaise `Invalid_argument` if the two lists are determined\nto have different lengths. Not tail-recursive.",
-      },
-    });
+    expect(response).toMatchInlineSnapshot(`
+      Object {
+        "documentation": " [List.map2 f [a1; ...; an] [b1; ...; bn]] is
+         [[f a1 b1; ...; f an bn]].
+         Raise [Invalid_argument] if the two lists are determined
+         to have different lengths.  Not tail-recursive. ",
+        "label": "map2",
+      }
+    `);
   });
 
   it("can get documentation at arbitrary position", async () => {
@@ -70,12 +72,12 @@ xdescribe("textDocument/completion", () => {
       Types.Position.create(0, 5),
     );
 
-    expect(response).toMatchObject({
-      documentation: {
-        kind: "markdown",
-        value: "`find_all` is another name for `List.filter`.",
-      },
-    });
+    expect(response).toMatchInlineSnapshot(`
+      Object {
+        "documentation": " [find_all] is another name for {!List.filter}. ",
+        "label": "find_all",
+      }
+    `);
   });
 
   it("can get documentation at arbitrary position (before dot)", async () => {
@@ -88,12 +90,10 @@ xdescribe("textDocument/completion", () => {
       Types.Position.create(0, 15),
     );
 
-    expect(response).toMatchObject({
-      documentation: {
-        kind: "markdown",
-        value:
-          "Operations on large files.\nThis sub-module provides 64-bit variants of the channel functions\nthat manipulate file positions and file sizes. By representing\npositions and sizes by 64-bit integers \\(type `int64`\\) instead of\nregular integers \\(type `int`\\), these alternate functions allow\noperating on files whose sizes are greater than `max_int`.",
-      },
-    });
+    expect(response).toMatchInlineSnapshot(`
+      Object {
+        "label": "find_all",
+      }
+    `);
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -86,13 +86,19 @@ describe("textDocument/completion", () => {
     `);
 
     let response = await queryCompletionItemResolve(
-      "find_all",
+      "LargeFile",
       Types.Position.create(0, 15),
     );
 
     expect(response).toMatchInlineSnapshot(`
       Object {
-        "label": "find_all",
+        "documentation": " Operations on large files.
+        This sub-module provides 64-bit variants of the channel functions
+        that manipulate file positions and file sizes.  By representing
+        positions and sizes by 64-bit integers (type [int64]) instead of
+        regular integers (type [int]), these alternate functions allow
+        operating on files whose sizes are greater than [max_int]. ",
+        "label": "LargeFile",
       }
     `);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -82,23 +82,27 @@ describe("textDocument/completion", () => {
 
   it("can get documentation at arbitrary position (before dot)", async () => {
     openDocument(outdent`
-    Stdlib.LargeFil.in_channel_length
+      module Outer = struct
+        (** documentation for [Inner] *)
+        module Inner = struct
+          let v = ()
+        end
+      end
+
+      let _ = ();;
+
+      Outer.Inner.v
     `);
 
     let response = await queryCompletionItemResolve(
-      "LargeFile",
-      Types.Position.create(0, 15),
+      "Inner",
+      Types.Position.create(9, 10),
     );
 
     expect(response).toMatchInlineSnapshot(`
       Object {
-        "documentation": " Operations on large files.
-        This sub-module provides 64-bit variants of the channel functions
-        that manipulate file positions and file sizes.  By representing
-        positions and sizes by 64-bit integers (type [int64]) instead of
-        regular integers (type [int]), these alternate functions allow
-        operating on files whose sizes are greater than [max_int]. ",
-        "label": "LargeFile",
+        "documentation": "documentation for [Inner]",
+        "label": "Inner",
       }
     `);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -3,7 +3,9 @@ import * as LanguageServer from "./../src/LanguageServer";
 
 import * as Types from "vscode-languageserver-types";
 
-describe("textDocument/completion", () => {
+const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0") ? describe : xdescribe;
+
+describe_opt("textDocument/completion", () => {
   let languageServer = null;
 
   async function openDocument(source) {

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -542,7 +542,19 @@ describe("textDocument/completion", () => {
         },
         Object {
           "label": "~f",
-          "textEdit": undefined,
+          "textEdit": Object {
+            "newText": "~f",
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 0,
+              },
+              "start": Object {
+                "character": 23,
+                "line": 0,
+              },
+            },
+          },
         },
       ]
     `);

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -3,7 +3,7 @@ import * as LanguageServer from "./../src/LanguageServer";
 
 import * as Types from "vscode-languageserver-types";
 
-xdescribe("textDocument/completion", () => {
+describe("textDocument/completion", () => {
   let languageServer = null;
 
   async function openDocument(source) {
@@ -88,6 +88,117 @@ xdescribe("textDocument/completion", () => {
     ]);
   });
 
+  it("completes identifier after completion-triggering character", async () => {
+    openDocument(outdent`
+      module Test = struct
+        let somenum = 42
+        let somestring = "hello"
+      end
+
+      let x = Test.
+    `);
+
+    let items = await queryCompletion(Types.Position.create(5, 13));
+
+    expect(items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "somenum",
+          "textEdit": Object {
+            "newText": "somenum",
+            "range": Object {
+              "end": Object {
+                "character": 13,
+                "line": 5,
+              },
+              "start": Object {
+                "character": 13,
+                "line": 5,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "somestring",
+          "textEdit": Object {
+            "newText": "somestring",
+            "range": Object {
+              "end": Object {
+                "character": 13,
+                "line": 5,
+              },
+              "start": Object {
+                "character": 13,
+                "line": 5,
+              },
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it("completes infix operators", async () => {
+    openDocument(outdent`
+      let (>>|) = (+)
+      let y = 1 >
+    `);
+
+    let items = await queryCompletion(Types.Position.create(1, 11));
+    expect(items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": ">>|",
+          "textEdit": Object {
+            "newText": ">>|",
+            "range": Object {
+              "end": Object {
+                "character": 11,
+                "line": 1,
+              },
+              "start": Object {
+                "character": 10,
+                "line": 1,
+              },
+            },
+          },
+        },
+        Object {
+          "label": ">",
+          "textEdit": Object {
+            "newText": ">",
+            "range": Object {
+              "end": Object {
+                "character": 11,
+                "line": 1,
+              },
+              "start": Object {
+                "character": 10,
+                "line": 1,
+              },
+            },
+          },
+        },
+        Object {
+          "label": ">=",
+          "textEdit": Object {
+            "newText": ">=",
+            "range": Object {
+              "end": Object {
+                "character": 11,
+                "line": 1,
+              },
+              "start": Object {
+                "character": 10,
+                "line": 1,
+              },
+            },
+          },
+        },
+      ]
+    `);
+  });
+
   it("completes from a module", async () => {
     openDocument(outdent`
       let f = List.m
@@ -128,18 +239,94 @@ xdescribe("textDocument/completion", () => {
       let somestring = "hello"
 
       let plus_42 (x:int) (y:int) =
-        somenum +
-    `);
+        somenum +    `);
 
     let items = await queryCompletion(Types.Position.create(4, 12));
     let items_top5 = items.slice(0, 5);
-    expect(items_top5).toMatchObject([
-      { label: "somenum" },
-      { label: "x" },
-      { label: "y" },
-      { label: "max_int" },
-      { label: "min_int" },
-    ]);
+    expect(items_top5).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "()",
+          "textEdit": Object {
+            "newText": "()",
+            "range": Object {
+              "end": Object {
+                "character": 12,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 4,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "::",
+          "textEdit": Object {
+            "newText": "::",
+            "range": Object {
+              "end": Object {
+                "character": 12,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 4,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Assert_failure",
+          "textEdit": Object {
+            "newText": "Assert_failure",
+            "range": Object {
+              "end": Object {
+                "character": 12,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 4,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Division_by_zero",
+          "textEdit": Object {
+            "newText": "Division_by_zero",
+            "range": Object {
+              "end": Object {
+                "character": 12,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 4,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "End_of_file",
+          "textEdit": Object {
+            "newText": "End_of_file",
+            "range": Object {
+              "end": Object {
+                "character": 12,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 4,
+              },
+            },
+          },
+        },
+      ]
+    `);
   });
 
   it("completes with invalid prefix", async () => {
@@ -283,18 +470,81 @@ xdescribe("textDocument/completion", () => {
   });
 
   it("completes labels", async () => {
-    openDocument(outdent`
-      let f = ListLabels.map
-    `);
+    openDocument("let f = ListLabels.map ~");
 
-    let items = await queryCompletion(Types.Position.create(0, 23));
-    let items_top5 = items.slice(0, 5);
-    expect(items_top5).toMatchObject([
-      { label: "~f" },
-      { label: "::" },
-      { label: "[]" },
-      { label: "!" },
-      { label: "exit" },
-    ]);
+    let items = await queryCompletion(Types.Position.create(0, 24));
+    let items_top5 = items.slice(0, 10);
+    expect(items_top5).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "~+",
+          "textEdit": Object {
+            "newText": "~+",
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 0,
+              },
+              "start": Object {
+                "character": 23,
+                "line": 0,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "~+.",
+          "textEdit": Object {
+            "newText": "~+.",
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 0,
+              },
+              "start": Object {
+                "character": 23,
+                "line": 0,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "~-",
+          "textEdit": Object {
+            "newText": "~-",
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 0,
+              },
+              "start": Object {
+                "character": 23,
+                "line": 0,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "~-.",
+          "textEdit": Object {
+            "newText": "~-.",
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 0,
+              },
+              "start": Object {
+                "character": 23,
+                "line": 0,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "~f",
+          "textEdit": undefined,
+        },
+      ]
+    `);
   });
 });

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -8,6 +8,11 @@ import * as Protocol from "vscode-languageserver-protocol";
 import * as Rpc from "vscode-jsonrpc";
 import { URI } from "vscode-uri";
 
+const ocamlVersion = cp.execSync("ocamlc --version").toString();
+export function ocamlVersionGEq(versString: string) {
+  return ocamlVersion >= versString;
+}
+
 let serverBin = os.platform() === "win32" ? "ocamllsp.exe" : "ocamllsp";
 
 let serverPath = path.join(


### PR DESCRIPTION
Fixes #51 

Prefix lookup is now taking infix operator characters into account, and prefix is used to generate a textedit that overrides it.