### PR TITLE
move jest extend matchers in jest.setup.ts

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
@@ -3,19 +3,7 @@ import * as path from "path";
 import * as child_process from "child_process";
 import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
-import { testUri, toEqualUri } from "./../src/LanguageServer";
-
-expect.extend({
-  toEqualUri: toEqualUri(this),
-});
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toEqualUri(uri: string): R;
-    }
-  }
-}
+import { testUri } from "./../src/LanguageServer";
 
 describe("textDocument/declaration", () => {
   let languageServer = null;

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-definition.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-definition.test.ts
@@ -1,19 +1,7 @@
 import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
-import { testUri, toEqualUri } from "./../src/LanguageServer";
-
-expect.extend({
-  toEqualUri: toEqualUri(this),
-});
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toEqualUri(uri: string): R;
-    }
-  }
-}
+import { testUri } from "./../src/LanguageServer";
 
 describe("textDocument/definition", () => {
   let languageServer = null;

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-typeDefinition.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-typeDefinition.test.ts
@@ -1,19 +1,7 @@
 import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
-import { testUri, toEqualUri } from "./../src/LanguageServer";
-
-expect.extend({
-  toEqualUri: toEqualUri(this),
-});
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toEqualUri(uri: string): R;
-    }
-  }
-}
+import { testUri } from "./../src/LanguageServer";
 
 describe("textDocument/definition", () => {
   let languageServer = null;

--- a/ocaml-lsp-server/test/e2e/jest.config.js
+++ b/ocaml-lsp-server/test/e2e/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  setupFilesAfterEnv: ["./jest.setup.ts"],
 };

--- a/ocaml-lsp-server/test/e2e/jest.setup.ts
+++ b/ocaml-lsp-server/test/e2e/jest.setup.ts
@@ -1,0 +1,13 @@
+import { toEqualUri } from "./src/LanguageServer";
+
+expect.extend({
+  toEqualUri,
+});
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toEqualUri(uri: string): R;
+    }
+  }
+}

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -94,26 +94,28 @@ export const testUri = (file: string) => {
   return URI.file(file).toString();
 };
 
-export const toEqualUri = (obj) => {
-  return (received: string, expected: string) => {
-    const options = {
-      comment: "Uri equality",
-      isNot: obj.isNot,
-      promise: obj.promise,
-    };
-    const pass =
-      URI.parse(received).toString() === URI.parse(received).toString();
-    const message = pass
-      ? () =>
-          obj.utils.matcherHint("toEqualUri", undefined, undefined, options) +
-          "\n\n" +
-          `Expected: not ${obj.utils.printExpected(expected)}\n` +
-          `Received: ${obj.utils.printReceived(received)}`
-      : () =>
-          obj.utils.matcherHint("toBe", undefined, undefined, options) +
-          "\n\n" +
-          `Expected: ${obj.utils.printExpected(expected)}\n` +
-          `Received: ${obj.utils.printReceived(received)}`;
-    return { pass, message };
+export const toEqualUri = (
+  obj: jest.MatcherContext,
+  received: string,
+  expected: string,
+) => {
+  const options = {
+    comment: "Uri equality",
+    isNot: obj.isNot,
+    promise: obj.promise,
   };
+  const pass =
+    URI.parse(received).toString() === URI.parse(received).toString();
+  const message = pass
+    ? () =>
+        obj.utils.matcherHint("toEqualUri", undefined, undefined, options) +
+        "\n\n" +
+        `Expected: not ${obj.utils.printExpected(expected)}\n` +
+        `Received: ${obj.utils.printReceived(received)}`
+    : () =>
+        obj.utils.matcherHint("toBe", undefined, undefined, options) +
+        "\n\n" +
+        `Expected: ${obj.utils.printExpected(expected)}\n` +
+        `Received: ${obj.utils.printReceived(received)}`;
+  return { pass, message };
 };


### PR DESCRIPTION
This PR moves the function that extends jest matchers with the `toEqualUri` to its own file, and add it to the [setupFilesAfterEnv](https://jestjs.io/docs/26.x/configuration#setupfilesafterenv-array) config. By doing so, it will be available in every test file by default.