### PR TITLE
refactor: add dune documents

### DIFF
--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -35,6 +35,8 @@ val make :
   -> DidOpenTextDocumentParams.t
   -> t
 
+val make_dune : DidOpenTextDocumentParams.t -> t
+
 val timer : t -> Scheduler.timer
 
 val uri : t -> Uri.t


### PR DESCRIPTION
In preparation for formatting dune files.

The change itself isn't very clean - we'd prefer a more a type safe approach. For now, we'd like to get the feature out and refactor later.