### PR TITLE
Support new languageclient format

### DIFF
--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -17,10 +17,17 @@ let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
 let on_request ~(params : Json.t option) _ =
   Fiber.return
     ( match params with
-    | Some (`String (file_uri : DocumentUri.t)) -> switch file_uri
-    | Some _
+    | Some (`String (file_uri : DocumentUri.t))
+    | Some (`List [ `String (file_uri : DocumentUri.t) ]) ->
+      switch file_uri
+    | Some json ->
+      Error
+        (Jsonrpc.Response.Error.make ~code:InvalidRequest
+           ~message:"The input parameter for ocamllsp/switchImplIntf is invalid"
+           ~data:(`Assoc [ ("param", json) ])
+           ())
     | None ->
       Error
         (Jsonrpc.Response.Error.make ~code:InvalidRequest
-           ~message:"ocamllsp/switchImplIntf must receive param : DocumentUri.t"
+           ~message:"ocamllsp/switchImplIntf must receive param: DocumentUri.t"
            ()) )


### PR DESCRIPTION
It seems that `vscode-languageclient.7.0.0` changed the way parameters are send to the LSP servers for custom requests and now send a list of string when sending a string. This broke out custom requests. This PR handles the new format send by VSCode client.