### PR TITLE
[Folding ranges]: support return type annotation

### DIFF
--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -117,6 +117,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_fun _
       | Pexp_poly _
       | Pexp_sequence _
+      | Pexp_constraint _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
       | Pexp_match (e, cases) ->
@@ -151,7 +152,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_ifthenelse _
       | Pexp_while _
       | Pexp_for _
-      | Pexp_constraint _
       | Pexp_coerce _
       | Pexp_send _
       | Pexp_new _

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -321,6 +321,13 @@ describe("textDocument/foldingRange", () => {
           "startCharacter": 0,
           "startLine": 0,
         },
+        Object {
+          "endCharacter": 9,
+          "endLine": 3,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 1,
+        },
       ]
     `);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -301,6 +301,30 @@ describe("textDocument/foldingRange", () => {
     `);
   });
 
+  it("supports return type annotation", async () => {
+    await openDocument(outdent`
+    let fn a b : int = 
+      let result = 
+        Stdlib.print_endline "";
+        a + b 
+      in
+      result
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 8,
+          "endLine": 5,
+          "kind": "region",
+          "startCharacter": 0,
+          "startLine": 0,
+        },
+      ]
+    `);
+  });
+
   it("returns folding ranges for modules", async () => {
     await openDocument(outdent`
           module type X = sig


### PR DESCRIPTION
Support folding with explicit return type annotation. Fix the following case:

https://user-images.githubusercontent.com/5595092/150073804-88daba85-8fd9-4c80-829b-7d99d2afb103.mov


