### PR TITLE
[refactor] extract hover request handling in separate file

### DIFF
--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -64,3 +64,9 @@ val close : t -> unit Fiber.t
 val get_impl_intf_counterparts : Uri.t -> Uri.t list
 
 val edit : t -> TextEdit.t -> WorkspaceEdit.t
+
+val doc_comment :
+  t -> Msource.position -> (* doc string *) string option Fiber.t
+
+val type_enclosing :
+  t -> Msource.position -> (Loc.t * (* type *) string) option Fiber.t

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -1,0 +1,74 @@
+open Import
+open Fiber.O
+
+let format_contents ~syntax ~markdown ~typ ~doc =
+  (* TODO for vscode, we should just use the language id. But that will not work
+     for all editors *)
+  `MarkupContent
+    (if markdown then
+      let value =
+        let markdown_name = Document.Syntax.markdown_name syntax in
+        match doc with
+        | None -> sprintf "```%s\n%s\n```" markdown_name typ
+        | Some s ->
+          let doc =
+            match Doc_to_md.translate s with
+            | Raw d -> sprintf "(** %s *)" d
+            | Markdown d -> d
+          in
+          sprintf "```%s\n%s\n```\n---\n%s" markdown_name typ doc
+      in
+      { MarkupContent.value; kind = MarkupKind.Markdown }
+    else
+      let value =
+        match doc with
+        | None -> sprintf "%s" typ
+        | Some d -> sprintf "%s\n%s" typ d
+      in
+      { MarkupContent.value; kind = MarkupKind.PlainText })
+
+let handle server { HoverParams.textDocument = { uri }; position; _ } =
+  let state : State.t = Server.state server in
+  let doc =
+    let store = state.store in
+    Document_store.get store uri
+  in
+  let pos = Position.logical position in
+  (* TODO we shouldn't acquiring the merlin thread twice per request *)
+  let* query_type = Document.type_enclosing doc pos in
+  match query_type with
+  | None -> Fiber.return None
+  | Some (loc, typ) ->
+    let syntax = Document.syntax doc in
+    let+ doc = Document.doc_comment doc pos
+    and+ typ =
+      (* We ask Ocamlformat to format this type *)
+      let* result = Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ in
+      match result with
+      | Ok v ->
+        (* OCamlformat adds an unnecessay newline at the end of the type *)
+        Fiber.return (String.trim v)
+      | Error `No_process -> Fiber.return typ
+      | Error (`Msg message) ->
+        (* We log OCamlformat errors and display the unformated type *)
+        let+ () =
+          let message =
+            sprintf
+              "An error occured while querying ocamlformat:\n\
+               Input type: %s\n\n\
+               Answer: %s" typ message
+          in
+          State.log_msg server ~type_:Warning ~message
+        in
+        typ
+    in
+    let contents =
+      let markdown =
+        let client_capabilities = State.client_capabilities state in
+        ClientCapabilities.markdown_support client_capabilities
+          ~field:(fun td -> Option.map td.hover ~f:(fun h -> h.contentFormat))
+      in
+      format_contents ~syntax ~markdown ~typ ~doc
+    in
+    let range = Range.of_loc loc in
+    Some (Hover.create ~contents ~range ())

--- a/ocaml-lsp-server/src/hover_req.mli
+++ b/ocaml-lsp-server/src/hover_req.mli
@@ -1,0 +1,8 @@
+open Import
+
+(** This module contains functionality to handle `textDocument/hover` LSP
+    request. *)
+
+(** [handle server hover_params] provides a response for LSP request
+    `textDocument/hover` *)
+val handle : State.t Server.t -> HoverParams.t -> Hover.t option Fiber.t

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -74,3 +74,11 @@ let modify_workspaces t ~f =
       Initialized { init with workspaces = f init.workspaces }
   in
   { t with init }
+
+let client_capabilities t = (initialize_params t).capabilities
+
+let log_msg server ~type_ ~message =
+  let state = Server.state server in
+  task_if_running state.detached ~f:(fun () ->
+      let log = LogMessageParams.create ~type_ ~message in
+      Server.notification server (Server_notification.LogMessage log))

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -46,3 +46,10 @@ val workspaces : t -> Workspaces.t
 val dune : t -> Dune.t
 
 val modify_workspaces : t -> f:(Workspaces.t -> Workspaces.t) -> t
+
+(** @return client capabilities passed from the client in [InitializeParams]
+    @raise Assertion_failure if the [t.init] is [Uninitialized] *)
+val client_capabilities : t -> ClientCapabilities.t
+
+val log_msg :
+  t Server.t -> type_:MessageType.t -> message:string -> unit Fiber.t


### PR DESCRIPTION
Mostly moves code around to help with https://github.com/ocaml/ocaml-lsp/pull/561#issuecomment-1008457123:

> Anyway, in the process of adding a new command I had to duplicate quite a lot of code from ocaml_lsp_server.ml to req_hover_extended.ml. Because the later is called from the former. So all the utils can't be called from the custom commands. I wonder where I should move that code to avoid duplication.