### PR TITLE
fix: jest toEqualUri helper and expected results

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
@@ -56,6 +56,6 @@ describe("textDocument/declaration", () => {
       end: { character: 0, line: 0 },
       start: { character: 0, line: 0 },
     });
-    expect(result[0].uri).toEqualUri(testUri(createPathForFile("lib.ml")));
+    expect(result[0].uri).toEqualUri(testUri(createPathForFile("lib.mli")));
   });
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-definition.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-definition.test.ts
@@ -48,6 +48,6 @@ describe("textDocument/definition", () => {
       end: { character: 4, line: 0 },
       start: { character: 4, line: 0 },
     });
-    expect(result[0].uri).toEqualUri(testUri("file.ml"));
+    expect(result[0].uri).toEqualUri(testUri("test.ml"));
   });
 });

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -94,18 +94,22 @@ export const testUri = (file: string) => {
   return URI.file(file).toString();
 };
 
-export const toEqualUri = (
-  obj: jest.MatcherContext,
+export const toEqualUri = function (
   received: string,
   expected: string,
-) => {
+) {
+
+  const obj = this;
+
   const options = {
     comment: "Uri equality",
     isNot: obj.isNot,
     promise: obj.promise,
   };
+
   const pass =
-    URI.parse(received).toString() === URI.parse(received).toString();
+    URI.parse(received).toString() === URI.parse(expected).toString();
+
   const message = pass
     ? () =>
         obj.utils.matcherHint("toEqualUri", undefined, undefined, options) +


### PR DESCRIPTION
Splitting out the commit from #545 (will rebase that PR) - issue with the `toEqualUri` helper not asserting correctly.