### PR TITLE
Fix jsonrpc memory leak

### DIFF
--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -191,12 +191,14 @@ let%expect_test "concurrent requests" =
     { "id": "initial", "method": "init", "jsonrpc": "2.0" }
     waiter: sending response
     waiter: making request
-    initial request response:
-    { "id": "initial", "jsonrpc": "2.0", "result": null }
     waitee: received request
     { "id": 100, "method": "shutdown", "jsonrpc": "2.0" }
+    initial request response:
+    { "id": "initial", "jsonrpc": "2.0", "result": null }
     waitee: stopping
     waitee: stopped
+    waiter: received response:
+    { "id": 100, "jsonrpc": "2.0", "result": 42 }
     [FAIL] unexpected Never raised |}]
 
 let%expect_test "test from jsonrpc_test.ml" =
@@ -266,5 +268,5 @@ let%expect_test "test from jsonrpc_test.ml" =
     Error:
     [ { exn = "(Failure \"special failure\")"; backtrace = "" } ]
     "<opaque>"
-    { "id": "testing", "jsonrpc": "2.0", "result": 2 }
-    { "id": 10, "jsonrpc": "2.0", "result": 1 } |}]
+    { "id": 10, "jsonrpc": "2.0", "result": 1 }
+    { "id": "testing", "jsonrpc": "2.0", "result": 2 } |}]


### PR DESCRIPTION
A recursive call inside a fork is going to allocate a closure that will only be
collected by the GC once all the recursive calls are done. Since we are looping
over all incoming packets, that's essentially a memory leak. This PR removes the
calls to fork_and_join_unit that rely on recursion.

I was always aware of this leak, but never bothered to fix it since it's quite
tiny (1 closure per incoming packet). I was looking for ways to use it other
than a pool, but eventually gave up.