### PR TITLE
Support related errors in diagnostics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Add sub-errors as "related" information in diagnostics (#457)
+
 # 1.6.1 (05/17/2020)
 
 ## Fixes

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -31,6 +31,7 @@ module TextDocumentSyncKind = TextDocumentSyncKind
 module CompletionOptions = CompletionOptions
 module ServerCapabilities = ServerCapabilities
 module Diagnostic = Diagnostic
+module DiagnosticRelatedInformation = DiagnosticRelatedInformation
 module PublishDiagnosticsParams = PublishDiagnosticsParams
 module MessageType = MessageType
 module WorkspaceEdit = WorkspaceEdit

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -147,8 +147,7 @@ let send_diagnostics ?diagnostics rpc doc =
                       | _ -> DiagnosticSeverity.Error
                     in
                     let message =
-                      Loc.print_main Format.str_formatter error;
-                      String.trim (Format.flush_str_formatter ())
+                      String.trim (Format.asprintf "%a@." Loc.print_main error)
                     in
                     create_diagnostic range message ~severity))
           in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
@@ -27,6 +27,44 @@ describe("textDocument/diagnostics", () => {
     languageServer = null;
   });
 
+  it("has related diagnostics", async () => {
+    let receivedDiganostics = new Promise((resolve, _reject) =>
+      languageServer.onNotification((method, params) => {
+        expect(method).toMatchInlineSnapshot(
+          `"textDocument/publishDiagnostics"`,
+        );
+        expect(params).toMatchInlineSnapshot(`
+          Object {
+            "diagnostics": Array [
+              Object {
+                "message": "This comment contains an unterminated string literal",
+                "range": Object {
+                  "end": Object {
+                    "character": 2,
+                    "line": 0,
+                  },
+                  "start": Object {
+                    "character": 0,
+                    "line": 0,
+                  },
+                },
+                "severity": 1,
+                "source": "ocamllsp",
+              },
+            ],
+            "uri": "file:///test.ml",
+            "version": 0,
+          }
+        `);
+        resolve(null);
+      }),
+    );
+    await openDocument(outdent`
+(* " *)
+    `);
+    await receivedDiganostics;
+  });
+
   it("unused values have diagnostic tags", async () => {
     let receivedDiganostics = new Promise((resolve, _reject) =>
       languageServer.onNotification((method, params) => {

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
@@ -48,6 +48,24 @@ describe("textDocument/diagnostics", () => {
                     "line": 0,
                   },
                 },
+                "relatedInformation": Array [
+                  Object {
+                    "location": Object {
+                      "range": Object {
+                        "end": Object {
+                          "character": 4,
+                          "line": 0,
+                        },
+                        "start": Object {
+                          "character": 3,
+                          "line": 0,
+                        },
+                      },
+                      "uri": "file:///test.ml",
+                    },
+                    "message": "String literal begins here",
+                  },
+                ],
                 "severity": 1,
                 "source": "ocamllsp",
               },


### PR DESCRIPTION
The utility is small because OCaml doesn't use sub-messages as much as it
should.