### PR TITLE
Use proper barrier for timer awaker

### DIFF
--- a/fiber-unix/src/barrier.ml
+++ b/fiber-unix/src/barrier.ml
@@ -6,40 +6,26 @@ type t =
 
 let create () =
   let r, w = Unix.pipe () in
-  Unix.set_nonblock r;
-  { r; w; buf = Bytes.create 8 }
+  { r; w; buf = Bytes.create 1 }
 
 let close t =
   Unix.close t.w;
   Unix.close t.r
 
-let read_one t =
-  match Unix.read t.r t.buf 0 (Bytes.length t.buf) with
-  | 0 -> Error `No_data
-  | _ -> Ok ()
-  | exception Unix.Unix_error (Unix.EAGAIN, _, _) -> Error `Unavailable
-  | exception Unix.Unix_error (Unix.EBADF, _, _) -> Error `Bad_fd
-  | exception Unix.Unix_error (e, _, _) -> failwith (Unix.error_message e)
+let rec empty_fd fd buf =
+  match Unix.select [ fd ] [] [] 0.0 with
+  | [], _, _ -> Ok ()
+  | _ ->
+    let _ = Unix.read fd buf 0 1 in
+    empty_fd fd buf
+  | exception Unix.Unix_error (Unix.EBADF, _, _) -> Error (`Closed (`Read true))
+  | exception Unix.Unix_error (e, _, _) ->
+    failwith ("read :" ^ Unix.error_message e)
 
-let read_all t =
-  let rec loop read_once =
-    match read_one t with
-    | Ok () -> loop true
-    | Error `Bad_fd -> Error (`Bad_fd, read_once)
-    | Error `Unavailable
-    | Error `No_data ->
-      Ok read_once
-  in
-  loop false
-
-let rec await ?(timeout = -1.) t =
+let await ?(timeout = -1.) t =
   match Unix.select [ t.r ] [] [] timeout with
   | [], _, _ -> Error `Timeout
-  | _ -> (
-    match read_all t with
-    | Ok true -> Ok ()
-    | Ok false -> await ~timeout t
-    | Error (`Bad_fd, read_once) -> Error (`Closed (`Read read_once)) )
+  | _ -> empty_fd t.r t.buf
   | exception Unix.Unix_error (Unix.EBADF, _, _) ->
     Error (`Closed (`Read false))
   | exception Unix.Unix_error (e, _, _) ->

--- a/fiber-unix/src/barrier.ml
+++ b/fiber-unix/src/barrier.ml
@@ -1,0 +1,53 @@
+type t =
+  { r : Unix.file_descr
+  ; w : Unix.file_descr
+  ; buf : Bytes.t
+  }
+
+let create () =
+  let r, w = Unix.pipe () in
+  Unix.set_nonblock r;
+  { r; w; buf = Bytes.create 8 }
+
+let close t =
+  Unix.close t.w;
+  Unix.close t.r
+
+let read_one t =
+  match Unix.read t.r t.buf 0 (Bytes.length t.buf) with
+  | 0 -> Error `No_data
+  | _ -> Ok ()
+  | exception Unix.Unix_error (Unix.EAGAIN, _, _) -> Error `Unavailable
+  | exception Unix.Unix_error (Unix.EBADF, _, _) -> Error `Bad_fd
+  | exception Unix.Unix_error (e, _, _) -> failwith (Unix.error_message e)
+
+let read_all t =
+  let rec loop read_once =
+    match read_one t with
+    | Ok () -> loop true
+    | Error `Bad_fd -> Error (`Bad_fd, read_once)
+    | Error `Unavailable
+    | Error `No_data ->
+      Ok read_once
+  in
+  loop false
+
+let rec await ?(timeout = -1.) t =
+  match Unix.select [ t.r ] [] [] timeout with
+  | [], _, _ -> Error `Timeout
+  | _ -> (
+    match read_all t with
+    | Ok true -> Ok ()
+    | Ok false -> await ~timeout t
+    | Error (`Bad_fd, read_once) -> Error (`Closed (`Read read_once)) )
+  | exception Unix.Unix_error (Unix.EBADF, _, _) ->
+    Error (`Closed (`Read false))
+  | exception Unix.Unix_error (e, _, _) ->
+    failwith ("read :" ^ Unix.error_message e ^ " " ^ string_of_float timeout)
+
+let b = Bytes.make 1 'O'
+
+let signal t =
+  match Unix.write t.w b 0 1 with
+  | 1 -> ()
+  | _ -> assert false

--- a/fiber-unix/src/barrier.mli
+++ b/fiber-unix/src/barrier.mli
@@ -1,0 +1,12 @@
+type t
+
+val create : unit -> t
+
+val signal : t -> unit
+
+val await :
+     ?timeout:float
+  -> t
+  -> (unit, [ `Timeout | `Closed of [ `Read of bool ] ]) result
+
+val close : t -> unit

--- a/fiber-unix/src/fiber_unix.ml
+++ b/fiber-unix/src/fiber_unix.ml
@@ -4,4 +4,5 @@ module Scheduler = Scheduler
 
 module Private = struct
   module Removable_queue = Removable_queue
+  module Barrier = Barrier
 end

--- a/fiber-unix/src/import.ml
+++ b/fiber-unix/src/import.ml
@@ -1,5 +1,11 @@
 include Stdune
 
+let with_mutex m ~f =
+  Mutex.lock m;
+  let res = f () in
+  Mutex.unlock m;
+  res
+
 module Json = struct
   type t = Yojson.Safe.t
 

--- a/fiber-unix/src/mvar.ml
+++ b/fiber-unix/src/mvar.ml
@@ -1,0 +1,25 @@
+open Import
+
+type 'a t =
+  { m : Mutex.t
+  ; cv : Condition.t
+  ; mutable cell : 'a option
+  }
+
+let create () = { m = Mutex.create (); cv = Condition.create (); cell = None }
+
+let get t =
+  let rec await_value t =
+    match t.cell with
+    | None ->
+      Condition.wait t.cv t.m;
+      await_value t
+    | Some v ->
+      t.cell <- None;
+      v
+  in
+  with_mutex t.m ~f:(fun () -> await_value t)
+
+let set t v =
+  with_mutex t.m ~f:(fun () -> t.cell <- Some v);
+  Condition.signal t.cv

--- a/fiber-unix/src/mvar.mli
+++ b/fiber-unix/src/mvar.mli
@@ -1,0 +1,7 @@
+type 'a t
+
+val create : unit -> 'a t
+
+val get : 'a t -> 'a
+
+val set : 'a t -> 'a -> unit

--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -200,9 +200,7 @@ let time_loop t =
     let to_run = ref [] in
     let earliest_next = ref None in
     with_mutex t.time_mutex ~f:(fun () ->
-        if is_empty t.timers then
-          ()
-        else
+        if not (is_empty t.timers) then
           let now = Unix.gettimeofday () in
           Table.filteri_inplace t.timers ~f:(fun ~key:_ ~data:active_timer ->
               let active_timer = !active_timer in

--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -1,39 +1,5 @@
 open Import
 
-module Mvar : sig
-  type 'a t
-
-  val create : unit -> 'a t
-
-  val get : 'a t -> 'a
-
-  val set : 'a t -> 'a -> unit
-end = struct
-  type 'a t =
-    { m : Mutex.t
-    ; cv : Condition.t
-    ; mutable cell : 'a option
-    }
-
-  let create () = { m = Mutex.create (); cv = Condition.create (); cell = None }
-
-  let get t =
-    let rec await_value t =
-      match t.cell with
-      | None ->
-        Condition.wait t.cv t.m;
-        await_value t
-      | Some v ->
-        t.cell <- None;
-        v
-    in
-    with_mutex t.m ~f:(fun () -> await_value t)
-
-  let set t v =
-    with_mutex t.m ~f:(fun () -> t.cell <- Some v);
-    Condition.signal t.cv
-end
-
 module Worker : sig
   (** Simple queue that is consumed by its own thread *)
   type 'work t

--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -1,11 +1,5 @@
 open Import
 
-let with_mutex m ~f =
-  Mutex.lock m;
-  let res = f () in
-  Mutex.unlock m;
-  res
-
 module Mvar : sig
   type 'a t
 

--- a/fiber-unix/test/barrier_tests.ml
+++ b/fiber-unix/test/barrier_tests.ml
@@ -1,0 +1,37 @@
+module Barrier = Fiber_unix.Private.Barrier
+
+let print_result x =
+  print_endline
+    ( match x with
+    | Ok () -> "ok"
+    | Error (`Closed (`Read b)) -> Printf.sprintf "closed: %b" b
+    | Error `Timeout -> "timeout" )
+
+let%expect_test "create & close" =
+  let b = Barrier.create () in
+  Barrier.close b;
+  [%expect {||}]
+
+let%expect_test "write" =
+  let b = Barrier.create () in
+  Barrier.signal b;
+  Barrier.close b;
+  [%expect {||}]
+
+let%expect_test "timeout" =
+  let b = Barrier.create () in
+  print_result (Barrier.await b ~timeout:0.1);
+  Barrier.close b;
+  [%expect {|
+    timeout |}]
+
+let%expect_test "read and write" =
+  let b = Barrier.create () in
+  Barrier.signal b;
+  Barrier.signal b;
+  print_result (Barrier.await b ~timeout:0.1);
+  print_result (Barrier.await b ~timeout:0.1);
+  Barrier.close b;
+  [%expect {|
+    ok
+    timeout |}]

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -184,7 +184,7 @@ let%expect_test "ent to end run of lsp tests" =
      Please change this test to not include a backtrace. *)
 
   ("Fiber_unix__Scheduler.Abort(1)")
-  Raised at Fiber_unix__Scheduler.run in file "fiber-unix/src/scheduler.ml", line 399, characters 15-30
+  Raised at Fiber_unix__Scheduler.run in file "fiber-unix/src/scheduler.ml", line 388, characters 15-30
   Called from Lsp_fiber_tests__Lsp_fiber_test.(fun) in file "lsp-fiber/test/lsp_fiber_test.ml", line 177, characters 2-66
   Called from Expect_test_collector.Make.Instance.exec in file "collector/expect_test_collector.ml", line 244, characters 12-19
 


### PR DESCRIPTION
The previous implementation relied on Thread.delay which was not
interruptible once the awaker was already asleep and we were waiting to
write into the mvar.

Barrier is a poor man's implementation of `pthread_cond_wait`, which I tried to
avoid binding to. @mnxn could you check that this work on windows?