### PR TITLE
add basic support for classes folding

### DIFF
--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -44,8 +44,16 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       self.module_type self module_declaration.pmd_type
     in
 
-    let class_declaration _self (class_decl : Parsetree.class_declaration) =
-      class_decl.Parsetree.pci_loc |> Range.of_loc |> push
+    let class_declaration (self : Ast_iterator.iterator)
+        (class_decl : Parsetree.class_declaration) =
+      class_decl.Parsetree.pci_loc |> Range.of_loc |> push;
+      self.class_expr self class_decl.pci_expr
+    in
+
+    let class_field (self : Ast_iterator.iterator)
+        (class_field : Parsetree.class_field) =
+      Range.of_loc class_field.pcf_loc |> push;
+      Ast_iterator.default_iterator.class_field self class_field
     in
 
     let value_binding (self : Ast_iterator.iterator)
@@ -107,6 +115,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_let _
       | Pexp_open _
       | Pexp_fun _
+      | Pexp_poly _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
       | Pexp_match (e, cases) ->
@@ -150,7 +159,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_letexception _
       | Pexp_assert _
       | Pexp_lazy _
-      | Pexp_poly _
       | Pexp_object _
       | Pexp_newtype _
       | Pexp_pack _
@@ -195,6 +203,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
     { Ast_iterator.default_iterator with
       case
     ; class_declaration
+    ; class_field
     ; expr
     ; extension
     ; module_binding

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -183,6 +183,46 @@ describe("textDocument/foldingRange", () => {
     `);
   });
 
+  it("returns folding ranges for classes", async () => {
+    await openDocument(outdent`
+    class foobar =
+      let a =
+        let () = Stdlib.print_endline "" in
+        let () = Stdlib.print_endline "" in
+        let () = Stdlib.print_endline "" in
+        ()
+      in
+      object
+        method add x y =
+          let z =
+            let a = 5 in
+            let b = 6 in
+            let () =
+              let () = Stdlib.print_endline "" in
+              let () = Stdlib.print_endline "" in
+              let () = Stdlib.print_endline "" in
+              ()
+            in
+            a + b
+          in
+          x + y + z
+      end
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 5,
+          "endLine": 21,
+          "kind": "region",
+          "startCharacter": 0,
+          "startLine": 0,
+        },
+      ]
+    `);
+  });
+
   it("returns folding ranges for modules", async () => {
     await openDocument(outdent`
           module type X = sig
@@ -242,29 +282,6 @@ describe("textDocument/foldingRange", () => {
               in
               x + 3
           end
-
-          class foobar =
-            let a =
-              let () = Stdlib.print_endline "" in
-              let () = Stdlib.print_endline "" in
-              let () = Stdlib.print_endline "" in
-              ()
-            in
-            object
-              method add x y =
-                let z =
-                  let a = 5 in
-                  let b = 6 in
-                  let () =
-                    let () = Stdlib.print_endline "" in
-                    let () = Stdlib.print_endline "" in
-                    let () = Stdlib.print_endline "" in
-                    ()
-                  in
-                  a + b
-                in
-                x + y + z
-            end
         `);
 
     let result = await foldingRange();
@@ -381,13 +398,6 @@ describe("textDocument/foldingRange", () => {
           "kind": "region",
           "startCharacter": 6,
           "startLine": 49,
-        },
-        Object {
-          "endCharacter": 5,
-          "endLine": 79,
-          "kind": "region",
-          "startCharacter": 0,
-          "startLine": 58,
         },
       ]
     `);

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -219,6 +219,34 @@ describe("textDocument/foldingRange", () => {
           "startCharacter": 0,
           "startLine": 0,
         },
+        Object {
+          "endCharacter": 6,
+          "endLine": 5,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 1,
+        },
+        Object {
+          "endCharacter": 15,
+          "endLine": 20,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 8,
+        },
+        Object {
+          "endCharacter": 13,
+          "endLine": 18,
+          "kind": "region",
+          "startCharacter": 6,
+          "startLine": 9,
+        },
+        Object {
+          "endCharacter": 12,
+          "endLine": 16,
+          "kind": "region",
+          "startCharacter": 8,
+          "startLine": 12,
+        },
       ]
     `);
   });


### PR DESCRIPTION
Currently, we can only fold the entire class. This PR adds basic support for folding what's defined in the class itself.
First commit only moves some tests

https://user-images.githubusercontent.com/5595092/148347407-621a8398-8271-41db-bfc9-4be115f73a75.mov

Let me know if you can think of anything else, definitely not used to using classes myself.


