### PR TITLE
[Folding ranges]: traverse Pexp_sequence nodes

### DIFF
--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -116,6 +116,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_open _
       | Pexp_fun _
       | Pexp_poly _
+      | Pexp_sequence _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
       | Pexp_match (e, cases) ->
@@ -146,7 +147,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_setfield _
       | Pexp_array _
       | Pexp_ifthenelse _
-      | Pexp_sequence _
       | Pexp_while _
       | Pexp_for _
       | Pexp_constraint _

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -251,6 +251,29 @@ describe("textDocument/foldingRange", () => {
     `);
   });
 
+  it("traverses Pexp_sequence nodes", async () => {
+    await openDocument(outdent`
+    let a = 
+      Stdlib.print_endline "";
+      let b = 
+        5 + 3 in
+      b
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 3,
+          "endLine": 4,
+          "kind": "region",
+          "startCharacter": 0,
+          "startLine": 0,
+        },
+      ]
+    `);
+  });
+
   it("returns folding ranges for modules", async () => {
     await openDocument(outdent`
           module type X = sig

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -270,6 +270,13 @@ describe("textDocument/foldingRange", () => {
           "startCharacter": 0,
           "startLine": 0,
         },
+        Object {
+          "endCharacter": 9,
+          "endLine": 3,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 2,
+        },
       ]
     `);
   });


### PR DESCRIPTION
`Pexp_sequence` nodes were not traversed, leading to the issue highlighted in the video below.

* First commit adds a test
* Second commit fixes the issue

https://user-images.githubusercontent.com/5595092/148502160-09682340-8ea3-47e6-9ab6-a73da7208d21.mov

