### PR TITLE
Add dependency to `dot-merlin-reader`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,7 @@ possible and does not make any assumptions about IO.
   cppo
   uutf
   csexp
+  dot-merlin-reader
   (menhir :with-test)
   (cinaps :with-test)
   (ppx_expect (and :with-test (>= v0.14.0)))

--- a/lsp.opam
+++ b/lsp.opam
@@ -27,6 +27,7 @@ depends: [
   "cppo"
   "uutf"
   "csexp"
+  "dot-merlin-reader"
   "menhir" {with-test}
   "cinaps" {with-test}
   "ppx_expect" {with-test & >= "v0.14.0"}


### PR DESCRIPTION
In anticipation to the activation of the new Merlin "external configuration reading", we should have a way to install `dot-merlin-reader` with `ocaml-lsp-server`.

It seems like the most reasonable way to do that is to add a package dependency.
The may advantage of this option is it's simplicity.

However it also has drawbacks:
- It is one more dependency, and the binary  `dot-merlin-reader` could be built with the already vendored sources of Merlin
- In theory the version `dot-merlin-reader` should always be in sync with the vendored version of Merlin (In practice I believe that  `dot-merlin-reader` should be fairly stable and protocol changes not frequent at all).

Other possibilities:
- Build the executable from the vendored sources. We may need to rename ocaml-lsp's `dot-merlin-reader` to prevent conflict with the `merlin` package. 
- Maybe we can build locally(ie not publicly installed) `dot-merlin-reader` and start ocamlmerlin in an environment where  `dot-merlin-reader` is an alias to our version ?