### PR TITLE
textDocument/formatting: return diff of changes

### DIFF
--- a/ocaml-lsp-server/src/fmt.ml
+++ b/ocaml-lsp-server/src/fmt.ml
@@ -126,7 +126,175 @@ let exec state bin args stdin =
   | Unix.WEXITED 0 -> Result.Ok res.stdout
   | _ -> Result.Error (Unexpected_result { message = res.stderr })
 
-let run state doc : (string, error) result Fiber.t =
+module Simple_diff = struct
+  (* based on *)
+  (* https://github.com/paulgb/simplediff/blob/031dc772ca6795cfdfed27384a6b79e772213233/python/simplediff/__init__.py *)
+
+  type item = string
+
+  type diff =
+    | Deleted of item array
+    | Added of item array
+    | Equal of item array
+
+  let longest_subsequence old_lines new_lines =
+    let _, old_index_map =
+      old_lines
+      |> Array.fold_left ~init:(0, String.Map.empty) ~f:(fun (i, m) line ->
+             ( i + 1
+             , String.Map.update
+                 ~f:(function
+                   | None -> Some [ i ]
+                   | Some xs -> Some (i :: xs))
+                 m line ))
+    in
+    let overlap = ref Int.Map.empty in
+
+    let sub_start_old = ref 0 in
+    let sub_start_new = ref 0 in
+    let sub_length = ref 0 in
+
+    Array.iteri new_lines ~f:(fun inew v ->
+        let overlap' = ref Int.Map.empty in
+        let old_indices =
+          String.Map.find old_index_map v |> Option.value ~default:[]
+        in
+        old_indices
+        |> List.iter ~f:(fun iold ->
+               let o =
+                 1
+                 + (Int.Map.find !overlap (iold - 1) |> Option.value ~default:0)
+               in
+               overlap' := Int.Map.set !overlap' iold o;
+
+               if o > !sub_length then (
+                 sub_length := o;
+                 sub_start_old := iold - o + 1;
+                 sub_start_new := inew - o + 1
+               ));
+
+        overlap := !overlap');
+
+    (!sub_start_new, !sub_start_old, !sub_length)
+
+  let get_diff old_lines new_lines =
+    let rec get_diff' old_lines new_lines =
+      match (old_lines, new_lines) with
+      | [||], [||] -> []
+      | old_lines, [||] -> [ Deleted old_lines ]
+      | [||], new_lines -> [ Added new_lines ]
+      | _, _ ->
+        let sub_start_new, sub_start_old, sub_length =
+          longest_subsequence old_lines new_lines
+        in
+        if sub_length = 0 then
+          [ Deleted old_lines; Added new_lines ]
+        else
+          let old_lines_presubseq =
+            Array.sub ~pos:0 ~len:sub_start_old old_lines
+          in
+          let new_lines_presubseq =
+            Array.sub ~pos:0 ~len:sub_start_new new_lines
+          in
+          let old_lines_postsubseq =
+            let start_index = sub_start_old + sub_length in
+            let len = Array.length old_lines - start_index in
+            Array.sub ~pos:start_index ~len old_lines
+          in
+          let new_lines_postsubseq =
+            let start_index = sub_start_new + sub_length in
+            let len = Array.length new_lines - start_index in
+            Array.sub ~pos:start_index ~len new_lines
+          in
+          let unchanged_lines =
+            Array.sub ~pos:sub_start_new ~len:sub_length new_lines
+          in
+          get_diff' old_lines_presubseq new_lines_presubseq
+          @ [ Equal unchanged_lines ]
+          @ get_diff' old_lines_postsubseq new_lines_postsubseq
+    in
+    get_diff' (Array.of_list old_lines) (Array.of_list new_lines)
+end
+
+type edit =
+  | Insert of string array
+  | Replace of string array * string array
+  | Delete of string array
+
+let text_edit ~line_sep ~line edit =
+  let deleted_lines, added_lines =
+    match edit with
+    | Insert adds -> (None, Some adds)
+    | Replace (dels, adds) -> (Some dels, Some adds)
+    | Delete dels -> (Some dels, None)
+  in
+  let start = { Position.character = 0; line } in
+  let end_ =
+    { Position.character = 0
+    ; line =
+        (match deleted_lines with
+        | None -> line
+        | Some dels -> line + Array.length dels)
+    }
+  in
+  let range = { Range.start; end_ } in
+  let newText =
+    match added_lines with
+    | None -> ""
+    | Some adds ->
+      (adds |> Array.to_list |> String.concat ~sep:line_sep) ^ line_sep
+  in
+  { TextEdit.newText; range }
+
+let diff_edits (orig : string) (formatted : string) : TextEdit.t list =
+  let orig_lines = String.split_lines orig in
+  let formatted_lines = String.split_lines formatted in
+  (* TODO: better way of knowing this ? *)
+  let line_sep =
+    match String.findi ~f:(fun c -> c = '\r') formatted with
+    | Some _ -> "\n\r"
+    | None -> "\n"
+  in
+  let line, prev_deleted_lines, edits_rev =
+    Simple_diff.get_diff orig_lines formatted_lines
+    |> List.fold_left
+         ~init:(0, [||], [])
+         ~f:(fun (line, prev_deleted_lines, edits_rev) edit ->
+           match (edit : Simple_diff.diff) with
+           | Deleted deleted_lines ->
+             (line, Array.append prev_deleted_lines deleted_lines, edits_rev)
+           | Added added_lines ->
+             let edit =
+               text_edit ~line_sep ~line
+                 (if Array.length prev_deleted_lines > 0 then
+                   Replace (prev_deleted_lines, added_lines)
+                 else
+                   Insert added_lines)
+             in
+             let line = line + Array.length prev_deleted_lines in
+             (line, [||], edit :: edits_rev)
+           | Equal equal_lines ->
+             let edits_rev =
+               if Array.length prev_deleted_lines > 0 then
+                 text_edit ~line_sep ~line (Delete prev_deleted_lines)
+                 :: edits_rev
+               else
+                 edits_rev
+             in
+             let line =
+               line + Array.length prev_deleted_lines + Array.length equal_lines
+             in
+             (line, [||], edits_rev))
+  in
+  let edits_rev =
+    if Array.length prev_deleted_lines > 0 then
+      text_edit ~line_sep ~line (Delete prev_deleted_lines) :: edits_rev
+    else
+      edits_rev
+  in
+  List.rev edits_rev
+
+let run state doc : (TextEdit.t list, error) result Fiber.t =
   let res =
     let open Result.O in
     let* formatter = formatter doc in
@@ -136,4 +304,6 @@ let run state doc : (string, error) result Fiber.t =
   in
   match res with
   | Error e -> Fiber.return (Error e)
-  | Ok (binary, args, contents) -> exec state binary args contents
+  | Ok (binary, args, contents) ->
+    exec state binary args contents
+    |> Fiber.map ~f:(Result.map ~f:(diff_edits contents))

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -16,4 +16,4 @@ type error =
 
 val message : error -> string
 
-val run : t -> Document.t -> (string, error) result Fiber.t
+val run : t -> Document.t -> (TextEdit.t list, error) result Fiber.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -8,6 +8,7 @@ module Option = Stdune.Option
 module Table = Stdune.Table
 module String = Stdune.String
 module List = Stdune.List
+module Array = Stdune.Array
 module Result = Stdune.Result
 module Poly = Stdune.Poly
 module Exn_with_backtrace = Stdune.Exn_with_backtrace

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -222,17 +222,7 @@ module Formatter = struct
             Server.notification rpc (ShowMessage msg))
       in
       Jsonrpc.Response.Error.raise error
-    | Result.Ok result ->
-      let pos line col = { Position.character = col; line } in
-      let range =
-        let start_pos = pos 0 0 in
-        match Msource.get_logical (Document.source doc) `End with
-        | `Logical (l, c) ->
-          let end_pos = pos l c in
-          { Range.start = start_pos; end_ = end_pos }
-      in
-      let change = { TextEdit.newText = result; range } in
-      Fiber.return (Some [ change ])
+    | Result.Ok result -> Fiber.return (Some result)
 end
 
 let markdown_support (client_capabilities : ClientCapabilities.t) ~field =
@@ -863,6 +853,7 @@ let start () =
     (fun () ->
       let open Fiber.O in
       let* () = Server.start server in
+
       Fiber.fork_and_join_unit
         (fun () -> Document_store.close store)
         (fun () -> Fiber.Pool.stop detached))

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-formatting.test.ts
@@ -64,7 +64,7 @@ maybeDescribe("textDocument/formatting", () => {
         languageServer,
         "let rec gcd a b =\n" +
           "  match (a, b) with\n" +
-          "  | 0, n\n" +
+          "    | 0, n\n" +
           "  | n, 0 ->\n" +
           "    n\n" +
           "  | _, _ -> gcd a (b mod a)\n",
@@ -74,15 +74,30 @@ maybeDescribe("textDocument/formatting", () => {
       let result = await query(languageServer, name);
       expect(result).toMatchObject([
         {
-          newText:
-            "let rec gcd a b =\n" +
-            "  match (a, b) with\n" +
-            "  | 0, n\n" +
-            "  | n, 0 ->\n" +
-            "    n\n" +
-            "  | _, _ -> gcd a (b mod a)\n",
+          range: { start: { character: 0, line: 2 }, end: { character: 0, line: 3 } },
+          newText: "  | 0, n\n"
         },
       ]);
+    });
+
+    it("leaves unchanged files alone", async () => {
+      languageServer = await LanguageServer.startAndInitialize();
+
+      let name = path.join(setupOcamlFormat(ocamlFormat), "test.ml");
+
+      await openDocument(
+        languageServer,
+        "let rec gcd a b =\n" +
+          "  match (a, b) with\n" +
+          "  | 0, n\n" +
+          "  | n, 0 ->\n" +
+          "    n\n" +
+          "  | _, _ -> gcd a (b mod a)\n",
+        name,
+      );
+
+      let result = await query(languageServer, name);
+      expect(result).toMatchObject([]);
     });
 
     it("can format an ocaml intf file", async () => {
@@ -92,7 +107,7 @@ maybeDescribe("textDocument/formatting", () => {
 
       await openDocument(
         languageServer,
-        "module Test : sig\n  type t =\n    | Foo\n    | Bar\n    | Baz\nend\n",
+        "module Test :           sig\n  type t =\n    | Foo\n    | Bar\n    | Baz\nend\n",
         name,
       );
 
@@ -100,8 +115,9 @@ maybeDescribe("textDocument/formatting", () => {
 
       expect(result).toMatchObject([
         {
+          range: { start: { character: 0, line: 0 }, end: { character: 0, line: 1 } },
           newText:
-            "module Test : sig\n  type t =\n    | Foo\n    | Bar\n    | Baz\nend\n",
+            "module Test : sig\n",
         },
       ]);
     });
@@ -127,16 +143,7 @@ maybeDescribe("textDocument/formatting", () => {
       );
 
       let result = await query(languageServer, name);
-      expect(result).toMatchObject([
-        {
-          newText:
-            "let rec gcd a b = match (a, b) with\n" +
-            "  | 0, n\n" +
-            "  | n, 0 ->\n" +
-            "    n\n" +
-            "  | _, _ -> gcd a (b mod a)\n",
-        },
-      ]);
+      expect(result).toMatchObject([]);
     });
   });
 });


### PR DESCRIPTION
Uses a simple diff algorithm to return a list of `TextEdit`s  for the delta from `ocamlformat`/`refmt`, rather than just returning a single `TextEdit` that replaces the whole file.

Why
===

My particular use case (from emacs with evil-mode):
- In my case I use emacs, and have it configured to format-on-save
- I noticed I had slow performance on some edits using `evil-mode`(/ spacemacs), which became almost unusable on large files, which I'd assumed was due to `tuareg`/`font-lock`. In particular, `O`  and `dd` would take a long time O(1s) to complete, which is pretty jarring.
- On closer investigation, I noticed performance was initially fine on these large files, but poor editing performance started after the first format of the buffer.
- The reason for this was `evil-mode` calling the `field-beginning` function as part of `evil-narrow-to-field` - calling `field-beginning` manually would be very fast before doing a format, then be the cause of the slowness afterwards.
- Intuitively this seems to be because `evil-mode` is using buffer information to figure out how indentation / other things (?) should work - sometimes this buffer information is based on recent nearby changes, and rewriting the whole file makes calculating this information less efficient.
- Another example of similar slowness from `field-beginning` around large-scale buffer changes is documented here: https://github.com/ProofGeneral/PG/issues/427#issuecomment-500612904

Generally:
- Admittedly, this might seem like a problem with emacs rather than `ocaml-lsp` itself, but intuitively it seems like this idea of the editor using change history to calculate things about the file might generalise to different editors, and `ocaml-lsp` is being a better LSP citizen by telling the editor to do less work 
- Other LSPs also calculate a diff, e.g. https://github.com/golang/tools/blob/a1fbb68135aa978db34613d32e259c0121a69e93/internal/lsp/diff/myers/diff.go

Implementation
===

I tried to find a simple algo to perform the diff that would work for both `ocamlformat` and `refmt`, and found `simple-diff` - this seemed to fit the bill, as I don't think that `textDocument/formatting` is ever used in batch and is more for formatting a single file at a time, so performance of the diff itself isn't critical. 

This seemed better than a more optimised diffing algorithm to avoid bringing in dependencies (e.g. with `patience_diff`) or depending on system binaries like `diff` being available, as they might not be available on Windows.

However, `simple-diff` seems to have a few bugs, so I inlined it and fixed them. I'd already gone down quite the rabbit hole at this point, so this seemed like the simplest solution!

--

I have tested this in emacs and it seems to make performance a lot better in large buffers after the first instance of `textDocument/formatting` - hopefully this is appealing in itself and is worth the additional complexity,

Very happy to rework the implementation if my assumptions there are off at all - particularly if I've overlooked an easy alternative for the algo, or if `textDocument/formatting` is designed to be used on a large number of files simultaneously (I'm not super familiar with LSP), in which case a more efficient diff algo would probably be beneficial.