### PR TITLE
Remove explicit schedulers

### DIFF
--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 module Worker : sig
   (** Simple queue that is consumed by its own thread *)
@@ -327,7 +328,8 @@ let iter (t : t) =
   ) else
     event_next t
 
-let create_timer t ~delay =
+let create_timer ~delay =
+  let+ t = Fiber.Var.get_exn me in
   { timer_scheduler = t; delay; timer_id = Timer_id.gen () }
 
 let set_delay t ~delay = t.delay <- delay

--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -168,8 +168,6 @@ let is_empty table = Table.length table = 0
 
 let me = Fiber.Var.create ()
 
-let scheduler () = Fiber.Var.get_exn me
-
 let signal_timers_available t =
   with_mutex t.timers_available_mutex ~f:(fun () ->
       Condition.signal t.timers_available)

--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -34,7 +34,7 @@ val stop : thread -> unit
 
 type timer
 
-val create_timer : t -> delay:float -> timer
+val create_timer : delay:float -> timer Fiber.t
 
 val set_delay : timer -> delay:float -> unit
 

--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -1,17 +1,13 @@
 open Import
 
-type t
-
-val create : unit -> t
-
 type run_error =
   | Never
   | Abort_requested
   | Exn of Exn_with_backtrace.t
 
-val run_result : t -> 'a Fiber.t -> ('a, run_error) result
+val run_result : 'a Fiber.t -> ('a, run_error) result
 
-val run : t -> 'a Fiber.t -> 'a
+val run : 'a Fiber.t -> 'a
 
 type thread
 
@@ -43,8 +39,8 @@ val schedule :
 
 val cancel_timer : timer -> unit Fiber.t
 
-val cancel_timers : t -> unit Fiber.t
+val cancel_timers : unit -> unit Fiber.t
 
 val wait_for_process : Pid.t -> Unix.process_status Fiber.t
 
-val abort : t -> unit
+val abort : unit -> unit Fiber.t

--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -17,7 +17,7 @@ type thread
 
 type 'a task
 
-val create_thread : t -> thread
+val create_thread : unit -> thread Fiber.t
 
 val await :
   'a task -> ('a, [ `Exn of Exn_with_backtrace.t | `Canceled ]) result Fiber.t
@@ -45,6 +45,6 @@ val cancel_timer : timer -> unit Fiber.t
 
 val cancel_timers : t -> unit Fiber.t
 
-val wait_for_process : t -> Pid.t -> Unix.process_status Fiber.t
+val wait_for_process : Pid.t -> Unix.process_status Fiber.t
 
 val abort : t -> unit

--- a/fiber-unix/src/scheduler.mli
+++ b/fiber-unix/src/scheduler.mli
@@ -45,8 +45,6 @@ val cancel_timer : timer -> unit Fiber.t
 
 val cancel_timers : t -> unit Fiber.t
 
-val scheduler : unit -> t Fiber.t
-
 val wait_for_process : t -> Pid.t -> Unix.process_status Fiber.t
 
 val abort : t -> unit

--- a/fiber-unix/test/scheduler_tests.ml
+++ b/fiber-unix/test/scheduler_tests.ml
@@ -21,11 +21,11 @@ let%expect_test "scheduler starts and runs a fiber" =
 
 let%expect_test "run an async task and wait it for it to finish" =
   let s = S.create () in
-  let th = S.create_thread s in
-  let async () =
-    S.async_exn th (fun () -> print_endline "running in a different thread")
-  in
   let run () =
+    let* th = S.create_thread () in
+    let async () =
+      S.async_exn th (fun () -> print_endline "running in a different thread")
+    in
     print_endline "running in scheduler";
     let task = async () in
     let+ res = S.await_no_cancel task in
@@ -229,7 +229,7 @@ let%expect_test "run process" =
     (stdout, stderr)
   in
   let run () =
-    let+ res = S.wait_for_process s pid in
+    let+ res = S.wait_for_process pid in
     print_endline ("stdout: " ^ stdout);
     print_endline ("stderr: " ^ stderr);
     printf "code: %s"

--- a/lsp-fiber/src/fiber_io.mli
+++ b/lsp-fiber/src/fiber_io.mli
@@ -11,4 +11,4 @@ val send : t -> Jsonrpc.packet -> unit Fiber.t
 
 val recv : t -> Jsonrpc.packet option Fiber.t
 
-val make : Scheduler.t -> Io.t -> t
+val make : Io.t -> t Fiber.t

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -10,9 +10,9 @@ module Test = struct
     let run ?(capabilities = ClientCapabilities.create ()) ?on_request
         ?on_notification (scheduler, state) (in_, out) =
       let initialize = InitializeParams.create ~capabilities () in
-      let client =
+      let+ client =
         let io = Io.make in_ out in
-        let stream_io = Lsp_fiber.Fiber_io.make scheduler io in
+        let+ stream_io = Lsp_fiber.Fiber_io.make io in
         let handler = Client.Handler.make ?on_request ?on_notification () in
         Client.make handler stream_io (scheduler, state)
       in
@@ -21,9 +21,9 @@ module Test = struct
 
   module Server = struct
     let run ?on_request ?on_notification (scheduler, state) (in_, out) =
-      let server =
+      let+ server =
         let io = Io.make in_ out in
-        let stream_io = Fiber_io.make scheduler io in
+        let+ stream_io = Fiber_io.make io in
         let handler = Server.Handler.make ?on_request ?on_notification () in
         Server.make handler stream_io (scheduler, state)
       in
@@ -81,7 +81,7 @@ module End_to_end_client = struct
 
   let run scheduler io =
     let received_notification = Fiber.Ivar.create () in
-    let client, running =
+    let* client, running =
       let on_request = { Client.Handler.on_request } in
       Test.Client.run ~on_request ~on_notification
         (scheduler, received_notification)
@@ -179,7 +179,7 @@ module End_to_end_server = struct
 
   let run scheduler io =
     let detached = Fiber.Pool.create () in
-    let _server, running =
+    let* _server, running =
       Test.Server.run ~on_request ~on_notification
         (scheduler, (Started, detached))
         io

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -1,16 +1,13 @@
-open Import
+open! Import
 
 type state =
   | Binary_not_found
   | Out_of_date
   | Running
 
-type t =
-  { scheduler : Scheduler.t
-  ; state : state Fiber.Ivar.t
-  }
+type t = { state : state Fiber.Ivar.t }
 
-let create scheduler = { scheduler; state = Fiber.Ivar.create () }
+let create () = { state = Fiber.Ivar.create () }
 
 let state t : state Fiber.t =
   let open Fiber.O in
@@ -35,7 +32,7 @@ let state t : state Fiber.t =
         let args = Array.of_list [ bin; "rpc"; "--help=plain" ] in
         Unix.create_process bin args stdin stdout stderr |> Stdune.Pid.of_int
       in
-      let* status = Scheduler.wait_for_process t.scheduler pid in
+      let* status = Scheduler.wait_for_process pid in
       let state =
         match status with
         (* TODO actually turn on *)

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -1,5 +1,3 @@
-open Import
-
 type state =
   | Binary_not_found
   | Out_of_date
@@ -9,4 +7,4 @@ type t
 
 val state : t -> state Fiber.t
 
-val create : Scheduler.t -> t
+val create : unit -> t

--- a/ocaml-lsp-server/src/fmt.mli
+++ b/ocaml-lsp-server/src/fmt.mli
@@ -6,7 +6,7 @@ open Import
 
 type t
 
-val create : Scheduler.t -> t
+val create : unit -> t
 
 type error =
   | Unsupported_syntax of Document.Syntax.t

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -41,7 +41,7 @@ let force_open_document (state : State.t) uri =
   let filename = Uri.to_path uri in
   let text = Io.String_path.read_file filename in
   let delay = Configuration.diagnostics_delay state.configuration in
-  let timer = Scheduler.create_timer state.scheduler ~delay in
+  let* timer = Scheduler.create_timer ~delay in
   let languageId = language_id_of_fname filename in
   let text_document =
     Lsp.Types.TextDocumentItem.create ~uri ~languageId ~version:0 ~text

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -773,7 +773,7 @@ let on_notification server (notification : Client_notification.t) :
     let open Fiber.O in
     let* doc =
       let delay = Configuration.diagnostics_delay state.configuration in
-      let timer = Scheduler.create_timer state.scheduler ~delay in
+      let* timer = Scheduler.create_timer ~delay in
       Document.make timer state.merlin params
     in
     Document_store.put store doc;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -898,4 +898,4 @@ let start () =
 
 let run () =
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
-  Scheduler.run (Scheduler.create ()) (start ())
+  Scheduler.run (start ())

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -8,7 +8,6 @@ type t =
   { store : Document_store.t
   ; merlin : Scheduler.thread
   ; init : init
-  ; scheduler : Scheduler.t
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -8,7 +8,6 @@ type t =
   { store : Document_store.t
   ; merlin : Scheduler.thread
   ; init : init
-  ; scheduler : Scheduler.t
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
   ; trace : TraceValue.t


### PR DESCRIPTION
Anything that needs the scheduler must now return Fiber.t

This brings us our code closer to dune's scheduler which we'll eventually adopt.