### PR TITLE
Fix the dune files to fix compilation errors in 4.06.x

### DIFF
--- a/fiber-test/dune
+++ b/fiber-test/dune
@@ -1,3 +1,3 @@
 (library
  (name fiber_test)
- (libraries stdune fiber))
+ (libraries fiber stdune))

--- a/fiber-unix/src/dune
+++ b/fiber-unix/src/dune
@@ -1,5 +1,5 @@
 (library
  (name fiber_unix)
  (public_name lsp.fiber_unix)
- (libraries stdune fiber threads.posix yojson)
+ (libraries fiber stdune threads.posix yojson)
  (preprocess future_syntax))

--- a/fiber-unix/test/dune
+++ b/fiber-unix/test/dune
@@ -4,17 +4,17 @@
   (>= %{ocaml_version} 4.08))
  (inline_tests)
  (libraries
+  base
   fiber
   fiber_test
-  jsonrpc
   fiber_unix
-  stdune
+  jsonrpc
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
+  ppx_expect.common
   ppx_expect.config
   ppx_expect.config_types
-  ppx_expect.common
-  base
-  ppx_inline_test.config)
+  ppx_inline_test.config
+  stdune)
  (preprocess
   (pps ppx_expect)))

--- a/jsonrpc-fiber/src/dune
+++ b/jsonrpc-fiber/src/dune
@@ -1,3 +1,4 @@
 (library
  (name jsonrpc_fiber)
- (libraries jsonrpc fiber yojson stdune fiber_unix ppx_yojson_conv_lib))
+ (libraries fiber fiber_unix jsonrpc ppx_yojson_conv_lib stdune yojson)
+ (preprocess future_syntax))

--- a/jsonrpc-fiber/test/dune
+++ b/jsonrpc-fiber/test/dune
@@ -2,8 +2,8 @@
  (name jsonrpc_test)
  (modules jsonrpc_test)
  (preprocess future_syntax)
- (libraries stdune fiber_unix jsonrpc jsonrpc_fiber yojson lsp fiber
-   ppx_yojson_conv_lib threads.posix))
+ (libraries fiber fiber_unix jsonrpc jsonrpc_fiber lsp ppx_yojson_conv_lib
+   stdune threads.posix yojson))
 
 (rule
  (alias test)
@@ -17,19 +17,19 @@
   (>= %{ocaml_version} 4.08))
  (inline_tests)
  (libraries
+  base
   fiber
-  yojson
+  fiber_test
+  fiber_unix
   jsonrpc
   jsonrpc_fiber
-  fiber_unix
-  fiber_test
-  stdune
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
+  ppx_expect.common
   ppx_expect.config
   ppx_expect.config_types
-  ppx_expect.common
-  base
-  ppx_inline_test.config)
+  ppx_inline_test.config
+  stdune
+  yojson)
  (preprocess
   (pps ppx_expect)))

--- a/jsonrpc/src/dune
+++ b/jsonrpc/src/dune
@@ -1,3 +1,4 @@
 (library
  (public_name jsonrpc)
- (libraries ppx_yojson_conv_lib yojson))
+ (libraries ppx_yojson_conv_lib result yojson)
+ (preprocess future_syntax))

--- a/lsp-fiber/src/dune
+++ b/lsp-fiber/src/dune
@@ -1,4 +1,5 @@
 (library
  (name lsp_fiber)
- (libraries jsonrpc jsonrpc_fiber fiber yojson stdune fiber_unix lsp
-   ppx_yojson_conv_lib))
+ (libraries fiber fiber_unix jsonrpc jsonrpc_fiber lsp ppx_yojson_conv_lib
+   result stdune yojson)
+ (preprocess future_syntax))

--- a/lsp-fiber/test/dune
+++ b/lsp-fiber/test/dune
@@ -8,21 +8,21 @@
  (enabled_if
   (>= %{ocaml_version} 4.08))
  (libraries
+  base
   fiber
-  yojson
-  jsonrpc
-  threads.posix
-  ppx_yojson_conv_lib
-  jsonrpc_fiber
-  fiber_unix
   fiber_test
-  lsp_fiber
+  fiber_unix
+  jsonrpc
+  jsonrpc_fiber
   lsp
-  stdune
+  lsp_fiber
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
+  ppx_expect.common
   ppx_expect.config
   ppx_expect.config_types
-  ppx_expect.common
-  base
-  ppx_inline_test.config))
+  ppx_inline_test.config
+  ppx_yojson_conv_lib
+  stdune
+  threads.posix
+  yojson))

--- a/lsp/bin/dune
+++ b/lsp/bin/dune
@@ -13,11 +13,11 @@
 (executable
  (name gen)
  (modules gen)
- (preprocess future_syntax)
- (libraries stdune lsp_gen))
+ (libraries lsp_gen stdune)
+ (preprocess future_syntax))
 
 (library
  (name lsp_gen)
- (preprocess future_syntax)
  (modules :standard \ gen)
- (libraries stdune))
+ (libraries stdune)
+ (preprocess future_syntax))

--- a/lsp/src/dune
+++ b/lsp/src/dune
@@ -3,7 +3,8 @@
 (library
  (name lsp)
  (public_name lsp)
- (libraries stdune yojson jsonrpc threads.posix ppx_yojson_conv_lib uutf)
+ (libraries jsonrpc ppx_yojson_conv_lib result stdune threads.posix uutf
+   yojson)
  (preprocess future_syntax)
  (lint
   (pps ppx_yojson_conv)))

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -3,7 +3,7 @@
  (package ocaml-lsp-server)
  (public_name ocamllsp)
  (preprocess future_syntax)
- (libraries stdune jsonrpc fiber_unix merlin.specific merlin.analysis
-   merlin.kernel merlin.merlin_utils merlin.parsing merlin.query_protocol lsp
-   lsp_fiber merlin.typing merlin.utils merlin.query_commands result yojson
-   ppx_yojson_conv_lib cmdliner fiber dune-build-info omd octavius))
+ (libraries cmdliner dune-build-info fiber fiber_unix jsonrpc lsp lsp_fiber
+   merlin.analysis merlin.kernel merlin.merlin_utils merlin.parsing
+   merlin.query_commands merlin.query_protocol merlin.specific merlin.typing
+   merlin.utils octavius omd ppx_yojson_conv_lib result stdune yojson))


### PR DESCRIPTION
To make it easier to compare to each dune file, I ordered all the libraries in alphabetical order, but that breaks the diff for this commit. For other things I did, I just added the `Result` library and `future_syntax` preprocess as needed. If you don't like it, I will undo the changes around the alphabetical sort.