### PR TITLE
External config readers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,6 @@ possible and does not make any assumptions about IO.
   cppo
   uutf
   csexp
-  dot-merlin-reader
   (menhir :with-test)
   (cinaps :with-test)
   (ppx_expect (and :with-test (>= v0.14.0)))
@@ -53,6 +52,7 @@ possible and does not make any assumptions about IO.
   menhir
   ppx_yojson_conv_lib
   dune-build-info
+  dot-merlin-reader
   (csexp (>= 1.2.3))
   (result (>= 1.5))
   (ocamlformat :with-test)

--- a/lsp.opam
+++ b/lsp.opam
@@ -28,7 +28,6 @@ depends: [
   "cppo"
   "uutf"
   "csexp"
-  "dot-merlin-reader"
   "menhir" {with-test}
   "cinaps" {with-test}
   "ppx_expect" {with-test & >= "v0.14.0"}

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -21,6 +21,7 @@ depends: [
   "menhir"
   "ppx_yojson_conv_lib"
   "dune-build-info"
+  "dot-merlin-reader"
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}
   "ocamlformat" {with-test}

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -106,11 +106,7 @@ let make_config uri =
       query = { mconfig.query with verbosity = 1; filename; directory }
     }
   in
-  Mconfig.load_dotmerlins mconfig
-    ~filenames:
-      [ (let base = "." ^ filename ^ ".merlin" in
-         Filename.concat directory base)
-      ]
+  Mconfig.get_external_config path mconfig
 
 let make_pipeline thread tdoc =
   let async_make_pipeline =


### PR DESCRIPTION
This PR will enable the use of the new Merlin configuration system.

Its merging should be accompanied by an update of the vendored `merlin` that removes the commit [@rgrinberg/merlin#3746f6b](https://github.com/rgrinberg/merlin/commit/3746f6bdf4f7be99f71f2d42a127b3d64b8127d0) that reverts external readers-related changes.

Once merged, we will be able to merge the Dune PR that removes the promotion of `.merlin` files: [dune#3554](https://github.com/ocaml/dune/pull/3554)

(without the right vendored merlin it is expected that the CI will fail)