### PR TITLE
Add code action annotate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Code action to annotate a value with its type (#397)
+
 # 1.5.0 (03/18/2020)
 
 - Support 4.12 and drop support for all earlier versions

--- a/ocaml-lsp-server/src/code_actions/action_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_annotate.ml
@@ -2,16 +2,15 @@ open Import
 
 let action_kind = "annotate"
 
-let check_context doc pos_start =
-  Document.with_pipeline doc (fun pipeline ->
-      let pos_start = Mpipeline.get_lexing_pos pipeline pos_start in
-      let typer = Mpipeline.typer_result pipeline in
-      let browse = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
-      match Mbrowse.enclosing pos_start [ browse ] with
-      | (_, (Expression _ | Pattern _)) :: _ -> `Valid
-      | _ :: _
-      | [] ->
-        `Invalid)
+let check_typeable_context pipeline pos_start =
+  let pos_start = Mpipeline.get_lexing_pos pipeline pos_start in
+  let typer = Mpipeline.typer_result pipeline in
+  let browse = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
+  match Mbrowse.enclosing pos_start [ browse ] with
+  | (_, (Expression _ | Pattern _)) :: _ -> `Valid
+  | _ :: _
+  | [] ->
+    `Invalid
 
 let get_source_text doc (loc : Loc.t) =
   let open Option.O in
@@ -39,25 +38,25 @@ let code_action doc (params : CodeActionParams.t) =
   let open Fiber.O in
   let uri = Uri.t_of_yojson (`String params.textDocument.uri) in
   let pos_start = Position.logical params.range.start in
-  let* context = check_context doc pos_start in
-  match context with
-  | Error e -> Fiber.return (Error (Jsonrpc.Response.Error.of_exn e))
-  | Ok `Invalid -> Fiber.return (Ok None)
-  | Ok `Valid -> (
-    let command = Query_protocol.Type_enclosing (None, pos_start, None) in
-    let+ res =
-      Document.with_pipeline doc (fun pipeline ->
+  let+ res =
+    Document.with_pipeline doc (fun pipeline ->
+        let context = check_typeable_context pipeline pos_start in
+        match context with
+        | `Invalid -> None
+        | `Valid ->
+          let command = Query_protocol.Type_enclosing (None, pos_start, None) in
           let config = Mpipeline.final_config pipeline in
           let config =
             { config with query = { config.query with verbosity = 0 } }
           in
           let pipeline = Mpipeline.make config (Document.source doc) in
-          Query_commands.dispatch pipeline command)
-    in
-    match res with
-    | Ok []
-    | Ok ((_, `Index _, _) :: _) ->
-      Ok None
-    | Ok ((location, `String value, _) :: _) ->
-      Ok (code_action_of_type_enclosing uri doc (location, value))
-    | Error e -> Error (Jsonrpc.Response.Error.of_exn e))
+          Some (Query_commands.dispatch pipeline command))
+  in
+  match res with
+  | Error e -> Error (Jsonrpc.Response.Error.of_exn e)
+  | Ok None
+  | Ok (Some [])
+  | Ok (Some ((_, `Index _, _) :: _)) ->
+    Ok None
+  | Ok (Some ((location, `String value, _) :: _)) ->
+    Ok (code_action_of_type_enclosing uri doc (location, value))

--- a/ocaml-lsp-server/src/code_actions/action_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_annotate.ml
@@ -1,0 +1,41 @@
+open Import
+
+let action_kind = "annotate"
+
+let get_source_text doc (loc : Loc.t) =
+  let open Option.O in
+  let source = Document.source doc in
+  let* start = Position.of_lexical_position loc.loc_start in
+  let+ end_ = Position.of_lexical_position loc.loc_end in
+  let (`Offset start) = Msource.get_offset source (Position.logical start) in
+  let (`Offset end_) = Msource.get_offset source (Position.logical end_) in
+  String.sub (Msource.text source) ~pos:start ~len:(end_ - start)
+
+let code_action_of_type_enclosing uri doc (loc, typ) =
+  let open Option.O in
+  let+ original_text = get_source_text doc loc in
+  let newText = Printf.sprintf "(%s : %s)" original_text typ in
+  let edit : WorkspaceEdit.t =
+    let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
+    let uri = Uri.to_string uri in
+    WorkspaceEdit.create ~changes:[ (uri, [ textedit ]) ] ()
+  in
+  let title = String.capitalize_ascii action_kind in
+  CodeAction.create ~title ~kind:(CodeActionKind.Other action_kind) ~edit
+    ~isPreferred:false ()
+
+let code_action doc (params : CodeActionParams.t) =
+  let uri = Uri.t_of_yojson (`String params.textDocument.uri) in
+  let command =
+    let start = Position.logical params.range.start in
+    Query_protocol.Type_enclosing (None, start, None)
+  in
+  let open Fiber.O in
+  let+ res = Document.dispatch doc command in
+  match res with
+  | Ok []
+  | Ok ((_, `Index _, _) :: _) ->
+    Ok None
+  | Ok ((location, `String value, _) :: _) ->
+    Ok (code_action_of_type_enclosing uri doc (location, value))
+  | Error e -> Error (Jsonrpc.Response.Error.of_exn e)

--- a/ocaml-lsp-server/src/code_actions/action_annotate.mli
+++ b/ocaml-lsp-server/src/code_actions/action_annotate.mli
@@ -1,0 +1,8 @@
+open Import
+
+val action_kind : string
+
+val code_action :
+     Document.t
+  -> CodeActionParams.t
+  -> (CodeAction.t option, Jsonrpc.Response.Error.t) Fiber.Result.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -16,6 +16,7 @@ let initialize_info : InitializeResult.t =
     let codeActionKinds =
       [ CodeActionKind.Other Action_destruct.action_kind
       ; CodeActionKind.Other Action_inferred_intf.action_kind
+      ; CodeActionKind.Other Action_annotate.action_kind
       ]
     in
     `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())
@@ -199,6 +200,8 @@ let code_action (state : State.t) (params : CodeActionParams.t) =
         , fun () -> Action_destruct.code_action doc params )
       ; ( CodeActionKind.Other Action_inferred_intf.action_kind
         , fun () -> Action_inferred_intf.code_action doc state params )
+      ; ( CodeActionKind.Other Action_annotate.action_kind
+        , fun () -> Action_annotate.code_action doc params )
       ]
   in
   let open Result.O in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -168,7 +168,7 @@ let f (x : t) = x
     ]);
   });
 
-  it("can annotate a value", async () => {
+  it("can annotate a function argument", async () => {
     await openDocument(
       outdent`
 type t = Foo of int | Bar of bool
@@ -218,6 +218,108 @@ let f x = Foo x
                   start: {
                     character: 6,
                     line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
+      },
+    ]);
+  });
+
+  it("can annotate a toplevel value", async () => {
+    await openDocument(
+      outdent`
+let iiii = 3 + 4
+`,
+      "file:///test.ml",
+    );
+    let start = Types.Position.create(0, 4);
+    let end = Types.Position.create(0, 5);
+    let actions = await codeAction("file:///test.ml", start, end);
+    expect(actions).toMatchObject([
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(iiii : int)",
+                range: {
+                  end: {
+                    character: 8,
+                    line: 0,
+                  },
+                  start: {
+                    character: 4,
+                    line: 0,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
+      },
+    ]);
+  });
+
+  it("can annotate an argument in a function call", async () => {
+    await openDocument(
+      outdent`
+let f x = x + 1
+let () =
+  let i = 8 in
+  print_int (f i)
+`,
+      "file:///test.ml",
+    );
+    let start = Types.Position.create(3, 15);
+    let end = Types.Position.create(3, 16);
+    let actions = await codeAction("file:///test.ml", start, end);
+    expect(actions).toMatchObject([
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(match i with | 0 -> (??) | _ -> (??))",
+                range: {
+                  end: {
+                    character: 16,
+                    line: 3,
+                  },
+                  start: {
+                    character: 15,
+                    line: 3,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        kind: "destruct",
+        title: "Destruct",
+      },
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(i : int)",
+                range: {
+                  end: {
+                    character: 16,
+                    line: 3,
+                  },
+                  start: {
+                    character: 15,
+                    line: 3,
                   },
                 },
               },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -71,7 +71,7 @@ let f (x : t) = x
           changes: {
             "file:///test.ml": [
               {
-                newText: "(x : type t = Foo of int | Bar of bool)",
+                newText: "(x : t)",
                 range: {
                   end: {
                     character: 17,

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -303,4 +303,44 @@ let f (x : t) = x
       },
     ]));
   });
+
+  it("does not annotate in a non expression context", async () => {
+    await openDocument(
+      outdent`
+type x =
+   | Foo of int
+   | Baz of string
+`,
+      "file:///test.ml",
+    );
+    let start = Types.Position.create(2, 5);
+    let end = Types.Position.create(2, 6);
+    let actions = await codeAction("file:///test.ml", start, end);
+    expect(actions).toEqual(expect.arrayContaining([
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(Baz : string -> x)",
+                range: {
+                  end: {
+                    character: 8,
+                    line: 2,
+                  },
+                  start: {
+                    character: 5,
+                    line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
+      },
+    ]));
+  });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -316,31 +316,6 @@ type x =
     let start = Types.Position.create(2, 5);
     let end = Types.Position.create(2, 6);
     let actions = await codeAction("file:///test.ml", start, end);
-    expect(actions).toEqual(expect.arrayContaining([
-      {
-        edit: {
-          changes: {
-            "file:///test.ml": [
-              {
-                newText: "(Baz : string -> x)",
-                range: {
-                  end: {
-                    character: 8,
-                    line: 2,
-                  },
-                  start: {
-                    character: 5,
-                    line: 2,
-                  },
-                },
-              },
-            ],
-          },
-        },
-        isPreferred: false,
-        kind: "annotate",
-        title: "Annotate",
-      },
-    ]));
+    expect(actions).toBeNull();
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -42,7 +42,7 @@ let f (x : t) = x
     let start = Types.Position.create(2, 16);
     let end = Types.Position.create(2, 17);
     let actions = await codeAction("file:///test.ml", start, end);
-    expect(actions).toMatchObject([
+    expect(actions).toEqual(expect.arrayContaining([
       {
         edit: {
           changes: {
@@ -63,34 +63,11 @@ let f (x : t) = x
             ],
           },
         },
+        isPreferred: false,
         kind: "destruct",
         title: "Destruct",
-      },
-      {
-        edit: {
-          changes: {
-            "file:///test.ml": [
-              {
-                newText: "(x : t)",
-                range: {
-                  end: {
-                    character: 17,
-                    line: 2,
-                  },
-                  start: {
-                    character: 16,
-                    line: 2,
-                  },
-                },
-              },
-            ],
-          },
-        },
-        isPreferred: false,
-        kind: "annotate",
-        title: "Annotate",
-      },
-    ]);
+      }
+    ]));
   });
 
   it("can infer module interfaces", async () => {
@@ -180,30 +157,7 @@ let f x = Foo x
     let start = Types.Position.create(2, 6);
     let end = Types.Position.create(2, 7);
     let actions = await codeAction("file:///test.ml", start, end);
-    expect(actions).toMatchObject([
-      {
-        edit: {
-          changes: {
-            "file:///test.ml": [
-              {
-                newText: "0 |_",
-                range: {
-                  end: {
-                    character: 7,
-                    line: 2,
-                  },
-                  start: {
-                    character: 6,
-                    line: 2,
-                  },
-                },
-              },
-            ],
-          },
-        },
-        kind: "destruct",
-        title: "Destruct",
-      },
+    expect(actions).toEqual(expect.arrayContaining([
       {
         edit: {
           changes: {
@@ -228,7 +182,7 @@ let f x = Foo x
         kind: "annotate",
         title: "Annotate",
       },
-    ]);
+    ]));
   });
 
   it("can annotate a toplevel value", async () => {
@@ -282,30 +236,7 @@ let () =
     let start = Types.Position.create(3, 15);
     let end = Types.Position.create(3, 16);
     let actions = await codeAction("file:///test.ml", start, end);
-    expect(actions).toMatchObject([
-      {
-        edit: {
-          changes: {
-            "file:///test.ml": [
-              {
-                newText: "(match i with | 0 -> (??) | _ -> (??))",
-                range: {
-                  end: {
-                    character: 16,
-                    line: 3,
-                  },
-                  start: {
-                    character: 15,
-                    line: 3,
-                  },
-                },
-              },
-            ],
-          },
-        },
-        kind: "destruct",
-        title: "Destruct",
-      },
+    expect(actions).toEqual(expect.arrayContaining([
       {
         edit: {
           changes: {
@@ -330,6 +261,6 @@ let () =
         kind: "annotate",
         title: "Annotate",
       },
-    ]);
+    ]));
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -66,6 +66,30 @@ let f (x : t) = x
         kind: "destruct",
         title: "Destruct",
       },
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(x : type t = Foo of int | Bar of bool)",
+                range: {
+                  end: {
+                    character: 17,
+                    line: 2,
+                  },
+                  start: {
+                    character: 16,
+                    line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
+      },
     ]);
   });
 
@@ -140,6 +164,69 @@ let f (x : t) = x
         },
         kind: "inferred_intf",
         title: "Insert inferred interface",
+      },
+    ]);
+  });
+
+  it("can annotate a value", async () => {
+    await openDocument(
+      outdent`
+type t = Foo of int | Bar of bool
+
+let f x = Foo x
+`,
+      "file:///test.ml",
+    );
+    let start = Types.Position.create(2, 6);
+    let end = Types.Position.create(2, 7);
+    let actions = await codeAction("file:///test.ml", start, end);
+    expect(actions).toMatchObject([
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "0 |_",
+                range: {
+                  end: {
+                    character: 7,
+                    line: 2,
+                  },
+                  start: {
+                    character: 6,
+                    line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        kind: "destruct",
+        title: "Destruct",
+      },
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(x : int)",
+                range: {
+                  end: {
+                    character: 7,
+                    line: 2,
+                  },
+                  start: {
+                    character: 6,
+                    line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
       },
     ]);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -263,4 +263,44 @@ let () =
       },
     ]));
   });
+
+  it("can annotate a variant with its name only", async () => {
+    await openDocument(
+      outdent`
+type t = Foo of int | Bar of bool
+
+let f (x : t) = x
+`,
+      "file:///test.ml",
+    );
+    let start = Types.Position.create(2, 16);
+    let end = Types.Position.create(2, 17);
+    let actions = await codeAction("file:///test.ml", start, end);
+    expect(actions).toEqual(expect.arrayContaining([
+      {
+        edit: {
+          changes: {
+            "file:///test.ml": [
+              {
+                newText: "(x : t)",
+                range: {
+                  end: {
+                    character: 17,
+                    line: 2,
+                  },
+                  start: {
+                    character: 16,
+                    line: 2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        isPreferred: false,
+        kind: "annotate",
+        title: "Annotate",
+      },
+    ]));
+  });
 });


### PR DESCRIPTION
New code action `annotate`, that adds a type next to the value on which the action is called. The goal is to be able to turn `let x = x + 1` into `let (x : int) = x + 1`.

I'm missing a few things before the PR is ready.

1. [x] I don't know how to get in the file what is in the original range of text
1. [x] I need to get the name of the type only and not its detail, for example in this snippet I should get `let f (x : t) = (x : t)` and not `let f (x : t) = (x : type t = Foo of int | Bar of bool)`
  ```
type t = Foo of int | Bar of bool

let f (x : t) = x
  ```

fix #396 