### PR TITLE
Fix mutex change of ownership (OpenBSD)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - Do not use vendored libraries when building the lsp package (#260)
 
+- Fix: correctly use mutexes on OpenBSD (#264)
+
 # 1.1.0 (10/14/2020)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ We recommend to install the server via a project such as
 To install the lsp server in a particular opam switch:
 
 ```
-$ opam pin add ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 $ opam install ocaml-lsp-server
 ```
 
@@ -24,13 +23,10 @@ you'd like to use it.
 
 ### Esy
 
-To add the lsp server to an esy project, add the following lines to your
-project's `package.json`:
+To add the lsp server to an esy project:
 
 ```
-  "devDependencies": {
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam"
-  }
+$ esy add @opam/ocaml-lsp-server
 ```
 
 ### Source
@@ -47,10 +43,12 @@ $ make build
 
 ## Usage
 
-Once `ocaml-lsp-server` is installed, the executable is called `ocamllsp`.
-For now, the server can only be used through the standard file descriptors `stdin` and `stdout`.
+Once `ocaml-lsp-server` is installed, the executable is called `ocamllsp`. For
+now, the server can only be used through the standard file descriptors `stdin`
+and `stdout`.
 
-For an example of usage of the server in a VSCode extension, see [here](https://github.com/ocamllabs/vscode-ocaml-platform/blob/master/src/Extension.ml).
+For an example of usage of the server in a VSCode extension, see
+[here](https://github.com/ocamllabs/vscode-ocaml-platform/blob/master/src/vscode_ocaml_platform.ml).
 
 ## Features
 
@@ -90,7 +88,7 @@ git clone --recursive git@github.com:ocaml/ocaml-lsp.git
 git submodule update --init --recursive
 
 # create local switch (or use global one) and install dependencies
-opam switch create . ocaml-base-compiler.4.09.1 --with-test
+opam switch create . ocaml-base-compiler.4.11.1 --with-test
 
 # don't forget to set your environment to use the local switch
 eval ($opam env)
@@ -110,10 +108,8 @@ To run tests execute:
 $ make test
 ```
 
-Note that tests require [Node.js][] and [Yarn][] installed.
-
-[node.js]: https://nodejs.org/en/
-[yarn]: https://yarnpkg.com/lang/en/
+Note that tests require [Node.js](https://nodejs.org/en/) and
+[Yarn][https://yarnpkg.com/lang/en/] installed.
 
 ## Relationship to Other Tools
 
@@ -124,8 +120,8 @@ and merlin independently.
 
 ## History
 
-The implementation of the lsp protocol itself was taken from [facebook's
-hack](https://github.com/facebook/hhvm/blob/master/hphp/hack/src/utils/lsp/lsp.mli)
+The implementation of the lsp protocol itself was taken from
+[facebook's hack](https://github.com/facebook/hhvm/blob/master/hphp/hack/src/utils/lsp/lsp.mli)
 
 Previously, this lsp server was a part of merlin, until it was realized that the
 lsp protocol covers a wider scope than merlin.

--- a/lsp.opam
+++ b/lsp.opam
@@ -35,9 +35,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
+  ["dune" "subst"] {pinned}
   ["ocaml" "unix.cma" "unvendor.ml"]
-  # broken by unvendor
-  # ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/lsp.opam.template
+++ b/lsp.opam.template
@@ -1,7 +1,6 @@
 build: [
+  ["dune" "subst"] {pinned}
   ["ocaml" "unix.cma" "unvendor.ml"]
-  # broken by unvendor
-  # ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/lsp/src/scheduler.ml
+++ b/lsp/src/scheduler.ml
@@ -93,7 +93,7 @@ end = struct
       | Finished -> assert false
       | Running _ -> loop ()
     in
-    loop ()
+    with_mutex t.mutex ~f:loop
 
   let create ~do_ =
     let t =
@@ -105,7 +105,6 @@ end = struct
     in
     Mutex.lock t.mutex;
     t.state <- Running (Thread.create run (do_, t));
-    Mutex.lock t.mutex;
     Mutex.unlock t.mutex;
     t
 

--- a/lsp/test/fiber_thread_test.ml
+++ b/lsp/test/fiber_thread_test.ml
@@ -8,7 +8,7 @@ let worker = Scheduler.create_thread s
 let fb () =
   Scheduler.async worker (fun () ->
       Thread.delay 1.0;
-      print_endline "pre epmtive thread finished")
+      print_endline "preemptive thread finished")
   |> Scheduler.await_no_cancel
 
 let _ =


### PR DESCRIPTION
OpenBSD is pretty strict about change of ownership for mutexes (`abort()`). This PR addresses that issue by moving mutex locking to their logically owning threads.