### PR TITLE
Preview: upgrade ocamlformat to 0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.20.1
+version=0.21.0
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.19.0
+version=0.20.1
 break-separators=before
 dock-collection-brackets=false
 break-sequences=true

--- a/fiber-test/fiber_test.ml
+++ b/fiber-test/fiber_test.ml
@@ -2,9 +2,7 @@ open Stdune
 open Fiber.O
 
 let printf = Printf.printf
-
 let print pp = Format.printf "%a@." Pp.to_fmt pp
-
 let print_dyn dyn = print (Dyn.pp dyn)
 
 module Scheduler : sig
@@ -13,15 +11,12 @@ module Scheduler : sig
   exception Never
 
   val yield : unit -> unit Fiber.t
-
   val create : unit -> t
-
   val run : t -> 'a Fiber.t -> 'a
 end = struct
   type t = unit Fiber.Ivar.t Queue.t
 
   let t_var = Fiber.Var.create ()
-
   let create () = Queue.create ()
 
   let yield () =

--- a/jsonrpc-fiber/src/import.ml
+++ b/jsonrpc-fiber/src/import.ml
@@ -22,9 +22,7 @@ module Json = struct
   type t = Ppx_yojson_conv_lib.Yojson.Safe.t
 
   let to_pretty_string (t : t) = Yojson.Safe.pretty_to_string ~std:false t
-
   let error = Ppx_yojson_conv_lib.Yojson_conv.of_yojson_error
-
   let pp ppf (t : t) = Yojson.Safe.pretty_print ppf t
 
   let rec of_dyn (t : Dyn.t) : t =
@@ -54,7 +52,6 @@ end
 
 module Log = struct
   let level : (string option -> bool) ref = ref (fun _ -> false)
-
   let out = ref Format.err_formatter
 
   type message =

--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -53,7 +53,6 @@ module Reply = struct
     | Later of ((Response.t -> unit Fiber.t) -> unit Fiber.t)
 
   let now (r : Response.t) = Now r
-
   let later f = Later f
 
   let send (t : t) sender =
@@ -66,9 +65,7 @@ module Make (Chan : sig
   type t
 
   val send : t -> packet list -> unit Fiber.t
-
   val recv : t -> packet option Fiber.t
-
   val close : t -> [ `Read | `Write ] -> unit Fiber.t
 end) =
 struct
@@ -91,9 +88,7 @@ struct
     type nonrec ('a, 'id) t = ('a, 'id) context
 
     let message = snd
-
     let session = fst
-
     let state t = (session t).state
   end
 
@@ -119,7 +114,6 @@ struct
     Fiber.return (Reply.now (Response.error req.id error), state)
 
   let state t = t.state
-
   let stopped t = Fiber.Ivar.read t.stopped
 
   let stop t =
@@ -308,7 +302,6 @@ struct
       ref
 
     let create () = ref []
-
     let notification t n = t := `Notification n :: !t
 
     let request t r =

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -8,7 +8,6 @@ module Reply : sig
   type t
 
   val now : Jsonrpc.Response.t -> t
-
   val later : ((Jsonrpc.Response.t -> unit Fiber.t) -> unit Fiber.t) -> t
 end
 
@@ -21,22 +20,17 @@ module Make (Chan : sig
   type t
 
   val send : t -> Jsonrpc.packet list -> unit Fiber.t
-
   val recv : t -> Jsonrpc.packet option Fiber.t
-
   val close : t -> [ `Read | `Write ] -> unit Fiber.t
 end) : sig
   type 'state t
 
   module Context : sig
     type ('state, 'req) t
-
     type 'a session
 
     val message : (_, 'req) t -> 'req Jsonrpc.Message.t
-
     val state : ('a, _) t -> 'a
-
     val session : ('a, _) t -> 'a session
   end
   with type 'a session := 'a t
@@ -52,24 +46,17 @@ end) : sig
     -> 'state t
 
   val state : 'a t -> 'a
-
   val stop : _ t -> unit Fiber.t
-
   val stopped : _ t -> unit Fiber.t
-
   val run : _ t -> unit Fiber.t
-
   val notification : _ t -> Jsonrpc.Message.notification -> unit Fiber.t
-
   val request : _ t -> Jsonrpc.Message.request -> Jsonrpc.Response.t Fiber.t
 
   module Batch : sig
     type t
 
     val create : unit -> t
-
     val notification : t -> Jsonrpc.Message.notification -> unit
-
     val request : t -> Jsonrpc.Message.request -> Jsonrpc.Response.t Fiber.t
   end
 

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -13,7 +13,6 @@ module Stream_chan = struct
     | `Write -> Out.write o None
 
   let send (_, o) p = Fiber.sequential_iter p ~f:(fun x -> Out.write o (Some x))
-
   let recv (i, _) = In.read i
 end
 

--- a/jsonrpc/src/import.ml
+++ b/jsonrpc/src/import.ml
@@ -31,11 +31,9 @@ module Json = struct
   module Jsonable = struct
     module type S = sig
       type json
-
       type t
 
       val yojson_of_t : t -> json
-
       val t_of_yojson : json -> t
     end
     with type json := t

--- a/jsonrpc/src/jsonrpc.ml
+++ b/jsonrpc/src/jsonrpc.ml
@@ -18,23 +18,16 @@ module Id = struct
     | json -> Json.error "Id.t" json
 
   let hash x = Hashtbl.hash x
-
   let equal = ( = )
 end
 
 module Constant = struct
   let jsonrpc = "jsonrpc"
-
   let jsonrpcv = "2.0"
-
   let id = "id"
-
   let method_ = "method"
-
   let params = "params"
-
   let result = "result"
-
   let error = "error"
 end
 
@@ -104,9 +97,7 @@ module Message = struct
   let yojson_of_either t : Json.t = yojson_of_t (Option.map ~f:Id.yojson_of_t) t
 
   type request = Id.t t
-
   type notification = unit t
-
   type either = Id.t option t
 
   let yojson_of_notification = yojson_of_t (fun () -> None)
@@ -198,7 +189,6 @@ module Response = struct
     exception E of t
 
     let raise t = raise (E t)
-
     let make ?data ~code ~message () = { data; code; message }
 
     let of_exn exn =
@@ -243,9 +233,7 @@ module Response = struct
     | _ -> Json.error "Jsonrpc.Result.t" json
 
   let make ~id ~result = { id; result }
-
   let ok id result = make ~id ~result:(Ok result)
-
   let error id error = make ~id ~result:(Error error)
 end
 

--- a/jsonrpc/src/jsonrpc.mli
+++ b/jsonrpc/src/jsonrpc.mli
@@ -20,11 +20,9 @@ module Json : sig
   module Jsonable : sig
     module type S = sig
       type json
-
       type t
 
       val yojson_of_t : t -> json
-
       val t_of_yojson : json -> t
     end
     with type json := t
@@ -40,7 +38,6 @@ module Id : sig
   include Json.Jsonable.S with type t := t
 
   val hash : t -> int
-
   val equal : t -> t -> bool
 end
 
@@ -52,7 +49,6 @@ module Message : sig
       ]
 
     val of_json : Json.t -> t
-
     val to_json : t -> Json.t
   end
 
@@ -65,17 +61,12 @@ module Message : sig
   val create : ?params:Structured.t -> id:'id -> method_:string -> unit -> 'id t
 
   type request = Id.t t
-
   type notification = unit t
-
   type either = Id.t option t
 
   val either_of_yojson : Json.t -> either
-
   val yojson_of_either : either -> Json.t
-
   val yojson_of_notification : notification -> Json.t
-
   val yojson_of_request : request -> Json.t
 end
 
@@ -105,11 +96,8 @@ module Response : sig
     exception E of t
 
     val make : ?data:Json.t -> code:Code.t -> message:string -> unit -> t
-
     val raise : t -> 'a
-
     val of_exn : exn -> t
-
     val yojson_of_t : t -> Json.t
   end
 
@@ -119,7 +107,6 @@ module Response : sig
     }
 
   val ok : Id.t -> Json.t -> t
-
   val error : Id.t -> Error.t -> t
 
   include Json.Jsonable.S with type t := t

--- a/lsp-fiber/src/fiber_io.ml
+++ b/lsp-fiber/src/fiber_io.ml
@@ -13,7 +13,6 @@ module Io =
     end)
     (struct
       type input = Lio.Reader.t
-
       type output = Lio.Writer.t
 
       let read_line ic =
@@ -39,7 +38,6 @@ let send (_, oc) packets =
       Lio.Writer.flush writer)
 
 let recv (ic, _) = Lio.with_read ic ~f:Io.read
-
 let make ic oc = (ic, oc)
 
 let close (ic, oc) what =

--- a/lsp-fiber/src/fiber_io.mli
+++ b/lsp-fiber/src/fiber_io.mli
@@ -6,9 +6,7 @@ open! Import
 type t
 
 val close : t -> [ `Read | `Write ] -> unit Fiber.t
-
 val send : t -> Jsonrpc.packet list -> unit Fiber.t
-
 val recv : t -> Jsonrpc.packet option Fiber.t
 
 val make :

--- a/lsp-fiber/src/import.ml
+++ b/lsp-fiber/src/import.ml
@@ -12,7 +12,6 @@ end
 
 module Log = struct
   let level : (string option -> bool) ref = ref (fun _ -> false)
-
   let out = ref Format.err_formatter
 
   type message =

--- a/lsp-fiber/src/rpc.ml
+++ b/lsp-fiber/src/rpc.ml
@@ -10,7 +10,6 @@ module Reply = struct
     | Later of (('r -> unit Fiber.t) -> unit Fiber.t)
 
   let now r = Now r
-
   let later f = Later f
 
   let to_jsonrpc t id to_json : Jsonrpc_fiber.Reply.t =
@@ -39,7 +38,6 @@ module Cancel = struct
       | Pending p -> p.callbacks <- f :: p.callbacks)
 
   let create () = ref (Pending { callbacks = [] })
-
   let destroy t = t := Finished
 
   let cancel t =
@@ -59,13 +57,9 @@ end
 
 module type S = sig
   type 'a out_request
-
   type out_notification
-
   type 'a in_request
-
   type in_notification
-
   type 'state t
 
   module Handler : sig
@@ -87,28 +81,19 @@ module type S = sig
   with type 'a session := 'a t
 
   val state : 'a t -> 'a
-
   val make : 'state Handler.t -> Fiber_io.t -> 'state -> 'state t
-
   val stop : _ t -> unit Fiber.t
-
   val request : _ t -> 'resp out_request -> 'resp Fiber.t
-
   val notification : _ t -> out_notification -> unit Fiber.t
-
   val on_cancel : (unit -> unit Fiber.t) -> unit Fiber.t
 
   module Batch : sig
     type t
-
     type _ session
 
     val create : _ session -> t
-
     val notification : t -> out_notification -> unit
-
     val request : t -> 'resp out_request -> 'resp Fiber.t
-
     val submit : t -> unit Fiber.t
   end
   with type 'a session := 'a t
@@ -116,15 +101,11 @@ end
 
 module type Request_intf = sig
   type 'a t
-
   type packed = E : 'r t -> packed
 
   val of_jsonrpc : Jsonrpc.Message.request -> (packed, string) result
-
   val yojson_of_result : 'a t -> 'a -> Json.t
-
   val to_jsonrpc_request : 'a t -> id:Id.t -> Jsonrpc.Message.request
-
   val response_of_json : 'a t -> Json.t -> 'a
 end
 
@@ -132,7 +113,6 @@ module type Notification_intf = sig
   type t
 
   val of_jsonrpc : Jsonrpc.Message.notification -> (t, string) result
-
   val to_jsonrpc : t -> Jsonrpc.Message.notification
 end
 
@@ -147,11 +127,8 @@ end)
 (In_notification : Notification_intf) =
 struct
   type 'a out_request = 'a Out_request.t
-
   type 'a in_request = 'a In_request.t
-
   type out_notification = Out_notification.t
-
   type in_notification = In_notification.t
 
   type 'state t =
@@ -331,6 +308,7 @@ end
 
 module Client = struct
   open Types
+
   include
     Make (InitializeResult) (Client_request) (Client_notification)
       (Server_request)
@@ -363,6 +341,7 @@ end
 
 module Server = struct
   open Types
+
   include
     Make (InitializeParams) (Server_request) (Server_notification)
       (Client_request)

--- a/lsp-fiber/src/rpc.mli
+++ b/lsp-fiber/src/rpc.mli
@@ -4,19 +4,14 @@ module Reply : sig
   type 'resp t
 
   val now : 'r -> 'r t
-
   val later : (('r -> unit Fiber.t) -> unit Fiber.t) -> 'r t
 end
 
 module type S = sig
   type 'a out_request
-
   type out_notification
-
   type 'a in_request
-
   type in_notification
-
   type 'state t
 
   module Handler : sig
@@ -38,28 +33,19 @@ module type S = sig
   with type 'a session := 'a t
 
   val state : 'a t -> 'a
-
   val make : 'state Handler.t -> Fiber_io.t -> 'state -> 'state t
-
   val stop : 'state t -> unit Fiber.t
-
   val request : _ t -> 'resp out_request -> 'resp Fiber.t
-
   val notification : _ t -> out_notification -> unit Fiber.t
-
   val on_cancel : (unit -> unit Fiber.t) -> unit Fiber.t
 
   module Batch : sig
     type t
-
     type _ session
 
     val create : _ session -> t
-
     val notification : t -> out_notification -> unit
-
     val request : t -> 'resp out_request -> 'resp Fiber.t
-
     val submit : t -> unit Fiber.t
   end
   with type 'a session := 'a t
@@ -76,7 +62,6 @@ module Client : sig
        and type in_notification = Server_notification.t
 
   val initialized : _ t -> InitializeResult.t Fiber.t
-
   val start : _ t -> InitializeParams.t -> unit Fiber.t
 end
 
@@ -91,6 +76,5 @@ module Server : sig
        and type in_notification = Client_notification.t
 
   val initialized : _ t -> InitializeParams.t Fiber.t
-
   val start : _ t -> unit Fiber.t
 end

--- a/lsp/bin/cinaps.ml
+++ b/lsp/bin/cinaps.ml
@@ -6,5 +6,4 @@ let ocaml =
      Ocaml.of_typescript asts)
 
 let print_ml () = Ocaml.output (Lazy.force ocaml) ~kind:Impl stdout
-
 let print_mli () = Ocaml.output (Lazy.force ocaml) ~kind:Intf stdout

--- a/lsp/bin/lsp_gen.ml
+++ b/lsp/bin/lsp_gen.ml
@@ -4,5 +4,4 @@ module Cinaps = Cinaps
 module Markdown = Markdown
 
 let print_ml = Cinaps.print_ml
-
 let print_mli = Cinaps.print_mli

--- a/lsp/bin/named.ml
+++ b/lsp/bin/named.ml
@@ -4,13 +4,9 @@ type 'a t =
   }
 
 let make ~name data = { name; data }
-
 let data t = t.data
-
 let name t = t.name
-
 let map t ~f = { t with data = f t.data }
-
 let set_data t data = { t with data }
 
 let to_dyn f { name; data } =

--- a/lsp/bin/ocaml/json_gen.ml
+++ b/lsp/bin/ocaml/json_gen.ml
@@ -35,7 +35,6 @@ let is_json_constr (constr : Type.constr) =
 
 module Name = struct
   let of_ = sprintf "%s_of_yojson"
-
   let to_ = sprintf "yojson_of_%s"
 
   let conv = function

--- a/lsp/bin/ocaml/json_gen.mli
+++ b/lsp/bin/ocaml/json_gen.mli
@@ -13,7 +13,6 @@ end
 
 module Poly_variant : sig
   val of_json : Ml.Type.constr list Named.t -> Ml.Expr.toplevel Named.t
-
   val to_json : Ml.Type.constr list Named.t -> Ml.Expr.toplevel Named.t
 end
 

--- a/lsp/bin/ocaml/ml.ml
+++ b/lsp/bin/ocaml/ml.ml
@@ -103,7 +103,6 @@ module Type = struct
   class virtual ['env, 'm] mapreduce =
     object (self : 'self)
       method virtual empty : 'm
-
       method virtual plus : 'm -> 'm -> 'm
 
       method poly_variant env constrs =
@@ -117,9 +116,7 @@ module Type = struct
         (Tuple r, s)
 
       method path _ p = (Path p, self#empty)
-
       method var _ n = (Var n, self#empty)
-
       method prim _ p = (Prim p, self#empty)
 
       method optional env p =
@@ -198,23 +195,14 @@ module Type = struct
     List.fold_right args ~init:t ~f:(fun arg acc -> Fun (arg, acc))
 
   let constr args ~name = { name; args }
-
   let list t = List t
-
   let assoc_list ~key ~data = Assoc (key, data)
-
   let t = Path (Ident "t")
-
   let module_t m = Path (Dot (Ident (String.capitalize_ascii m), "t"))
-
   let string = Prim String
-
   let name s = Path (Ident s)
-
   let int = Prim Int
-
   let bool = Prim Bool
-
   let alpha = Var "a"
 
   let enum constrs =
@@ -225,7 +213,6 @@ module Type = struct
       (List.map constrs ~f:(fun constr -> { name = constr; args = [] }))
 
   let json = Path (Dot (Ident "Json", "t"))
-
   let unit = Prim Unit
 
   let void =

--- a/lsp/bin/ocaml/ml.mli
+++ b/lsp/bin/ocaml/ml.mli
@@ -16,17 +16,12 @@ module Kind : sig
 
   module Map : sig
     type 'a t = ('a, 'a) pair
-
     type kind
 
     val get : 'a t -> kind -> 'a
-
     val iter : 'a t -> f:('a -> unit) -> unit
-
     val map : 'a t -> f:('a -> 'b) -> 'b t
-
     val both : 'a t -> 'b t -> ('a * 'b) t
-
     val make_both : 'a -> 'a t
   end
   with type kind := t
@@ -91,13 +86,9 @@ module Type : sig
 
   (* This is for lists where the keys are equal to strings *)
   val assoc_list : key:t -> data:t -> t
-
   val pp_decl : name:string -> kind:Kind.t -> decl -> unit Pp.t
-
   val pp : t -> kind:Kind.t -> unit Pp.t
-
   val field : t -> name:string -> field
-
   val constr : t list -> name:string -> constr
 
   (** Simplified sum types*)
@@ -107,25 +98,15 @@ module Type : sig
   val poly_enum : string list -> t
 
   val list : t -> t
-
   val module_t : string -> t
-
   val t : t
-
   val string : t
-
   val name : string -> t
-
   val int : t
-
   val bool : t
-
   val alpha : t
-
   val json : t
-
   val unit : t
-
   val void : t
 
   (** Fold and map over a type expression.
@@ -137,7 +118,6 @@ module Type : sig
   class virtual ['env, 'm] mapreduce :
     object ('self)
       method virtual empty : 'm
-
       method virtual plus : 'm -> 'm -> 'm
 
       (** doesn't really to be here, but putting it here avoids passing [empty]
@@ -146,35 +126,20 @@ module Type : sig
         'a. f:('a -> 'a * 'm) -> 'a list -> 'a list * 'm
 
       method alias : 'env -> t -> decl * 'm
-
       method app : 'env -> t -> t list -> t * 'm
-
       method assoc : 'env -> t -> t -> t * 'm
-
       method constr : 'env -> constr -> constr * 'm
-
       method field : 'env -> field -> field * 'm
-
       method list : 'env -> t -> t * 'm
-
       method path : 'env -> Path.t -> t * 'm
-
       method optional : 'env -> t -> t * 'm
-
       method poly_variant : 'env -> constr list -> t * 'm
-
       method prim : 'env -> prim -> t * 'm
-
       method record : 'env -> field list -> decl * 'm
-
       method t : 'env -> t -> t * 'm
-
       method decl : 'env -> decl -> decl * 'm
-
       method tuple : 'env -> t list -> t * 'm
-
       method var : 'env -> string -> t * 'm
-
       method variant : 'env -> constr list -> decl * 'm
     end
 end
@@ -256,6 +221,5 @@ module Module : sig
     | Value of Expr.toplevel
 
   val pp_sig : sig_ t -> unit Pp.t
-
   val pp_impl : impl t -> unit Pp.t
 end

--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -37,7 +37,6 @@ let preprocess =
   let traverse =
     object (self)
       inherit Unresolved.map as super
-
       val mutable current_name = None
 
       method name =
@@ -196,7 +195,6 @@ module Module : sig
   type t = (Module.sig_ Module.t, Module.impl Module.t) Kind.pair
 
   val add_private_values : t -> Expr.toplevel Named.t list -> t
-
   val type_decls : Module.Name.t -> Type.decl Named.t list Kind.Map.t -> t
 
   (** Use Json.Nullable_option or Json.Assoc.t where appropriate *)
@@ -243,9 +241,7 @@ end = struct
       let open Ml.Type in
       object (self)
         inherit [unit, unit] Ml.Type.mapreduce as super
-
         method empty = ()
-
         method plus () () = ()
 
         method! field x f =
@@ -272,9 +268,7 @@ end = struct
       let open Ml.Type in
       object (self)
         inherit [unit, unit] Ml.Type.mapreduce as super
-
         method empty = ()
-
         method plus () () = ()
 
         method! optional x t =
@@ -338,7 +332,6 @@ let pp_file pp ch =
 module Create : sig
   (* Generate create functions with optional/labeled arguments *)
   val intf_of_type : Ml.Type.decl Named.t -> Ml.Module.sig_ Named.t list
-
   val impl_of_type : Ml.Type.decl Named.t -> Ml.Module.impl Named.t list
 end = struct
   let f_name name =

--- a/lsp/bin/ocaml/ocaml.mli
+++ b/lsp/bin/ocaml/ocaml.mli
@@ -3,5 +3,4 @@ module Module : sig
 end
 
 val of_typescript : Ts_types.Unresolved.t list -> Module.t list
-
 val output : Module.t list -> kind:Ml.Kind.t -> out_channel -> unit

--- a/lsp/bin/ocaml/w.ml
+++ b/lsp/bin/ocaml/w.ml
@@ -3,15 +3,12 @@ open Pp.O
 open Pp
 
 type t = unit Pp.t
-
 type w = t
 
 (* This module contains all the writing primitives *)
 
 let ident = verbatim
-
 let i = verbatim
-
 let quoted s = i (sprintf "%S" s)
 
 let surround delim a =
@@ -31,18 +28,13 @@ module Json = struct
 
   module Literal = struct
     let str n = sprintf "`String %S" n
-
     let int i = sprintf "`Int (%d)" i
-
     let null = "`Null"
-
     let bool b = sprintf "`Bool %b" b
   end
 
   let str = sprintf "`String %s"
-
   let int = sprintf "`Int %s"
-
   let bool = sprintf "`Bool %s"
 end
 
@@ -77,20 +69,15 @@ end
 
 module Type = struct
   let string = i "string"
-
   let int = i "int"
-
   let name = i
-
   let bool = i "bool"
 
   let gen_decl kw name body =
     Pp.concat [ Pp.textf "%s %s =" kw name; Pp.newline; body ]
 
   let and_ name body = gen_decl "and" name body
-
   let decl name body = gen_decl "type" name body
-
   let record fields = Gen.record ~delim:":" fields
 
   let field_attrs ~field ~attrs =
@@ -141,11 +128,8 @@ module Type = struct
       ]
 
   let opt_attr = ident "option [@yojson.option]"
-
   let opt_field f = Pp.seq f opt_attr
-
   let default f def = Pp.concat [ f; ident "[@default "; ident def; ident "]" ]
-
   let key name = concat [ ident "[@key "; quoted name; ident "]" ]
 
   let gen_variant ~poly constrs =
@@ -169,7 +153,6 @@ module Type = struct
           Gen.clause ~delim:"of" (ident name) xs)
 
   let poly constrs = concat [ i "["; gen_variant ~poly:true constrs; i "]" ]
-
   let variant constrs = gen_variant ~poly:false constrs
 end
 
@@ -221,5 +204,4 @@ let opens names =
       Pp.concat [ textf "open! %s" name; newline ])
 
 let module_ name body = gen_module "= struct" name body
-
 let record fields = Gen.record ~delim:"=" fields

--- a/lsp/bin/ocaml/w.mli
+++ b/lsp/bin/ocaml/w.mli
@@ -3,30 +3,23 @@
 open Import
 
 type t = unit Pp.t
-
 type w = t
 
 val surround : [ `Curly | `Paren | `Square ] -> 'a Pp.t -> 'a Pp.t
 
 module Json : sig
   val invalid_pat : string -> w * w
-
   val typ : string
 
   module Literal : sig
     val str : string -> string
-
     val int : int -> string
-
     val null : string
-
     val bool : bool -> string
   end
 
   val str : string -> string
-
   val int : string -> string
-
   val bool : string -> string
 end
 
@@ -38,58 +31,34 @@ end
 
 module Type : sig
   val string : w
-
   val int : w
-
   val bool : w
-
   val name : string -> w
-
   val and_ : string -> w -> w
-
   val decl : string -> w -> w
-
   val record : (string * w) list -> w
-
   val field_attrs : field:w -> attrs:Attr.t list -> w
-
   val rec_decls : (string * w) list -> w
-
   val var : string -> w
-
   val poly : (string * w list) list -> w
-
   val app : w -> w list -> w
-
   val tuple : w list -> w
-
   val deriving : w -> record:bool -> w
-
   val opt_attr : w
-
   val opt_field : w -> w
-
   val default : w -> string -> w
-
   val key : string -> w
-
   val variant : (string * w list) list -> w
 end
 
 module Sig : sig
   val module_ : string -> w -> w
-
   val include_ : string -> (w * w) list -> w
-
   val val_ : string -> w list -> w
-
   val assoc : w -> w -> w
 end
 
 val warnings : string -> w
-
 val module_ : string -> w -> w
-
 val opens : string list -> w
-
 val record : (string * w) list -> w

--- a/lsp/bin/typescript/ts_types.ml
+++ b/lsp/bin/typescript/ts_types.ml
@@ -78,34 +78,24 @@ module type S = sig
   and t = decl Named.t
 
   val to_dyn : t -> Dyn.t
-
   val dyn_of_typ : typ -> Dyn.t
-
   val dyn_of_field : field -> Dyn.t
 
   class map :
     object
       method typ : typ -> typ
-
       method sum : typ list -> typ
-
       method interface : interface -> interface
-
       method enum_anon : Enum.t -> Enum.t
-
       method field : field -> field
-
       method t : t -> t
     end
 
   class ['a] fold :
     object
       method field : field -> init:'a -> 'a
-
       method ident : ident -> init:'a -> 'a
-
       method t : t -> init:'a -> 'a
-
       method typ : typ -> init:'a -> 'a
     end
 end
@@ -375,7 +365,6 @@ module Resolved = Make (Prim)
 let subst unresolved =
   object
     val params = String.Map.empty
-
     val inside = None
 
     (* Resolve self references. *)

--- a/lsp/src/client_notification.mli
+++ b/lsp/src/client_notification.mli
@@ -17,5 +17,4 @@ type t =
   | Unknown_notification of Jsonrpc.Message.notification
 
 val of_jsonrpc : Jsonrpc.Message.notification -> (t, string) result
-
 val to_jsonrpc : t -> Jsonrpc.Message.notification

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -90,9 +90,7 @@ val yojson_of_result : 'a t -> 'a -> Json.t
 type packed = E : 'r t -> packed
 
 val of_jsonrpc : Jsonrpc.Message.request -> (packed, string) Result.t
-
 val to_jsonrpc_request : _ t -> id:Jsonrpc.Id.t -> Jsonrpc.Message.request
-
 val response_of_json : 'a t -> Json.t -> 'a
 
 val text_document :

--- a/lsp/src/header.ml
+++ b/lsp/src/header.ml
@@ -4,13 +4,11 @@ type t =
   }
 
 let content_type t = t.content_type
-
 let content_length t = t.content_length
 
 module Private = struct
   module Key = struct
     let content_length = "Content-Length"
-
     let content_type = "Content-Type"
   end
 end

--- a/lsp/src/header.mli
+++ b/lsp/src/header.mli
@@ -3,17 +3,13 @@ open! Import
 type t
 
 val content_length : t -> int
-
 val content_type : t -> string
-
 val create : ?content_type:string -> content_length:int -> unit -> t
-
 val to_string : t -> string
 
 module Private : sig
   module Key : sig
     val content_length : string
-
     val content_type : string
   end
 end

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -19,7 +19,6 @@ module String = struct
   include StringLabels
 
   let print () s = Printf.sprintf "%S" s
-
   let index = index_opt
 
   let rec check_prefix s ~prefix len i =
@@ -78,25 +77,17 @@ module Json = struct
   type t = Ppx_yojson_conv_lib.Yojson.Safe.t
 
   let to_pretty_string (t : t) = Yojson.Safe.pretty_to_string ~std:false t
-
   let to_string t = Yojson.Safe.to_string t
-
   let of_string s = Yojson.Safe.from_string s
-
   let yojson_of_t x = x
-
   let t_of_yojson x = x
-
   let error = Ppx_yojson_conv_lib.Yojson_conv.of_yojson_error
-
   let yojson_of_list = Ppx_yojson_conv_lib.Yojson_conv.yojson_of_list
-
   let pp ppf (t : t) = Yojson.Safe.pretty_print ppf t
 
   module Jsonable = Ppx_yojson_conv_lib.Yojsonable
 
   let bool b = `Bool b
-
   let field fields name conv = List.assoc_opt name fields |> Option.map conv
 
   let field_exn fields name conv =
@@ -255,7 +246,6 @@ module Json = struct
     type t
 
     let t_of_yojson = error "Void.t"
-
     let yojson_of_t (_ : t) = assert false
   end
 

--- a/lsp/src/io.ml
+++ b/lsp/src/io.ml
@@ -34,23 +34,18 @@ module Make (Io : sig
   type 'a t
 
   val return : 'a -> 'a t
-
   val raise : exn -> 'a t
 
   module O : sig
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
-
     val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
   end
 end) (Chan : sig
   type input
-
   type output
 
   val read_line : input -> string option Io.t
-
   val read_exactly : input -> int -> string option Io.t
-
   val write : output -> string -> unit Io.t
 end) =
 struct

--- a/lsp/src/io.mli
+++ b/lsp/src/io.mli
@@ -6,26 +6,20 @@ module Make (Io : sig
   type 'a t
 
   val return : 'a -> 'a t
-
   val raise : exn -> 'a t
 
   module O : sig
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
-
     val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
   end
 end) (Chan : sig
   type input
-
   type output
 
   val read_line : input -> string option Io.t
-
   val read_exactly : input -> int -> string option Io.t
-
   val write : output -> string -> unit Io.t
 end) : sig
   val read : Chan.input -> Jsonrpc.packet option Io.t
-
   val write : Chan.output -> Jsonrpc.packet -> unit Io.t
 end

--- a/lsp/src/server_notification.mli
+++ b/lsp/src/server_notification.mli
@@ -18,5 +18,4 @@ type t =
   | Unknown_notification of Jsonrpc.Message.notification
 
 val to_jsonrpc : t -> Jsonrpc.Message.notification
-
 val of_jsonrpc : Jsonrpc.Message.notification -> (t, string) Result.t

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -20,9 +20,6 @@ type _ t =
 type packed = E : 'r t -> packed
 
 val yojson_of_result : 'a t -> 'a -> Json.t
-
 val to_jsonrpc_request : _ t -> id:Jsonrpc.Id.t -> Jsonrpc.Message.request
-
 val of_jsonrpc : Jsonrpc.Message.request -> (packed, string) Result.t
-
 val response_of_json : 'a t -> Json.t -> 'a

--- a/lsp/src/snippet.ml
+++ b/lsp/src/snippet.ml
@@ -39,7 +39,6 @@ type t =
   | Concat of t * t
 
 let tabstop index = Tabstop (Some index, `None)
-
 let placeholder ?index content = Tabstop (index, `Placeholder content)
 
 let choice ?index values =
@@ -56,9 +55,7 @@ let text str = Text str
 
 module O = struct
   let ( ^^ ) lhs rhs = Concat (lhs, rhs)
-
   let ( @+ ) lhs_str rhs = Concat (Text lhs_str, rhs)
-
   let ( +@ ) lhs rhs_str = Concat (lhs, Text rhs_str)
 end
 

--- a/lsp/src/snippet.mli
+++ b/lsp/src/snippet.mli
@@ -22,9 +22,7 @@ type variable_transform =
 type t
 
 val tabstop : int -> t
-
 val placeholder : ?index:int -> t -> t
-
 val choice : ?index:int -> string list -> t
 
 val variable :
@@ -43,14 +41,10 @@ val text : string -> t
 
 module O : sig
   val ( ^^ ) : t -> t -> t
-
   val ( @+ ) : string -> t -> t
-
   val ( +@ ) : t -> string -> t
 end
 
 val concat : ?sep:t -> t list -> t
-
 val to_string : t -> string
-
 val pp : Format.formatter -> t -> unit

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -64,13 +64,9 @@ let find_offset ~utf8 ~utf16_range:range =
 type t = TextDocumentItem.t
 
 let text (t : TextDocumentItem.t) = t.text
-
 let make (t : DidOpenTextDocumentParams.t) = t.textDocument
-
 let documentUri (t : TextDocumentItem.t) = t.uri
-
 let version (t : TextDocumentItem.t) = t.version
-
 let languageId (t : TextDocumentItem.t) = t.languageId
 
 let apply_content_change ?version (t : TextDocumentItem.t)

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -3,13 +3,9 @@ open Types
 type t
 
 val make : DidOpenTextDocumentParams.t -> t
-
 val languageId : t -> string
-
 val documentUri : t -> Uri0.t
-
 val version : t -> int
-
 val text : t -> string
 
 exception Invalid_utf8

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -849,13 +849,9 @@ module ChangeAnnotationIdentifier = struct
   type t = string [@@deriving_inline yojson]
 
   let _ = fun (_ : t) -> ()
-
   let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
   let _ = t_of_yojson
-
   let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
   let _ = yojson_of_t
 
   [@@@end]
@@ -2246,13 +2242,9 @@ module Integer = struct
   type t = int [@@deriving_inline yojson]
 
   let _ = fun (_ : t) -> ()
-
   let t_of_yojson = (int_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
   let _ = t_of_yojson
-
   let yojson_of_t = (yojson_of_int : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
   let _ = yojson_of_t
 
   [@@@end]
@@ -14010,13 +14002,9 @@ module URI = struct
   type t = string [@@deriving_inline yojson]
 
   let _ = fun (_ : t) -> ()
-
   let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
   let _ = t_of_yojson
-
   let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
   let _ = yojson_of_t
 
   [@@@end]
@@ -15997,13 +15985,9 @@ module Decimal = struct
   type t = int [@@deriving_inline yojson]
 
   let _ = fun (_ : t) -> ()
-
   let t_of_yojson = (int_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
   let _ = t_of_yojson
-
   let yojson_of_t = (yojson_of_int : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
   let _ = yojson_of_t
 
   [@@@end]
@@ -38742,13 +38726,9 @@ module Uinteger = struct
   type t = int [@@deriving_inline yojson]
 
   let _ = fun (_ : t) -> ()
-
   let t_of_yojson = (int_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-
   let _ = t_of_yojson
-
   let yojson_of_t = (yojson_of_int : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-
   let _ = yojson_of_t
 
   [@@@end]

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -21,11 +21,8 @@ let to_string { scheme; authority; path } =
   Buffer.contents b
 
 let yojson_of_t t = `String (to_string t)
-
 let equal = ( = )
-
 let compare (x : t) (y : t) = Stdlib.compare x y
-
 let hash = Hashtbl.hash
 
 let to_dyn { scheme; authority; path } =

--- a/lsp/src/uri0.mli
+++ b/lsp/src/uri0.mli
@@ -5,15 +5,9 @@ type t
 include Json.Jsonable.S with type t := t
 
 val compare : t -> t -> int
-
 val equal : t -> t -> bool
-
 val to_dyn : t -> Dyn.t
-
 val hash : t -> int
-
 val to_path : t -> string
-
 val of_path : string -> t
-
 val to_string : t -> string

--- a/lsp/src/uri_lexer.mli
+++ b/lsp/src/uri_lexer.mli
@@ -5,5 +5,4 @@ type t =
   }
 
 val of_string : string -> t
-
 val escape_path : string -> string

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -2,7 +2,6 @@ open Import
 open Fiber.O
 
 let action_kind = "destruct"
-
 let kind = CodeActionKind.Other action_kind
 
 let code_action_of_case_analysis doc uri (loc, newText) =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -1,5 +1,4 @@
 open Import
 
 val kind : CodeActionKind.t
-
 val t : State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -39,5 +39,4 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
       Some (code_action_of_intf doc intf params.range))
 
 let kind = CodeActionKind.Other action_kind
-
 let t state = { Code_action.kind; run = code_action state }

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.mli
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.mli
@@ -1,5 +1,4 @@
 open Import
 
 val kind : CodeActionKind.t
-
 val t : State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -144,5 +144,4 @@ let code_action_remove doc (params : CodeActionParams.t) =
   | Some d -> code_action_remove_value doc pos d
 
 let mark = { Code_action.kind = QuickFix; run = code_action_mark }
-
 let remove = { Code_action.kind = QuickFix; run = code_action_remove }

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.mli
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.mli
@@ -1,3 +1,2 @@
 val mark : Code_action.t
-
 val remove : Code_action.t

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -5,9 +5,7 @@ module Resolve = struct
   type t = CompletionParams.t
 
   let uri (t : t) = t.textDocument.uri
-
   let yojson_of_t = CompletionParams.yojson_of_t
-
   let t_of_yojson = CompletionParams.t_of_yojson
 
   let of_completion_item (ci : CompletionItem.t) =
@@ -151,8 +149,7 @@ module Complete_by_prefix = struct
     let kind = completion_kind entry.kind in
     let textEdit = `TextEdit { TextEdit.range; newText = entry.name } in
     CompletionItem.create ~label:entry.name ?kind ~detail:entry.desc
-      ~deprecated:
-        entry.deprecated
+      ~deprecated:entry.deprecated
         (* Without this field the client is not forced to respect the order
            provided by merlin. *)
       ~sortText:(sortText_of_index idx) ~data:compl_params ~textEdit ()

--- a/ocaml-lsp-server/src/configuration.ml
+++ b/ocaml-lsp-server/src/configuration.ml
@@ -10,9 +10,6 @@ let default =
   }
 
 let diagnostics_delay t = t.diagnostics_delay
-
 let request = { ConfigurationParams.items = [] }
-
 let of_response (_ : Json.t list) = default
-
 let update t _ = t

--- a/ocaml-lsp-server/src/configuration.mli
+++ b/ocaml-lsp-server/src/configuration.mli
@@ -3,11 +3,7 @@ open Import
 type t
 
 val diagnostics_delay : t -> float
-
 val default : t
-
 val update : t -> DidChangeConfigurationParams.t -> t
-
 val request : ConfigurationParams.t
-
 val of_response : Json.t list -> t

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -2,7 +2,6 @@ open Import
 open Fiber.O
 
 let capability = ("handleInferIntf", `Bool true)
-
 let meth = "ocamllsp/inferIntf"
 
 let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.mli
@@ -1,7 +1,6 @@
 open Import
 
 val capability : string * Json.t
-
 val meth : string
 
 val on_request :

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -1,7 +1,6 @@
 open Import
 
 let capability = ("handleSwitchImplIntf", `Bool true)
-
 let meth = "ocamllsp/switchImplIntf"
 
 (** see the spec for [ocamllsp/switchImplIntf] *)

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
@@ -1,7 +1,6 @@
 open Import
 
 val capability : string * Json.t
-
 val meth : string
 
 val on_request :

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
@@ -2,7 +2,6 @@ open Import
 open Fiber.O
 
 let capability = ("handleTypedHoles", `Bool true)
-
 let meth = "ocamllsp/typedHoles"
 
 module Request_params = struct

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
@@ -1,7 +1,6 @@
 open Import
 
 val capability : string * Json.t
-
 val meth : string
 
 val on_request :

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -2,7 +2,6 @@ open Import
 open Fiber.O
 
 let capability = ("handleWrappingAstNode", `Bool true)
-
 let meth = "ocamllsp/wrappingAstNode"
 
 module Request_params = struct

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.mli
@@ -1,7 +1,6 @@
 open Import
 
 val capability : string * Json.t
-
 val meth : string
 
 val on_request :

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -13,7 +13,6 @@ module Id = struct
   include Drpc.Diagnostic.Id
 
   let equal x y = compare x y = Eq
-
   let to_dyn = Dyn.opaque
 end
 

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -8,7 +8,6 @@ val create :
   -> t
 
 val send : t -> [ `All | `One of Uri.t ] -> unit Fiber.t
-
 val workspace_root : t -> Uri.t
 
 module Dune : sig

--- a/ocaml-lsp-server/src/diff.ml
+++ b/ocaml-lsp-server/src/diff.ml
@@ -129,8 +129,7 @@ let edit ~from:orig ~to_:formatted : TextEdit.t list =
   in
   let line, prev_deleted_lines, edits_rev =
     Simple_diff.get_diff orig_lines formatted_lines
-    |> List.fold_left
-         ~init:(0, [||], [])
+    |> List.fold_left ~init:(0, [||], [])
          ~f:(fun (line, prev_deleted_lines, edits_rev) edit ->
            match (edit : Simple_diff.diff) with
            | Deleted deleted_lines ->

--- a/ocaml-lsp-server/src/doc_to_md.ml
+++ b/ocaml-lsp-server/src/doc_to_md.ml
@@ -2,13 +2,9 @@ open Import
 module Oct = Octavius
 
 let ocaml = "ocaml"
-
 let to_inline_code code = Omd.Code (ocaml, code)
-
 let to_code_block code = Omd.Code_block (ocaml, code)
-
 let space = Omd.Text " "
-
 let new_line = Omd.NL
 
 (* [put_in_between elem lst] inserts [elem] between all elements of [lst] *)

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -133,7 +133,6 @@ let timer = function
   | Merlin m -> m.timer
 
 let text t = Text_document.text (tdoc t)
-
 let source t = Msource.make (text t)
 
 let await task =

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -12,7 +12,6 @@ module Syntax : sig
     | Dune
 
   val human_name : t -> string
-
   val markdown_name : t -> string
 end
 
@@ -23,9 +22,7 @@ module Kind : sig
 end
 
 val is_merlin : t -> bool
-
 val kind : t -> Kind.t
-
 val syntax : t -> Syntax.t
 
 val make :
@@ -36,15 +33,10 @@ val make :
   -> t Fiber.t
 
 val timer : t -> Lev_fiber.Timer.Wheel.task
-
 val uri : t -> Uri.t
-
 val text : t -> string
-
 val source : t -> Msource.t
-
 val with_pipeline_exn : t -> (Mpipeline.t -> 'a) -> 'a Fiber.t
-
 val version : t -> int
 
 val update_text :
@@ -54,7 +46,6 @@ val dispatch :
   t -> 'a Query_protocol.t -> ('a, Exn_with_backtrace.t) result Fiber.t
 
 val dispatch_exn : t -> 'a Query_protocol.t -> 'a Fiber.t
-
 val close : t -> unit Fiber.t
 
 (** [get_impl_intf_counterparts uri] returns the implementation/interface

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -4,9 +4,7 @@ open Fiber.O
 type t = (Uri.t, Document.t) Table.t
 
 let make () = Table.create (module Uri) 50
-
 let put store doc = Table.set store (Document.uri doc) doc
-
 let get_opt store = Table.find store
 
 let get store uri =

--- a/ocaml-lsp-server/src/document_store.mli
+++ b/ocaml-lsp-server/src/document_store.mli
@@ -3,15 +3,9 @@ open Import
 type t
 
 val make : unit -> t
-
 val put : t -> Document.t -> unit
-
 val get : t -> Uri.t -> Document.t
-
 val get_opt : t -> Uri.t -> Document.t option
-
 val remove_document : t -> Uri.t -> unit Fiber.t
-
 val get_size : t -> int
-
 val close : t -> unit Fiber.t

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -24,7 +24,6 @@ module For_diff = struct
   type t = Diff.t list
 
   let yojson_of_t : t -> Json.t = Json.yojson_of_list Diff.yojson_of_t
-
   let diagnostic_data t = (fst view_promotion_capability, yojson_of_t t)
 end
 
@@ -32,13 +31,9 @@ module Chan : sig
   type t
 
   val create : Csexp_rpc.Session.t -> t
-
   val write : t -> Csexp.t list option -> unit Fiber.t
-
   val read : t -> Csexp.t option Fiber.t
-
   val stop : t -> unit Fiber.t
-
   val run : t -> unit Fiber.t
 end = struct
   open Fiber.O
@@ -49,7 +44,6 @@ end = struct
     }
 
   let stop t = Csexp_rpc.Session.write t.session None
-
   let write t sexp = Csexp_rpc.Session.write t.session sexp
 
   let read t =
@@ -110,17 +104,11 @@ module Instance : sig
   type t
 
   val format_dune_file : t -> Document.t -> string Fiber.t
-
   val stop : t -> unit Fiber.t
-
   val run : t -> unit Fiber.t
-
   val source : t -> Registry.Dune.t
-
   val create : Registry.Dune.t -> config -> t
-
   val promotions : t -> Drpc.Diagnostic.Promotion.t String.Map.t
-
   val client : t -> Client.t option
 end = struct
   module Id = Stdune.Id.Make ()
@@ -610,7 +598,6 @@ let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
        })
 
 let enabled = false
-
 let create_disabled () = ref Closed
 
 let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -9,7 +9,6 @@ end
 type t
 
 val view_promotion_capability : string * Json.t
-
 val run : t -> unit Fiber.t
 
 val create :
@@ -21,13 +20,8 @@ val create :
   -> t
 
 val update_workspaces : t -> Workspaces.t -> unit
-
 val stop : t -> unit Fiber.t
-
 val commands : string list
-
 val on_command : t -> ExecuteCommandParams.t -> Json.t Fiber.t
-
 val code_actions : t -> Document.t -> CodeAction.t list
-
 val for_doc : t -> Document.t -> Instance.t list

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -122,8 +122,10 @@ include struct
   module MarkupContent = MarkupContent
   module MarkupKind = MarkupKind
   module MessageType = MessageType
+
   module OptionalVersionedTextDocumentIdentifier =
     OptionalVersionedTextDocumentIdentifier
+
   module ParameterInformation = ParameterInformation
   module ProgressParams = ProgressParams
   module ProgressToken = ProgressToken

--- a/ocaml-lsp-server/src/lazy_fiber.mli
+++ b/ocaml-lsp-server/src/lazy_fiber.mli
@@ -1,5 +1,4 @@
 type 'a t
 
 val create : (unit -> 'a Fiber.t) -> 'a t
-
 val force : 'a t -> 'a Fiber.t

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -178,7 +178,6 @@ let create () =
   { running = Table.create (module String) 0; pool = Fiber.Pool.create () }
 
 let run t = Fiber.Pool.run t.pool
-
 let stop t = Fiber.Pool.stop t.pool
 
 let get_process t ~dir =

--- a/ocaml-lsp-server/src/merlin_config.mli
+++ b/ocaml-lsp-server/src/merlin_config.mli
@@ -1,9 +1,6 @@
 type t
 
 val create : unit -> t
-
 val stop : t -> unit Fiber.t
-
 val run : t -> unit Fiber.t
-
 val get_external_config : t -> Mconfig.t -> string -> Mconfig.t Fiber.t

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -11,5 +11,4 @@ type error =
   | Unknown_extension of Uri.t
 
 val message : error -> string
-
 val run : Document.t -> (TextEdit.t list, error) result Fiber.t

--- a/ocaml-lsp-server/src/ocamlformat_rpc.ml
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.ml
@@ -12,9 +12,7 @@ module Process : sig
   type t
 
   val pid : t -> Pid.t
-
   val thread : t -> Lev_fiber.Thread.t
-
   val client : t -> Ocamlformat_rpc_lib.client
 
   val create :
@@ -34,11 +32,8 @@ end = struct
     }
 
   let pid t = t.pid
-
   let thread t = t.io_thread
-
   let client t = t.client
-
   let supported_versions = [ "v1" ]
 
   let pick_client ~pid input output io_thread =
@@ -169,7 +164,6 @@ let create_state () =
     { ask_init = Fiber.Ivar.create (); wait_init = Fiber.Ivar.create () }
 
 let _create () = ref (create_state ())
-
 let create () = ref Disabled
 
 let maybe_fill ivar x =

--- a/ocaml-lsp-server/src/ocamlformat_rpc.mli
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.mli
@@ -3,7 +3,6 @@ open Import
 type t
 
 val create : unit -> t
-
 val stop : t -> unit Fiber.t
 
 val format_type :

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -1,15 +1,9 @@
 open Import
-
 include module type of Lsp.Types.Position with type t = Lsp.Types.Position.t
 
 val compare_inclusion : t -> Lsp.Types.Range.t -> [ `Inside | `Outside of t ]
-
 val ( - ) : t -> t -> t
-
 val compare : t -> t -> Ordering.t
-
 val logical : t -> [> `Logical of int * int ]
-
 val of_lexical_position : Lexing.position -> t option
-
 val start : t

--- a/ocaml-lsp-server/src/progress.mli
+++ b/ocaml-lsp-server/src/progress.mli
@@ -10,7 +10,5 @@ val create :
   -> t
 
 val end_build_if_running : t -> unit Fiber.t
-
 val build_progress : t -> Drpc.Progress.t -> unit Fiber.t
-
 val should_report_build_progress : t -> bool

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -1,5 +1,4 @@
 open Import
-
 include module type of Lsp.Types.Range with type t = Lsp.Types.Range.t
 
 (** [compare r1 r2] compares first start positions, if equal compares the end
@@ -7,7 +6,5 @@ include module type of Lsp.Types.Range with type t = Lsp.Types.Range.t
 val compare : t -> t -> Ordering.t
 
 val compare_size : t -> t -> Ordering.t
-
 val first_line : t
-
 val of_loc : Loc.t -> t

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -34,17 +34,11 @@ val create :
   -> t
 
 val wheel : t -> Lev_fiber.Timer.Wheel.t
-
 val initialize_params : t -> InitializeParams.t
-
 val initialize : t -> InitializeParams.t -> Workspaces.t -> Dune.t -> t
-
 val workspace_root : t -> Uri.t
-
 val workspaces : t -> Workspaces.t
-
 val dune : t -> Dune.t
-
 val modify_workspaces : t -> f:(Workspaces.t -> Workspaces.t) -> t
 
 (** @return client capabilities passed from the client in [InitializeParams]

--- a/ocaml-lsp-server/src/typed_hole.ml
+++ b/ocaml-lsp-server/src/typed_hole.ml
@@ -1,5 +1,4 @@
 let syntax_repr = "_"
-
 let can_be_hole s = String.equal syntax_repr s
 
 (* the pattern matching below is taken and modified (minimally, to adapt the

--- a/ocaml-lsp-server/src/workspaces.mli
+++ b/ocaml-lsp-server/src/workspaces.mli
@@ -3,7 +3,5 @@ open Import
 type t
 
 val create : InitializeParams.t -> t
-
 val on_change : t -> DidChangeWorkspaceFoldersParams.t -> t
-
 val workspace_folders : t -> WorkspaceFolder.t list


### PR DESCRIPTION
Based on #533

This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!