### PR TITLE
Better ocamlformatrpc integration

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -3,6 +3,8 @@ open Fiber.O
 
 let action_kind = "destruct"
 
+let kind = CodeActionKind.Other action_kind
+
 let code_action_of_case_analysis doc uri (loc, newText) =
   let range : Range.t = Range.of_loc loc in
   let edit : WorkspaceEdit.t =
@@ -24,7 +26,7 @@ let code_action_of_case_analysis doc uri (loc, newText) =
   CodeAction.create ~title ~kind:(CodeActionKind.Other action_kind) ~edit
     ~command ~isPreferred:false ()
 
-let code_action doc (params : CodeActionParams.t) =
+let code_action (state : State.t) doc (params : CodeActionParams.t) =
   let uri = params.textDocument.uri in
   match Document.kind doc with
   | Intf -> Fiber.return None
@@ -34,9 +36,15 @@ let code_action doc (params : CodeActionParams.t) =
       let finish = Position.logical params.range.end_ in
       Query_protocol.Case_analysis (start, finish)
     in
-    let+ res = Document.dispatch doc command in
+    let* res = Document.dispatch doc command in
     match res with
-    | Ok res -> Some (code_action_of_case_analysis doc uri res)
+    | Ok (loc, newText) -> (
+      let+ formattedText =
+        Ocamlformat_rpc.(format_type state.ocamlformat_rpc ~typ:newText)
+      in
+      match formattedText with
+      | Ok formattedText -> Some (code_action_of_case_analysis doc uri (loc, formattedText))
+      | Error _ -> Some (code_action_of_case_analysis doc uri (loc, newText)))
     | Error
         { exn =
             ( Merlin_analysis.Destruct.Wrong_parent _ | Query_commands.No_nodes
@@ -45,8 +53,7 @@ let code_action doc (params : CodeActionParams.t) =
             | Merlin_analysis.Destruct.Nothing_to_do )
         ; backtrace = _
         } ->
-      None
+      Fiber.return None
     | Error exn -> Exn_with_backtrace.reraise exn)
 
-let t =
-  { Code_action.kind = CodeActionKind.Other action_kind; run = code_action }
+let t state = { Code_action.kind; run = code_action state }

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -39,11 +39,11 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
     let* res = Document.dispatch doc command in
     match res with
     | Ok (loc, newText) -> (
-      let+ formattedText =
-        Ocamlformat_rpc.(format_type state.ocamlformat_rpc ~typ:newText)
+      let+ formatted_text =
+        Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ:newText
       in
-      match formattedText with
-      | Ok formattedText -> Some (code_action_of_case_analysis doc uri (loc, formattedText))
+      match formatted_text with
+      | Ok formatted_text -> Some (code_action_of_case_analysis doc uri (loc, formatted_text))
       | Error _ -> Some (code_action_of_case_analysis doc uri (loc, newText)))
     | Error
         { exn =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -1,1 +1,5 @@
-val t : Code_action.t
+open Import
+
+val kind : CodeActionKind.t
+
+val t : State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -25,12 +25,12 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
   | Impl -> Fiber.return None
   | Intf -> (
     let* intf = Inference.infer_intf ~force_open_impl:true state doc in
-    let+ formattedIntf =
+    let+ formatted_intf =
       Ocamlformat_rpc.(format_type state.ocamlformat_rpc ~typ:intf)
     in
-    match formattedIntf with
-    | Ok formattedIntf ->
-      Some (code_action_of_intf doc formattedIntf params.range)
+    match formatted_intf with
+    | Ok formatted_intf ->
+      Some (code_action_of_intf doc formatted_intf params.range)
     | Error _ -> Some (code_action_of_intf doc intf params.range))
 
 let kind = CodeActionKind.Other action_kind

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -14,8 +14,7 @@ let not_supported () =
 let initialize_info : InitializeResult.t =
   let codeActionProvider =
     let codeActionKinds =
-      Action_inferred_intf.kind
-      :: Action_destruct.kind
+      Action_inferred_intf.kind :: Action_destruct.kind
       :: List.map
            ~f:(fun (c : Code_action.t) -> c.kind)
            [ Action_type_annotate.t
@@ -341,7 +340,12 @@ module Formatter = struct
 
   let run rpc doc =
     let state = Server.state rpc in
-    let* res = Ocamlformat.run state.State.ocamlformat doc in
+    let* res =
+    let* res = Ocamlformat_rpc.format_doc state.State.ocamlformat_rpc doc in
+      match res with
+      | Ok res -> Fiber.return @@ Ok res
+      | Error _ -> Ocamlformat.run state.State.ocamlformat doc
+    in
     match res with
     | Ok result -> Fiber.return (Some result)
     | Error e ->

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -15,10 +15,10 @@ let initialize_info : InitializeResult.t =
   let codeActionProvider =
     let codeActionKinds =
       Action_inferred_intf.kind
+      :: Action_destruct.kind
       :: List.map
            ~f:(fun (c : Code_action.t) -> c.kind)
-           [ Action_destruct.t
-           ; Action_type_annotate.t
+           [ Action_type_annotate.t
            ; Action_construct.t
            ; Action_refactor_open.unqualify
            ; Action_refactor_open.qualify
@@ -307,7 +307,7 @@ let code_action (state : State.t) (params : CodeActionParams.t) =
     (* XXX this is a really bad use of resources. we should be batching all the
        merlin related work *)
     Fiber.parallel_map ~f:code_action
-      [ Action_destruct.t
+      [ Action_destruct.t state
       ; Action_inferred_intf.t state
       ; Action_type_annotate.t
       ; Action_construct.t

--- a/ocaml-lsp-server/src/ocamlformat_rpc.ml
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.ml
@@ -161,6 +161,12 @@ let format_type t ~typ =
       | Ok s -> s
       | Error e -> Exn_with_backtrace.reraise e))
 
+let format_doc t doc =
+  let txt = Document.source doc |> Msource.text in
+  let+ res = (format_type t ~typ:txt) in
+  Result.map res ~f:(fun to_ ->
+    Diff.edit ~from:txt ~to_)
+
 let create_state () =
   Waiting_for_init
     { ask_init = Fiber.Ivar.create (); wait_init = Fiber.Ivar.create () }

--- a/ocaml-lsp-server/src/ocamlformat_rpc.mli
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.mli
@@ -9,6 +9,11 @@ val stop : t -> unit Fiber.t
 val format_type :
   t -> typ:string -> (string, [> `Msg of string | `No_process ]) result Fiber.t
 
+val format_doc :
+  t ->
+  Document.t ->
+  (TextEdit.t list, [> `Msg of string | `No_process ]) result Fiber.t
+
 val run :
      logger:(type_:MessageType.t -> message:string -> unit Fiber.t)
   -> t


### PR DESCRIPTION
This PR addresses issue #495.

- In case of generated code via destruct or "inferred interface", ocaml-lsp now tries to format them using ocamlformat-rpc. If this fails, the non-formatted text is used. (When there are "merlin holes" no formatting is possible untill the merged https://github.com/ocaml-ppx/ocamlformat/pull/1698 is released).
- In case of user querying formatting the whole file, ocaml-lsp first tries ocamlformat-rpc and fallback to regular ocamlformat if it fails.