### PR TITLE
Improve completion kinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- More accurate completion kinds.
+  New completion kinds for variants and fields. Removed inaccurate completion
+  kinds for constructors and types. (#510)
+
 # 1.8.2 (09/14/2021)
 
 - Disable experimental dune support. It was accidentally left enabled.

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -17,15 +17,14 @@ end
 let completion_kind kind : CompletionItemKind.t option =
   match kind with
   | `Value -> Some Value
-  | `Constructor -> Some Constructor
-  | `Variant -> None
-  | `Label -> Some Property
-  | `Module
-  | `Modtype ->
-    Some Module
-  | `Type -> Some TypeParameter
+  | `Variant -> Some EnumMember
+  | `Label -> Some Field
+  | `Module -> Some Module
+  | `Modtype -> Some Interface
   | `MethodCall -> Some Method
   | `Keyword -> Some Keyword
+  | `Constructor -> Some Constructor
+  | `Type -> Some TypeParameter
 
 let prefix_of_position ~short_path source position =
   match Msource.text source with


### PR DESCRIPTION
Introduce these mappings:

label -> field
variant -> enum member

For items without precise kinds, we no longer select a related but
inaccurate kind.