### PR TITLE
Separate ocamlformat_rpc servers for popup and for file formatting

### DIFF
--- a/ocaml-lsp-server/src/ocamlformat_rpc.mli
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.mli
@@ -16,5 +16,6 @@ val format_doc :
 
 val run :
      logger:(type_:MessageType.t -> message:string -> unit Fiber.t)
+  -> format_style:[< `ProjectStyle | `VSCodePopup ]
   -> t
   -> (unit, [> `Binary_not_found ]) result Fiber.t

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -18,12 +18,13 @@ type t =
   ; trace : TraceValue.t
   ; ocamlformat : Ocamlformat.t
   ; ocamlformat_rpc : Ocamlformat_rpc.t
+  ; ocamlformat_rpc_popup : Ocamlformat_rpc.t
   ; diagnostics : Diagnostics.t
   ; symbols_thread : Scheduler.thread Lazy_fiber.t
   }
 
 let create ~store ~merlin ~detached ~configuration ~ocamlformat ~ocamlformat_rpc
-    ~diagnostics ~symbols_thread =
+    ~ocamlformat_rpc_popup ~diagnostics ~symbols_thread =
   { init = Uninitialized
   ; merlin_config = Merlin_config.create ()
   ; store
@@ -33,6 +34,7 @@ let create ~store ~merlin ~detached ~configuration ~ocamlformat ~ocamlformat_rpc
   ; trace = `Off
   ; ocamlformat
   ; ocamlformat_rpc
+  ; ocamlformat_rpc_popup
   ; diagnostics
   ; symbols_thread
   }

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -18,6 +18,7 @@ type t =
   ; trace : TraceValue.t
   ; ocamlformat : Ocamlformat.t
   ; ocamlformat_rpc : Ocamlformat_rpc.t
+  ; ocamlformat_rpc_popup : Ocamlformat_rpc.t
   ; diagnostics : Diagnostics.t
   ; symbols_thread : Scheduler.thread Lazy_fiber.t
   }
@@ -29,6 +30,7 @@ val create :
   -> configuration:Configuration.t
   -> ocamlformat:Ocamlformat.t
   -> ocamlformat_rpc:Ocamlformat_rpc.t
+  -> ocamlformat_rpc_popup:Ocamlformat_rpc.t
   -> diagnostics:Diagnostics.t
   -> symbols_thread:Scheduler.thread Lazy_fiber.t
   -> t


### PR DESCRIPTION
This PR fixed a regression introduced in #549, where ocamlformat_rpc is used to format the whole file, but with the special configuration used for popups.

With this PR, there is two instances of the ocamlformat_rpc server: One with the options for popups, and one with the default options.

Until we have a way of having the `.ocamlformat` options instead of the default option, the formatting of a file fallback automatically to using the ocamlformat binary.

Including `.ocamlformat` options is not trivial for the following reasons:
- First, we have to aggregate the information for multiple files (`.ocamlformat` in the directory or parent directory, global `.ocamlformat` file, `.ocamlformat-ignore`...). All of these files have to be parsed.
- Moreover, not all options in `.ocamlformat` files are accepted by the rpc server: as of today, the "version=..." is not accepted by ocamlformat_rpc, but is valid in `.ocamlformat`.

I think that this should be done on the ocamlformat side, as the code is already there for the ocamlformat binary. One way of doing it would be to send a path to the server, and the server adopts all the options that ocamlformat would have when run on path. 
I can file an issue on ocamlformat repo, if you think that would be a good solution, and start to work on a PR.