### PR TITLE
Fix install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ git submodule update --init --recursive
 opam switch create . ocaml-base-compiler.4.12.0 --with-test
 
 # don't forget to set your environment to use the local switch
-eval ($opam env)
+eval $(opam env)
 
 # build
 make all

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -5,7 +5,7 @@
  (libraries cmdliner dune-build-info fiber fiber_unix jsonrpc lsp lsp_fiber
    merlin.analysis merlin.kernel merlin.merlin_utils merlin.parsing
    merlin.query_commands merlin.query_protocol merlin.specific merlin.typing
-   merlin.utils octavius omd ppx_yojson_conv_lib result stdune csexp
+   merlin.utils octavius omd ppx_yojson_conv_lib re result stdune csexp
    yojson dune_rpc))
 
 (include_subdirs unqualified)

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -5,7 +5,7 @@
  (libraries cmdliner dune-build-info fiber fiber_unix jsonrpc lsp lsp_fiber
    merlin.analysis merlin.kernel merlin.merlin_utils merlin.parsing
    merlin.query_commands merlin.query_protocol merlin.specific merlin.typing
-   merlin.utils octavius omd ppx_yojson_conv_lib re result stdune csexp
+   merlin.utils octavius omd ppx_yojson_conv_lib result stdune csexp
    yojson dune_rpc))
 
 (include_subdirs unqualified)

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -95,5 +95,6 @@ module LogMessageParams = LogMessageParams
 module Log = Lsp_fiber.Import.Log
 module Drpc = Dune_rpc.V1
 module Pid = Stdune.Pid
+module Re = Re
 
 let sprintf = Stdune.sprintf


### PR DESCRIPTION
Error when installing with [Vim-lsp-settings](https://github.com/mattn/vim-lsp-settings)

Here is a part of error.

```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> installed ocamlfind.1.9.1
-> installed ocamlbuild.0.14.0
-> installed uchar.0.0.2
-> installed topkg.1.0.3
-> installed uutf.1.0.2
-> installed dune.2.8.5
-> installed easy-format.1.3.2
-> installed dune-build-info.2.8.5
-> installed result.1.5
-> installed pp.1.1.2
-> installed csexp.1.5.1
-> installed cppo.1.6.7
-> installed jsonrpc.1.6.1
-> installed biniou.1.2.1
-> installed yojson.1.7.0
-> installed ppx_yojson_conv_lib.v0.14.0
-> installed dot-merlin-reader.4.1
[ERROR] The compilation of ocaml-lsp-server failed at
        "/Users/sk/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/opam-init/hooks/
sandbox.sh
        build dune build -j 7 ocaml-lsp-server.install --release".
-> installed lsp.1.6.1

#=== ERROR while compiling ocaml-lsp-server.1.6.1 =============================#
# context     2.0.8 | macos/x86_64 | ocaml-system.4.12.0 | pinned(git+file:///Users/sk/.local/share/vim-l
sp-settings/servers/ocaml-lsp/ocaml-lsp-files#master#5724e699)
# path        ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/_opam/.opam-switch/build/
ocaml-lsp-server.1.6.1
# command     ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/opam-init/hooks/san
dbox.sh build dune build -j 7 ocaml-lsp-server.install --release
# exit-code   1
# env-file    ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/log/ocaml-lsp-serve
r-33670-f32cc7.env
# output-file ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/log/ocaml-lsp-serve
r-33670-f32cc7.out
### output ###
# File "ocaml-lsp-server/src/dune", line 8, characters 49-51:
# 8 |    merlin.utils octavius omd ppx_yojson_conv_lib re result stdune csexp
#                                                      ^^
# Error: Library "re" not found.
# Hint: try:
#   dune external-lib-deps --missing --release -j 7 ocaml-lsp-server.install



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build ocaml-lsp-server 1.6.1
+-
+- The following changes have been performed
| - install biniou              1.2.1
| - install cppo                1.6.7
| - install csexp               1.5.1
| - install dot-merlin-reader   4.1
| - install dune                2.8.5
| - install dune-build-info     2.8.5
| - install easy-format         1.3.2
| - install jsonrpc             1.6.1
| - install lsp                 1.6.1
| - install ocamlbuild          0.14.0
| - install ocamlfind           1.9.1
| - install pp                  1.1.2
| - install ppx_yojson_conv_lib v0.14.0
| - install result              1.5
| - install topkg               1.0.3
| - install uchar               0.0.2
| - install uutf                1.0.2
| - install yojson              1.7.0
+-
```

This is probably due to forgetting to import the Re library.

The environment is macOS BigSur 11.3.1.
