### PR TITLE
[Folding ranges]: support if/else

### DIFF
--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -117,6 +117,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_fun _
       | Pexp_poly _
       | Pexp_sequence _
+      | Pexp_ifthenelse _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
       | Pexp_match (e, cases) ->
@@ -148,7 +149,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_field _
       | Pexp_setfield _
       | Pexp_array _
-      | Pexp_ifthenelse _
       | Pexp_while _
       | Pexp_for _
       | Pexp_constraint _

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -335,6 +335,34 @@ describe("textDocument/foldingRange", () => {
           "startCharacter": 0,
           "startLine": 0,
         },
+        Object {
+          "endCharacter": 29,
+          "endLine": 4,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 2,
+        },
+        Object {
+          "endCharacter": 29,
+          "endLine": 8,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 6,
+        },
+        Object {
+          "endCharacter": 29,
+          "endLine": 14,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 12,
+        },
+        Object {
+          "endCharacter": 29,
+          "endLine": 18,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 16,
+        },
       ]
     `);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -300,6 +300,44 @@ describe("textDocument/foldingRange", () => {
       ]
     `);
   });
+  it("supports if/else", async () => {
+    await openDocument(outdent`
+    let fn a =
+      if a == true then
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        ()
+      else
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        ()
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 6,
+          "endLine": 20,
+          "kind": "region",
+          "startCharacter": 0,
+          "startLine": 0,
+        },
+      ]
+    `);
+  });
 
   it("returns folding ranges for modules", async () => {
     await openDocument(outdent`


### PR DESCRIPTION
For now, it only traverses the `Pexp_ifthenelse` so what's inside can be folded. 

https://user-images.githubusercontent.com/5595092/150080689-109f670e-333a-4804-a3ae-986487edc221.mov

Initially, I wanted to add support for folding the entire `if` and `else` but I'm not sure how to do it because the locations are the ones from the expressions themselves (`if_expr`, `then_expr` and `else_expr`) and don't take into account the location of the `if`/`else` keywords
