### PR TITLE
add support for refactor-open (qualify and unqualify) code action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,34 @@
 
 - Change the formatting-on-save error notification to a warning notification (#472)
 
+- Code action to qualify ("put module name in identifiers") and unqualify
+  ("remove module name from identifiers") module names in identifiers (#399)
+
+  Starting from:
+  ```ocaml
+  open Unix
+
+  let times = Unix.times ()
+  let f x = x.Unix.tms_stime, x.Unix.tms_utime
+  ```
+
+  Calling "remove module name from identifiers" with the cursor on the open
+  statement will produce:
+  ```ocaml
+  open Unix
+
+  let times = times ()
+  let f x = x.tms_stime, x.tms_utime
+  ```
+
+  Calling "put module name in identifiers" will restore:
+  ```ocaml
+  open Unix
+
+  let times = Unix.times ()
+  let f x = x.Unix.tms_stime, x.Unix.tms_utime
+  ```
+
 # 1.7.0 (07/28/2021)
 
 ## Features
@@ -83,7 +111,6 @@
 ## Features
 
 - Code action to annotate a value with its type (#397)
-
 ## Fixes
 
 - Fix interface/implementation switching on Windows (#427)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,12 @@
   let f x = x.Unix.tms_stime, x.Unix.tms_utime
   ```
 
+- Bug fix: do not show "random" documentation on hover
+  - fixed by [merlin#1364](https://github.com/ocaml/merlin/pull/1364)
+  - fixes duplicate:
+    - [ocaml-lsp#344](https://github.com/ocaml/ocaml-lsp/issues/344)
+    - [vscode-ocaml-platform#111](https://github.com/ocamllabs/vscode-ocaml-platform/issues/111)
+
 # 1.7.0 (07/28/2021)
 
 ## Features

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
@@ -1,0 +1,37 @@
+open Import
+
+let code_action (mode : [ `Qualify | `Unqualify ]) (action_kind : string) doc
+    (params : CodeActionParams.t) =
+  let open Fiber.O in
+  let+ res =
+    let command =
+      let pos_start = Position.logical params.range.start in
+      Query_protocol.Refactor_open (mode, pos_start)
+    in
+    Document.dispatch_exn doc command
+  in
+  match res with
+  | [] -> None
+  | changes ->
+    let code_action =
+      let edit : WorkspaceEdit.t =
+        let edits =
+          List.map changes ~f:(fun (newText, loc) ->
+              { TextEdit.newText; range = Range.of_loc loc })
+        in
+        let uri = params.textDocument.uri in
+        WorkspaceEdit.create ~changes:[ (uri, edits) ] ()
+      in
+      let kind = CodeActionKind.Other action_kind in
+      let title = String.capitalize_ascii action_kind in
+      CodeAction.create ~title ~kind ~edit ~isPreferred:false ()
+    in
+    Some code_action
+
+let unqualify =
+  let action_kind = "remove module name from identifiers" in
+  { Code_action.action_kind; run = code_action `Unqualify action_kind }
+
+let qualify =
+  let action_kind = "put module name in identifiers" in
+  { Code_action.action_kind; run = code_action `Qualify action_kind }

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.mli
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.mli
@@ -1,0 +1,5 @@
+(** code action for Merlin command refactor-open-unqualify *)
+val unqualify : Code_action.t
+
+(** code action for Merlin command refactor-open-qualify *)
+val qualify : Code_action.t

--- a/ocaml-lsp-server/src/code_actions/code_action.ml
+++ b/ocaml-lsp-server/src/code_actions/code_action.ml
@@ -1,0 +1,6 @@
+open Import
+
+type t =
+  { action_kind : string
+  ; run : Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t
+  }

--- a/ocaml-lsp-server/src/code_actions/code_action.mli
+++ b/ocaml-lsp-server/src/code_actions/code_action.mli
@@ -1,0 +1,6 @@
+open Import
+
+type t =
+  { action_kind : string
+  ; run : Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t
+  }

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -22,6 +22,8 @@ let initialize_info : InitializeResult.t =
       ; CodeActionKind.Other Action_inferred_intf.action_kind
       ; CodeActionKind.Other Action_type_annotate.action_kind
       ; CodeActionKind.Other Action_construct.action_kind
+      ; CodeActionKind.Other Action_refactor_open.unqualify.action_kind
+      ; CodeActionKind.Other Action_refactor_open.qualify.action_kind
       ]
     in
     `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())
@@ -282,6 +284,10 @@ let code_action (state : State.t) (params : CodeActionParams.t) =
         , fun () -> Action_type_annotate.code_action doc params )
       ; ( CodeActionKind.Other Action_construct.action_kind
         , fun () -> Action_construct.code_action doc params )
+      ; ( CodeActionKind.Other Action_refactor_open.unqualify.action_kind
+        , fun () -> Action_refactor_open.unqualify.run doc params )
+      ; ( CodeActionKind.Other Action_refactor_open.qualify.action_kind
+        , fun () -> Action_refactor_open.qualify.run doc params )
       ]
   in
   let code_action_results = List.filter_opt code_action_results in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -464,22 +464,7 @@ let x : foo = 1
           "kind": "markdown",
           "value": "\`\`\`ocaml
       unit
-      \`\`\`
-      ---
-      List operations.
-
-      Some functions are flagged as not tail-recursive. A tail-recursive
-      function uses constant stack space, while a non-tail-recursive function
-      uses stack space proportional to the length of its list argument, which
-      can be a problem with very long lists. When the function takes several
-      list arguments, an approximate formula giving stack usage \\\\(in some
-      unspecified constant unit\\\\) is shown in parentheses.
-
-      The above considerations can usually be ignored if your lists are not
-      longer than about 10000 elements.
-
-      The labeled version of this module can be used as described in the
-      \`StdLabels\` module.",
+      \`\`\`",
         },
         "range": Object {
           "end": Object {


### PR DESCRIPTION
Reservations I have:
- [x] I'm not sure code action names are easily understandable / friendly to newcomers

Blockers: 

- [x] Code actions are shown only if the cursor is on `open` statement, but they can be shown even if the code action won't do anything, e.g.,

```ocaml
open Unix (* both qualify and unqualify code actions will be shown *)
let u = () 
```
- [x] (this is merged into ocaml/merlin#master, we need to rebase vendored merlin) `refactor-open qualify` qualifies with full paths, e.g., for `open Import`, it does `Dune__exe.Import.foo...`.

To-do 
- [x] add tests
- [x] add an entry to the README, so that users know about these code actions