### PR TITLE
Add dune promotion information to diagnostics

### DIFF
--- a/dune
+++ b/dune
@@ -18,7 +18,7 @@
   (subdir
    dune_filesystem_stubs
    (copy_files#
-     %{workspace_root}/submodules/dune/otherlibs/stdune-unstable/dune_filesystem_stubs/*.*)
+    %{workspace_root}/submodules/dune/otherlibs/stdune-unstable/dune_filesystem_stubs/*.*)
    (library
     (name dune_filesystem_stubs)
     (public_name lsp.filesystem_stubs)
@@ -27,7 +27,7 @@
      (language c)
      (names readdir))))
   (copy_files#
-    %{workspace_root}/submodules/dune/otherlibs/stdune-unstable/*.*)
+   %{workspace_root}/submodules/dune/otherlibs/stdune-unstable/*.*)
   (library
    (name stdune)
    (libraries

--- a/lsp-fiber/src/dune
+++ b/lsp-fiber/src/dune
@@ -1,4 +1,12 @@
 (library
  (name lsp_fiber)
- (libraries fiber fiber_unix jsonrpc jsonrpc_fiber lsp ppx_yojson_conv_lib
-   result stdune yojson))
+ (libraries
+  fiber
+  fiber_unix
+  jsonrpc
+  jsonrpc_fiber
+  lsp
+  ppx_yojson_conv_lib
+  result
+  stdune
+  yojson))

--- a/lsp/src/dune
+++ b/lsp/src/dune
@@ -3,8 +3,14 @@
 (library
  (name lsp)
  (public_name lsp)
- (libraries jsonrpc ppx_yojson_conv_lib result stdune threads.posix uutf
-   yojson)
+ (libraries
+  jsonrpc
+  ppx_yojson_conv_lib
+  result
+  stdune
+  threads.posix
+  uutf
+  yojson)
  (lint
   (pps ppx_yojson_conv)))
 

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -2,10 +2,34 @@
  (name main)
  (package ocaml-lsp-server)
  (public_name ocamllsp)
- (libraries cmdliner dune-build-info fiber fiber_unix jsonrpc lsp lsp_fiber
-   merlin.analysis merlin.kernel merlin.merlin_utils merlin.parsing
-   merlin.query_commands merlin.query_protocol merlin.specific merlin.typing
-   merlin.utils octavius omd ppx_yojson_conv_lib re result stdune csexp
-   yojson dune_rpc csexp_rpc ocamlformat-rpc-lib ocamlc_loc))
+ (libraries
+  cmdliner
+  dune-build-info
+  fiber
+  fiber_unix
+  jsonrpc
+  lsp
+  lsp_fiber
+  merlin.analysis
+  merlin.kernel
+  merlin.merlin_utils
+  merlin.parsing
+  merlin.query_commands
+  merlin.query_protocol
+  merlin.specific
+  merlin.typing
+  merlin.utils
+  octavius
+  omd
+  ppx_yojson_conv_lib
+  re
+  result
+  stdune
+  csexp
+  yojson
+  dune_rpc
+  csexp_rpc
+  ocamlformat-rpc-lib
+  ocamlc_loc))
 
 (include_subdirs unqualified)

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -6,8 +6,15 @@ type run =
 
 type t
 
+val view_promotion_capability : string * Json.t
+
 val run : t -> (unit, run) result Fiber.t
 
-val create : build_dir:string -> Diagnostics.t -> Progress.t -> t Fiber.t
+val create :
+     build_dir:string
+  -> ClientCapabilities.t
+  -> Diagnostics.t
+  -> Progress.t
+  -> t Fiber.t
 
 val stop : t -> unit Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -63,6 +63,7 @@ let initialize_info : InitializeResult.t =
               ; Req_infer_intf.capability
               ; Req_typed_holes.capability
               ; Req_wrapping_ast_node.capability
+              ; Dune.view_promotion_capability
               ] )
         ]
     in
@@ -1082,8 +1083,9 @@ let start () =
   let dune = ref None in
   let run_dune () =
     let* (init_params : InitializeParams.t) = Server.initialized server in
+    let capabilities = init_params.capabilities in
     let progress =
-      Progress.create init_params.capabilities
+      Progress.create capabilities
         ~report_progress:(fun progress ->
           Server.notification server
             (Server_notification.WorkDoneProgress progress))
@@ -1102,7 +1104,7 @@ let start () =
     | None -> Fiber.return ()
     | Some build_dir -> (
       let* dune =
-        let+ dune' = Dune.create ~build_dir diagnostics progress in
+        let+ dune' = Dune.create ~build_dir capabilities diagnostics progress in
         dune := Some dune';
         dune'
       in


### PR DESCRIPTION
This will allow vscode to display diffs. I'm not sure if the client should provide a capability that tells us if it can do anything with this information. Of course it can always just ignore this data.