### PR TITLE
(nix) Replace hand-written source filtering to nix-gitignore

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,13 +5,10 @@ let
   args = {
     inherit (pkgs.ocaml-ng.ocamlPackages_4_12) ocaml;
     selection = ./opam-selection.nix;
-    src = builtins.filterSource (path: type:
-      let name = baseNameOf path;
-      in if type == "directory" then
-        name != ".git" && name != "_build" && name != "node_modules" && name
-        != ".log"
-      else
-        (strings.hasSuffix ".opam" name || name == "unvendor.ml")) ../.;
+    src = let ignores = pkgs.lib.strings.fileContents ../.gitignore
+            + builtins.foldl' (acc: e: acc + "\n" + e) "\n"
+                [ "nix" "shell.nix" "default.nix" ];
+          in pkgs.nix-gitignore.gitignoreSourcePure ignores ../.;
   };
   opam-selection = opam2nix.build args;
   localPackages = let contents = builtins.attrNames (builtins.readDir ../.);


### PR DESCRIPTION
`builtins.filterSource` checks files and directories *deeply*, so all the source files deeper than project root are abandoned at nix build.
The PR suggests to use `gitIgnoreSourcePure` to ignore files unneeded at build by using `.gitignore`.