### PR TITLE
refactor: no more local open of fiber

### DIFF
--- a/fiber-test/fiber_test.ml
+++ b/fiber-test/fiber_test.ml
@@ -1,4 +1,5 @@
 open Stdune
+open Fiber.O
 
 let printf = Printf.printf
 
@@ -25,7 +26,6 @@ end = struct
 
   let yield () =
     let ivar = Fiber.Ivar.create () in
-    let open Fiber.O in
     let* t = Fiber.Var.get_exn t_var in
     Queue.push t ivar;
     Fiber.Ivar.read ivar

--- a/fiber-unix/src/scheduler.ml
+++ b/fiber-unix/src/scheduler.ml
@@ -165,7 +165,6 @@ type 'a task =
 let await task = Fiber.Ivar.read task.ivar
 
 let await_no_cancel task =
-  let open Fiber.O in
   let+ res = Fiber.Ivar.read task.ivar in
   match res with
   | Ok x -> Ok x
@@ -173,7 +172,6 @@ let await_no_cancel task =
   | Error (`Exn exn) -> Error exn
 
 let cancel_task task =
-  let open Fiber.O in
   let* status = Fiber.Ivar.peek task.ivar in
   match status with
   | Some _ -> Fiber.return ()
@@ -253,7 +251,6 @@ let set_delay t ~delay = t.delay <- delay
 
 let schedule (type a) (timer : timer) (f : unit -> a Fiber.t) :
     (a, [ `Cancelled ]) result Fiber.t =
-  let open Fiber.O in
   let active_timer =
     let scheduled = Unix.gettimeofday () in
     { scheduled; ivar = Fiber.Ivar.create (); parent = timer }

--- a/fiber-unix/test/scheduler_tests.ml
+++ b/fiber-unix/test/scheduler_tests.ml
@@ -178,7 +178,6 @@ let%expect_test "detached + timer" =
     timer finished |}]
 
 let%expect_test "multiple timers" =
-  let open Fiber.O in
   let timer delay =
     let+ timer = S.create_timer ~delay in
     (delay, timer)
@@ -202,7 +201,6 @@ let%expect_test "multiple timers" =
     timer 0.3 |}]
 
 let%expect_test "sleep test" =
-  let open Fiber.O in
   let run () =
     Fiber.parallel_iter [ 0.3; 0.2; 0.1 ] ~f:(fun delay ->
         let+ () = S.sleep delay in

--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 module Id = struct
   include Id
@@ -136,7 +137,6 @@ struct
       ]
 
   let run t =
-    let open Fiber.O in
     let send_response resp =
       log t (fun () ->
           Log.msg "sending response" [ ("response", Response.yojson_of_t resp) ]);
@@ -284,7 +284,6 @@ struct
     | None -> Table.add_exn t.pending id ivar
 
   let read_request_ivar req ivar =
-    let open Fiber.O in
     let+ res = Fiber.Ivar.read ivar in
     match res with
     | Ok s -> s
@@ -292,7 +291,6 @@ struct
 
   let request t (req : Message.request) =
     check_running t;
-    let open Fiber.O in
     let* () =
       let req = { req with Message.id = Some req.id } in
       Chan.send t.chan [ Message req ]

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -244,7 +244,6 @@ let%expect_test "test from jsonrpc_test.ml" =
   in
   let session = Jrpc.create ~on_notification ~on_request ~name:"test" chan () in
   let write_reqs () =
-    let open Fiber.O in
     let* () =
       Fiber.sequential_iter initial_requests ~f:(fun req ->
           Out.write reqs_out (Some req))

--- a/lsp-fiber/src/fiber_io.ml
+++ b/lsp-fiber/src/fiber_io.ml
@@ -54,7 +54,6 @@ let close_write t =
     | Error exn -> Exn_with_backtrace.reraise exn)
 
 let recv t =
-  let open Fiber.O in
   match !(t.in_thread) with
   | None -> Fiber.return None
   | Some thread ->
@@ -95,7 +94,6 @@ let close (t : t) what =
     match !(t.in_thread) with
     | None -> Fiber.return ()
     | Some thread -> (
-      let open Fiber.O in
       let+ close =
         Scheduler.async_exn thread (fun () -> Io.close_in t.io)
         |> Scheduler.await_no_cancel

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -66,7 +66,6 @@ module End_to_end_client = struct
          ~code:InternalError ())
 
   let on_notification (client : _ Client.t) n =
-    let open Fiber.O in
     let state = Client.state client in
     let received_notification = state in
     let req = Server_notification.to_jsonrpc n in
@@ -81,7 +80,6 @@ module End_to_end_client = struct
       let on_request = { Client.Handler.on_request } in
       Test.Client.run ~on_request ~on_notification received_notification io
     in
-    let open Fiber.O in
     let init () : unit Fiber.t =
       Format.eprintf "client: waiting for initialization@.%!";
       let* (_ : InitializeResult.t) = Client.initialized client in
@@ -125,7 +123,6 @@ module End_to_end_server = struct
       | Client_request.ExecuteCommand _ ->
         Format.eprintf "server: executing command@.%!";
         let result = `String "successful execution" in
-        let open Fiber.O in
         let* () =
           let* timer = Scheduler.create_timer ~delay:0.5 in
           Fiber.Pool.task detached ~f:(fun () ->

--- a/ocaml-lsp-server/src/code_actions/action_add_rec.ml
+++ b/ocaml-lsp-server/src/code_actions/action_add_rec.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let action_title = "Add missing `rec` keyword"
 
@@ -60,9 +61,7 @@ let code_action_add_rec uri diagnostics doc loc =
     ~kind:CodeActionKind.QuickFix ~edit ~isPreferred:false ()
 
 let code_action doc (params : CodeActionParams.t) =
-  let open Fiber.O in
   let pos_start = Position.logical params.range.start in
-
   let m_diagnostic =
     List.find params.context.diagnostics ~f:(fun d ->
         let is_unbound () =

--- a/ocaml-lsp-server/src/code_actions/action_construct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_construct.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let action_kind = "construct"
 
@@ -16,7 +17,6 @@ let code_action doc (params : CodeActionParams.t) =
     if not (Typed_hole.can_be_hole prefix) then
       Fiber.return None
     else
-      let open Fiber.O in
       let+ structures =
         Document.with_pipeline_exn doc (fun pipeline ->
             let typedtree =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let action_kind = "destruct"
 
@@ -33,7 +34,6 @@ let code_action doc (params : CodeActionParams.t) =
       let finish = Position.logical params.range.end_ in
       Query_protocol.Case_analysis (start, finish)
     in
-    let open Fiber.O in
     let+ res = Document.dispatch doc command in
     match res with
     | Ok res -> Some (code_action_of_case_analysis doc uri res)

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let action_kind = "inferred_intf"
 
@@ -20,7 +21,6 @@ let code_action_of_intf doc intf range =
     ~isPreferred:false ()
 
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
-  let open Fiber.O in
   match Document.kind doc with
   | Impl -> Fiber.return None
   | Intf ->

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
@@ -1,8 +1,8 @@
 open Import
+open Fiber.O
 
 let code_action (mode : [ `Qualify | `Unqualify ]) (action_kind : string) doc
     (params : CodeActionParams.t) =
-  let open Fiber.O in
   let+ res =
     let command =
       let pos_start = Position.logical params.range.start in

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let action_kind = "type-annotate"
 
@@ -41,7 +42,6 @@ let code_action_of_type_enclosing uri doc (loc, typ) =
     ~isPreferred:false ()
 
 let code_action doc (params : CodeActionParams.t) =
-  let open Fiber.O in
   let pos_start = Position.logical params.range.start in
   let+ res =
     Document.with_pipeline_exn doc (fun pipeline ->

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let capability = ("handleInferIntf", `Bool true)
 
@@ -9,7 +10,6 @@ let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
   match params with
   | Some (`List [ json_uri ]) -> (
     let json_uri = DocumentUri.t_of_yojson json_uri in
-    let open Fiber.O in
     match Document_store.get_opt state.store json_uri with
     | None ->
       Jsonrpc.Response.Error.raise

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let capability = ("handleTypedHoles", `Bool true)
 
@@ -55,7 +56,6 @@ let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
               (Uri.to_string uri))
          ()
   | Some doc ->
-    let open Fiber.O in
     let+ holes = Document.dispatch_exn doc Holes in
     Json.yojson_of_list
       (fun (loc, _type) -> loc |> Range.of_loc |> Range.yojson_of_t)

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let capability = ("handleWrappingAstNode", `Bool true)
 
@@ -33,7 +34,6 @@ let on_request ~params state =
   in
   let doc = Document_store.get state.State.store text_document_uri in
   let pos = Position.logical cursor_position in
-  let open Fiber.O in
   let+ node =
     Document.with_pipeline_exn doc (fun pipeline ->
         let typer = Mpipeline.typer_result pipeline in

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -111,7 +111,6 @@ let timer = function
 let source t = Msource.make (Text_document.text (tdoc t))
 
 let await task =
-  let open Fiber.O in
   let* () = Server.on_cancel (fun () -> Scheduler.cancel_task task) in
   let+ res = Scheduler.await task in
   match res with
@@ -127,14 +126,12 @@ let with_pipeline (t : t) f =
   match t with
   | Dune _ -> Code_error.raise "Document.dune" []
   | Merlin t ->
-    let open Fiber.O in
     let* pipeline = Lazy_fiber.force t.pipeline in
     Scheduler.async_exn t.merlin (fun () ->
         Mpipeline.with_pipeline pipeline (fun () -> f pipeline))
     |> await
 
 let with_pipeline_exn doc f =
-  let open Fiber.O in
   let+ res = with_pipeline doc f in
   match res with
   | Ok s -> s
@@ -166,7 +163,6 @@ let make_pipeline merlin_config thread tdoc =
         Scheduler.async_exn thread (fun () ->
             Text_document.text tdoc |> Msource.make |> Mpipeline.make config)
       in
-      let open Fiber.O in
       let+ res = await async_make_pipeline in
       match res with
       | Ok s -> s

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -1,4 +1,5 @@
 open! Import
+open Fiber.O
 
 type t = (Uri.t, Document.t) Table.t
 
@@ -22,7 +23,6 @@ let remove_document store uri =
   match Table.find store uri with
   | None -> Fiber.return ()
   | Some doc ->
-    let open Fiber.O in
     let+ () = Document.close doc in
     Table.remove store uri
 
@@ -30,6 +30,5 @@ let get_size store = Table.length store
 
 let close t =
   let docs = Table.fold t ~init:[] ~f:(fun doc acc -> doc :: acc) in
-  let open Fiber.O in
   let+ () = Fiber.parallel_iter docs ~f:Document.close in
   Table.clear t

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let outline_kind kind : SymbolKind.t =
   match kind with
@@ -39,7 +40,6 @@ let symbols_of_outline uri outline =
 
 let run (client_capabilities : ClientCapabilities.t) doc uri =
   let command = Query_protocol.Outline in
-  let open Fiber.O in
   let+ outline = Document.dispatch_exn doc command in
   let symbols =
     let hierarchicalDocumentSymbolSupport =

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -35,7 +35,6 @@ module Csexp_rpc = Csexp_rpc.Make (struct
   let create () = Scheduler.create_thread ()
 
   let task t ~f =
-    let open Fiber.O in
     let res = Scheduler.async t f in
     match res with
     | Error `Stopped -> Fiber.return (Error `Stopped)

--- a/ocaml-lsp-server/src/fmt.ml
+++ b/ocaml-lsp-server/src/fmt.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 type command_result =
   { stdout : string
@@ -19,7 +20,6 @@ let create () =
   { stdout; stderr; stdin }
 
 let run_command state prog stdin_value args : command_result Fiber.t =
-  let open Fiber.O in
   let stdin_i, stdin_o = Unix.pipe ~cloexec:true () in
   let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
   let stderr_i, stderr_o = Unix.pipe ~cloexec:true () in
@@ -127,7 +127,6 @@ let formatter doc =
 
 let exec state bin args stdin =
   let refmt = Fpath.to_string bin in
-  let open Fiber.O in
   let+ res = run_command state refmt stdin args in
   match res.status with
   | Unix.WEXITED 0 -> Result.Ok res.stdout

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 let infer_intf_for_impl doc =
   match Document.kind doc with
@@ -37,7 +38,6 @@ let language_id_of_fname s =
     Code_error.raise "unsupported file extension" [ ("extension", String ext) ]
 
 let force_open_document (state : State.t) uri =
-  let open Fiber.O in
   let filename = Uri.to_path uri in
   let text = Io.String_path.read_file filename in
   let delay = Configuration.diagnostics_delay state.configuration in
@@ -52,7 +52,6 @@ let force_open_document (state : State.t) uri =
   doc
 
 let infer_intf ~force_open_impl (state : State.t) doc =
-  let open Fiber.O in
   match Document.kind doc with
   | Impl -> Code_error.raise "the provided document is not an interface." []
   | Intf ->

--- a/ocaml-lsp-server/src/progress.ml
+++ b/ocaml-lsp-server/src/progress.ml
@@ -1,4 +1,5 @@
 open Import
+open Fiber.O
 
 type enabled =
   { (* TODO this needs to be mutexed *)
@@ -36,7 +37,6 @@ let end_build_if_running = function
   | Enabled e -> end_build e ~message:"Build interrupted"
 
 let start_build (t : enabled) =
-  let open Fiber.O in
   let* () = end_build t ~message:"Starting new build" in
   let token = `String ("dune-build-" ^ Int.to_string t.build_counter) in
   t.token <- Some token;
@@ -56,7 +56,6 @@ let build_progress t (progress : Drpc.Progress.t) =
   match t with
   | Disabled -> Code_error.raise "progress reporting is not supported" []
   | Enabled ({ token; report_progress; _ } as t) -> (
-    let open Fiber.O in
     match progress with
     | Success -> end_build t ~message:"Build finished"
     | Failed -> end_build t ~message:"Build failed"


### PR DESCRIPTION
It added too much noise for little benefit. After we get rid of result, bind is basically the same thing everywhere.