### PR TITLE
implement handling 'didSwitchImplIntf' - switching between impl and intf files

### DIFF
--- a/ocaml-lsp-server/docs/ocamllsp/switchImplIntf-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/switchImplIntf-spec.md
@@ -1,0 +1,34 @@
+#### Switch Implementation/Interface Request
+
+Switch Implementation/Interface Request is sent from client to server  to get
+URI(s) of the file(s) that the current file can switch to, e.g.,  if the user
+has "foo.ml" and "foo.mli" files, the client, who want to  switch from one to
+the other, sends this request.
+
+If there are one or more files, to which the currently open file can  switch to,
+exist in the same folder, then URIs of all those existing  files are returned.
+In case there is no file to switch to in that folder,  the most likely candidate
+for creation is returned, e.g., if a user wants  to switch from "foo.ml", but no
+files already exist in the project that  could be returned, a URI for "foo.mli"
+is returned.
+
+##### Client capability
+
+nothing that should be noted
+
+##### Server capability
+
+property name: `handleSwitchImplIntf`
+property type: `boolean`
+
+##### Request
+
+- method: `ocamllsp/switchImplIntf`
+- params: `DocumentUri` (see [`DocumentUri`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#uri) in LSP specification)
+
+##### Response
+
+- result: DocumentUri[] (non-empty)
+- error: code and message set in case an exception happens during the willSaveWaitUntil request.
+
+

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -38,6 +38,7 @@ module CodeLens = CodeLens
 module DocumentHighlight = DocumentHighlight
 module DocumentHighlightKind = DocumentHighlightKind
 module DocumentSymbol = DocumentSymbol
+module DocumentUri = DocumentUri
 module SymbolInformation = SymbolInformation
 module CompletionItem = CompletionItem
 module CompletionList = CompletionList

--- a/ocaml-lsp-server/src/switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/switch_impl_intf.ml
@@ -1,0 +1,61 @@
+open Import
+
+let capability = ("handleSwitchImplIntf", `Bool true)
+
+let meth = "ocamllsp/switchImplIntf"
+
+(** See the spec for 'ocamllsp/switchImplIntf' *)
+let switch (state : State.t) (param : DocumentUri.t) :
+    (Json.t, Jsonrpc.Response.Error.t) result =
+  let file_uri = Uri.t_of_yojson (`String param) in
+  let filepath = Uri.to_path file_uri in
+  let ml, mli, re, rei, mll, mly = ("ml", "mli", "re", "rei", "mll", "mly") in
+  let open Result.O in
+  let+ doc = Document_store.get state.store file_uri in
+  let extensions_to_switch_to =
+    match Document.syntax doc with
+    | Ocaml -> (
+      match Document.kind doc with
+      | Intf -> [ ml; mly; mll; re ]
+      | Impl -> [ mli; mly; mll; rei ] )
+    | Reason -> (
+      match Document.kind doc with
+      | Intf -> [ re; ml ]
+      | Impl -> [ rei; mli ] )
+    | Ocamllex -> [ mli; rei ]
+    | Menhir -> [ mli; rei ]
+  in
+  let path_without_extension = Filename.remove_extension filepath ^ "." in
+  let find_switch (exts : string list) =
+    List.filter_map exts ~f:(fun ext ->
+        let file_to_switch_to = path_without_extension ^ ext in
+        Option.some_if (Sys.file_exists file_to_switch_to) file_to_switch_to)
+  in
+  let to_switch_to =
+    match find_switch extensions_to_switch_to with
+    | [] ->
+      let main_switch_to_candidate_ext = List.hd extensions_to_switch_to in
+      let main_switch_to_candidate_path =
+        path_without_extension ^ main_switch_to_candidate_ext
+      in
+      [ main_switch_to_candidate_path ]
+    | to_switch_to -> to_switch_to
+  in
+  let to_switch_to_json_array =
+    List.map to_switch_to ~f:(fun s -> `String (Uri.to_string @@ Uri.of_path s))
+  in
+  `List to_switch_to_json_array
+
+let on_request ~(params : Json.t option) state =
+  Fiber.return
+    ( match params with
+    | Some (`String (file_uri : DocumentUri.t)) ->
+      let open Result.O in
+      let+ res = switch state file_uri in
+      (res, state)
+    | Some _
+    | None ->
+      Error
+        (Jsonrpc.Response.Error.make ~code:InvalidRequest
+           ~message:"ocamllsp/switchImplIntf must receive param : DocumentUri.t"
+           ()) )

--- a/ocaml-lsp-server/src/switch_impl_intf.mli
+++ b/ocaml-lsp-server/src/switch_impl_intf.mli
@@ -1,0 +1,10 @@
+open Import
+
+val capability : string * Json.t
+
+val meth : string
+
+val on_request :
+     params:Json.t option
+  -> State.t
+  -> (Json.t * State.t, Jsonrpc.Response.Error.t) result Fiber.t

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -1,0 +1,108 @@
+import { assert } from "console";
+import { promises as fs } from "fs";
+import * as path from "path";
+import { DocumentUri, TextDocumentItem } from "vscode-languageserver-types";
+import { URI } from "vscode-uri";
+import * as LanguageServer from "./../src/LanguageServer";
+
+describe("ocamllsp/switchImplIntf", () => {
+  let languageServer: LanguageServer.LanguageServer = null;
+
+  async function openDocument(documentUri: DocumentUri) {
+    languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: TextDocumentItem.create(documentUri, "ocaml", 0, ""),
+    });
+  }
+
+  /* sends request "ocamllsp/switchImplIntf" */
+  async function ocamllspSwitchImplIntf(
+    documentUri: DocumentUri,
+  ): Promise<Array<DocumentUri>> {
+    return languageServer.sendRequest("ocamllsp/switchImplIntf", documentUri);
+  }
+
+  let testWorkspacePath = path.join(__dirname, "..", "test_files/");
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+    await fs.rmdir(testWorkspacePath, { recursive: true });
+    fs.mkdir(testWorkspacePath);
+  });
+
+  afterEach(async () => {
+    await fs.rmdir(testWorkspacePath, { recursive: true });
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  let createPathForFile = (filename: string) =>
+    path.join(testWorkspacePath, filename);
+
+  let createFileAtPath = async (path: string) =>
+    fs.writeFile(path, "", { flag: "a+" });
+
+  let pathToDocumentUri = (path: string): DocumentUri =>
+    URI.file(path).toString();
+
+  let [mli, ml, mll, mly, rei, re] = ["mli", "ml", "mll", "mly", "rei", "re"];
+
+  let testRequest = async (
+    requestParam: DocumentUri,
+    expectedResponse: DocumentUri[],
+  ) => {
+    let response = await ocamllspSwitchImplIntf(requestParam);
+    expect(response).toEqual(expectedResponse);
+  };
+
+  /**
+   * For testing 'ocamllsp/switchImplIntf'
+   *
+   * @param extsForCreation file name extensiosn for files to be created in (test) workspace folder.
+   *    The first file created (even if only one file is created) is treated as the file a user wants to switch from.
+   * @param extExpected file name extensions that are expected to be returned as a reponse
+   *    to 'ocamllsp/switchImplIntf'
+   */
+  let testingPipeline = async (
+    extsForCreation: string[],
+    extExpected: string[],
+  ) => {
+    assert(
+      extsForCreation.length > 0,
+      "extensions for creation should not be empty",
+    );
+    assert(
+      extExpected.length > 0,
+      "expected response extensions should not be empty",
+    );
+
+    let filePathsForCreation = extsForCreation.map((ext) => {
+      let filename = "test.".concat(ext);
+      return createPathForFile(filename);
+    });
+
+    await Promise.all(filePathsForCreation.map(createFileAtPath));
+
+    let filePathToSwitchFrom = filePathsForCreation[0];
+    let fileURIToSwitchFrom = pathToDocumentUri(filePathToSwitchFrom);
+    await openDocument(fileURIToSwitchFrom);
+
+    let expectedFileURIs = extExpected.map((ext) => {
+      let filename = "test.".concat(ext);
+      let filePath = createPathForFile(filename);
+      return pathToDocumentUri(filePath);
+    });
+
+    testRequest(fileURIToSwitchFrom, expectedFileURIs);
+  };
+
+  test.each([
+    [[mli], [ml]],
+    [[mli, ml], [ml]],
+    [[ml], [mli]],
+    [[ml, mli], [mli]],
+    [
+      [mli, ml, mll],
+      [ml, mll],
+    ],
+  ])("test switches", testingPipeline);
+});

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -57,10 +57,11 @@ describe("ocamllsp/switchImplIntf", () => {
   /**
    * For testing 'ocamllsp/switchImplIntf'
    *
-   * @param extsForCreation file name extensiosn for files to be created in (test) workspace folder.
-   *    The first file created (even if only one file is created) is treated as the file a user wants to switch from.
-   * @param extExpected file name extensions that are expected to be returned as a reponse
-   *    to 'ocamllsp/switchImplIntf'
+   * @param extsForCreation file name extension for files to be created in
+   *    (test) workspace folder. The first file created (even if only one file
+   *    is created) is treated as the file a user wants to switch from.
+   * @param extExpected file name extensions that are expected to be returned as
+   *    a reponse to 'ocamllsp/switchImplIntf'
    */
   let testingPipeline = async (
     extsForCreation: string[],

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -105,5 +105,5 @@ describe("ocamllsp/switchImplIntf", () => {
       [mli, ml, mll],
       [ml, mll],
     ],
-  ])("test switches", testingPipeline);
+  ])("test switches (%s => %s)", testingPipeline);
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -3,7 +3,9 @@ import * as LanguageServer from "./../src/LanguageServer";
 
 import * as Types from "vscode-languageserver-types";
 
-const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0") ? describe : xdescribe;
+const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0")
+  ? describe
+  : xdescribe;
 
 describe_opt("textDocument/completion", () => {
   let languageServer = null;

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -4,7 +4,7 @@ import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/hover", () => {
-  let languageServer;
+  let languageServer: LanguageServer.LanguageServer;
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);


### PR DESCRIPTION
- [x] implement switching between impl and intf files if it exists
- [x] propose possible filenames if the opposite file doesn't exist, i.e., if a user is trying to switch from 'foo.ml', s/he will be proposed filenames `foo.mli`, `foo.mly`, `foo.mll`, `foo.rei` (I am also working on handling this on vscode extension side but bindings are hard); each file has a list of extensions that it maps to in the order of most likely to least likely
- [x] write tests 