### PR TITLE
fix e2e tests node v16

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -25,7 +25,6 @@ describe("ocamllsp/switchImplIntf", () => {
 
   beforeEach(async () => {
     languageServer = await LanguageServer.startAndInitialize();
-    await fs.rmdir(testWorkspacePath, { recursive: true });
     await fs.mkdir(testWorkspacePath);
   });
 


### PR DESCRIPTION
The upgrade to node v16 introduced in #522 broke one of the e2e tests. This PR should fix it. 