### PR TITLE
Define ocaml-lsp to be only compatible with a limited set of the OCaml compiler

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -40,7 +40,7 @@ possible and does not make any assumptions about IO.
   (menhir :with-test)
   (cinaps :with-test)
   (ppx_expect (and :with-test (>= v0.14.0)))
-  (ocaml (>= 4.06))
+  (ocaml (and (>= 4.06) (< 4.12)))
   (dune (>= 2.0))))
 
 (package
@@ -58,7 +58,7 @@ possible and does not make any assumptions about IO.
   (ocamlformat :with-test)
   (reason :with-test)
   (ocamlfind (>= 1.5.2))
-  (ocaml (>= 4.06))
+  (ocaml (and (>= 4.06) (< 4.12)))
   (dune (>= 2.5.0))))
 
 (package
@@ -70,5 +70,5 @@ possible and does not make any assumptions about IO.
   stdlib-shims
   ppx_yojson_conv_lib
   (result (>= 1.5))
-  (ocaml (>= 4.06))
+  (ocaml (and (>= 4.06) (< 4.12)))
   (dune (>= 2.5.0))))

--- a/jsonrpc.opam
+++ b/jsonrpc.opam
@@ -20,7 +20,7 @@ depends: [
   "stdlib-shims"
   "ppx_yojson_conv_lib"
   "result" {>= "1.5"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.12"}
   "dune" {>= "2.5.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"

--- a/lsp.opam
+++ b/lsp.opam
@@ -32,7 +32,7 @@ depends: [
   "menhir" {with-test}
   "cinaps" {with-test}
   "ppx_expect" {with-test & >= "v0.14.0"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.12"}
   "dune" {>= "2.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -26,7 +26,7 @@ depends: [
   "ocamlformat" {with-test}
   "reason" {with-test}
   "ocamlfind" {>= "1.5.2"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "4.12"}
   "dune" {>= "2.5.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"


### PR DESCRIPTION
Right now every packages defined in this repository fails on OCaml 4.12 with the following error message:
```
File "_build/.dune/default/ocaml-lsp-server/vendor/merlin/src/ocaml/utils/dune", line 2, characters 13-25:
2 | (copy_files# 412/*.ml{,i})
                 ^^^^^^^^^^^^
Error: Cannot find directory:
ocaml-lsp-server/vendor/merlin/src/ocaml/utils/412
```
It is safe to assume that since they're using merlin and that it is always only compatible with a limited set of the OCaml compiler, them too are also always compatible with a limited set of the compiler and thus should be restricted as such in their package description.