### PR TITLE
fix bug in 'switchImplIntf':

### DIFF
--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -37,6 +37,18 @@ module Syntax = struct
     ; ("ocaml.menhir", Menhir)
     ]
 
+  let of_fname s =
+    match Filename.extension s with
+    | ".mli"
+    | ".ml" ->
+      Ocaml
+    | ".rei"
+    | ".re" ->
+      Reason
+    | ".mll" -> Ocamllex
+    | ".mly" -> Menhir
+    | ext -> failwith ("Unknown extension " ^ ext)
+
   let of_language_id language_id =
     match List.assoc all language_id with
     | Some id -> id

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -12,12 +12,16 @@ module Syntax : sig
   val human_name : t -> string
 
   val markdown_name : t -> string
+
+  val of_fname : string -> t
 end
 
 module Kind : sig
   type t =
     | Intf
     | Impl
+
+  val of_fname : string -> t
 end
 
 val kind : t -> Kind.t

--- a/ocaml-lsp-server/src/switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/switch_impl_intf.ml
@@ -5,21 +5,27 @@ let capability = ("handleSwitchImplIntf", `Bool true)
 let meth = "ocamllsp/switchImplIntf"
 
 (** See the spec for 'ocamllsp/switchImplIntf' *)
-let switch (state : State.t) (param : DocumentUri.t) :
-    (Json.t, Jsonrpc.Response.Error.t) result =
-  let file_uri = Uri.t_of_yojson (`String param) in
-  let filepath = Uri.to_path file_uri in
+let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
+  let filepath =
+    let file_uri = Uri.t_of_yojson (`String param) in
+    let possible_filepath = Uri.to_path file_uri in
+    if possible_filepath = Uri.to_string file_uri then
+      (* remove URI scheme *)
+      String.split ~on:':' possible_filepath |> List.tl |> List.hd
+    else
+      possible_filepath
+    (* Note: URI lib such as ocaml-uri would help eliminate brittle URI handling *)
+  in
+  let filename = Filename.basename filepath in
   let ml, mli, re, rei, mll, mly = ("ml", "mli", "re", "rei", "mll", "mly") in
-  let open Result.O in
-  let+ doc = Document_store.get state.store file_uri in
   let extensions_to_switch_to =
-    match Document.syntax doc with
+    match Document.Syntax.of_fname filename with
     | Ocaml -> (
-      match Document.kind doc with
+      match Document.Kind.of_fname filename with
       | Intf -> [ ml; mly; mll; re ]
       | Impl -> [ mli; mly; mll; rei ] )
     | Reason -> (
-      match Document.kind doc with
+      match Document.Kind.of_fname filename with
       | Intf -> [ re; ml ]
       | Impl -> [ rei; mli ] )
     | Ocamllex -> [ mli; rei ]
@@ -44,14 +50,14 @@ let switch (state : State.t) (param : DocumentUri.t) :
   let to_switch_to_json_array =
     List.map to_switch_to ~f:(fun s -> `String (Uri.to_string @@ Uri.of_path s))
   in
-  `List to_switch_to_json_array
+  Ok (`List to_switch_to_json_array)
 
 let on_request ~(params : Json.t option) state =
   Fiber.return
     ( match params with
     | Some (`String (file_uri : DocumentUri.t)) ->
       let open Result.O in
-      let+ res = switch state file_uri in
+      let+ res = switch file_uri in
       (res, state)
     | Some _
     | None ->

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -106,4 +106,20 @@ describe("ocamllsp/switchImplIntf", () => {
       [ml, mll],
     ],
   ])("test switches (%s => %s)", testingPipeline);
+
+  it("can switch from file URI with non-file scheme", async () => {
+    let mlFpath = createPathForFile("test.ml");
+    await createFileAtPath(mlFpath);
+    let mlUri = pathToDocumentUri(mlFpath);
+
+    let newMliFpath = createPathForFile("test.mli");
+    await createFileAtPath(newMliFpath);
+    let mliUriUntitledScheme: DocumentUri = URI.file(newMliFpath)
+      .with({
+        scheme: "untitled",
+      })
+      .toString();
+
+    testRequest(mliUriUntitledScheme, [mlUri]);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/ocamllabs/vscode-ocaml-platform/issues/382:
 
  one couldn't switch from a new file that's not saved on disk
  (in vscode it's a file with URI scheme 'untitled')

  The previous switching logic depended on document store, which only
  knows files that were opened with a 'textDocument/didOpen'
  notification. VS Code doesn't send such notifications for unsaved files,
  hence the bug. Now switching handled file URIs directly without
  dependence on document store, which works for any 'switchImplIntf'
  request with a valid URI.

Note: handling of URIs is brittle as is the current URI module. I would strongly be in favor of adding a vendored dep `ocaml-uri`.

TODO:
- [x] add proper error handling using `result`
- [x] add tests for 'untitled' scheme (without loss of generality for other schemes that follow URI conventions of `scheme:/path`)