### PR TITLE
Avoid unexpected shell redirection to file in make install-test-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all:
 # results in a conflict
 .PHONY: install-test-deps
 install-test-deps:
-	opam install menhir cinaps ppx_expect>=v0.14.0 \
+	opam install menhir cinaps 'ppx_expect>=v0.14.0' \
 		ocamlformat.$$(cat .ocamlformat | grep version | cut -d '=' -f 2) ocamlformat-rpc
 
 .PHONY: dev


### PR DESCRIPTION
Without the quotes in bash a file `=v0.14.0` is created with the output of the command and the installation can get stuck because the Y/N prompt isn't visible.