### PR TITLE
Show typed holes as errors

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -157,15 +157,12 @@ let set_diagnostics rpc doc =
               in
               let holes_as_err_diags =
                 Query_commands.dispatch pipeline Holes
-                |> List.map ~f:(fun (loc, _type) ->
+                |> List.map ~f:(fun (loc, typ) ->
                        let range = Range.of_loc loc in
                        let severity = DiagnosticSeverity.Error in
                        let message =
-                         "This is a typed hole.\n\
-                          If you meant to use a wildcard pattern, here an \
-                          expression is expected not a pattern. Your code will \
-                          not compile if you do not replace this with a valid \
-                          expression."
+                         "This typed hole should be replaced with an \
+                          expression of type " ^ typ
                        in
                        (* we set specific diagnostic code = "hole" to be able to
                           filter through diagnostics easily *)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -169,7 +169,9 @@ let set_diagnostics rpc doc =
                        create_diagnostic ~code:(`String "hole") range message
                          ~severity)
               in
-              List.append holes_as_err_diags merlin_diagnostics)
+              List.append holes_as_err_diags merlin_diagnostics
+              |> List.sort ~compare:(fun d1 d2 ->
+                     Range.compare d1.Diagnostic.range d2.Diagnostic.range))
         in
         Diagnostics.set state.diagnostics (`Merlin (uri, diagnostics));
         Diagnostics.send state.diagnostics)

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -1,6 +1,11 @@
 open Import
 include Lsp.Types.Range
 
+let compare (x : t) (y : t) =
+  match Position.compare x.start y.start with
+  | (Lt | Gt) as r -> r
+  | Ordering.Eq -> Position.compare x.end_ y.end_
+
 (* Compares ranges by their lengths*)
 let compare_size (x : t) (y : t) =
   let dx = Position.(x.end_ - x.start) in

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -2,6 +2,10 @@ open Import
 
 include module type of Lsp.Types.Range with type t = Lsp.Types.Range.t
 
+(** [compare r1 r2] compares first start positions, if equal compares the end
+    positions. *)
+val compare : t -> t -> Ordering.t
+
 val compare_size : t -> t -> Ordering.t
 
 val first_line : t


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16353531/122763198-7f359c00-d2b7-11eb-9e27-49c327eef4b5.png)

https://github.com/ocamllabs/vscode-ocaml-platform/pull/640 uses this PR to add support for commands to jump to previous/next typed hole. 

This is the first PR in a series to add support for merlin `Construct` command in ocaml-lsp.