### PR TITLE
Clear diagnostics for non-project files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - #268: Do not use vendored libraries when building the lsp package (#260)
 
+- #271: Clear diagnostics when files are closed
 
 # 1.1.0 (10/14/2020)
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -81,55 +81,56 @@ let send_diagnostics ?diagnostics rpc doc =
   in
   match diagnostics with
   | Some diagnostics ->
-    async @@ fun () ->
-    let notif = create_publishDiagnostics uri diagnostics in
-    Server.notification rpc notif
+    async (fun () ->
+        let notif = create_publishDiagnostics uri diagnostics in
+        Server.notification rpc notif)
   | None -> (
     match Document.syntax doc with
     | Menhir
     | Ocamllex ->
       Fiber.return ()
     | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
-      async @@ fun () ->
-      let no_reason_merlin =
-        let message =
-          sprintf "Could not detect %s. Please install reason"
-            ocamlmerlin_reason
-        in
-        let range =
-          let pos = Position.create ~line:1 ~character:1 in
-          Range.create ~start:pos ~end_:pos
-        in
-        create_diagnostic range message
-      in
-      let notif = create_publishDiagnostics uri [ no_reason_merlin ] in
-      Server.notification rpc notif
+      async (fun () ->
+          let no_reason_merlin =
+            let message =
+              sprintf "Could not detect %s. Please install reason"
+                ocamlmerlin_reason
+            in
+            let range =
+              let pos = Position.create ~line:1 ~character:1 in
+              Range.create ~start:pos ~end_:pos
+            in
+            create_diagnostic range message
+          in
+          let notif = create_publishDiagnostics uri [ no_reason_merlin ] in
+          Server.notification rpc notif)
     | Reason
     | Ocaml ->
-      async @@ fun () ->
-      let open Fiber.O in
-      let* diagnostics =
-        Document.with_pipeline_exn doc @@ fun pipeline ->
-        let command =
-          Query_protocol.Errors { lexing = true; parsing = true; typing = true }
-        in
-        let errors = Query_commands.dispatch pipeline command in
-        List.map errors ~f:(fun (error : Loc.error) ->
-            let loc = Loc.loc_of_report error in
-            let range = Range.of_loc loc in
-            let severity =
-              match error.source with
-              | Warning -> DiagnosticSeverity.Warning
-              | _ -> DiagnosticSeverity.Error
-            in
-            let message =
-              Loc.print_main Format.str_formatter error;
-              String.trim (Format.flush_str_formatter ())
-            in
-            create_diagnostic range message ~severity)
-      in
-      let notif = create_publishDiagnostics uri diagnostics in
-      Server.notification rpc notif )
+      async (fun () ->
+          let open Fiber.O in
+          let* diagnostics =
+            Document.with_pipeline_exn doc (fun pipeline ->
+                let command =
+                  Query_protocol.Errors
+                    { lexing = true; parsing = true; typing = true }
+                in
+                let errors = Query_commands.dispatch pipeline command in
+                List.map errors ~f:(fun (error : Loc.error) ->
+                    let loc = Loc.loc_of_report error in
+                    let range = Range.of_loc loc in
+                    let severity =
+                      match error.source with
+                      | Warning -> DiagnosticSeverity.Warning
+                      | _ -> DiagnosticSeverity.Error
+                    in
+                    let message =
+                      Loc.print_main Format.str_formatter error;
+                      String.trim (Format.flush_str_formatter ())
+                    in
+                    create_diagnostic range message ~severity))
+          in
+          let notif = create_publishDiagnostics uri diagnostics in
+          Server.notification rpc notif) )
 
 let on_initialize rpc =
   let log_consumer (section, title, text) =

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -668,6 +668,10 @@ let on_notification server (notification : Client_notification.t) :
     Fiber.return state
   | TextDocumentDidClose { textDocument = { uri } } ->
     let uri = Uri.t_of_yojson (`String uri) in
+    let doc = Document_store.get_opt store uri in
+    let _clear_diagnostics : unit Fiber.t =
+      send_diagnostics ~diagnostics:[] server (Option.value_exn doc)
+    in
     let open Fiber.O in
     let+ () = Document_store.remove_document store uri in
     state

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -109,25 +109,27 @@ let send_diagnostics ?diagnostics rpc doc =
       async (fun () ->
           let open Fiber.O in
           let* diagnostics =
-            Document.with_pipeline_exn doc (fun pipeline ->
-                let command =
-                  Query_protocol.Errors
-                    { lexing = true; parsing = true; typing = true }
+            let command =
+              Query_protocol.Errors
+                { lexing = true; parsing = true; typing = true }
+            in
+            let+ errors =
+              Document.with_pipeline_exn doc (fun pipeline ->
+                  Query_commands.dispatch pipeline command)
+            in
+            List.map errors ~f:(fun (error : Loc.error) ->
+                let loc = Loc.loc_of_report error in
+                let range = Range.of_loc loc in
+                let severity =
+                  match error.source with
+                  | Warning -> DiagnosticSeverity.Warning
+                  | _ -> DiagnosticSeverity.Error
                 in
-                let errors = Query_commands.dispatch pipeline command in
-                List.map errors ~f:(fun (error : Loc.error) ->
-                    let loc = Loc.loc_of_report error in
-                    let range = Range.of_loc loc in
-                    let severity =
-                      match error.source with
-                      | Warning -> DiagnosticSeverity.Warning
-                      | _ -> DiagnosticSeverity.Error
-                    in
-                    let message =
-                      Loc.print_main Format.str_formatter error;
-                      String.trim (Format.flush_str_formatter ())
-                    in
-                    create_diagnostic range message ~severity))
+                let message =
+                  Loc.print_main Format.str_formatter error;
+                  String.trim (Format.flush_str_formatter ())
+                in
+                create_diagnostic range message ~severity)
           in
           let notif = create_publishDiagnostics uri diagnostics in
           Server.notification rpc notif) )

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -59,7 +59,7 @@ let initialize_info : InitializeResult.t =
 
 let ocamlmerlin_reason = "ocamlmerlin-reason"
 
-let send_diagnostics rpc doc =
+let send_diagnostics ?diagnostics rpc doc =
   let state : State.t = Server.state rpc in
   let uri = Document.uri doc |> Lsp.Uri.to_string in
   let create_diagnostic ?severity range message =
@@ -79,50 +79,57 @@ let send_diagnostics rpc doc =
         | Ok () ->
           ())
   in
-  match Document.syntax doc with
-  | Menhir
-  | Ocamllex ->
-    Fiber.return ()
-  | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
+  match diagnostics with
+  | Some diagnostics ->
     async @@ fun () ->
-    let no_reason_merlin =
-      let message =
-        sprintf "Could not detect %s. Please install reason" ocamlmerlin_reason
-      in
-      let range =
-        let pos = Position.create ~line:1 ~character:1 in
-        Range.create ~start:pos ~end_:pos
-      in
-      create_diagnostic range message
-    in
-    let notif = create_publishDiagnostics uri [ no_reason_merlin ] in
-    Server.notification rpc notif
-  | Reason
-  | Ocaml ->
-    async @@ fun () ->
-    let open Fiber.O in
-    let* diagnostics =
-      Document.with_pipeline_exn doc @@ fun pipeline ->
-      let command =
-        Query_protocol.Errors { lexing = true; parsing = true; typing = true }
-      in
-      let errors = Query_commands.dispatch pipeline command in
-      List.map errors ~f:(fun (error : Loc.error) ->
-          let loc = Loc.loc_of_report error in
-          let range = Range.of_loc loc in
-          let severity =
-            match error.source with
-            | Warning -> DiagnosticSeverity.Warning
-            | _ -> DiagnosticSeverity.Error
-          in
-          let message =
-            Loc.print_main Format.str_formatter error;
-            String.trim (Format.flush_str_formatter ())
-          in
-          create_diagnostic range message ~severity)
-    in
     let notif = create_publishDiagnostics uri diagnostics in
     Server.notification rpc notif
+  | None -> (
+    match Document.syntax doc with
+    | Menhir
+    | Ocamllex ->
+      Fiber.return ()
+    | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
+      async @@ fun () ->
+      let no_reason_merlin =
+        let message =
+          sprintf "Could not detect %s. Please install reason"
+            ocamlmerlin_reason
+        in
+        let range =
+          let pos = Position.create ~line:1 ~character:1 in
+          Range.create ~start:pos ~end_:pos
+        in
+        create_diagnostic range message
+      in
+      let notif = create_publishDiagnostics uri [ no_reason_merlin ] in
+      Server.notification rpc notif
+    | Reason
+    | Ocaml ->
+      async @@ fun () ->
+      let open Fiber.O in
+      let* diagnostics =
+        Document.with_pipeline_exn doc @@ fun pipeline ->
+        let command =
+          Query_protocol.Errors { lexing = true; parsing = true; typing = true }
+        in
+        let errors = Query_commands.dispatch pipeline command in
+        List.map errors ~f:(fun (error : Loc.error) ->
+            let loc = Loc.loc_of_report error in
+            let range = Range.of_loc loc in
+            let severity =
+              match error.source with
+              | Warning -> DiagnosticSeverity.Warning
+              | _ -> DiagnosticSeverity.Error
+            in
+            let message =
+              Loc.print_main Format.str_formatter error;
+              String.trim (Format.flush_str_formatter ())
+            in
+            create_diagnostic range message ~severity)
+      in
+      let notif = create_publishDiagnostics uri diagnostics in
+      Server.notification rpc notif )
 
 let on_initialize rpc =
   let log_consumer (section, title, text) =


### PR DESCRIPTION
When one opens a source file of a library they use (with go-to-definition, for example), merlin reports errors in that file. When the file is closed, the errors remain in the problems pane (see the screenshot). This PR clears the reported errors when such a non-project source is closed. I define non-project source file as a file with URI that contains ".opam", "_opam", or "_esy". 

![image](https://user-images.githubusercontent.com/16353531/97085336-368cec80-161d-11eb-9533-a9c123a8d5aa.png)
