### PR TITLE
Jump to the first hole on destruct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+# Unreleased 
+
+## Features 
+
+- Jump to the first hole on calling `Destruct` code action (only with client VSCode OCaml
+  Platform) (#468)
+
+  Example: when a user invokes `Destruct` code action on `Some 1`, this code is replaced
+  by `match Some 1 with None -> _ | Some _ -> _`, where the 1st and 3rd underscores
+  are "typed holes", a concept created by Merlin to be able to put "holes" in OCaml code.
+
+  With this change, now for VSCode OCaml Platform users, on such invocation of `Destruct`,
+  the cursor will jump to the first typed hole and select it, so that user can start
+  editing right away.
+
 # 1.7.0 (07/28/2021)
 
 ## Features

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -3,8 +3,9 @@ open Import
 let action_kind = "destruct"
 
 let code_action_of_case_analysis doc uri (loc, newText) =
+  let range : Range.t = Range.of_loc loc in
   let edit : WorkspaceEdit.t =
-    let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
+    let textedit : TextEdit.t = { range; newText } in
     let version = Document.version doc in
     let textDocument =
       OptionalVersionedTextDocumentIdentifier.create ~uri ~version ()
@@ -15,8 +16,13 @@ let code_action_of_case_analysis doc uri (loc, newText) =
     WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
   in
   let title = String.capitalize_ascii action_kind in
+  let command =
+    Command.create ~title:"Jump to Next Hole" ~command:"ocaml.next-hole"
+      ~arguments:[ `Assoc [ ("position", Position.yojson_of_t range.start) ] ]
+      ()
+  in
   CodeAction.create ~title ~kind:(CodeActionKind.Other action_kind) ~edit
-    ~isPreferred:false ()
+    ~command ~isPreferred:false ()
 
 let code_action doc (params : CodeActionParams.t) =
   let uri = params.textDocument.uri in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -53,6 +53,18 @@ let f (x : t) = x
     expect(actions).toMatchInlineSnapshot(`
       Array [
         Object {
+          "command": Object {
+            "arguments": Array [
+              Object {
+                "position": Object {
+                  "character": 16,
+                  "line": 2,
+                },
+              },
+            ],
+            "command": "ocaml.next-hole",
+            "title": "Jump to Next Hole",
+          },
           "edit": Object {
             "documentChanges": Array [
               Object {


### PR DESCRIPTION
- Is based on #467 and https://github.com/ocamllabs/vscode-ocaml-platform/pull/643
- I am not sure whether embedding in a code action a command, which is not available in an editor results in user-visible warning or error; if that's the case, I can add the command only for vscode client

The gif below shows how jumps to first holes work along with jumping to prev/next holes.

https://user-images.githubusercontent.com/16353531/123289585-05591900-d52a-11eb-97db-f5d94b1441b9.mov

