### PR TITLE
Improve error handling

### DIFF
--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -120,7 +120,8 @@ and event =
 
 and job =
   | Pending :
-      (unit -> 'a) * ('a, [ `Exn of Exn.t | `Canceled ]) result Fiber.Ivar.t
+      (unit -> 'a)
+      * ('a, [ `Exn of Exn_with_backtrace.t | `Canceled ]) result Fiber.Ivar.t
       -> job
 
 and thread =
@@ -250,7 +251,7 @@ let create_thread scheduler =
   let worker =
     let do_ (Pending (f, ivar)) =
       let res =
-        match Result.try_with f with
+        match Exn_with_backtrace.try_with f with
         | Ok x -> Ok x
         | Error exn -> Error (`Exn exn)
       in
@@ -268,7 +269,8 @@ let add_pending_events t by =
       assert (t.events_pending >= 0))
 
 type 'a task =
-  { ivar : ('a, [ `Exn of Exn.t | `Canceled ]) result Fiber.Ivar.t
+  { ivar :
+      ('a, [ `Exn of Exn_with_backtrace.t | `Canceled ]) result Fiber.Ivar.t
   ; task : Worker.task
   }
 

--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -19,9 +19,10 @@ type 'a task
 
 val create_thread : t -> thread
 
-val await : 'a task -> ('a, [ `Exn of Exn.t | `Canceled ]) result Fiber.t
+val await :
+  'a task -> ('a, [ `Exn of Exn_with_backtrace.t | `Canceled ]) result Fiber.t
 
-val await_no_cancel : 'a task -> 'a Or_exn.t Fiber.t
+val await_no_cancel : 'a task -> ('a, Exn_with_backtrace.t) result Fiber.t
 
 val cancel_task : 'a task -> unit Fiber.t
 

--- a/jsonrpc-fiber/src/import.ml
+++ b/jsonrpc-fiber/src/import.ml
@@ -181,31 +181,6 @@ module Json = struct
   end
 end
 
-module Fiber = struct
-  include Fiber
-
-  module Result = struct
-    type nonrec ('a, 'e) t = ('a, 'e) result Fiber.t
-
-    let lift x = Fiber.map x ~f:(fun x -> Ok x)
-
-    let return x = Fiber.return (Ok x)
-
-    let ( >>= ) x f =
-      Fiber.bind
-        ~f:(function
-          | Error _ as e -> Fiber.return e
-          | Ok x -> f x)
-        x
-
-    module O = struct
-      let ( let+ ) x f = Fiber.map ~f:(Result.map ~f) x
-
-      let ( let* ) x f = x >>= f
-    end
-  end
-end
-
 module Log = struct
   let level : (string option -> bool) ref = ref (fun _ -> false)
 

--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -100,14 +100,19 @@ struct
   let log t = Log.log ~section:t.name
 
   let response_error_of_exns id exns =
-    let data =
-      Json.yojson_of_list
-        (fun e -> e |> Exn_with_backtrace.to_dyn |> Json.of_dyn)
-        exns
-    in
     let error =
-      Response.Error.make ~code:InternalError ~data
-        ~message:"uncaught exception" ()
+      match exns with
+      | [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E e; backtrace = _ }
+        ] ->
+        e
+      | exns ->
+        let data =
+          Json.yojson_of_list
+            (fun e -> e |> Exn_with_backtrace.to_dyn |> Json.of_dyn)
+            exns
+        in
+        Response.Error.make ~code:InternalError ~data
+          ~message:"uncaught exception" ()
     in
     Response.error id error
 

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -1,4 +1,3 @@
-open Import
 open Jsonrpc
 
 module Notify : sig

--- a/lsp-fiber/src/rpc.mli
+++ b/lsp-fiber/src/rpc.mli
@@ -1,14 +1,11 @@
 open! Import
-open Jsonrpc
 
 module Reply : sig
   type 'resp t
 
-  val now : ('r, Jsonrpc.Response.Error.t) result -> 'r t
+  val now : 'r -> 'r t
 
-  val later :
-       ((('r, Jsonrpc.Response.Error.t) result -> unit Fiber.t) -> unit Fiber.t)
-    -> 'r t
+  val later : (('r -> unit Fiber.t) -> unit Fiber.t) -> 'r t
 end
 
 module type S = sig
@@ -46,8 +43,7 @@ module type S = sig
 
   val stop : 'state t -> unit Fiber.t
 
-  val request :
-    _ t -> 'resp out_request -> ('resp, Response.Error.t) result Fiber.t
+  val request : _ t -> 'resp out_request -> 'resp Fiber.t
 
   val notification : _ t -> out_notification -> unit Fiber.t
 

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -195,23 +195,23 @@ let%expect_test "ent to end run of lsp tests" =
   test End_to_end_client.run End_to_end_server.run;
   [%expect
     {|
-    client: waiting for initialization
-    server: initializing server
-    server: returning initialization result
-    client: server initialized. sending request
-    server: executing command
-    server: sending message notification to client
-    server: scheduling show message
-    server: scheduling show message
-    client: sending request
-    client: Successfully executed command with result:
-    "successful execution"
-    client: waiting to receive notification before shutdown
-    server: sending show message notification
-    server: 0 ran
-    client: received notification
-    window/showMessage
-    client: filled received_notification
-    client: sending request to shutdown
-    Successful termination of test
-    [TEST] finished |}]
+  client: waiting for initialization
+  server: initializing server
+  server: returning initialization result
+  client: server initialized. sending request
+  client: sending request
+  server: executing command
+  server: sending message notification to client
+  server: scheduling show message
+  server: scheduling show message
+  client: Successfully executed command with result:
+  "successful execution"
+  client: waiting to receive notification before shutdown
+  server: sending show message notification
+  server: 0 ran
+  client: received notification
+  window/showMessage
+  client: filled received_notification
+  client: sending request to shutdown
+  Successful termination of test
+  [TEST] finished |}]

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -26,9 +26,12 @@ let code_action doc (params : CodeActionParams.t) =
     match res with
     | Ok res -> Some (code_action_of_case_analysis uri res)
     | Error
-        ( Merlin_analysis.Destruct.Wrong_parent _ | Query_commands.No_nodes
-        | Merlin_analysis.Destruct.Not_allowed _
-        | Merlin_analysis.Destruct.Useless_refine
-        | Merlin_analysis.Destruct.Nothing_to_do ) ->
+        { exn =
+            ( Merlin_analysis.Destruct.Wrong_parent _ | Query_commands.No_nodes
+            | Merlin_analysis.Destruct.Not_allowed _
+            | Merlin_analysis.Destruct.Useless_refine
+            | Merlin_analysis.Destruct.Nothing_to_do )
+        ; backtrace = _
+        } ->
       None
-    | Error exn -> raise exn)
+    | Error exn -> Exn_with_backtrace.reraise exn)

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -14,7 +14,7 @@ let code_action_of_case_analysis uri (loc, newText) =
 let code_action doc (params : CodeActionParams.t) =
   let uri = params.textDocument.uri in
   match Document.kind doc with
-  | Intf -> Fiber.return (Ok None)
+  | Intf -> Fiber.return None
   | Impl -> (
     let command =
       let start = Position.logical params.range.start in
@@ -24,11 +24,11 @@ let code_action doc (params : CodeActionParams.t) =
     let open Fiber.O in
     let+ res = Document.dispatch doc command in
     match res with
-    | Ok res -> Ok (Some (code_action_of_case_analysis uri res))
+    | Ok res -> Some (code_action_of_case_analysis uri res)
     | Error
         ( Merlin_analysis.Destruct.Wrong_parent _ | Query_commands.No_nodes
         | Merlin_analysis.Destruct.Not_allowed _
         | Merlin_analysis.Destruct.Useless_refine
         | Merlin_analysis.Destruct.Nothing_to_do ) ->
-      Ok None
-    | Error exn -> Error (Jsonrpc.Response.Error.of_exn exn))
+      None
+    | Error exn -> raise exn)

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -3,6 +3,4 @@ open Import
 val action_kind : string
 
 val code_action :
-     Document.t
-  -> CodeActionParams.t
-  -> (CodeAction.t option, Jsonrpc.Response.Error.t) Fiber.Result.t
+  Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -14,10 +14,7 @@ let code_action_of_intf uri intf range =
 let code_action doc (state : State.t) (params : CodeActionParams.t) =
   let open Fiber.O in
   match Document.kind doc with
-  | Impl -> Fiber.return (Ok None)
-  | Intf -> (
+  | Impl -> Fiber.return None
+  | Intf ->
     let+ intf = Inference.infer_intf ~force_open_impl:true state doc in
-    match intf with
-    | Error e -> Error (Jsonrpc.Response.Error.of_exn e)
-    | Ok intf ->
-      Ok (Some (code_action_of_intf (Document.uri doc) intf params.range)))
+    Some (code_action_of_intf (Document.uri doc) intf params.range)

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.mli
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.mli
@@ -3,7 +3,4 @@ open Import
 val action_kind : string
 
 val code_action :
-     Document.t
-  -> State.t
-  -> CodeActionParams.t
-  -> (CodeAction.t option, Jsonrpc.Response.Error.t) Result.t Fiber.t
+  Document.t -> State.t -> CodeActionParams.t -> CodeAction.t option Fiber.t

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -51,12 +51,10 @@ let code_action doc (params : CodeActionParams.t) =
           Some (Query_commands.dispatch pipeline command))
   in
   match res with
-  | Error e -> Error (Jsonrpc.Response.Error.of_exn e)
+  | Error e -> raise e
   | Ok None
   | Ok (Some [])
   | Ok (Some ((_, `Index _, _) :: _)) ->
-    Ok None
+    None
   | Ok (Some ((location, `String value, _) :: _)) ->
-    Ok
-      (code_action_of_type_enclosing params.textDocument.uri doc
-         (location, value))
+    code_action_of_type_enclosing params.textDocument.uri doc (location, value)

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -51,7 +51,7 @@ let code_action doc (params : CodeActionParams.t) =
           Some (Query_commands.dispatch pipeline command))
   in
   match res with
-  | Error e -> raise e
+  | Error e -> Exn_with_backtrace.reraise e
   | Ok None
   | Ok (Some [])
   | Ok (Some ((_, `Index _, _) :: _)) ->

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.mli
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.mli
@@ -3,6 +3,4 @@ open Import
 val action_kind : string
 
 val code_action :
-     Document.t
-  -> CodeActionParams.t
-  -> (CodeAction.t option, Jsonrpc.Response.Error.t) Fiber.Result.t
+  Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -174,7 +174,7 @@ let complete doc lsp_position =
     |> CompletionParams.yojson_of_t
   in
   let items = List.mapi ~f:(item ~compl_info) items in
-  Ok (`CompletionList { CompletionList.isIncomplete = false; items })
+  `CompletionList { CompletionList.isIncomplete = false; items }
 
 let format_doc ~markdown doc =
   match markdown with
@@ -212,4 +212,4 @@ let resolve doc (compl : CompletionItem.t) (resolve : Resolve.t) query_doc
   let+ documentation = query_doc doc @@ Position.logical position in
   let documentation = Option.map ~f:(format_doc ~markdown) documentation in
   let compl = { compl with documentation; data = None } in
-  Ok compl
+  compl

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -13,10 +13,7 @@ module Resolve : sig
 end
 
 val complete :
-     Document.t
-  -> Position.t
-  -> ([> `CompletionList of CompletionList.t ], Jsonrpc.Response.Error.t) result
-     Fiber.t
+  Document.t -> Position.t -> [> `CompletionList of CompletionList.t ] Fiber.t
 
 (** creates a server response for ["completionItem/resolve"] *)
 val resolve :
@@ -25,7 +22,7 @@ val resolve :
   -> Resolve.t
   -> (Document.t -> [> `Logical of int * int ] -> string option Fiber.t)
   -> markdown:bool
-  -> (CompletionItem.t, Jsonrpc.Response.Error.t) result Fiber.t
+  -> CompletionItem.t Fiber.t
 
 val prefix_of_position :
   short_path:bool -> Msource.t -> [< Msource.position ] -> string

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
@@ -5,6 +5,4 @@ val capability : string * Json.t
 val meth : string
 
 val on_request :
-     params:Jsonrpc.Message.Structured.t option
-  -> State.t
-  -> (Json.t, Jsonrpc.Response.Error.t) result Fiber.t
+  params:Jsonrpc.Message.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -5,9 +5,9 @@ let capability = ("handleSwitchImplIntf", `Bool true)
 let meth = "ocamllsp/switchImplIntf"
 
 (** see the spec for [ocamllsp/switchImplIntf] *)
-let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
+let switch (param : DocumentUri.t) : Json.t =
   let files_to_switch_to = Document.get_impl_intf_counterparts param in
-  Ok (Json.yojson_of_list Uri.yojson_of_t files_to_switch_to)
+  Json.yojson_of_list Uri.yojson_of_t files_to_switch_to
 
 let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
   Fiber.return
@@ -16,13 +16,13 @@ let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
       let file_uri = DocumentUri.t_of_yojson file_uri in
       switch file_uri
     | Some json ->
-      Error
+      Jsonrpc.Response.Error.raise
         (Jsonrpc.Response.Error.make ~code:InvalidRequest
            ~message:"The input parameter for ocamllsp/switchImplIntf is invalid"
            ~data:(`Assoc [ ("param", (json :> Json.t)) ])
            ())
     | None ->
-      Error
+      Jsonrpc.Response.Error.raise
         (Jsonrpc.Response.Error.make ~code:InvalidRequest
            ~message:"ocamllsp/switchImplIntf must receive param: DocumentUri.t"
            ()))

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
@@ -5,6 +5,4 @@ val capability : string * Json.t
 val meth : string
 
 val on_request :
-     params:Jsonrpc.Message.Structured.t option
-  -> _
-  -> (Json.t, Jsonrpc.Response.Error.t) result Fiber.t
+  params:Jsonrpc.Message.Structured.t option -> _ -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -40,7 +40,8 @@ val uri : t -> Uri.t
 
 val source : t -> Msource.t
 
-val with_pipeline : t -> (Mpipeline.t -> 'a) -> ('a, exn) result Fiber.t
+val with_pipeline :
+  t -> (Mpipeline.t -> 'a) -> ('a, Exn_with_backtrace.t) result Fiber.t
 
 val with_pipeline_exn : t -> (Mpipeline.t -> 'a) -> 'a Fiber.t
 
@@ -49,7 +50,8 @@ val version : t -> int
 val update_text :
   ?version:int -> t -> TextDocumentContentChangeEvent.t list -> t Fiber.t
 
-val dispatch : t -> 'a Query_protocol.t -> ('a, exn) result Fiber.t
+val dispatch :
+  t -> 'a Query_protocol.t -> ('a, Exn_with_backtrace.t) result Fiber.t
 
 val dispatch_exn : t -> 'a Query_protocol.t -> 'a Fiber.t
 
@@ -58,5 +60,5 @@ val close : t -> unit Fiber.t
 (** [get_impl_intf_counterparts uri] returns the implementation/interface
     counterparts for the URI [uri].
 
-    For instance, the counterparts of the file {/file.ml} are {[/file.mli]}. *)
+    For instance, the counterparts of the file [/file.ml] are [/file.mli]. *)
 val get_impl_intf_counterparts : Uri.t -> Uri.t list

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -10,9 +10,9 @@ let get_opt store = Table.find store
 
 let get store uri =
   match Table.find store uri with
-  | Some doc -> Ok doc
+  | Some doc -> doc
   | None ->
-    Error
+    Jsonrpc.Response.Error.raise
       (Jsonrpc.Response.Error.make ~code:InvalidRequest
          ~message:(Format.asprintf "no document found with uri: %a" Uri.pp uri)
          ())

--- a/ocaml-lsp-server/src/document_store.mli
+++ b/ocaml-lsp-server/src/document_store.mli
@@ -6,7 +6,7 @@ val make : unit -> t
 
 val put : t -> Document.t -> unit
 
-val get : t -> Uri.t -> (Document.t, Jsonrpc.Response.Error.t) result
+val get : t -> Uri.t -> Document.t
 
 val get_opt : t -> Uri.t -> Document.t option
 

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -10,6 +10,7 @@ module String = Stdune.String
 module List = Stdune.List
 module Result = Stdune.Result
 module Poly = Stdune.Poly
+module Exn_with_backtrace = Stdune.Exn_with_backtrace
 module Loc = Location
 module Scheduler = Fiber_unix.Scheduler
 module Server = Lsp_fiber.Server

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -6,7 +6,7 @@ let infer_intf_for_impl doc =
     Code_error.raise
       "expected an implementation document, got an interface instead" []
   | Impl ->
-    Document.with_pipeline doc (fun pipeline ->
+    Document.with_pipeline_exn doc (fun pipeline ->
         let typer = Mpipeline.typer_result pipeline in
         let pos = Mpipeline.get_lexing_pos pipeline `Start in
         let env, _ = Mbrowse.leaf_node (Mtyper.node_at typer pos) in
@@ -51,7 +51,7 @@ let force_open_document (state : State.t) uri =
   doc
 
 let infer_intf ~force_open_impl (state : State.t) doc =
-  let open Fiber.Result.O in
+  let open Fiber.O in
   match Document.kind doc with
   | Impl -> Code_error.raise "the provided document is not an interface." []
   | Intf ->
@@ -62,7 +62,7 @@ let infer_intf ~force_open_impl (state : State.t) doc =
       | None, false ->
         Code_error.raise
           "The implementation for this interface has not been open." []
-      | None, true -> force_open_document state impl_uri |> Fiber.Result.lift
-      | Some impl, _ -> Fiber.Result.return impl
+      | None, true -> force_open_document state impl_uri
+      | Some impl, _ -> Fiber.return impl
     in
     infer_intf_for_impl impl

--- a/ocaml-lsp-server/src/inference.mli
+++ b/ocaml-lsp-server/src/inference.mli
@@ -1,4 +1,3 @@
-val infer_intf_for_impl : Document.t -> (string, exn) result Fiber.t
+val infer_intf_for_impl : Document.t -> string Fiber.t
 
-val infer_intf :
-  force_open_impl:bool -> State.t -> Document.t -> (string, exn) result Fiber.t
+val infer_intf : force_open_impl:bool -> State.t -> Document.t -> string Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -7,7 +7,7 @@ let client_capabilities (state : State.t) =
 
 let make_error = Jsonrpc.Response.Error.make
 
-let not_supported =
+let not_supported () =
   Jsonrpc.Response.Error.raise
     (make_error ~code:InternalError ~message:"Request not supported yet!" ())
 
@@ -596,7 +596,6 @@ let ocaml_on_request :
             k resp)
       , state )
   in
-  let not_supported = Fiber.return (Reply.now not_supported, state) in
   match req with
   | Client_request.Initialize ip ->
     let res, state = on_initialize rpc ip in
@@ -668,7 +667,7 @@ let ocaml_on_request :
   | Client_request.TextDocumentRename req -> later rename req
   | Client_request.TextDocumentFoldingRange req -> later folding_range req
   | Client_request.SignatureHelp req -> later signature_help req
-  | Client_request.ExecuteCommand _ -> not_supported
+  | Client_request.ExecuteCommand _ -> not_supported ()
   | Client_request.TextDocumentLinkResolve l -> now l
   | Client_request.TextDocumentLink _ -> now None
   | Client_request.WillSaveWaitUntilTextDocument _ -> now None
@@ -700,11 +699,11 @@ let ocaml_on_request :
       ()
   | Client_request.TextDocumentOnTypeFormatting _ -> now None
   | Client_request.SelectionRange req -> later selection_range req
-  | Client_request.TextDocumentMoniker _ -> not_supported
-  | Client_request.SemanticTokensFull _ -> not_supported
-  | Client_request.SemanticTokensDelta _ -> not_supported
-  | Client_request.SemanticTokensRange _ -> not_supported
-  | Client_request.LinkedEditingRange _ -> not_supported
+  | Client_request.TextDocumentMoniker _ -> not_supported ()
+  | Client_request.SemanticTokensFull _ -> not_supported ()
+  | Client_request.SemanticTokensDelta _ -> not_supported ()
+  | Client_request.SemanticTokensRange _ -> not_supported ()
+  | Client_request.LinkedEditingRange _ -> not_supported ()
   | Client_request.UnknownRequest _ ->
     Jsonrpc.Response.Error.raise
       (make_error ~code:InvalidRequest ~message:"Got unknown request" ())
@@ -748,7 +747,7 @@ let on_request :
         , state ))
   | _ -> (
     match syntax with
-    | Some (Ocamllex | Menhir) -> Fiber.return (Reply.now not_supported, state)
+    | Some (Ocamllex | Menhir) -> not_supported ()
     | _ -> ocaml_on_request server req)
 
 let on_notification server (notification : Client_notification.t) :


### PR DESCRIPTION
First of all I removed all the result types in LSP. The code much cleaner
without all this extra noise, and I apologize to the other contributors for
cargo culting this silly style.

I fixed how `Jsonrpc.Response.Error.E` are handled. They are now passed as responses
instead of being wrapped as internal errors.

Finally, exceptions are now reported to clients as soon as possible. This has
the advantage that the client will see errors sooner, but the disadvantage that
we aren't reporting all errors. I think it's a good trade off.