### PR TITLE
jsonrpc: client side cancellation api

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -271,4 +271,6 @@ struct
     let ivar = Fiber.Ivar.create () in
     Table.add_exn t.pending req.id ivar;
     Fiber.Ivar.read ivar
+
+  let cancel t id = Table.remove t.pending id
 end

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -8,11 +8,15 @@ module Notify : sig
 end
 
 module Reply : sig
+  type with_ =
+    | Response of Response.t
+    | Cancel
+
   type t
 
-  val now : Response.t -> t
+  val later : ((with_ -> unit Fiber.t) -> unit Fiber.t) -> t
 
-  val later : ((Response.t -> unit Fiber.t) -> unit Fiber.t) -> t
+  val now : Response.t -> t
 end
 
 (** IO free implementation of the jsonrpc protocol. We stay completely agnostic

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -65,4 +65,6 @@ end) : sig
   val notification : _ t -> Message.notification -> unit Fiber.t
 
   val request : _ t -> Message.request -> Response.t Fiber.t
+
+  val cancel : _ t -> Jsonrpc.Id.t -> unit
 end

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -142,7 +142,7 @@ let%expect_test "concurrent requests" =
             in
             print_endline "waiter: received response:";
             print (Response response);
-            let* () = send (Jsonrpc.Response.ok request.id `Null) in
+            let* () = send (Response (Jsonrpc.Response.ok request.id `Null)) in
             print_endline "waiter: stopping";
             let+ () = Jrpc.stop self in
             print_endline "waiter: stopped")
@@ -158,7 +158,9 @@ let%expect_test "concurrent requests" =
       print (Message { request with id = Some request.id });
       let response =
         Reply.later (fun send ->
-            let* () = send (Jsonrpc.Response.ok request.id (`Int 42)) in
+            let* () =
+              send (Response (Jsonrpc.Response.ok request.id (`Int 42)))
+            in
             if request.method_ = "shutdown" then (
               let self = Context.session c in
               print_endline "waitee: stopping";


### PR DESCRIPTION
This PR adds the minimum api to jsonrpc to support cancellation. Proper
cancellation will be built on top of lsp using this API.