### PR TITLE
Support merlin `holes` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,26 @@
 
 - Add support for navigating to a symbol inside a workspace (#398)
 
+- Add support for jumping to the next typed hole
+  - Note: implemented as a custom request, this will require a language server client that
+    knows about this request. At the moment, only VS Code OCaml Platform client support is
+    planned.
+  - Merlin has a concept of "typed holes" that are syntactically represented as `_`. Files
+    that incorporate typed holes are not considered valid OCaml, but Merlin and OCaml-LSP
+    support them. One example when such typed holes can occur is when on "destructs" a
+    value, e.g., destructing `(Some 1)` will generate code
+
+    ```ocaml
+    match Some 1 with Some _ -> _ | None -> _
+    ```
+
+    While the first underscore is a valid "match-all"/wildcard pattern, the rest of
+    underscores are typed holes. It is reasonable that user wants to jump to such typed
+    holes to be able to edit them. One should note that at the time of this writing, there
+    is work on Merlin, which allows to generate real code for such typed holes
+    automatically based on the type of the hole and available values in the current
+    context.
+
 # 1.6.1 (05/17/2020)
 
 ## Fixes

--- a/ocaml-lsp-server/docs/ocamllsp/nextHole-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/nextHole-spec.md
@@ -1,0 +1,45 @@
+# Next Hole Request
+
+Merlin has a concept of "typed holes" that are syntactically represented as `_`. Files
+that incorporate typed holes are not considered valid OCaml, but Merlin and OCaml-LSP
+support them. One example when such typed holes can occur is when on "destructs" a value,
+e.g., destructing `(Some 1)` will generate code `match Some 1 with Some _ -> _ | None ->
+_`. While the first underscore is a valid "match-all"/wildcard pattern, the rest of
+underscores are typed holes.
+
+It is reasonable that user wants to jump to such typed holes to be able to edit them. One
+should note that at the time of this writing, there is work on Merlin, which allows to
+generate real code for such typed holes automatically based on the type of the hole and
+available values in the current context.
+
+## Client capability
+
+nothing that should be noted
+
+## Server capability
+
+property name: `handleNextHole`
+
+property type: `boolean`
+
+## Request
+
+- method: `ocamllsp/nextHole`
+- params:
+
+```json
+{
+  "uri": DocumentUri,
+  "position": Position
+}
+```
+
+## Response
+
+- result: `Range | Null`
+  - `Range` if the next hole was found
+  - `Null` if there are no holes in the file
+- error: code and message set in case an exception happens during the
+  `ocamllsp/nextHole` request.
+  - in case of any errors in finding a next hole in a file, the handler throws an
+    exception, which is returned from the language server.

--- a/ocaml-lsp-server/src/custom_requests/req_next_hole.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_next_hole.ml
@@ -1,0 +1,50 @@
+open Import
+
+let capability = ("handleNextHole", `Bool true)
+
+let meth = "ocamllsp/nextHole"
+
+type request_params =
+  { uri : Uri.t
+  ; position : Position.t
+  }
+
+(* Request params must have the form as in the given string. *)
+let params_s = "{ uri: <DocumentUri>, position: <Position> }"
+
+let parse_params params =
+  match params with
+  | `Assoc [ ("uri", uri); ("position", position) ] ->
+    let uri = Uri.t_of_yojson uri in
+    let position = Position.t_of_yojson position in
+    Some { uri; position }
+  | _ -> None
+
+let failwith_err err = failwith @@ Printf.sprintf "%s: %s" meth err
+
+let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
+    =
+  match params with
+  | None -> failwith_err "Expected a paramater, but didn't get one"
+  | Some params -> (
+    match parse_params params with
+    | None ->
+      failwith_err
+      @@ Printf.sprintf "Expected a parameter %s, but got %s" params_s
+           (Json.to_string (params :> Json.t))
+    | Some { uri; position = { line; character } } -> (
+      let uri_s = Uri.to_string uri in
+      let store = state.store in
+      let doc = Document_store.get_opt store uri in
+      match doc with
+      | None ->
+        failwith_err
+        @@ Printf.sprintf "Document %s wasn't found in the document store" uri_s
+      | Some doc -> (
+        let open Fiber.O in
+        let* range =
+          Holes_cmd.next_hole doc @@ Position.create ~line ~character
+        in
+        match range with
+        | Some range -> range |> Range.yojson_of_t |> Fiber.return
+        | None -> Fiber.return `Null)))

--- a/ocaml-lsp-server/src/custom_requests/req_next_hole.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_next_hole.mli
@@ -1,0 +1,8 @@
+open Import
+
+val capability : string * Json.t
+
+val meth : string
+
+val on_request :
+  params:Jsonrpc.Message.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/holes_cmd.ml
+++ b/ocaml-lsp-server/src/holes_cmd.ml
@@ -1,0 +1,33 @@
+open Import
+
+let holes_lst doc =
+  let open Fiber.O in
+  let+ holes_lst = Document.dispatch_exn doc Holes in
+  List.map holes_lst ~f:(fun (loc, str) -> (Range.of_loc loc, `Type str))
+
+let next_hole doc (pos : Position.t) =
+  let open Fiber.O in
+  let+ holes = holes_lst doc in
+  let is_in_range { Position.line; character } { Range.start; end_ } =
+    (line == start.line && character >= start.character)
+    || (line == end_.line && character <= end_.character)
+    || (line > start.line && line < end_.line)
+  in
+  let holes_sorted =
+    List.sort holes ~compare:(fun (range1, _) (range2, _) ->
+        Range.compare range1 range2)
+  in
+  (* we want to find such a range that starts after the current position *)
+  List.find holes_sorted ~f:(fun (range, _) ->
+      match Position.compare pos range.Range.start with
+      | Ordering.Lt -> true
+      | Gt -> false
+      | Eq ->
+        (* we don't want the same range that we're in now; we need the next one *)
+        not (is_in_range pos range))
+  |> (function
+       (* if the current position is larger than all other ranges, we cycle back
+          to first hole in the file *)
+       | None -> List.hd_opt holes_sorted
+       | Some _ as o -> o)
+  |> Option.map ~f:fst

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -804,6 +804,7 @@ let on_request :
     match
       [ (Req_switch_impl_intf.meth, Req_switch_impl_intf.on_request)
       ; (Req_infer_intf.meth, Req_infer_intf.on_request)
+      ; (Req_next_hole.meth, Req_next_hole.on_request)
       ]
       |> List.assoc_opt meth
     with

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -52,6 +52,7 @@ let initialize_info : InitializeResult.t =
               [ ("interfaceSpecificLangId", `Bool true)
               ; Req_switch_impl_intf.capability
               ; Req_infer_intf.capability
+              ; Req_next_hole.capability
               ] )
         ]
     in

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -1,6 +1,11 @@
 open Import
 include Lsp.Types.Range
 
+let compare (x : t) (y : t) =
+  match Position.compare x.start y.start with
+  | (Lt | Gt) as r -> r
+  | Ordering.Eq -> Position.compare x.end_ y.end_
+
 (* Compares ranges by their lengths*)
 let compare_size (x : t) (y : t) =
   let dx = Position.(x.end_ - x.start) in

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -2,6 +2,10 @@ open Import
 
 include module type of Lsp.Types.Range with type t = Lsp.Types.Range.t
 
+(** [compare r1 r2] compares first start positions, if equal compares the end
+    positions. *)
+val compare : t -> t -> Ordering.t
+
 val compare_size : t -> t -> Ordering.t
 
 val first_line : t

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-nextHole.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-nextHole.ts
@@ -1,0 +1,127 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Types from "vscode-languageserver-types";
+
+describe("ocamllsp/nextHole", () => {
+  let languageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "ocaml",
+        0,
+        source,
+      ),
+    });
+  }
+
+  function currPos(line, character) {
+    return {
+      line,
+      character,
+    };
+  }
+
+  async function sendNextHoleReq(position) {
+    return languageServer.sendRequest("ocamllsp/nextHole", {
+      uri: "file:///test.ml",
+      position,
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("null when no holes in file", async () => {
+    await openDocument(
+      outdent`
+let u = 1
+`,
+    );
+
+    let r = await sendNextHoleReq(currPos(1, 1));
+    expect(r).toMatchInlineSnapshot(`null`);
+  });
+
+  it("one hole", async () => {
+    await openDocument(
+      outdent`
+let k = match () with () -> _
+`,
+    );
+
+    let r = await sendNextHoleReq(currPos(0, 3));
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 29,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 28,
+          "line": 0,
+        },
+      }
+    `);
+  });
+
+  it("several holes", async () => {
+    await openDocument(
+      outdent`
+let u =
+  let i = match Some 1 with None -> _ | Some -> _ in
+  let b = match () with () -> _ in
+  ()
+      `,
+    );
+    let r0 = await sendNextHoleReq(currPos(0, 1));
+    expect(r0).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 36,
+          "line": 1,
+        },
+      }
+    `);
+
+    let r1 = await sendNextHoleReq(currPos(1, 36));
+    expect(r1).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 49,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 48,
+          "line": 1,
+        },
+      }
+    `);
+
+    let r2 = await sendNextHoleReq(currPos(1, 49));
+    expect(r2).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 30,
+          "line": 2,
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
I implemented a custom request since the functionality didn't fit with any existing request. The user can jump from any location to the first hole that comes after that position. If there are no position _after_ the current one, the cursor jumps to the first hole in the file.

In vscode: 

https://user-images.githubusercontent.com/16353531/121877703-55fb9580-cd24-11eb-8473-b30267552339.mov

Soon will make a PR to the VOP (vscode ocaml platform) repo with the code handling this request
