### PR TITLE
Serve requests concurrently

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -89,11 +89,10 @@ struct
   let log t = Log.log ~section:t.name
 
   let response_error_of_exns id exns =
-    let data : Json.t =
-      `List
-        (List.map
-           ~f:(fun e -> e |> Exn_with_backtrace.to_dyn |> Json.of_dyn)
-           exns)
+    let data =
+      Json.yojson_of_list
+        (fun e -> e |> Exn_with_backtrace.to_dyn |> Json.of_dyn)
+        exns
     in
     let error =
       Response.Error.make ~code:InternalError ~data

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -7,6 +7,14 @@ module Notify : sig
     | Continue
 end
 
+module Reply : sig
+  type t
+
+  val now : Response.t -> t
+
+  val later : ((Response.t -> unit Fiber.t) -> unit Fiber.t) -> t
+end
+
 (** IO free implementation of the jsonrpc protocol. We stay completely agnostic
     of transport by only dealing with abstract jsonrpc packets *)
 module Make (Chan : sig
@@ -34,8 +42,7 @@ end) : sig
   with type 'a session := 'a t
 
   val create :
-       ?on_request:
-         (('state, Id.t) Context.t -> (Response.t Fiber.t * 'state) Fiber.t)
+       ?on_request:(('state, Id.t) Context.t -> (Reply.t * 'state) Fiber.t)
     -> ?on_notification:
          (('state, unit) Context.t -> (Notify.t * 'state) Fiber.t)
     -> name:string

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -34,7 +34,8 @@ end) : sig
   with type 'a session := 'a t
 
   val create :
-       ?on_request:(('state, Id.t) Context.t -> (Response.t * 'state) Fiber.t)
+       ?on_request:
+         (('state, Id.t) Context.t -> (Response.t Fiber.t * 'state) Fiber.t)
     -> ?on_notification:
          (('state, unit) Context.t -> (Notify.t * 'state) Fiber.t)
     -> name:string

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -102,7 +102,7 @@ let%expect_test "serving requests" =
       let state = Context.state c in
       assert (r = { request with id = r.id });
       let response = Jsonrpc.Response.ok r.id response_data in
-      Fiber.return (Fiber.return response, state)
+      Fiber.return (Reply.now response, state)
     in
     let out = Out.of_ref responses in
     let jrpc = Jrpc.create ~name:"test" ~on_request (in_, out) () in
@@ -132,16 +132,20 @@ let%expect_test "concurrent requests" =
       print_endline "waiter: received request";
       print (Message { request with id = Some request.id });
       let response =
-        print_endline "waiter: making request";
-        let+ response =
-          let request =
-            Jsonrpc.Message.create ~id:(`Int 100) ~method_:"shutdown" ()
-          in
-          Jrpc.request self request
-        in
-        print_endline "waiter: received response:";
-        print (Response response);
-        Jsonrpc.Response.ok request.id `Null
+        Reply.later (fun send ->
+            print_endline "waiter: making request";
+            let* response =
+              let request =
+                Jsonrpc.Message.create ~id:(`Int 100) ~method_:"shutdown" ()
+              in
+              Jrpc.request self request
+            in
+            print_endline "waiter: received response:";
+            print (Response response);
+            let* () = send (Jsonrpc.Response.ok request.id `Null) in
+            print_endline "waiter: stopping";
+            let+ () = Jrpc.stop self in
+            print_endline "waiter: stopped")
       in
       Fiber.return (response, ())
     in
@@ -152,18 +156,19 @@ let%expect_test "concurrent requests" =
       print_endline "waitee: received request";
       let request = Context.message c in
       print (Message { request with id = Some request.id });
-      let response = Jsonrpc.Response.ok request.id (`Int 42) in
-      let* () =
-        if request.method_ = "shutdown" then (
-          let self = Context.session c in
-          print_endline "waitee: stopping";
-          let+ () = Jrpc.stop self in
-          print_endline "waitee: stopped"
-        ) else
-          Fiber.return ()
+      let response =
+        Reply.later (fun send ->
+            let* () = send (Jsonrpc.Response.ok request.id (`Int 42)) in
+            if request.method_ = "shutdown" then (
+              let self = Context.session c in
+              print_endline "waitee: stopping";
+              let+ () = Jrpc.stop self in
+              print_endline "waitee: stopped"
+            ) else
+              Fiber.return ())
       in
       let state = Context.state c in
-      Fiber.return (Fiber.return response, state)
+      Fiber.return (response, state)
     in
     Jrpc.create ~on_request ~name:"waitee" chan ()
   in
@@ -191,11 +196,11 @@ let%expect_test "concurrent requests" =
     { "id": "initial", "method": "init", "jsonrpc": "2.0" }
     waiter: making request
     waitee: received request
-    { "id": 100, "method": "random", "jsonrpc": "2.0" }
+    { "id": 100, "method": "shutdown", "jsonrpc": "2.0" }
+    waitee: stopping
     waiter: received response:
     { "id": 100, "jsonrpc": "2.0", "result": 42 }
-    initial request response:
-    { "id": "initial", "jsonrpc": "2.0", "result": null }
+    waiter: stopping
     [FAIL] unexpected Never raised |}]
 
 let%expect_test "test from jsonrpc_test.ml" =
@@ -209,7 +214,7 @@ let%expect_test "test from jsonrpc_test.ml" =
   let on_request ctx =
     let req = Context.message ctx in
     let state = Context.state ctx in
-    Fiber.return (Fiber.return (Jsonrpc.Response.ok req.id (response ())), state)
+    Fiber.return (Reply.now (Jsonrpc.Response.ok req.id (response ())), state)
   in
   let on_notification ctx =
     let n = Context.message ctx in

--- a/lsp-fiber/src/rpc.ml
+++ b/lsp-fiber/src/rpc.ml
@@ -143,22 +143,22 @@ struct
   let to_jsonrpc (type state) (t : state t) h_on_request h_on_notification =
     let open Fiber.O in
     let on_request (ctx : (state, Id.t) Session.Context.t) :
-        (Response.t * state) Fiber.t =
+        (Response.t Fiber.t * state) Fiber.t =
       let req = Session.Context.message ctx in
       let state = Session.Context.state ctx in
       match In_request.of_jsonrpc req with
       | Error message ->
         let code = Jsonrpc.Response.Error.Code.InvalidParams in
         let error = Jsonrpc.Response.Error.make ~code ~message () in
-        Fiber.return (Response.error req.id error, state)
+        Fiber.return (Fiber.return (Response.error req.id error), state)
       | Ok (In_request.E r) -> (
         let+ response = h_on_request.on_request t r in
         match response with
-        | Error e -> (Response.error req.id e, state)
+        | Error e -> (Fiber.return (Response.error req.id e), state)
         | Ok (response, state) ->
           let json = In_request.yojson_of_result r response in
           let response = Response.ok req.id json in
-          (response, state) )
+          (Fiber.return response, state) )
     in
     let on_notification ctx : (Notify.t * state) Fiber.t =
       let r = Session.Context.message ctx in


### PR DESCRIPTION
Change the return type for `on_request` to allow concurrent handling.