### PR TITLE
Implement basic cancellation

### DIFF
--- a/lsp-fiber/src/import.ml
+++ b/lsp-fiber/src/import.ml
@@ -333,3 +333,11 @@ module Client_request = Lsp.Client_request
 module Server_request = Lsp.Server_request
 module Server_notification = Lsp.Server_notification
 module Client_notification = Lsp.Client_notification
+
+module Jrpc_id = struct
+  include Jsonrpc.Id
+
+  let to_dyn = function
+    | `String s -> Dyn.String s
+    | `Int i -> Dyn.Int i
+end

--- a/lsp-fiber/src/rpc.mli
+++ b/lsp-fiber/src/rpc.mli
@@ -50,6 +50,8 @@ module type S = sig
     _ t -> 'resp out_request -> ('resp, Response.Error.t) result Fiber.t
 
   val notification : _ t -> out_notification -> unit Fiber.t
+
+  val on_cancel : (unit -> unit Fiber.t) -> unit
 end
 
 module Client : sig


### PR DESCRIPTION
Now `$/cancelRequest` is used to release positions in the merlin queue

In the future, we'll need something a little more robust. Such as:

- Run cancellers inside Fiber_detached
- Allow to hook finalizers as well as cancellers