### PR TITLE
Fix completion for polymorphic variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# Unreleased 
+# Unreleased
 
-## Features 
+## Features
 
 - Jump to the first hole on calling `Destruct` code action (only with client VSCode OCaml
   Platform) (#468)
@@ -16,6 +16,26 @@
 - Use ocamlformat to properly format type snippets. This feature requires the
   `ocamlformat-rpc` opam package to be installed. (#386)
 
+- Add completion support for polymorphic variants, when it is possible to pin down the
+  precise type. Examples (`<|>` stands for the cursor) when completion will work (#473)
+
+  Function application:
+
+  ```
+  let foo (a: [`Alpha | `Beta]) = ()
+
+  foo `A<|>
+  ```
+
+  Type explicitly shown:
+
+  ```
+  let a : [`Alpha | `Beta] = `B<|>
+  ```
+
+  Note: this is actually a bug fix, since we were ignoring the backtick when constructing
+  the prefix for completion.
+
 # 1.7.0 (07/28/2021)
 
 ## Features
@@ -24,7 +44,7 @@
 
 - Add support for navigating to a symbol inside a workspace (#398)
 
-- Show typed holes as errors 
+- Show typed holes as errors
 
   Merlin has a concept of "typed holes" that are syntactically represented as `_`. Files
   that incorporate typed holes are not considered valid OCaml, but Merlin and OCaml-LSP

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -46,35 +46,50 @@ let prefix_of_position ~short_path source position =
       min (String.length text - 1) (index - 1)
     in
     let pos =
-      let ident_or_infix_char = function
-        | 'a' .. 'z'
-        | 'A' .. 'Z'
-        | '0' .. '9'
-        | '\''
-        | '_'
-        (* Infix function characters *)
-        | '$'
-        | '&'
-        | '*'
-        | '+'
-        | '-'
-        | '/'
-        | '='
-        | '>'
-        | '@'
-        | '^'
-        | '!'
-        | '?'
-        | '%'
-        | '<'
-        | ':'
-        | '~'
-        | '#' ->
-          true
-        | '.' -> not short_path
-        | _ -> false
+      let should_terminate = ref false in
+      let has_seen_dot = ref false in
+      let is_prefix_char c =
+        if !should_terminate then
+          false
+        else
+          match c with
+          | 'a' .. 'z'
+          | 'A' .. 'Z'
+          | '0' .. '9'
+          | '\''
+          | '_'
+          (* Infix function characters *)
+          | '$'
+          | '&'
+          | '*'
+          | '+'
+          | '-'
+          | '/'
+          | '='
+          | '>'
+          | '@'
+          | '^'
+          | '!'
+          | '?'
+          | '%'
+          | '<'
+          | ':'
+          | '~'
+          | '#' ->
+            true
+          | '`' ->
+            if !has_seen_dot then
+              false
+            else (
+              should_terminate := true;
+              true
+            )
+          | '.' ->
+            has_seen_dot := true;
+            not short_path
+          | _ -> false
       in
-      String.rfindi text ~from ~f:(fun c -> not (ident_or_infix_char c))
+      String.rfindi text ~from ~f:(fun c -> not (is_prefix_char c))
     in
     let pos =
       match pos with

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -2,6 +2,7 @@ import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
 
 import * as Types from "vscode-languageserver-types";
+import { Position } from "vscode-languageserver-types";
 
 const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0")
   ? describe
@@ -431,12 +432,249 @@ describe_opt("textDocument/completion", () => {
         y: string
       }
 
-      let _ = 
+      let _ =
     `);
 
     let items: Array<any> = await queryCompletion(Types.Position.create(5, 8));
     expect(
       items.filter((compl) => compl.label === "x" || compl.label === "y"),
     ).toHaveLength(0);
+  });
+
+  it("works for polymorphic variants - function application context - 1", async () => {
+    openDocument(outdent`
+let f (_a: [\`String | \`Int of int]) = ()
+
+let u = f \`Str
+    `);
+
+    let items = await queryCompletion(Position.create(2, 15));
+
+    expect(items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "Stream",
+          "textEdit": Object {
+            "newText": "Stream",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "String",
+          "textEdit": Object {
+            "newText": "String",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "StringLabels",
+          "textEdit": Object {
+            "newText": "StringLabels",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Str",
+          "textEdit": Object {
+            "newText": "Str",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it("works for polymorphic variants - function application context - 2", async () => {
+    openDocument(outdent`
+let f (_a: [\`String | \`Int of int]) = ()
+
+let u = f \`In
+    `);
+
+    let items = await queryCompletion(Position.create(2, 14));
+
+    expect(items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "Invalid_argument",
+          "textEdit": Object {
+            "newText": "Invalid_argument",
+            "range": Object {
+              "end": Object {
+                "character": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int",
+          "textEdit": Object {
+            "newText": "Int",
+            "range": Object {
+              "end": Object {
+                "character": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int32",
+          "textEdit": Object {
+            "newText": "Int32",
+            "range": Object {
+              "end": Object {
+                "character": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int64",
+          "textEdit": Object {
+            "newText": "Int64",
+            "range": Object {
+              "end": Object {
+                "character": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 12,
+                "line": 2,
+              },
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it("works for polymorphic variants", async () => {
+    openDocument(outdent`
+type t = [ \`Int | \`String ]
+
+let x : t = \`I
+    `);
+
+    let items = await queryCompletion(Position.create(2, 15));
+
+    expect(items).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "label": "Invalid_argument",
+          "textEdit": Object {
+            "newText": "Invalid_argument",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 14,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int",
+          "textEdit": Object {
+            "newText": "Int",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 14,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int32",
+          "textEdit": Object {
+            "newText": "Int32",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 14,
+                "line": 2,
+              },
+            },
+          },
+        },
+        Object {
+          "label": "Int64",
+          "textEdit": Object {
+            "newText": "Int64",
+            "range": Object {
+              "end": Object {
+                "character": 15,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 14,
+                "line": 2,
+              },
+            },
+          },
+        },
+      ]
+    `);
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -453,64 +453,16 @@ let u = f \`Str
     expect(items).toMatchInlineSnapshot(`
       Array [
         Object {
-          "label": "Stream",
+          "label": "\`String",
           "textEdit": Object {
-            "newText": "Stream",
+            "newText": "\`String",
             "range": Object {
               "end": Object {
                 "character": 15,
                 "line": 2,
               },
               "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "String",
-          "textEdit": Object {
-            "newText": "String",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "StringLabels",
-          "textEdit": Object {
-            "newText": "StringLabels",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Str",
-          "textEdit": Object {
-            "newText": "Str",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
+                "character": 11,
                 "line": 2,
               },
             },
@@ -532,64 +484,16 @@ let u = f \`In
     expect(items).toMatchInlineSnapshot(`
       Array [
         Object {
-          "label": "Invalid_argument",
+          "label": "\`Int",
           "textEdit": Object {
-            "newText": "Invalid_argument",
+            "newText": "\`Int",
             "range": Object {
               "end": Object {
                 "character": 14,
                 "line": 2,
               },
               "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int",
-          "textEdit": Object {
-            "newText": "Int",
-            "range": Object {
-              "end": Object {
-                "character": 14,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int32",
-          "textEdit": Object {
-            "newText": "Int32",
-            "range": Object {
-              "end": Object {
-                "character": 14,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int64",
-          "textEdit": Object {
-            "newText": "Int64",
-            "range": Object {
-              "end": Object {
-                "character": 14,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 12,
+                "character": 11,
                 "line": 2,
               },
             },
@@ -611,64 +515,16 @@ let x : t = \`I
     expect(items).toMatchInlineSnapshot(`
       Array [
         Object {
-          "label": "Invalid_argument",
+          "label": "\`Int",
           "textEdit": Object {
-            "newText": "Invalid_argument",
+            "newText": "\`Int",
             "range": Object {
               "end": Object {
                 "character": 15,
                 "line": 2,
               },
               "start": Object {
-                "character": 14,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int",
-          "textEdit": Object {
-            "newText": "Int",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 14,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int32",
-          "textEdit": Object {
-            "newText": "Int32",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 14,
-                "line": 2,
-              },
-            },
-          },
-        },
-        Object {
-          "label": "Int64",
-          "textEdit": Object {
-            "newText": "Int64",
-            "range": Object {
-              "end": Object {
-                "character": 15,
-                "line": 2,
-              },
-              "start": Object {
-                "character": 14,
+                "character": 13,
                 "line": 2,
               },
             },


### PR DESCRIPTION
When reconstructing prefix, we were ignoring backtick, which resulted in wrong completion entries, see the first commit.

I modified prefix building function to 
- not ignore a backtick 
- make sure that if the prefix that we were building already included a dot, e.g., the prefix so far is `Fiber.return`, we ignore the backtick that, say, comes before that prefix ie `Fiber.return. (I understand that the user shouldn't put the backtick there in the first place, but let's provide the best completions when we can)

I used some mutations along with `String.rfindi` instead of hand-writing the loop because I though it's still easier to reason about that a hand-written loop.