### PR TITLE
Use completion prefix to determine active signature help parameter

### DIFF
--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -26,3 +26,6 @@ val resolve :
   -> (Document.t -> [> `Logical of int * int ] -> string option Fiber.t)
   -> markdown:bool
   -> (CompletionItem.t, Jsonrpc.Response.Error.t) result Fiber.t
+
+val prefix_of_position :
+  short_path:bool -> Msource.t -> [< Msource.position ] -> string

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -354,7 +354,10 @@ let signature_help (state : State.t)
   let* doc = Fiber.return (Document_store.get store uri) in
   let pos = Position.logical position in
   let prefix =
-    Compl.prefix_of_position (Document.source doc) pos ~short_path:false
+    (* The value of [short_path] doesn't make a difference to the final result
+       because labels cannot include dots. However, a true value is slightly
+       faster for getting the prefix. *)
+    Compl.prefix_of_position (Document.source doc) pos ~short_path:true
   in
   Document.with_pipeline_exn doc (fun pipeline ->
       let typer = Mpipeline.typer_result pipeline in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -183,4 +183,29 @@ describe_opt("textDocument/completion", () => {
       activeParameter: 1,
     });
   });
+
+  it("can make an optional parameter active by prefix", async () => {
+    openDocument(outdent`
+      let _ = Hashtbl.create ?ra
+    `);
+
+    let items = await querySignatureHelp(Types.Position.create(0, 26));
+    expect(items).toMatchObject({
+      signatures: [
+        {
+          label: "Hashtbl.create : ?random:bool -> int -> ('a, 'b) Hashtbl.t",
+          parameters: [
+            {
+              label: [17, 29],
+            },
+            {
+              label: [33, 36],
+            },
+          ],
+        },
+      ],
+      activeSignature: 0,
+      activeParameter: 0,
+    });
+  });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -87,6 +87,28 @@ describe_opt("textDocument/completion", () => {
     });
   });
 
+  it("can provide signature help for an anonymous function", async () => {
+    openDocument(outdent`
+      let _ = (fun x -> x + 1)
+    `);
+
+    let items = await querySignatureHelp(Types.Position.create(0, 26));
+    expect(items).toMatchObject({
+      signatures: [
+        {
+          label: "_ : int -> int",
+          parameters: [
+            {
+              label: [4, 7],
+            },
+          ],
+        },
+      ],
+      activeSignature: 0,
+      activeParameter: 0,
+    });
+  });
+
   it("can make the non-labelled parameter active", async () => {
     openDocument(outdent`
       let _ = ListLabels.map []

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -136,4 +136,29 @@ describe_opt("textDocument/completion", () => {
       activeParameter: 0,
     });
   });
+
+  it("can make a labelled parameter active by prefix", async () => {
+    openDocument(outdent`
+      let _ = ListLabels.mem ~se
+    `);
+
+    let items = await querySignatureHelp(Types.Position.create(0, 26));
+    expect(items).toMatchObject({
+      signatures: [
+        {
+          label: "ListLabels.mem : 'a -> set:'a list -> bool",
+          parameters: [
+            {
+              label: [17, 19],
+            },
+            {
+              label: [23, 34],
+            },
+          ],
+        },
+      ],
+      activeSignature: 0,
+      activeParameter: 1,
+    });
+  });
 });


### PR DESCRIPTION
Depends on https://github.com/rgrinberg/merlin/pull/9

Passes the result of `Compl.prefix_of_position` to merlin so it can determine which labelled parameter is active.

Original issue pointed out in this comment: https://github.com/ocaml/ocaml-lsp/pull/324#issuecomment-737107231

Examples: 

![image](https://user-images.githubusercontent.com/25037249/100948537-e840f800-34bc-11eb-9585-2a338c2afa1c.png)

![image](https://user-images.githubusercontent.com/25037249/100948604-17f00000-34bd-11eb-9315-790f701e3f86.png)
