### PR TITLE
fix: crash when inferring interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 - Add better support for code folding: more folds and more precise folds
 
+## Fixes
+
+- Fix infer interface code action crash when implementation source does not
+  exist (#597)
+
 # 1.9.1
 
 ## Fixes

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -23,17 +23,20 @@ let code_action_of_intf doc intf range =
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
   match Document.kind doc with
   | Impl -> Fiber.return None
-  | Intf ->
+  | Intf -> (
     let* intf = Inference.infer_intf ~force_open_impl:true state doc in
-    let+ formatted_intf =
-      Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ:intf
-    in
-    let intf =
-      match formatted_intf with
-      | Ok formatted_intf -> formatted_intf
-      | Error _ -> intf
-    in
-    Some (code_action_of_intf doc intf params.range)
+    match intf with
+    | None -> Fiber.return None
+    | Some intf ->
+      let+ formatted_intf =
+        Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ:intf
+      in
+      let intf =
+        match formatted_intf with
+        | Ok formatted_intf -> formatted_intf
+        | Error _ -> intf
+      in
+      Some (code_action_of_intf doc intf params.range))
 
 let kind = CodeActionKind.Other action_kind
 

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -39,23 +39,28 @@ let language_id_of_fname s =
 
 let force_open_document (state : State.t) uri =
   let filename = Uri.to_path uri in
-  let text = Io.String_path.read_file filename in
-  let languageId = language_id_of_fname filename in
-  let text_document =
-    TextDocumentItem.create ~uri ~languageId ~version:0 ~text
-  in
-  let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
-  let+ doc =
-    Document.make (State.wheel state) state.merlin_config
-      ~merlin_thread:state.merlin params
-  in
-  Document_store.put state.store doc;
-  doc
+  match Io.String_path.read_file filename with
+  | exception Sys_error _ ->
+    Log.log ~section:"debug" (fun () ->
+        Log.msg "Unable to open file" [ ("filename", `String filename) ]);
+    Fiber.return None
+  | text ->
+    let languageId = language_id_of_fname filename in
+    let text_document =
+      TextDocumentItem.create ~uri ~languageId ~version:0 ~text
+    in
+    let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
+    let+ doc =
+      Document.make (State.wheel state) state.merlin_config
+        ~merlin_thread:state.merlin params
+    in
+    Document_store.put state.store doc;
+    Some doc
 
 let infer_intf ~force_open_impl (state : State.t) doc =
   match Document.kind doc with
   | Impl -> Code_error.raise "the provided document is not an interface." []
-  | Intf ->
+  | Intf -> (
     let intf_uri = Document.uri doc in
     let impl_uri = Document.get_impl_intf_counterparts intf_uri |> List.hd in
     let* impl =
@@ -64,6 +69,10 @@ let infer_intf ~force_open_impl (state : State.t) doc =
         Code_error.raise
           "The implementation for this interface has not been open." []
       | None, true -> force_open_document state impl_uri
-      | Some impl, _ -> Fiber.return impl
+      | Some impl, _ -> Fiber.return (Some impl)
     in
-    infer_intf_for_impl impl
+    match impl with
+    | None -> Fiber.return None
+    | Some impl ->
+      let+ res = infer_intf_for_impl impl in
+      Some res)

--- a/ocaml-lsp-server/src/inference.mli
+++ b/ocaml-lsp-server/src/inference.mli
@@ -1,3 +1,4 @@
 val infer_intf_for_impl : Document.t -> string Fiber.t
 
-val infer_intf : force_open_impl:bool -> State.t -> Document.t -> string Fiber.t
+val infer_intf :
+  force_open_impl:bool -> State.t -> Document.t -> string option Fiber.t


### PR DESCRIPTION
Do not handle when trying to inferring interfaces for mli only modules.