### PR TITLE
Handle workspace change notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # 1.8.0 (08/19/2021)
 
+## Fixes
+
+- Handle workspace change notifications. Previously, the server would only use
+  the set of workspaces given at startup to search for workspace symbols. After
+  this change, workspace folders that are added later will also be considered.
+  (#498)
+
 ## Features
 
 - Add a new code action `Add missing rec keyword`, which is available when

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -184,7 +184,9 @@ let lsp_of_dune dune =
          | D.Error -> DiagnosticSeverity.Error
          | Warning -> DiagnosticSeverity.Warning)
   in
-  let make_message message = Format.asprintf "%a@." Pp.to_fmt message in
+  let make_message message =
+    String.trim (Format.asprintf "%a@." Pp.to_fmt message)
+  in
   let relatedInformation =
     match D.related dune with
     | [] -> None

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -8,6 +8,6 @@ type t
 
 val run : t -> (unit, run) result Fiber.t
 
-val create : build_dir:string -> Diagnostics.t -> Progress.t -> t
+val create : build_dir:string -> Diagnostics.t -> Progress.t -> t Fiber.t
 
 val stop : t -> unit Fiber.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -75,6 +75,7 @@ include struct
   module DiagnosticRelatedInformation = DiagnosticRelatedInformation
   module DiagnosticSeverity = DiagnosticSeverity
   module DidChangeConfigurationParams = DidChangeConfigurationParams
+  module DidChangeWorkspaceFoldersParams = DidChangeWorkspaceFoldersParams
   module DidOpenTextDocumentParams = DidOpenTextDocumentParams
   module DocumentHighlight = DocumentHighlight
   module DocumentHighlightKind = DocumentHighlightKind

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -11,6 +11,7 @@ include struct
   module Fpath = Path
   module Int = Int
   module List = List
+  module Map = Map
   module Option = Option
   module Ordering = Ordering
   module Pid = Pid
@@ -128,4 +129,5 @@ include struct
   module WorkspaceEdit = WorkspaceEdit
   module WorkspaceFolder = WorkspaceFolder
   module WorkspaceSymbolParams = WorkspaceSymbolParams
+  module WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities
 end

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -1101,8 +1101,8 @@ let start () =
     match build_dir with
     | None -> Fiber.return ()
     | Some build_dir -> (
-      let dune =
-        let dune' = Dune.create ~build_dir diagnostics progress in
+      let* dune =
+        let+ dune' = Dune.create ~build_dir diagnostics progress in
         dune := Some dune';
         dune'
       in

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -4,12 +4,19 @@ type init =
   | Uninitialized
   | Initialized of InitializeParams.t
 
+module Uri_map = Map.Make (struct
+  include Uri
+
+  let compare x y = Ordering.of_int (compare x y)
+end)
+
 type t =
   { store : Document_store.t
   ; merlin : Scheduler.thread
   ; init : init
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
+  ; workspace_folders : WorkspaceFolder.t Uri_map.t option
   ; trace : TraceValue.t
   ; ocamlformat : Fmt.t
   ; ocamlformat_rpc : Ocamlformat_rpc.t

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -2,9 +2,7 @@ open Import
 
 type init =
   | Uninitialized
-  | Initialized of InitializeParams.t
-
-module Uri_map : Map.S with type key = Uri.t
+  | Initialized of InitializeParams.t * Workspaces.t
 
 type t =
   { store : Document_store.t
@@ -12,7 +10,6 @@ type t =
   ; init : init
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
-  ; workspace_folders : WorkspaceFolder.t Uri_map.t option
   ; trace : TraceValue.t
   ; ocamlformat : Fmt.t
   ; ocamlformat_rpc : Ocamlformat_rpc.t
@@ -20,4 +17,12 @@ type t =
   ; symbols_thread : Scheduler.thread Lazy_fiber.t
   }
 
+val initialize_params : t -> InitializeParams.t
+
+val initialize : t -> InitializeParams.t -> t
+
 val workspace_root : t -> Uri.t
+
+val workspaces : t -> Workspaces.t
+
+val modify_workspaces : t -> f:(Workspaces.t -> Workspaces.t) -> t

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -4,12 +4,15 @@ type init =
   | Uninitialized
   | Initialized of InitializeParams.t
 
+module Uri_map : Map.S with type key = Uri.t
+
 type t =
   { store : Document_store.t
   ; merlin : Scheduler.thread
   ; init : init
   ; detached : Fiber.Pool.t
   ; configuration : Configuration.t
+  ; workspace_folders : WorkspaceFolder.t Uri_map.t option
   ; trace : TraceValue.t
   ; ocamlformat : Fmt.t
   ; ocamlformat_rpc : Ocamlformat_rpc.t

--- a/ocaml-lsp-server/src/workspaces.ml
+++ b/ocaml-lsp-server/src/workspaces.ml
@@ -1,0 +1,68 @@
+open Import
+
+module Uri_map = Map.Make (struct
+  include Uri
+
+  let compare x y = Ordering.of_int (compare x y)
+end)
+
+type t =
+  { workspace_folders : WorkspaceFolder.t Uri_map.t option
+  ; root_uri : Uri.t option
+  ; root_path : string option
+  }
+
+let create (ip : InitializeParams.t) =
+  let workspace_folders =
+    match ip.workspaceFolders with
+    | None
+    | Some None ->
+      None
+    | Some (Some workspace_folders) ->
+      Uri_map.of_list_map_exn workspace_folders
+        ~f:(fun (ws : WorkspaceFolder.t) -> (ws.uri, ws))
+      |> Option.some
+  in
+  let root_uri = ip.rootUri in
+  let root_path =
+    match ip.rootPath with
+    | None -> None
+    | Some s -> s
+  in
+  { workspace_folders; root_uri; root_path }
+
+let on_change t { DidChangeWorkspaceFoldersParams.event = { added; removed } } =
+  assert (t.workspace_folders <> None);
+  let workspace_folders =
+    let init = Option.value t.workspace_folders ~default:Uri_map.empty in
+    let init =
+      List.fold_left removed ~init ~f:(fun acc (a : WorkspaceFolder.t) ->
+          Uri_map.remove acc a.uri)
+    in
+    List.fold_left added ~init ~f:(fun acc (a : WorkspaceFolder.t) ->
+        Uri_map.set acc a.uri a)
+    |> Option.some
+  in
+  { t with workspace_folders }
+
+let workspace_folders { root_uri; root_path; workspace_folders } =
+  match workspace_folders with
+  | Some s -> Uri_map.values s
+  | None -> (
+    (* WorkspaceFolders has the most priority. Then rootUri and finally
+       rootPath *)
+    match (workspace_folders, root_uri, root_path) with
+    | Some workspace_folders, _, _ -> Uri_map.values workspace_folders
+    | _, Some root_uri, _ ->
+      [ WorkspaceFolder.create ~uri:root_uri
+          ~name:(Filename.basename (Uri.to_path root_uri))
+      ]
+    | _, _, Some root_path ->
+      [ WorkspaceFolder.create ~uri:(Uri.of_path root_path)
+          ~name:(Filename.basename root_path)
+      ]
+    | _ ->
+      let cwd = Sys.getcwd () in
+      [ WorkspaceFolder.create ~uri:(Uri.of_path cwd)
+          ~name:(Filename.basename cwd)
+      ])

--- a/ocaml-lsp-server/src/workspaces.mli
+++ b/ocaml-lsp-server/src/workspaces.mli
@@ -1,0 +1,9 @@
+open Import
+
+type t
+
+val create : InitializeParams.t -> t
+
+val on_change : t -> DidChangeWorkspaceFoldersParams.t -> t
+
+val workspace_folders : t -> WorkspaceFolder.t list


### PR DESCRIPTION
The server will now maintain the set of open workspace folders and use
this set for querying symbols.

Support for dune is a bit more complicated, but the idea is going to be manage a dune connection per workspace folder.