### PR TITLE
Improve display of merlin errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
   Note: this is actually a bug fix, since we were ignoring the backtick when constructing
   the prefix for completion.
 
+- Parse merlin errors (best effort) into a more structured form. This allows
+  reporting all locations as "related information" (#475)
+
 # 1.7.0 (07/28/2021)
 
 ## Features

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -6,6 +6,6 @@
    merlin.analysis merlin.kernel merlin.merlin_utils merlin.parsing
    merlin.query_commands merlin.query_protocol merlin.specific merlin.typing
    merlin.utils octavius omd ppx_yojson_conv_lib re result stdune csexp
-   yojson dune_rpc ocamlformat-rpc-lib))
+   yojson dune_rpc ocamlformat-rpc-lib ocamlc_loc))
 
 (include_subdirs unqualified)

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
@@ -180,9 +180,7 @@ describe("textDocument/diagnostics", () => {
             sig val x : int end
           is not included in
             sig val x : unit end
-          Values do not match: val x : int is not included in val x : unit
-          File \\"test.ml\\", line 2, characters 2-14: Expected declaration
-          File \\"test.ml\\", line 4, characters 6-7: Actual declaration",
+          Values do not match: val x : int is not included in val x : unit",
                 "range": Object {
                   "end": Object {
                     "character": 3,
@@ -193,6 +191,40 @@ describe("textDocument/diagnostics", () => {
                     "line": 2,
                   },
                 },
+                "relatedInformation": Array [
+                  Object {
+                    "location": Object {
+                      "range": Object {
+                        "end": Object {
+                          "character": 14,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "character": 2,
+                          "line": 2,
+                        },
+                      },
+                      "uri": "file:///test.ml",
+                    },
+                    "message": "Expected declaration",
+                  },
+                  Object {
+                    "location": Object {
+                      "range": Object {
+                        "end": Object {
+                          "character": 7,
+                          "line": 4,
+                        },
+                        "start": Object {
+                          "character": 6,
+                          "line": 4,
+                        },
+                      },
+                      "uri": "file:///test.ml",
+                    },
+                    "message": "Actual declaration",
+                  },
+                ],
                 "severity": 1,
                 "source": "ocamllsp",
               },

--- a/ocaml-lsp-server/vendor/dune
+++ b/ocaml-lsp-server/vendor/dune
@@ -11,3 +11,9 @@
  (library
   (name dune_rpc)
   (libraries stdune csexp (re_export dune_rpc_private))))
+
+(subdir ocamlc_loc
+ (copy_files %{workspace_root}/submodules/dune/src/ocamlc_loc/*.{ml,mli})
+ (library
+  (name ocamlc_loc)
+  (libraries re stdune)))


### PR DESCRIPTION
Dune already has a library to parse compiler errors into a more structured form for better error reporting in watch mode. So we might as well use it to improve the errors we get from merlin.