### PR TITLE
Add ocamllsp/inferIntf as a custom request

### DIFF
--- a/ocaml-lsp-server/docs/ocamllsp/inferIntf-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/inferIntf-spec.md
@@ -7,6 +7,9 @@ The document URI in the request has to be open before sending a the request.
 
 If the file cannot be found in the document store, an error will be returned.
 
+Warning: this custom request is meant to be consumed by `ocaml-vscode-platform` exclusively,
+it can be removed any time and should not be relied on.
+
 ##### Client capability
 
 nothing that should be noted

--- a/ocaml-lsp-server/docs/ocamllsp/inferIntf-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/inferIntf-spec.md
@@ -1,0 +1,27 @@
+#### Infer Interface Request
+
+Infer Interface Request is sent from the client to the server to get the infered
+interface for a given module implementation.
+
+The document URI in the request has to be open before sending a the request.
+
+If the file cannot be found in the document store, an error will be returned.
+
+##### Client capability
+
+nothing that should be noted
+
+##### Server capability
+
+property name: `handleInferIntf`
+property type: `boolean`
+
+##### Request
+
+- method: `ocamllsp/inferIntf`
+- params: `DocumentUri` (see [`DocumentUri`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#uri) in LSP specification)
+
+##### Response
+
+- result: String
+- error: code and message set in case an exception happens during the processing of the request.

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -2,20 +2,6 @@ open Import
 
 let action_kind = "inferred_intf"
 
-let infer_intf impl =
-  Document.with_pipeline impl (fun pipeline ->
-      let typer = Mpipeline.typer_result pipeline in
-      let pos = Mpipeline.get_lexing_pos pipeline `Start in
-      let env, _ = Mbrowse.leaf_node (Mtyper.node_at typer pos) in
-      let sig_ : Types.signature =
-        let typedtree = Mtyper.get_typedtree typer in
-        match typedtree with
-        | `Interface _ -> assert false
-        | `Implementation impl -> impl.str_type
-      in
-      Printtyp.wrap_printing_env env (fun () ->
-          Format.asprintf "%a@." Printtyp.signature sig_))
-
 let code_action_of_intf uri intf range =
   let edit : WorkspaceEdit.t =
     let textedit : TextEdit.t = { range; newText = intf } in
@@ -26,46 +12,13 @@ let code_action_of_intf uri intf range =
   CodeAction.create ~title ~kind:(CodeActionKind.Other action_kind) ~edit
     ~isPreferred:false ()
 
-let language_id_of_fname s =
-  match Filename.extension s with
-  | ".mli" -> "ocaml.interface"
-  | ".ml" -> "ocaml"
-  | ".rei"
-  | ".re" ->
-    "reason"
-  | ".mll" -> "ocaml.ocamllex"
-  | ".mly" -> "ocaml.menhir"
-  | ext -> failwith ("Unknown extension " ^ ext)
-
-let force_open_document (state : State.t) uri =
-  let open Fiber.O in
-  let filename = Uri.to_path uri in
-  let text = Io.read_file (Fpath.of_string filename) in
-  let delay = Configuration.diagnostics_delay state.configuration in
-  let timer = Scheduler.create_timer state.scheduler ~delay in
-  let languageId = language_id_of_fname filename in
-  let text_document =
-    Lsp.Types.TextDocumentItem.create ~uri:(Uri.to_string uri) ~languageId
-      ~version:0 ~text
-  in
-  let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
-  let+ doc = Document.make timer state.merlin params in
-  Document_store.put state.store doc;
-  doc
-
 let code_action doc (state : State.t) (params : CodeActionParams.t) =
   let open Fiber.O in
   match Document.kind doc with
   | Impl -> Fiber.return (Ok None)
   | Intf -> (
-    let intf_uri = Document.uri doc in
-    let impl_uri = Document.get_impl_intf_counterparts intf_uri |> List.hd in
-    let* impl =
-      match Document_store.get_opt state.store impl_uri with
-      | None -> force_open_document state impl_uri
-      | Some impl -> Fiber.return impl
-    in
-    let+ intf = infer_intf impl in
+    let+ intf = Inference.infer_intf ~force_open_impl:true state doc in
     match intf with
     | Error e -> Error (Jsonrpc.Response.Error.of_exn e)
-    | Ok intf -> Ok (Some (code_action_of_intf intf_uri intf params.range)) )
+    | Ok intf ->
+      Ok (Some (code_action_of_intf (Document.uri doc) intf params.range)) )

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -1,0 +1,30 @@
+open Import
+
+let capability = ("handleInferIntf", `Bool true)
+
+let meth = "ocamllsp/inferIntf"
+
+let on_request ~(params : Json.t option) (state : State.t) =
+  match params with
+  | Some (`String (_ : DocumentUri.t) as json_uri) -> (
+    let open Fiber.O in
+    match Document_store.get_opt state.store (Uri.t_of_yojson json_uri) with
+    | None ->
+      Fiber.return
+      @@ Error
+           (Jsonrpc.Response.Error.make ~code:InvalidParams
+              ~message:
+                "ocamllsp/inferIntf received a URI for an unloaded file. Load \
+                 the file first."
+              ())
+    | Some impl -> (
+      let+ intf = Inference.infer_intf_for_impl impl in
+      match intf with
+      | Error e -> Error (Jsonrpc.Response.Error.of_exn e)
+      | Ok intf -> Ok (Json.t_of_yojson (`String intf), state) ) )
+  | Some _
+  | None ->
+    Fiber.return
+    @@ Error
+         (Jsonrpc.Response.Error.make ~code:InvalidRequest
+            ~message:"ocamllsp/inferIntf must receive param : DocumentUri.t" ())

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
@@ -1,0 +1,10 @@
+open Import
+
+val capability : string * Json.t
+
+val meth : string
+
+val on_request :
+     params:Json.t option
+  -> State.t
+  -> (Json.t * State.t, Jsonrpc.Response.Error.t) result Fiber.t

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -1,0 +1,68 @@
+open Import
+
+let infer_intf_for_impl doc =
+  match Document.kind doc with
+  | Intf ->
+    Fiber.return
+      (Error
+         (Invalid_argument "the provided document is not an implementation."))
+  | Impl ->
+    Document.with_pipeline doc (fun pipeline ->
+        let typer = Mpipeline.typer_result pipeline in
+        let pos = Mpipeline.get_lexing_pos pipeline `Start in
+        let env, _ = Mbrowse.leaf_node (Mtyper.node_at typer pos) in
+        let sig_ : Types.signature =
+          let typedtree = Mtyper.get_typedtree typer in
+          match typedtree with
+          | `Interface _ -> assert false
+          | `Implementation doc -> doc.str_type
+        in
+        Printtyp.wrap_printing_env env (fun () ->
+            Format.asprintf "%a@." Printtyp.signature sig_))
+
+let language_id_of_fname s =
+  match Filename.extension s with
+  | ".mli" -> "ocaml.interface"
+  | ".ml" -> "ocaml"
+  | ".rei"
+  | ".re" ->
+    "reason"
+  | ".mll" -> "ocaml.ocamllex"
+  | ".mly" -> "ocaml.menhir"
+  | ext -> failwith ("Unknown extension " ^ ext)
+
+let force_open_document (state : State.t) uri =
+  let open Fiber.O in
+  let filename = Uri.to_path uri in
+  let text = Io.read_file (Fpath.of_string filename) in
+  let delay = Configuration.diagnostics_delay state.configuration in
+  let timer = Scheduler.create_timer state.scheduler ~delay in
+  let languageId = language_id_of_fname filename in
+  let text_document =
+    Lsp.Types.TextDocumentItem.create ~uri:(Uri.to_string uri) ~languageId
+      ~version:0 ~text
+  in
+  let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
+  let+ doc = Document.make timer state.merlin params in
+  Document_store.put state.store doc;
+  doc
+
+let infer_intf ~force_open_impl (state : State.t) doc =
+  let open Fiber.Result.O in
+  match Document.kind doc with
+  | Impl ->
+    Fiber.return
+      (Error (Invalid_argument "the provided document is not an interface."))
+  | Intf ->
+    let intf_uri = Document.uri doc in
+    let impl_uri = Document.get_impl_intf_counterparts intf_uri |> List.hd in
+    let* impl =
+      match (Document_store.get_opt state.store impl_uri, force_open_impl) with
+      | None, false ->
+        Fiber.return
+          (Error
+             (Failure "The implementation for this interface has not been open."))
+      | None, true -> force_open_document state impl_uri |> Fiber.Result.lift
+      | Some impl, _ -> Fiber.Result.return impl
+    in
+    infer_intf_for_impl impl

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -2,10 +2,7 @@ open Import
 
 let infer_intf_for_impl doc =
   match Document.kind doc with
-  | Intf ->
-    Fiber.return
-      (Error
-         (Invalid_argument "the provided document is not an implementation."))
+  | Intf -> failwith "the provided document is not an implementation."
   | Impl ->
     Document.with_pipeline doc (fun pipeline ->
         let typer = Mpipeline.typer_result pipeline in

--- a/ocaml-lsp-server/src/inference.mli
+++ b/ocaml-lsp-server/src/inference.mli
@@ -1,0 +1,4 @@
+val infer_intf_for_impl : Document.t -> (string, exn) result Fiber.t
+
+val infer_intf :
+  force_open_impl:bool -> State.t -> Document.t -> (string, exn) result Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -44,6 +44,7 @@ let initialize_info : InitializeResult.t =
           , `Assoc
               [ ("interfaceSpecificLangId", `Bool true)
               ; Req_switch_impl_intf.capability
+              ; Req_infer_intf.capability
               ] )
         ]
     in
@@ -662,7 +663,9 @@ let on_request :
   match req with
   | Client_request.UnknownRequest { meth; params } -> (
     match
-      [ (Req_switch_impl_intf.meth, Req_switch_impl_intf.on_request) ]
+      [ (Req_switch_impl_intf.meth, Req_switch_impl_intf.on_request)
+      ; (Req_infer_intf.meth, Req_infer_intf.on_request)
+      ]
       |> List.assoc_opt meth
     with
     | None ->

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
@@ -1,0 +1,50 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Types from "vscode-languageserver-types";
+
+describe("ocamllsp/inferIntf", () => {
+  let languageServer = null;
+
+  async function openDocument(source, name) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///" + name,
+        "ocaml",
+        0,
+        source,
+      ),
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  async function inferIntf(name) {
+    return await languageServer.sendRequest(
+      "ocamllsp/inferIntf",
+      "file:///" + name,
+    );
+  }
+
+  it("can infer module interfaces", async () => {
+    await openDocument(
+      outdent`
+type t = Foo of int | Bar of bool
+
+let f (x : t) = x
+`,
+      "test.ml",
+    );
+    let actions = await inferIntf("test.ml");
+    expect(actions).toEqual(
+      "type t = Foo of int | Bar of bool\nval f : t -> t\n",
+    );
+  });
+});

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -90,11 +90,11 @@ let f (x : t) = x
               {
                 newText: "type t = Foo of int | Bar of bool\nval f : t -> t\n",
                 range: {
-                  end: {
+                  start: {
                     character: 0,
                     line: 0,
                   },
-                  start: {
+                  end: {
                     character: 0,
                     line: 0,
                   },


### PR DESCRIPTION
I've been experimenting with `workspace/applyEdit`.

I tried two options:

- Sending the request when receiving a `didOpen` for an interface that does not yet exist. Unfortunately, it does not work because VSCode does not send `didOpen` notifications for file previews. And if we save the file, then there's no way to know if the file is new or if it already exists, in which case we should not try to initialize it.

- Sending a notification when switching from an implementation to an interface that does not exist. Unfortunately, the `applyEdit` request does not seem to be processed by VSCode. Moreover, the implementation file might not be in the store, so we would need to open it manually in this case, which seem hacky.

After experimenting with it, I still think a custom request is our best option there. Since we already provide the interface inference feature through a code action that can be triggered manually, the fact that this feature will only be available on VSCode seems acceptable to me.

I'm open to other suggestions on how we could provide it with normal LSP capabilities though, let me know if you have any other idea.