### PR TITLE
Fix source installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the same packages that `ocaml-lsp-server` is using.
 ```sh
 $ git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git
 $ cd ocaml-lsp
-$ make build
+$ make all
 ```
 
 ## Usage


### PR DESCRIPTION
... by replacing `make build` with `make all` in accordance with Makefile changes in https://github.com/ocaml/ocaml-lsp/pull/329.