### PR TITLE
[Folding ranges]: support try/with

### DIFF
--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -119,6 +119,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_sequence _
       | Pexp_ifthenelse _
       | Pexp_constraint _
+      | Pexp_try _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
       | Pexp_match (e, cases) ->
@@ -143,7 +144,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
         Ast_iterator.default_iterator.expr self expr
       | Pexp_ident _
       | Pexp_constant _
-      | Pexp_try _
       | Pexp_tuple _
       | Pexp_construct _
       | Pexp_variant _

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -119,9 +119,9 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_sequence _
       | Pexp_ifthenelse _
       | Pexp_constraint _
-      | Pexp_try _
       | Pexp_function _ ->
         Ast_iterator.default_iterator.expr self expr
+      | Pexp_try (e, cases)
       | Pexp_match (e, cases) ->
         Range.of_loc expr.pexp_loc |> push;
         self.expr self e;

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -427,6 +427,13 @@ describe("textDocument/foldingRange", () => {
           "startLine": 0,
         },
         Object {
+          "endCharacter": 8,
+          "endLine": 13,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 1,
+        },
+        Object {
           "endCharacter": 29,
           "endLine": 4,
           "kind": "region",

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -426,6 +426,27 @@ describe("textDocument/foldingRange", () => {
           "startCharacter": 0,
           "startLine": 0,
         },
+        Object {
+          "endCharacter": 29,
+          "endLine": 4,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 2,
+        },
+        Object {
+          "endCharacter": 8,
+          "endLine": 13,
+          "kind": "region",
+          "startCharacter": 13,
+          "startLine": 8,
+        },
+        Object {
+          "endCharacter": 29,
+          "endLine": 11,
+          "kind": "region",
+          "startCharacter": 4,
+          "startLine": 9,
+        },
       ]
     `);
   });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -398,6 +398,38 @@ describe("textDocument/foldingRange", () => {
     `);
   });
 
+  it("returns folding ranges for try/with", async () => {
+    await openDocument(outdent`
+    let result =
+      try
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        Some 6
+      with
+      | Not_found ->
+        let () =
+          Stdlib.print_endline "";
+          Stdlib.print_endline ""
+        in
+        None
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 8,
+          "endLine": 13,
+          "kind": "region",
+          "startCharacter": 0,
+          "startLine": 0,
+        },
+      ]
+    `);
+  });
+
   it("returns folding ranges for modules", async () => {
     await openDocument(outdent`
           module type X = sig


### PR DESCRIPTION
It only traverses the `Pexp_try` for now. Not sure how we could support folding the `try` and `with` separately due to the way locations are reported (same as with the if/else).

We could add support for folding the entire `try/with` expression though. Do we want to support that?


