### PR TITLE
Comply to jsonrpc spec

### DIFF
--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -46,7 +46,7 @@ let%expect_test "server accepts notifications" =
   let notif =
     { Jsonrpc.Message.id = None
     ; method_ = "method"
-    ; params = Some (`String "bar")
+    ; params = Some (`List [ `String "bar" ])
     }
   in
   let run () =
@@ -91,7 +91,10 @@ let%expect_test "stopped fiber" =
 let%expect_test "serving requests" =
   let id = `Int 1 in
   let request =
-    { Jsonrpc.Message.id = Some id; method_ = "bla"; params = Some (`Int 100) }
+    { Jsonrpc.Message.id = Some id
+    ; method_ = "bla"
+    ; params = Some (`List [ `Int 100 ])
+    }
   in
   let response_data = `String "response" in
   let run () =
@@ -233,10 +236,10 @@ let%expect_test "test from jsonrpc_test.ml" =
       Jsonrpc.Message.create ~id:None ?params ~method_ ()
     in
     [ Message (request (`Int 10) "foo")
-    ; Message (request ~params:`Null (`String "testing") "bar")
-    ; Message (notification ~params:`Null "notif1")
-    ; Message (notification ~params:`Null "notif2")
-    ; Message (notification ~params:`Null "raise")
+    ; Message (request (`String "testing") "bar")
+    ; Message (notification "notif1")
+    ; Message (notification "notif2")
+    ; Message (notification "raise")
     ]
   in
   let reqs_in, reqs_out = pipe () in
@@ -262,11 +265,11 @@ let%expect_test "test from jsonrpc_test.ml" =
   [%expect
     {|
     >> received notification
-    { "params": null, "method": "notif1", "jsonrpc": "2.0" }
+    { "method": "notif1", "jsonrpc": "2.0" }
     >> received notification
-    { "params": null, "method": "notif2", "jsonrpc": "2.0" }
+    { "method": "notif2", "jsonrpc": "2.0" }
     Uncaught error when handling notification:
-    { "params": null, "method": "raise", "jsonrpc": "2.0" }
+    { "method": "raise", "jsonrpc": "2.0" }
     Error:
     [ { exn = "(Failure \"special failure\")"; backtrace = "" } ]
     "<opaque>"

--- a/jsonrpc/src/jsonrpc.mli
+++ b/jsonrpc/src/jsonrpc.mli
@@ -15,15 +15,26 @@ module Id : sig
 end
 
 module Message : sig
+  module Structured : sig
+    type t =
+      [ `Assoc of (string * Json.t) list
+      | `List of Json.t list
+      ]
+
+    val of_json : Json.t -> t
+
+    val to_json : t -> Json.t
+  end
+
   type 'id t =
     { id : 'id
     ; method_ : string
-    ; params : Json.t option
+    ; params : Structured.t option
     }
 
   val params : _ t -> (Json.t -> 'a) -> ('a, string) Result.t
 
-  val create : ?params:Json.t -> id:'id -> method_:string -> unit -> 'id t
+  val create : ?params:Structured.t -> id:'id -> method_:string -> unit -> 'id t
 
   type request = Id.t t
 

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -209,7 +209,7 @@ let%expect_test "ent to end run of lsp tests" =
   [%expect.unreachable]
   [@@expect.uncaught_exn
     {|
-  ("Fiber_unix__Scheduler.Abort(1)")
+  ("Fiber_unix__Scheduler.Abort(_)")
   Trailing output
   ---------------
   client: waiting for initialization
@@ -229,5 +229,4 @@ let%expect_test "ent to end run of lsp tests" =
   client: received notification
   window/showMessage
   client: filled received_notification
-  client: sending request to shutdown
-  Test failed to terminate inside 3.00 seconds |}]
+  client: sending request to shutdown |}]

--- a/lsp/src/client_notification.ml
+++ b/lsp/src/client_notification.ml
@@ -76,5 +76,5 @@ let of_jsonrpc (r : Jsonrpc.Message.notification) =
 
 let to_jsonrpc t =
   let method_ = method_ t in
-  let params = Some (yojson_of_t t) in
+  let params = Some (Jsonrpc.Message.Structured.of_json (yojson_of_t t)) in
   { Jsonrpc.Message.id = (); params; method_ }

--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -65,7 +65,7 @@ type _ t =
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
   | UnknownRequest :
       { meth : string
-      ; params : Json.t option
+      ; params : Jsonrpc.Message.Structured.t option
       }
       -> Json.t t
 
@@ -227,10 +227,11 @@ let method_ (type a) (t : a t) =
   | _ -> assert false
 
 let params (type a) (t : a t) =
-  match t with
-  | Initialize params -> InitializeParams.yojson_of_t params
-  | ExecuteCommand params -> ExecuteCommandParams.yojson_of_t params
-  | _ -> assert false
+  Jsonrpc.Message.Structured.of_json
+    ( match t with
+    | Initialize params -> InitializeParams.yojson_of_t params
+    | ExecuteCommand params -> ExecuteCommandParams.yojson_of_t params
+    | _ -> assert false )
 
 let to_jsonrpc_request t ~id =
   let method_ = method_ t in

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -65,7 +65,7 @@ type _ t =
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
   | UnknownRequest :
       { meth : string
-      ; params : Json.t option
+      ; params : Jsonrpc.Message.Structured.t option
       }
       -> Json.t t
 
@@ -81,5 +81,7 @@ val response_of_json : 'a t -> Json.t -> 'a
 
 val text_document :
      _ t
-  -> (meth:string -> params:Json.t option -> TextDocumentIdentifier.t option)
+  -> (   meth:string
+      -> params:Jsonrpc.Message.Structured.t option
+      -> TextDocumentIdentifier.t option)
   -> TextDocumentIdentifier.t option

--- a/lsp/src/server_notification.ml
+++ b/lsp/src/server_notification.ml
@@ -28,7 +28,7 @@ let yojson_of_t = function
 
 let to_jsonrpc t =
   let method_ = method_ t in
-  let params = Some (yojson_of_t t) in
+  let params = Some (Jsonrpc.Message.Structured.of_json (yojson_of_t t)) in
   { Jsonrpc.Message.id = (); params; method_ }
 
 let of_jsonrpc (r : Jsonrpc.Message.notification) =

--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -12,7 +12,7 @@ type _ t =
   | ShowMessageRequest :
       ShowMessageRequestParams.t
       -> MessageActionItem.t option t
-  | UnknownRequest : string * Json.t option -> Json.t t
+  | UnknownRequest : string * Jsonrpc.Message.Structured.t option -> Json.t t
 
 type packed = E : 'r t -> packed
 
@@ -27,14 +27,16 @@ let method_ (type a) (t : a t) =
   | UnknownRequest _ -> assert false
 
 let params (type a) (t : a t) =
-  match t with
-  | WorkspaceApplyEdit params -> ApplyWorkspaceEditParams.yojson_of_t params
-  | WorkspaceFolders -> `Null
-  | WorkspaceConfiguration params -> ConfigurationParams.yojson_of_t params
-  | ClientRegisterCapability params -> RegistrationParams.yojson_of_t params
-  | ClientUnregisterCapability params -> UnregistrationParams.yojson_of_t params
-  | ShowMessageRequest params -> ShowMessageRequestParams.yojson_of_t params
-  | UnknownRequest (_, _) -> assert false
+  Jsonrpc.Message.Structured.of_json
+    ( match t with
+    | WorkspaceApplyEdit params -> ApplyWorkspaceEditParams.yojson_of_t params
+    | WorkspaceFolders -> `Null
+    | WorkspaceConfiguration params -> ConfigurationParams.yojson_of_t params
+    | ClientRegisterCapability params -> RegistrationParams.yojson_of_t params
+    | ClientUnregisterCapability params ->
+      UnregistrationParams.yojson_of_t params
+    | ShowMessageRequest params -> ShowMessageRequestParams.yojson_of_t params
+    | UnknownRequest (_, _) -> assert false )
 
 let to_jsonrpc_request t ~id =
   let method_ = method_ t in

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -12,7 +12,7 @@ type _ t =
   | ShowMessageRequest :
       ShowMessageRequestParams.t
       -> MessageActionItem.t option t
-  | UnknownRequest : string * Json.t option -> Json.t t
+  | UnknownRequest : string * Jsonrpc.Message.Structured.t option -> Json.t t
 
 type packed = E : 'r t -> packed
 

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -7,7 +7,7 @@ let meth = "ocamllsp/inferIntf"
 let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
     =
   match params with
-  | Some (`List [ `String (_ : DocumentUri.t) ] as json_uri) -> (
+  | Some (`List [ (`String (_ : DocumentUri.t) as json_uri) ]) -> (
     let open Fiber.O in
     match Document_store.get_opt state.store (Uri.t_of_yojson json_uri) with
     | None ->

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -4,9 +4,9 @@ let capability = ("handleInferIntf", `Bool true)
 
 let meth = "ocamllsp/inferIntf"
 
-let on_request ~(params : Json.t option) (state : State.t) =
+let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
+    =
   match params with
-  | Some (`String (_ : DocumentUri.t) as json_uri)
   | Some (`List [ `String (_ : DocumentUri.t) ] as json_uri) -> (
     let open Fiber.O in
     match Document_store.get_opt state.store (Uri.t_of_yojson json_uri) with
@@ -28,7 +28,7 @@ let on_request ~(params : Json.t option) (state : State.t) =
     @@ Error
          (Jsonrpc.Response.Error.make ~code:InvalidRequest
             ~message:"The input parameter for ocamllsp/inferIntf is invalid"
-            ~data:(`Assoc [ ("param", json) ])
+            ~data:(`Assoc [ ("param", (json :> Json.t)) ])
             ())
   | None ->
     Fiber.return

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
@@ -5,6 +5,6 @@ val capability : string * Json.t
 val meth : string
 
 val on_request :
-     params:Json.t option
+     params:Jsonrpc.Message.Structured.t option
   -> State.t
   -> (Json.t, Jsonrpc.Response.Error.t) result Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -9,22 +9,17 @@ let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
   let files_to_switch_to =
     Document.get_impl_intf_counterparts (Uri.t_of_yojson (`String param))
   in
-  Ok
-    (Json.yojson_of_list
-       (fun uri -> uri |> Uri.to_string |> fun s -> `String s)
-       files_to_switch_to)
+  Ok (Json.yojson_of_list Uri.yojson_of_t files_to_switch_to)
 
-let on_request ~(params : Json.t option) _ =
+let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
   Fiber.return
     ( match params with
-    | Some (`String (file_uri : DocumentUri.t))
-    | Some (`List [ `String (file_uri : DocumentUri.t) ]) ->
-      switch file_uri
+    | Some (`List [ `String (file_uri : DocumentUri.t) ]) -> switch file_uri
     | Some json ->
       Error
         (Jsonrpc.Response.Error.make ~code:InvalidRequest
            ~message:"The input parameter for ocamllsp/switchImplIntf is invalid"
-           ~data:(`Assoc [ ("param", json) ])
+           ~data:(`Assoc [ ("param", (json :> Json.t)) ])
            ())
     | None ->
       Error

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
@@ -5,4 +5,6 @@ val capability : string * Json.t
 val meth : string
 
 val on_request :
-  params:Json.t option -> _ -> (Json.t, Jsonrpc.Response.Error.t) result Fiber.t
+     params:Jsonrpc.Message.Structured.t option
+  -> _
+  -> (Json.t, Jsonrpc.Response.Error.t) result Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -855,7 +855,7 @@ let on_notification server (notification : Client_notification.t) :
         log ~title:Logger.Title.Warning "unknown notification: %s %a"
           req.method_
           (fun () -> Json.to_pretty_string)
-          json );
+          (json :> Json.t) );
       Fiber.return state )
 
 let start () =

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
@@ -26,11 +26,10 @@ describe("ocamllsp/inferIntf", () => {
     languageServer = null;
   });
 
-  async function inferIntf(name) {
-    return await languageServer.sendRequest(
-      "ocamllsp/inferIntf",
-      "file:///" + name,
-    );
+  async function inferIntf(name: string) {
+    return await languageServer.sendRequest("ocamllsp/inferIntf", [
+      `file:///${name}`,
+    ]);
   }
 
   it("can infer module interfaces", async () => {

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -18,7 +18,7 @@ describe("ocamllsp/switchImplIntf", () => {
   async function ocamllspSwitchImplIntf(
     documentUri: DocumentUri,
   ): Promise<Array<DocumentUri>> {
-    return languageServer.sendRequest("ocamllsp/switchImplIntf", documentUri);
+    return languageServer.sendRequest("ocamllsp/switchImplIntf", [documentUri]);
   }
 
   let testWorkspacePath = path.join(__dirname, "..", "test_files/");


### PR DESCRIPTION
Only objects or arrays are allowed as parameters. We reflect this in the
new `Structured.t` type for this field.

This drops support for older versions of the client. So we can only merge this
once everyone upgrades.