### PR TITLE
Simplify URI handling

### DIFF
--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -75,6 +75,7 @@ let preprocess =
         | "ResponseError"
         | "ResponseMessage"
         | "Message"
+        | "DocumentUri"
         | "MarkedString" ->
           raise_notrace Skip
         | name ->

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -255,7 +255,7 @@ module Json = struct
   end
 
   module Assoc = struct
-    type ('a, 'b) t = ('a * 'b) list constraint 'a = string
+    type ('a, 'b) t = ('a * 'b) list
 
     let yojson_of_t f g xs =
       let f k =

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -88,7 +88,7 @@ let utf16_range_change (text_utf8 : string) ({ start; end_ } : Range.t)
 
 let make (t : DidOpenTextDocumentParams.t) = t.textDocument
 
-let documentUri (t : t) = Uri0.t_of_yojson (`String t.uri)
+let documentUri (t : t) = t.uri
 
 let version (t : t) = t.version
 

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -25,6 +25,8 @@ module MarkedString = struct
     | _ -> Json.error "invalid MarkedString" json
 end
 
+module DocumentUri = Uri0
+
 (*$ Lsp_gen.print_ml () *)
 
 module DeleteFileOptions = struct
@@ -139,22 +141,6 @@ module DeleteFileOptions = struct
   let create ?(recursive : bool option) ?(ignoreIfNotExists : bool option)
       (() : unit) : t =
     { recursive; ignoreIfNotExists }
-end
-
-module DocumentUri = struct
-  type t = string [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
-  let _ = t_of_yojson
-
-  let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
-  let _ = yojson_of_t
-
-  [@@@end]
 end
 
 module DeleteFile = struct

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -9,6 +9,8 @@ module MarkedString : sig
   include Json.Jsonable.S with type t := t
 end
 
+module DocumentUri : module type of Uri0 with type t = Uri0.t
+
 (*$ Lsp_gen.print_mli () *)
 
 module DeleteFileOptions : sig
@@ -20,12 +22,6 @@ module DeleteFileOptions : sig
   include Json.Jsonable.S with type t := t
 
   val create : ?recursive:bool -> ?ignoreIfNotExists:bool -> unit -> t
-end
-
-module DocumentUri : sig
-  type t = string
-
-  include Json.Jsonable.S with type t := t
 end
 
 module DeleteFile : sig

--- a/lsp/src/uri0.mli
+++ b/lsp/src/uri0.mli
@@ -1,6 +1,8 @@
 open! Import
 
-include Json.Jsonable.S
+type t = private string
+
+include Json.Jsonable.S with type t := t
 
 val equal : t -> t -> bool
 

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -5,7 +5,6 @@ let action_kind = "destruct"
 let code_action_of_case_analysis uri (loc, newText) =
   let edit : WorkspaceEdit.t =
     let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
-    let uri = Uri.to_string uri in
     WorkspaceEdit.create ~changes:[ (uri, [ textedit ]) ] ()
   in
   let title = String.capitalize_ascii action_kind in
@@ -13,7 +12,7 @@ let code_action_of_case_analysis uri (loc, newText) =
     ~isPreferred:false ()
 
 let code_action doc (params : CodeActionParams.t) =
-  let uri = Uri.t_of_yojson (`String params.textDocument.uri) in
+  let uri = params.textDocument.uri in
   match Document.kind doc with
   | Intf -> Fiber.return (Ok None)
   | Impl -> (

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -5,7 +5,6 @@ let action_kind = "inferred_intf"
 let code_action_of_intf uri intf range =
   let edit : WorkspaceEdit.t =
     let textedit : TextEdit.t = { range; newText = intf } in
-    let uri = Uri.to_string uri in
     WorkspaceEdit.create ~changes:[ (uri, [ textedit ]) ] ()
   in
   let title = String.capitalize_ascii "Insert inferred interface" in

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -27,7 +27,6 @@ let code_action_of_type_enclosing uri doc (loc, typ) =
   let newText = Printf.sprintf "(%s : %s)" original_text typ in
   let edit : WorkspaceEdit.t =
     let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
-    let uri = Uri.to_string uri in
     WorkspaceEdit.create ~changes:[ (uri, [ textedit ]) ] ()
   in
   let title = String.capitalize_ascii action_kind in
@@ -36,7 +35,6 @@ let code_action_of_type_enclosing uri doc (loc, typ) =
 
 let code_action doc (params : CodeActionParams.t) =
   let open Fiber.O in
-  let uri = Uri.t_of_yojson (`String params.textDocument.uri) in
   let pos_start = Position.logical params.range.start in
   let+ res =
     Document.with_pipeline doc (fun pipeline ->
@@ -59,4 +57,6 @@ let code_action doc (params : CodeActionParams.t) =
   | Ok (Some ((_, `Index _, _) :: _)) ->
     Ok None
   | Ok (Some ((location, `String value, _) :: _)) ->
-    Ok (code_action_of_type_enclosing uri doc (location, value))
+    Ok
+      (code_action_of_type_enclosing params.textDocument.uri doc
+         (location, value))

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -3,7 +3,7 @@ open Import
 module Resolve = struct
   type t = CompletionParams.t
 
-  let uri (t : t) = Uri.t_of_yojson (`String t.textDocument.uri)
+  let uri (t : t) = t.textDocument.uri
 
   let yojson_of_t = CompletionParams.yojson_of_t
 
@@ -167,9 +167,7 @@ let complete doc lsp_position =
               ; deprecated = false (* TODO this is wrong *)
               } ))
   in
-  let textDocument =
-    TextDocumentIdentifier.create ~uri:(Document.uri doc |> Lsp.Uri.to_string)
-  in
+  let textDocument = TextDocumentIdentifier.create ~uri:(Document.uri doc) in
   let compl_info =
     CompletionParams.create ~textDocument ~position:lsp_position ()
     |> CompletionParams.yojson_of_t

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -7,9 +7,10 @@ let meth = "ocamllsp/inferIntf"
 let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
     =
   match params with
-  | Some (`List [ (`String (_ : DocumentUri.t) as json_uri) ]) -> (
+  | Some (`List [ json_uri ]) -> (
+    let json_uri = DocumentUri.t_of_yojson json_uri in
     let open Fiber.O in
-    match Document_store.get_opt state.store (Uri.t_of_yojson json_uri) with
+    match Document_store.get_opt state.store json_uri with
     | None ->
       Fiber.return
       @@ Error

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -6,15 +6,15 @@ let meth = "ocamllsp/switchImplIntf"
 
 (** see the spec for [ocamllsp/switchImplIntf] *)
 let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
-  let files_to_switch_to =
-    Document.get_impl_intf_counterparts (Uri.t_of_yojson (`String param))
-  in
+  let files_to_switch_to = Document.get_impl_intf_counterparts param in
   Ok (Json.yojson_of_list Uri.yojson_of_t files_to_switch_to)
 
 let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
   Fiber.return
     (match params with
-    | Some (`List [ `String (file_uri : DocumentUri.t) ]) -> switch file_uri
+    | Some (`List [ file_uri ]) ->
+      let file_uri = DocumentUri.t_of_yojson file_uri in
+      switch file_uri
     | Some json ->
       Error
         (Jsonrpc.Response.Error.make ~code:InvalidRequest

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -23,10 +23,7 @@ let rec symbol item =
     ~selectionRange:range ~children ()
 
 let rec symbol_info ?containerName uri item =
-  let location =
-    let uri = Uri.to_string uri in
-    { Location.uri; range = range item }
-  in
+  let location = { Location.uri; range = range item } in
   let info =
     let kind = outline_kind item.outline_kind in
     SymbolInformation.create ~name:item.Query_protocol.outline_name ~kind

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -43,8 +43,7 @@ let force_open_document (state : State.t) uri =
   let timer = Scheduler.create_timer state.scheduler ~delay in
   let languageId = language_id_of_fname filename in
   let text_document =
-    Lsp.Types.TextDocumentItem.create ~uri:(Uri.to_string uri) ~languageId
-      ~version:0 ~text
+    Lsp.Types.TextDocumentItem.create ~uri ~languageId ~version:0 ~text
   in
   let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
   let+ doc = Document.make timer state.merlin params in


### PR DESCRIPTION
Make DocumentUri equivalent to Uri0. This removes a bunch of conversions.