### PR TITLE
Fix cancel request param (de)serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased 
+# Unreleased
 
 ## Features
 
@@ -16,6 +16,8 @@
 - More accurate completion kinds.
   New completion kinds for variants and fields. Removed inaccurate completion
   kinds for constructors and types. (#510)
+
+- Fix handling request cancellation (#616)
 
 # 1.9.1
 

--- a/lsp/src/cancel_request.ml
+++ b/lsp/src/cancel_request.ml
@@ -4,7 +4,7 @@ let meth_ = "$/cancelRequest"
 
 let t_of_yojson json =
   match json with
-  | `Assoc fields -> Json.field_exn fields "params" Jsonrpc.Id.t_of_yojson
+  | `Assoc fields -> Json.field_exn fields "id" Jsonrpc.Id.t_of_yojson
   | _ -> Json.error "invalid id" json
 
-let yojson_of_t id = `Assoc [ ("params", Jsonrpc.Id.yojson_of_t id) ]
+let yojson_of_t id = `Assoc [ ("id", Jsonrpc.Id.yojson_of_t id) ]

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -98,7 +98,7 @@ module Json = struct
   let field_exn fields name conv =
     match field fields name conv with
     | Some f -> f
-    | None -> error ("missing field" ^ name) (`Assoc fields)
+    | None -> error ("missing field: " ^ name) (`Assoc fields)
 
   let rec of_dyn (t : Dyn.t) : t =
     match t with


### PR DESCRIPTION
- fix: better missing json-field error formatting
- fix: $/cancelRequest params were incorrectly (de)serialized

Noticed this problem luckily thanks to learning how to use logging yesterday :D 
