### PR TITLE
Support async waiting for process

### DIFF
--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -47,4 +47,6 @@ val cancel_timers : t -> unit Fiber.t
 
 val scheduler : unit -> t
 
+val wait_for_process : t -> Pid.t -> Unix.process_status Fiber.t
+
 val abort : t -> unit

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -12,4 +12,8 @@ type error =
 
 val message : error -> string
 
-val run : Document.t -> (string, error) Result.t
+val run :
+     Scheduler.t
+  -> Scheduler.thread
+  -> Document.t
+  -> (string, error) result Fiber.t

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -1,8 +1,12 @@
-open Import
-
 (** Generic formatting facility for OCaml and Reason sources.
 
     Relies on [ocamlformat] for OCaml and [refmt] for reason *)
+
+open Import
+
+type t
+
+val create : Scheduler.t -> t
 
 type error =
   | Unsupported_syntax of Document.Syntax.t
@@ -12,8 +16,4 @@ type error =
 
 val message : error -> string
 
-val run :
-     Scheduler.t
-  -> Scheduler.thread
-  -> Document.t
-  -> (string, error) result Fiber.t
+val run : t -> Document.t -> (string, error) result Fiber.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -87,28 +87,3 @@ module LogMessageParams = LogMessageParams
 module Log = Lsp_fiber.Import.Log
 
 let sprintf = Stdune.sprintf
-
-module Fiber = struct
-  include Fiber
-
-  module Result = struct
-    type nonrec ('a, 'e) t = ('a, 'e) result Fiber.t
-
-    let lift x = Fiber.map x ~f:(fun x -> Ok x)
-
-    let return x = Fiber.return (Ok x)
-
-    let ( >>= ) x f =
-      Fiber.bind
-        ~f:(function
-          | Error _ as e -> Fiber.return e
-          | Ok x -> f x)
-        x
-
-    module O = struct
-      let ( let+ ) x f = Fiber.map ~f:(Stdune.Result.map ~f) x
-
-      let ( let* ) x f = x >>= f
-    end
-  end
-end

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -208,8 +208,8 @@ module Formatter = struct
 
   let run rpc doc =
     let open Fiber.O in
-    let { State.scheduler; ocamlformat = thread; _ } = Server.state rpc in
-    let* res = Fmt.run scheduler thread doc in
+    let state = Server.state rpc in
+    let* res = Fmt.run state.State.ocamlformat doc in
     match res with
     | Result.Error e ->
       let message = Fmt.message e in
@@ -824,7 +824,7 @@ let start () =
   let detached = Fiber.Pool.create () in
   let server =
     let merlin = Scheduler.create_thread scheduler in
-    let ocamlformat = Scheduler.create_thread scheduler in
+    let ocamlformat = Fmt.create scheduler in
     Server.make handler stream
       { store
       ; init = Uninitialized

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -207,7 +207,10 @@ module Formatter = struct
     make_error ~code ~message ()
 
   let run rpc doc =
-    match Fmt.run doc with
+    let open Fiber.O in
+    let { State.scheduler; ocamlformat = thread; _ } = Server.state rpc in
+    let* res = Fmt.run scheduler thread doc in
+    match res with
     | Result.Error e ->
       let message = Fmt.message e in
       let error = jsonrpc_error e in
@@ -821,10 +824,12 @@ let start () =
   let detached = Fiber.Pool.create () in
   let server =
     let merlin = Scheduler.create_thread scheduler in
+    let ocamlformat = Scheduler.create_thread scheduler in
     Server.make handler stream
       { store
       ; init = Uninitialized
       ; merlin
+      ; ocamlformat
       ; scheduler
       ; configuration
       ; detached

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -12,4 +12,5 @@ type t =
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t
+  ; ocamlformat : Scheduler.thread
   }

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -12,5 +12,5 @@ type t =
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t
-  ; ocamlformat : Scheduler.thread
+  ; ocamlformat : Fmt.t
   }

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -12,4 +12,5 @@ type t =
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t
+  ; ocamlformat : Scheduler.thread
   }

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -12,5 +12,5 @@ type t =
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t
-  ; ocamlformat : Scheduler.thread
+  ; ocamlformat : Fmt.t
   }


### PR DESCRIPTION
This allows us to run ocamlformat asynchronously. This is not very useful right
now, but will be once we run ocamlformat in server mode and use dune rpc.