### PR TITLE
Revert verbosity back to 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 1.6.1 (05/03/2020)
+
+## Fixes
+
+- Switch `verbosity` from 1 to 0. This is the same default that merlin uses.
+  The old value for verbosity (#433)
+
 # 1.6.0 (04/30/2020)
 
 ## Features

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -136,7 +136,7 @@ let make_config uri =
   let mconfig =
     { mconfig with
       ocaml = { mconfig.ocaml with real_paths = false }
-    ; query = { mconfig.query with verbosity = 1; filename; directory }
+    ; query = { mconfig.query with filename; directory }
     }
   in
   Mconfig.get_external_config path mconfig


### PR DESCRIPTION
This matches merlin's default behavior and prevents stack overflows in some
situations.