### PR TITLE
jest: use node environment instead of jsdom

### DIFF
--- a/ocaml-lsp-server/test/e2e/jest.config.js
+++ b/ocaml-lsp-server/test/e2e/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ["<rootDir>"],
+  testEnvironment: "node",
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },


### PR DESCRIPTION
The default test environment of jest `26.x` is `jsdom`, which provides a browser-like environment https://jestjs.io/docs/26.x/configuration#testenvironment-string

Since we're not developing a browser app and to avoid some overhead, we can use the `node` environment instead.

The default value for jest `27.x` [was changed to `node`](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults). Since we're still running the version `26.x`, this PR explicitly specifies to use the `node` env.