### PR TITLE
Easier & cleaner logging

### DIFF
--- a/ocaml-lsp-server/src/logger.ml
+++ b/ocaml-lsp-server/src/logger.ml
@@ -1,0 +1,56 @@
+open Import
+
+type level = MessageType.t =
+  | Error
+  | Warning
+  | Info
+  | Log
+
+type t =
+  { log_level : level
+  ; send_notification : Server_notification.t -> unit Fiber.t
+  }
+
+type logger_instance =
+  | Uninitialized
+  | Initialized of t
+
+let logger_instance = ref Uninitialized
+
+let unwrap_exn logger_instance =
+  match !logger_instance with
+  | Uninitialized -> Code_error.raise "uninitialized logger used" []
+  | Initialized instance -> instance
+
+(* TODO: show_level is for [ShowMessage]s *)
+let initialize ~log_level ~show_level:_ ~send_notification : unit =
+  logger_instance := Initialized { log_level; send_notification }
+
+let should_log msg_log_level =
+  let log_level = (unwrap_exn logger_instance).log_level in
+  match (log_level, msg_log_level) with
+  | Log, _ -> true
+  | Info, (Info | Warning | Error) -> true
+  | Info, Log -> false
+  | Warning, (Warning | Error) -> true
+  | Warning, _ -> false
+  | Error, Error -> true
+  | Error, _ -> false
+
+let log msg_log_lvl msg_f =
+  let { send_notification; _ } = unwrap_exn logger_instance in
+  if not (should_log msg_log_lvl) then
+    Fiber.return ()
+  else
+    let log_msg_params =
+      LogMessageParams.create ~type_:msg_log_lvl ~message:(msg_f ())
+    in
+    send_notification (Server_notification.LogMessage log_msg_params)
+
+let log_e f = log Error f
+
+let log_w f = log Warning f
+
+let log_i f = log Info f
+
+let log_l f = log Log f

--- a/ocaml-lsp-server/src/logger.mli
+++ b/ocaml-lsp-server/src/logger.mli
@@ -1,0 +1,32 @@
+open Import
+
+(** A logger module that allows to
+
+    - avoid passing a logging callback or server instance to functions that
+      don't actually need access to server for anything but logging
+    - set an application-wide logging level
+
+    Each log level has an small integer value given below. Setting [log_level]
+    on initialization tells the logger to ignore logs that have higher logging
+    value. For users, it makes sense to put [Info] or something even lower.
+
+    Error - 0, Warning - 1, Info - 2, Log - 3
+
+    {b MUST} be initialized after server is created.
+
+    TODO: extend logging to show messages, ie also support 'window/showMessage'
+    notif-s *)
+
+val initialize :
+     log_level:MessageType.t
+  -> show_level:MessageType.t
+  -> send_notification:(Server_notification.t -> unit Fiber.t)
+  -> unit
+
+val log_e : (unit -> string) -> unit Fiber.t
+
+val log_w : (unit -> string) -> unit Fiber.t
+
+val log_i : (unit -> string) -> unit Fiber.t
+
+val log_l : (unit -> string) -> unit Fiber.t

--- a/ocaml-lsp-server/src/ocamlformat_rpc.mli
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.mli
@@ -1,5 +1,3 @@
-open Import
-
 type t
 
 val create : unit -> t
@@ -9,7 +7,4 @@ val stop : t -> unit Fiber.t
 val format_type :
   t -> typ:string -> (string, [> `Msg of string | `No_process ]) result Fiber.t
 
-val run :
-     logger:(type_:MessageType.t -> message:string -> unit -> unit Fiber.t)
-  -> t
-  -> (unit, [> `Binary_not_found ]) result Fiber.t
+val run : t -> (unit, [> `Binary_not_found ]) result Fiber.t


### PR DESCRIPTION
Sets up easier logging facility without passing around the `server` or a `logger` callback. Very much a proof of concept.

@rgrinberg What do you think of such a logger? It seems to make logging easier and cleaner. Kind of does what #421 says (?)

I am trying to improve logging generally, which would also include adding support for merlin logs.