### PR TITLE
Support Eliom as a separate syntax

### DIFF
--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -29,12 +29,14 @@ module Syntax = struct
     | Reason
     | Ocamllex
     | Menhir
+    | Eliom
 
   let human_name = function
     | Ocaml -> "OCaml"
     | Reason -> "Reason"
     | Ocamllex -> "OCamllex"
     | Menhir -> "Menhir/ocamlyacc"
+    | Eliom -> "Eliom"
 
   let all =
     [ ("ocaml.interface", Ocaml)
@@ -42,15 +44,18 @@ module Syntax = struct
     ; ("reason", Reason)
     ; ("ocaml.ocamllex", Ocamllex)
     ; ("ocaml.menhir", Menhir)
+    ; ("ocaml.eliom", Eliom)
+    ; ("ocaml.eliom.interface", Eliom)
     ]
 
   let of_fname s =
     match Filename.extension s with
-    | ".eliomi"
-    | ".eliom"
     | ".mli"
     | ".ml" ->
       Ocaml
+    | ".eliomi"
+    | ".eliom" ->
+      Eliom
     | ".rei"
     | ".re" ->
       Reason
@@ -192,13 +197,18 @@ let get_impl_intf_counterparts uri =
   in
   let fname = Filename.basename fpath in
   let ml, mli, eliom, eliomi, re, rei, mll, mly =
-    ("ml", "mli", "eliom", "eliomi", "re", "rei", "mll", "mly") in
+    ("ml", "mli", "eliom", "eliomi", "re", "rei", "mll", "mly")
+  in
   let exts_to_switch_to =
     match Syntax.of_fname fname with
     | Ocaml -> (
       match Kind.of_fname fname with
       | Intf -> [ ml; mly; mll; eliom; re ]
       | Impl -> [ mli; mly; mll; eliomi; rei ] )
+    | Eliom -> (
+      match Kind.of_fname fname with
+      | Intf -> [ eliom ]
+      | Impl -> [ eliomi ] )
     | Reason -> (
       match Kind.of_fname fname with
       | Intf -> [ re; ml ]

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -8,6 +8,7 @@ module Syntax : sig
     | Reason
     | Ocamllex
     | Menhir
+    | Eliom
 
   val human_name : t -> string
 

--- a/ocaml-lsp-server/src/fmt.ml
+++ b/ocaml-lsp-server/src/fmt.ml
@@ -84,7 +84,9 @@ let binary t =
 let formatter doc =
   match Document.syntax doc with
   | (Ocamllex | Menhir) as s -> Error (Unsupported_syntax s)
-  | Ocaml -> Ok (Ocaml (Document.uri doc))
+  | Ocaml
+  | Eliom ->
+    Ok (Ocaml (Document.uri doc))
   | Reason -> Ok (Reason (Document.kind doc))
 
 let exec bin args stdin =

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -21,15 +21,15 @@ let infer_intf_for_impl doc =
 
 let language_id_of_fname s =
   match Filename.extension s with
-  | ".mli"
-  | ".eliomi" -> "ocaml.interface"
-  | ".ml"
-  | ".eliom" -> "ocaml"
+  | ".mli" -> "ocaml.interface"
+  | ".ml" -> "ocaml"
   | ".rei"
   | ".re" ->
     "reason"
   | ".mll" -> "ocaml.ocamllex"
   | ".mly" -> "ocaml.menhir"
+  | ".eliomi" -> "ocaml.eliom.interface"
+  | ".eliom" -> "ocaml.eliom"
   | ext ->
     Code_error.raise "unsupported file extension" [ ("extension", String ext) ]
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -118,7 +118,8 @@ let send_diagnostics ?diagnostics rpc doc =
           let notif = create_publishDiagnostics uri [ no_reason_merlin ] in
           Server.notification rpc notif)
     | Reason
-    | Ocaml ->
+    | Ocaml
+    | Eliom ->
       async (fun () ->
           let open Fiber.O in
           let* diagnostics =


### PR DESCRIPTION
Related to https://github.com/ocaml/ocaml-lsp/issues/353

@jrochel The language IDs are now `ocaml.eliom` and `ocaml.eliom.interface`, not sure this is solving the problem you have, since the previous setup should have been working fine, but let me know!