### PR TITLE
Add support for a custom request to get AST node enclosing the cursor (for REPL support)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,10 @@
   let f x = x.Unix.tms_stime, x.Unix.tms_utime
   ```
 
+- Add support for a custom request `ocamllsp/wrappingAstNode`, which brings the smallest
+  AST (Abstract Syntax Tree) node enclosing given position. This request is used by VS
+  Code OCaml Platform and is not directly used by OCaml LSP users (#482)
+
 - Bug fix: do not show "random" documentation on hover
   - fixed by [merlin#1364](https://github.com/ocaml/merlin/pull/1364)
   - fixes duplicate:

--- a/ocaml-lsp-server/docs/ocamllsp/wrappingAstNode-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/wrappingAstNode-spec.md
@@ -1,0 +1,57 @@
+#### Wrapping AST Node
+
+(Could also be named `Enclosing AST Node`)
+
+Returns the range of the (typed) AST node enclosing the cursor at given position in the document with the given URI.
+
+Let's see some examples (`<n>` is
+cursor position for example number `n`)
+
+```ocaml
+let k = <1> 1
+<2>
+module M = struct<3>
+  let a =
+    let <4> b = 1 in
+    b + 1
+end
+```
+
+| Your cursor | Evaluated expression        | Rationale                                                                                        |
+| ----------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
+| <1>         | `let k = 1`                 | Toplevel expression under cursor                                                                 |
+| <2>         | whole code block            | Cursor is in-between, so whole "file" is evaluated                                               |
+| <3>         | `module M = ... end`        | Cursor is on the module definition                                                               |
+| <4>         | `let a = let b = 1 in b + 1 | "Toplevel" expression for the cursor; it's used because it's "closer" than the module definition |
+
+The returned range can be a null when the document is empty.
+
+The document URI in the request has to be open before sending a the request. If the file cannot be found in the document store (i.e., wasn't previously opened), will return an error.
+
+Note: stability of this custom request is not guaranteed. Talk to the maintainers if you want to depend on it.
+
+##### Client capability
+
+nothing that should be noted
+
+##### Server capability
+
+property name: `handleWrappingAstNode`
+property type: `boolean`
+
+##### Request
+
+- method: `ocamllsp/wrappingAstNode`
+- params:
+
+  ```json
+  {
+    "uri": DocumentUri,
+    "position": Position
+  }
+  ```
+
+##### Response
+
+- result: `Range | null`
+- error: code and message set in case an exception happens during the processing of the request.

--- a/ocaml-lsp-server/src/custom_requests/custom_request.ml
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.ml
@@ -1,0 +1,27 @@
+open Import
+
+type 't req_params_spec =
+  { params_schema : Jsonrpc.Message.Structured.t
+  ; of_jsonrpc_params : Jsonrpc.Message.Structured.t -> 't option
+  }
+
+let of_jsonrpc_params_exn spec params =
+  let raise_invalid_params ?data ~message () =
+    Jsonrpc.Response.Error.raise
+    @@ Jsonrpc.Response.Error.make ?data
+         ~code:Jsonrpc.Response.Error.Code.InvalidParams ~message ()
+  in
+  match params with
+  | None -> raise_invalid_params ~message:"Expected params but received none" ()
+  | Some params -> (
+    match spec.of_jsonrpc_params params with
+    | Some t -> t
+    | None ->
+      let error_json =
+        `Assoc
+          [ ("params_expected", (spec.params_schema :> Json.t))
+          ; ("params_received", (params :> Json.t))
+          ]
+      in
+      raise_invalid_params ~message:"Unexpected parameter format"
+        ~data:error_json ())

--- a/ocaml-lsp-server/src/custom_requests/custom_request.mli
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.mli
@@ -1,0 +1,13 @@
+type 't req_params_spec =
+  { params_schema : Jsonrpc.Message.Structured.t
+        (** used to document the structure of the params; example:
+            [`Assoc \[ "uri" , `String "<Uri>" \]]; *)
+  ; of_jsonrpc_params : Jsonrpc.Message.Structured.t -> 't option
+        (** parses given structured JSON if it's of the expected schema;
+            otherwise, return [None] *)
+  }
+
+val of_jsonrpc_params_exn :
+     'req_params req_params_spec
+  -> Jsonrpc.Message.Structured.t option
+  -> 'req_params

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -1,0 +1,63 @@
+open Import
+
+let capability = ("handleWrappingAstNode", `Bool true)
+
+let meth = "ocamllsp/wrappingAstNode"
+
+module Request_params = struct
+  type t =
+    { text_document_uri : Uri.t
+    ; cursor_position : Position.t
+    }
+
+  let params_schema =
+    `Assoc
+      [ ("uri", `String "<DocumentUri>"); ("position", `String "<Position>") ]
+
+  let of_jsonrpc_params params : t option =
+    match params with
+    | `Assoc [ ("uri", uri); ("position", position) ] ->
+      let text_document_uri = Uri.t_of_yojson uri in
+      let cursor_position = Position.t_of_yojson position in
+      Some { text_document_uri; cursor_position }
+    | _ -> None
+
+  let of_jsonrpc_params_exn params : t =
+    let params_spec = { Custom_request.params_schema; of_jsonrpc_params } in
+    Custom_request.of_jsonrpc_params_exn params_spec params
+end
+
+let on_request ~params state =
+  let { Request_params.text_document_uri; cursor_position } =
+    Request_params.of_jsonrpc_params_exn params
+  in
+  let doc = Document_store.get state.State.store text_document_uri in
+  let pos = Position.logical cursor_position in
+  let open Fiber.O in
+  let+ node =
+    Document.with_pipeline_exn doc (fun pipeline ->
+        let typer = Mpipeline.typer_result pipeline in
+        let pos = Mpipeline.get_lexing_pos pipeline pos in
+        let enclosing_nodes (* from smallest node to largest *) =
+          Mbrowse.enclosing pos
+            [ Mbrowse.of_typedtree (Mtyper.get_typedtree typer) ]
+        in
+        let loc_of_structure_item { Typedtree.str_loc; _ } = str_loc in
+        let find_fst_structure_item_or_structure = function
+          | _, Browse_raw.Structure_item (str_item, _) ->
+            Some (loc_of_structure_item str_item)
+          | _, Structure { str_items; _ } -> (
+            match str_items with
+            | [] -> None
+            | hd :: rest ->
+              let last = List.last rest |> Option.value ~default:hd in
+              let { Loc.loc_start; _ } = loc_of_structure_item hd in
+              let { Loc.loc_end; _ } = loc_of_structure_item last in
+              Some { Loc.loc_start; loc_end; loc_ghost = false })
+          | _ -> None
+        in
+        List.find_map enclosing_nodes ~f:find_fst_structure_item_or_structure)
+  in
+  match node with
+  | None -> `Null
+  | Some loc -> Range.of_loc loc |> Range.yojson_of_t

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.mli
@@ -1,0 +1,8 @@
+open Import
+
+val capability : string * Json.t
+
+val meth : string
+
+val on_request :
+  params:Jsonrpc.Message.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -58,6 +58,7 @@ let initialize_info : InitializeResult.t =
               ; Req_switch_impl_intf.capability
               ; Req_infer_intf.capability
               ; Req_typed_holes.capability
+              ; Req_wrapping_ast_node.capability
               ] )
         ]
     in
@@ -954,6 +955,7 @@ let on_request :
       [ (Req_switch_impl_intf.meth, Req_switch_impl_intf.on_request)
       ; (Req_infer_intf.meth, Req_infer_intf.on_request)
       ; (Req_typed_holes.meth, Req_typed_holes.on_request)
+      ; (Req_wrapping_ast_node.meth, Req_wrapping_ast_node.on_request)
       ]
       |> List.assoc_opt meth
     with

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
@@ -1,0 +1,185 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Types from "vscode-languageserver-types";
+import { Position } from "vscode-languageserver-types";
+
+describe("ocamllsp/wrappingAstNode", () => {
+  let languageServer = null;
+
+  async function openDocument(source: string) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "ocaml",
+        0,
+        source,
+      ),
+    });
+  }
+
+  async function sendWrappingAstNodeRequest({
+    line,
+    character,
+  }: {
+    line: number;
+    character: number;
+  }) {
+    return languageServer.sendRequest("ocamllsp/wrappingAstNode", {
+      uri: "file:///test.ml",
+      position: Position.create(line, character),
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("empty document", async () => {
+    await openDocument(
+      outdent`
+`,
+    );
+
+    let r = await sendWrappingAstNodeRequest({ line: 0, character: 0 });
+    expect(r).toMatchInlineSnapshot(`null`);
+  });
+
+  let code_snippet_0 = outdent`
+let k = 1
+
+module M = struct
+  let a =
+    let b = 1 in
+    b + 1
+
+  let c = 2
+end
+  `;
+
+  it("when on a toplevel let binding", async () => {
+    await openDocument(code_snippet_0);
+
+    let r = await sendWrappingAstNodeRequest({ line: 0, character: 5 });
+
+    /* given range corresponds to:
+        let k = 1
+    */
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 9,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      }
+    `);
+  });
+
+  it("in between toplevel bindings (let and module def)", async () => {
+    await openDocument(code_snippet_0);
+
+    let r = await sendWrappingAstNodeRequest({ line: 1, character: 0 });
+
+    /* given range corresponds to:
+        whole `code_snippet_0`
+    */
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 3,
+          "line": 8,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      }
+    `);
+  });
+
+  it("on keyword struct", async () => {
+    await openDocument(code_snippet_0);
+
+    let r = await sendWrappingAstNodeRequest({ line: 2, character: 14 });
+
+    /* given range corresponds to: the whole module definition M
+        module M = struct
+          let a =
+            let b = 1 in
+            b + 1
+
+          let c = 2
+        end
+    */
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 3,
+          "line": 8,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 2,
+        },
+      }
+    `);
+  });
+
+  it("on `b`'s let-binding (nested let-binding in a module def)", async () => {
+    await openDocument(code_snippet_0);
+    let r = await sendWrappingAstNodeRequest({ line: 4, character: 10 });
+
+    /* given range corresponds to:
+        let a =
+          let b = 1 in
+          b + 1
+    */
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 9,
+          "line": 5,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 3,
+        },
+      }
+    `);
+  });
+
+  it("between `a`'s and `c`'s let-bindings in a module def", async () => {
+    await openDocument(code_snippet_0);
+
+    let r = await sendWrappingAstNodeRequest({ line: 6, character: 0 });
+
+    /* given range corresponds to: values in M, but not module binding itself
+        let a =
+          let b = 1 in
+          b + 1
+
+        let c = 2
+    */
+    expect(r).toMatchInlineSnapshot(`
+      Object {
+        "end": Object {
+          "character": 11,
+          "line": 7,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 3,
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
This PR adds support for "Evaluate expression under cursor".

This PR will soon have a counter-part in vscode-ocaml-platform repo. From that PR's changelog:

Let's see some examples (`<n>` is cursor position for example number `n`)


```ocaml
let k = <1> 1
<2>
module M = struct<3>
  let a =
    let <4> b = 1 in
    b + 1
  <5>
  let u = ()
end
```

| Your cursor | Evaluated expression        | Rationale                                                                                        |
| ----------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
| <1>         | `let k = 1`                 | Toplevel expression under cursor                                                                 |
| <2>         | whole code block            | Cursor is in-between, so whole "file" is evaluated                                               |
| <3>         | `module M = ... end`        | Cursor is on the module definition                                                               |
| <4>         | `let a = let b = 1 in b + 1 | "Toplevel" expression for the cursor; it's used because it's "closer" than the module definition |
| <5>         | `let a = ... let u = ()`    | It's often useful to have module's definitions in the REPL environment                           

cc @arozovyk in case you're interested in the implementation of a custom request at the intersection of vscode-ocaml-platform, LSP, and merlin