### PR TITLE
refactor: move side-effects into fiber

### DIFF
--- a/lsp-fiber/src/fiber_io.ml
+++ b/lsp-fiber/src/fiber_io.ml
@@ -29,8 +29,9 @@ module Io =
         | Error (`Partial_eof _) -> None
 
       let write oc s =
-        Lio.Writer.add_string oc s;
-        Fiber.return ()
+        Fiber.of_thunk (fun () ->
+            Lio.Writer.add_string oc s;
+            Fiber.return ())
     end)
 
 let send (_, oc) packets =
@@ -43,7 +44,8 @@ let recv (ic, _) = Lio.with_read ic ~f:Io.read
 let make ic oc = (ic, oc)
 
 let close (ic, oc) what =
-  (match what with
-  | `Write -> Lio.close oc
-  | `Read -> Lio.close ic);
-  Fiber.return ()
+  Fiber.of_thunk (fun () ->
+      (match what with
+      | `Write -> Lio.close oc
+      | `Read -> Lio.close ic);
+      Fiber.return ())

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -7,27 +7,28 @@ let meth = "ocamllsp/inferIntf"
 
 let on_request ~(params : Jsonrpc.Message.Structured.t option) (state : State.t)
     =
-  match params with
-  | Some (`List [ json_uri ]) -> (
-    let json_uri = DocumentUri.t_of_yojson json_uri in
-    match Document_store.get_opt state.store json_uri with
-    | None ->
-      Jsonrpc.Response.Error.raise
-        (Jsonrpc.Response.Error.make ~code:InvalidParams
-           ~message:
-             "ocamllsp/inferIntf received a URI for an unloaded file. Load the \
-              file first."
-           ())
-    | Some impl ->
-      let+ intf = Inference.infer_intf_for_impl impl in
-      Json.t_of_yojson (`String intf))
-  | Some json ->
-    Jsonrpc.Response.Error.raise
-      (Jsonrpc.Response.Error.make ~code:InvalidRequest
-         ~message:"The input parameter for ocamllsp/inferIntf is invalid"
-         ~data:(`Assoc [ ("param", (json :> Json.t)) ])
-         ())
-  | None ->
-    Jsonrpc.Response.Error.raise
-      (Jsonrpc.Response.Error.make ~code:InvalidRequest
-         ~message:"ocamllsp/inferIntf must receive param: DocumentUri.t" ())
+  Fiber.of_thunk (fun () ->
+      match params with
+      | Some (`List [ json_uri ]) -> (
+        let json_uri = DocumentUri.t_of_yojson json_uri in
+        match Document_store.get_opt state.store json_uri with
+        | None ->
+          Jsonrpc.Response.Error.raise
+            (Jsonrpc.Response.Error.make ~code:InvalidParams
+               ~message:
+                 "ocamllsp/inferIntf received a URI for an unloaded file. Load \
+                  the file first."
+               ())
+        | Some impl ->
+          let+ intf = Inference.infer_intf_for_impl impl in
+          Json.t_of_yojson (`String intf))
+      | Some json ->
+        Jsonrpc.Response.Error.raise
+          (Jsonrpc.Response.Error.make ~code:InvalidRequest
+             ~message:"The input parameter for ocamllsp/inferIntf is invalid"
+             ~data:(`Assoc [ ("param", (json :> Json.t)) ])
+             ())
+      | None ->
+        Jsonrpc.Response.Error.raise
+          (Jsonrpc.Response.Error.make ~code:InvalidRequest
+             ~message:"ocamllsp/inferIntf must receive param: DocumentUri.t" ()))

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -9,20 +9,18 @@ let switch (param : DocumentUri.t) : Json.t =
   let files_to_switch_to = Document.get_impl_intf_counterparts param in
   Json.yojson_of_list Uri.yojson_of_t files_to_switch_to
 
-let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
-  Fiber.return
-    (match params with
-    | Some (`List [ file_uri ]) ->
-      let file_uri = DocumentUri.t_of_yojson file_uri in
-      switch file_uri
-    | Some json ->
-      Jsonrpc.Response.Error.raise
-        (Jsonrpc.Response.Error.make ~code:InvalidRequest
-           ~message:"The input parameter for ocamllsp/switchImplIntf is invalid"
-           ~data:(`Assoc [ ("param", (json :> Json.t)) ])
-           ())
-    | None ->
-      Jsonrpc.Response.Error.raise
-        (Jsonrpc.Response.Error.make ~code:InvalidRequest
-           ~message:"ocamllsp/switchImplIntf must receive param: DocumentUri.t"
-           ()))
+let on_request ~(params : Jsonrpc.Message.Structured.t option) =
+  match params with
+  | Some (`List [ file_uri ]) ->
+    let file_uri = DocumentUri.t_of_yojson file_uri in
+    switch file_uri
+  | Some json ->
+    Jsonrpc.Response.Error.raise
+      (Jsonrpc.Response.Error.make ~code:InvalidRequest
+         ~message:"The input parameter for ocamllsp/switchImplIntf is invalid"
+         ~data:(`Assoc [ ("param", (json :> Json.t)) ])
+         ())
+  | None ->
+    Jsonrpc.Response.Error.raise
+      (Jsonrpc.Response.Error.make ~code:InvalidRequest
+         ~message:"ocamllsp/switchImplIntf must receive param: DocumentUri.t" ())

--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.mli
@@ -4,5 +4,4 @@ val capability : string * Json.t
 
 val meth : string
 
-val on_request :
-  params:Jsonrpc.Message.Structured.t option -> _ -> Json.t Fiber.t
+val on_request : params:Jsonrpc.Message.Structured.t option -> Json.t

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -29,35 +29,37 @@ module Request_params = struct
 end
 
 let on_request ~params state =
-  let { Request_params.text_document_uri; cursor_position } =
-    Request_params.of_jsonrpc_params_exn params
-  in
-  let doc = Document_store.get state.State.store text_document_uri in
-  let pos = Position.logical cursor_position in
-  let+ node =
-    Document.with_pipeline_exn doc (fun pipeline ->
-        let typer = Mpipeline.typer_result pipeline in
-        let pos = Mpipeline.get_lexing_pos pipeline pos in
-        let enclosing_nodes (* from smallest node to largest *) =
-          Mbrowse.enclosing pos
-            [ Mbrowse.of_typedtree (Mtyper.get_typedtree typer) ]
-        in
-        let loc_of_structure_item { Typedtree.str_loc; _ } = str_loc in
-        let find_fst_structure_item_or_structure = function
-          | _, Browse_raw.Structure_item (str_item, _) ->
-            Some (loc_of_structure_item str_item)
-          | _, Structure { str_items; _ } -> (
-            match str_items with
-            | [] -> None
-            | hd :: rest ->
-              let last = List.last rest |> Option.value ~default:hd in
-              let { Loc.loc_start; _ } = loc_of_structure_item hd in
-              let { Loc.loc_end; _ } = loc_of_structure_item last in
-              Some { Loc.loc_start; loc_end; loc_ghost = false })
-          | _ -> None
-        in
-        List.find_map enclosing_nodes ~f:find_fst_structure_item_or_structure)
-  in
-  match node with
-  | None -> `Null
-  | Some loc -> Range.of_loc loc |> Range.yojson_of_t
+  Fiber.of_thunk (fun () ->
+      let { Request_params.text_document_uri; cursor_position } =
+        Request_params.of_jsonrpc_params_exn params
+      in
+      let doc = Document_store.get state.State.store text_document_uri in
+      let pos = Position.logical cursor_position in
+      let+ node =
+        Document.with_pipeline_exn doc (fun pipeline ->
+            let typer = Mpipeline.typer_result pipeline in
+            let pos = Mpipeline.get_lexing_pos pipeline pos in
+            let enclosing_nodes (* from smallest node to largest *) =
+              Mbrowse.enclosing pos
+                [ Mbrowse.of_typedtree (Mtyper.get_typedtree typer) ]
+            in
+            let loc_of_structure_item { Typedtree.str_loc; _ } = str_loc in
+            let find_fst_structure_item_or_structure = function
+              | _, Browse_raw.Structure_item (str_item, _) ->
+                Some (loc_of_structure_item str_item)
+              | _, Structure { str_items; _ } -> (
+                match str_items with
+                | [] -> None
+                | hd :: rest ->
+                  let last = List.last rest |> Option.value ~default:hd in
+                  let { Loc.loc_start; _ } = loc_of_structure_item hd in
+                  let { Loc.loc_end; _ } = loc_of_structure_item last in
+                  Some { Loc.loc_start; loc_end; loc_ghost = false })
+              | _ -> None
+            in
+            List.find_map enclosing_nodes
+              ~f:find_fst_structure_item_or_structure)
+      in
+      match node with
+      | None -> `Null
+      | Some loc -> Range.of_loc loc |> Range.yojson_of_t)

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -203,17 +203,18 @@ let make_merlin wheel merlin_config ~merlin_thread tdoc syntax =
     { merlin_config; tdoc; pipeline; merlin = merlin_thread; timer; syntax }
 
 let make wheel config ~merlin_thread (doc : DidOpenTextDocumentParams.t) =
-  let tdoc = Text_document.make doc in
-  let syntax = Syntax.of_text_document tdoc in
-  match syntax with
-  | Ocaml
-  | Reason ->
-    make_merlin wheel config ~merlin_thread tdoc syntax
-  | Ocamllex
-  | Menhir
-  | Cram
-  | Dune ->
-    Fiber.return (Other (tdoc, syntax))
+  Fiber.of_thunk (fun () ->
+      let tdoc = Text_document.make doc in
+      let syntax = Syntax.of_text_document tdoc in
+      match syntax with
+      | Ocaml
+      | Reason ->
+        make_merlin wheel config ~merlin_thread tdoc syntax
+      | Ocamllex
+      | Menhir
+      | Cram
+      | Dune ->
+        Fiber.return (Other (tdoc, syntax)))
 
 let update_text ?version t changes =
   match

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -20,15 +20,17 @@ let get store uri =
          ())
 
 let remove_document store uri =
-  match Table.find store uri with
-  | None -> Fiber.return ()
-  | Some doc ->
-    let+ () = Document.close doc in
-    Table.remove store uri
+  Fiber.of_thunk (fun () ->
+      match Table.find store uri with
+      | None -> Fiber.return ()
+      | Some doc ->
+        let+ () = Document.close doc in
+        Table.remove store uri)
 
 let get_size store = Table.length store
 
 let close t =
-  let docs = Table.fold t ~init:[] ~f:(fun doc acc -> doc :: acc) in
-  let+ () = Fiber.parallel_iter docs ~f:Document.close in
-  Table.clear t
+  Fiber.of_thunk (fun () ->
+      let docs = Table.fold t ~init:[] ~f:(fun doc acc -> doc :: acc) in
+      let+ () = Fiber.parallel_iter docs ~f:Document.close in
+      Table.clear t)

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -227,10 +227,11 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
   List.rev_map !ranges ~f:folding_range
 
 let compute (state : State.t) (params : FoldingRangeParams.t) =
-  let doc = Document_store.get state.store params.textDocument.uri in
-  let+ ranges =
-    Document.with_pipeline_exn doc (fun pipeline ->
-        let parsetree = Mpipeline.reader_parsetree pipeline in
-        fold_over_parsetree parsetree)
-  in
-  Some ranges
+  Fiber.of_thunk (fun () ->
+      let doc = Document_store.get state.store params.textDocument.uri in
+      let+ ranges =
+        Document.with_pipeline_exn doc (fun pipeline ->
+            let parsetree = Mpipeline.reader_parsetree pipeline in
+            fold_over_parsetree parsetree)
+      in
+      Some ranges)

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -28,45 +28,49 @@ let format_contents ~syntax ~markdown ~typ ~doc =
       { MarkupContent.value; kind = MarkupKind.PlainText })
 
 let handle server { HoverParams.textDocument = { uri }; position; _ } =
-  let state : State.t = Server.state server in
-  let doc =
-    let store = state.store in
-    Document_store.get store uri
-  in
-  let pos = Position.logical position in
-  let* type_enclosing = Document.type_enclosing doc pos in
-  match type_enclosing with
-  | None -> Fiber.return None
-  | Some { Document.loc; typ; doc = documentation } ->
-    let syntax = Document.syntax doc in
-    let+ typ =
-      (* We ask Ocamlformat to format this type *)
-      let* result = Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ in
-      match result with
-      | Ok v ->
-        (* OCamlformat adds an unnecessay newline at the end of the type *)
-        Fiber.return (String.trim v)
-      | Error `No_process -> Fiber.return typ
-      | Error (`Msg message) ->
-        (* We log OCamlformat errors and display the unformated type *)
-        let+ () =
-          let message =
-            sprintf
-              "An error occured while querying ocamlformat:\n\
-               Input type: %s\n\n\
-               Answer: %s" typ message
-          in
-          State.log_msg server ~type_:Warning ~message
-        in
-        typ
-    in
-    let contents =
-      let markdown =
-        let client_capabilities = State.client_capabilities state in
-        ClientCapabilities.markdown_support client_capabilities
-          ~field:(fun td -> Option.map td.hover ~f:(fun h -> h.contentFormat))
+  Fiber.of_thunk (fun () ->
+      let state : State.t = Server.state server in
+      let doc =
+        let store = state.store in
+        Document_store.get store uri
       in
-      format_contents ~syntax ~markdown ~typ ~doc:documentation
-    in
-    let range = Range.of_loc loc in
-    Some (Hover.create ~contents ~range ())
+      let pos = Position.logical position in
+      let* type_enclosing = Document.type_enclosing doc pos in
+      match type_enclosing with
+      | None -> Fiber.return None
+      | Some { Document.loc; typ; doc = documentation } ->
+        let syntax = Document.syntax doc in
+        let+ typ =
+          (* We ask Ocamlformat to format this type *)
+          let* result =
+            Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ
+          in
+          match result with
+          | Ok v ->
+            (* OCamlformat adds an unnecessay newline at the end of the type *)
+            Fiber.return (String.trim v)
+          | Error `No_process -> Fiber.return typ
+          | Error (`Msg message) ->
+            (* We log OCamlformat errors and display the unformated type *)
+            let+ () =
+              let message =
+                sprintf
+                  "An error occured while querying ocamlformat:\n\
+                   Input type: %s\n\n\
+                   Answer: %s" typ message
+              in
+              State.log_msg server ~type_:Warning ~message
+            in
+            typ
+        in
+        let contents =
+          let markdown =
+            let client_capabilities = State.client_capabilities state in
+            ClientCapabilities.markdown_support client_capabilities
+              ~field:(fun td ->
+                Option.map td.hover ~f:(fun h -> h.contentFormat))
+          in
+          format_contents ~syntax ~markdown ~typ ~doc:documentation
+        in
+        let range = Range.of_loc loc in
+        Some (Hover.create ~contents ~range ()))

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -927,7 +927,10 @@ let on_request :
   match req with
   | Client_request.UnknownRequest { meth; params } -> (
     match
-      [ (Req_switch_impl_intf.meth, Req_switch_impl_intf.on_request)
+      [ ( Req_switch_impl_intf.meth
+        , fun ~params _ ->
+            Fiber.of_thunk (fun () ->
+                Fiber.return (Req_switch_impl_intf.on_request ~params)) )
       ; (Req_infer_intf.meth, Req_infer_intf.on_request)
       ; (Req_typed_holes.meth, Req_typed_holes.on_request)
       ; (Req_wrapping_ast_node.meth, Req_wrapping_ast_node.on_request)

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -8,54 +8,58 @@ type command_result =
   }
 
 let run_command prog stdin_value args : command_result Fiber.t =
-  let stdin_i, stdin_o = Unix.pipe ~cloexec:true () in
-  let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
-  let stderr_i, stderr_o = Unix.pipe ~cloexec:true () in
-  let pid =
-    let argv = prog :: args in
-    Spawn.spawn ~prog ~argv ~stdin:stdin_i ~stdout:stdout_o ~stderr:stderr_o ()
-    |> Stdune.Pid.of_int
-  in
-  Unix.close stdin_i;
-  Unix.close stdout_o;
-  Unix.close stderr_o;
-  let blockity =
-    if Sys.win32 then
-      `Blocking
-    else (
-      Unix.set_nonblock stdin_o;
-      Unix.set_nonblock stdout_i;
-      `Non_blocking true
-    )
-  in
-  let make fd what =
-    let fd = Lev_fiber.Fd.create fd blockity in
-    Lev_fiber.Io.create fd what
-  in
-  let* stdin_o = make stdin_o Output in
-  let* stdout_i = make stdout_i Input in
-  let* stderr_i = make stderr_i Input in
-  let stdin () =
-    let+ () =
-      Lev_fiber.Io.with_write stdin_o ~f:(fun w ->
-          Lev_fiber.Io.Writer.add_string w stdin_value;
-          Lev_fiber.Io.Writer.flush w)
-    in
-    Lev_fiber.Io.close stdin_o
-  in
-  let read from () =
-    let+ res = Lev_fiber.Io.with_read from ~f:Lev_fiber.Io.Reader.to_string in
-    Lev_fiber.Io.close from;
-    res
-  in
-  let+ status, (stdout, stderr) =
-    Fiber.fork_and_join
-      (fun () -> Lev_fiber.waitpid ~pid:(Pid.to_int pid))
-      (fun () ->
-        Fiber.fork_and_join_unit stdin (fun () ->
-            Fiber.fork_and_join (read stdout_i) (read stderr_i)))
-  in
-  { stdout; stderr; status }
+  Fiber.of_thunk (fun () ->
+      let stdin_i, stdin_o = Unix.pipe ~cloexec:true () in
+      let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
+      let stderr_i, stderr_o = Unix.pipe ~cloexec:true () in
+      let pid =
+        let argv = prog :: args in
+        Spawn.spawn ~prog ~argv ~stdin:stdin_i ~stdout:stdout_o ~stderr:stderr_o
+          ()
+        |> Stdune.Pid.of_int
+      in
+      Unix.close stdin_i;
+      Unix.close stdout_o;
+      Unix.close stderr_o;
+      let blockity =
+        if Sys.win32 then
+          `Blocking
+        else (
+          Unix.set_nonblock stdin_o;
+          Unix.set_nonblock stdout_i;
+          `Non_blocking true
+        )
+      in
+      let make fd what =
+        let fd = Lev_fiber.Fd.create fd blockity in
+        Lev_fiber.Io.create fd what
+      in
+      let* stdin_o = make stdin_o Output in
+      let* stdout_i = make stdout_i Input in
+      let* stderr_i = make stderr_i Input in
+      let stdin () =
+        let+ () =
+          Lev_fiber.Io.with_write stdin_o ~f:(fun w ->
+              Lev_fiber.Io.Writer.add_string w stdin_value;
+              Lev_fiber.Io.Writer.flush w)
+        in
+        Lev_fiber.Io.close stdin_o
+      in
+      let read from () =
+        let+ res =
+          Lev_fiber.Io.with_read from ~f:Lev_fiber.Io.Reader.to_string
+        in
+        Lev_fiber.Io.close from;
+        res
+      in
+      let+ status, (stdout, stderr) =
+        Fiber.fork_and_join
+          (fun () -> Lev_fiber.waitpid ~pid:(Pid.to_int pid))
+          (fun () ->
+            Fiber.fork_and_join_unit stdin (fun () ->
+                Fiber.fork_and_join (read stdout_i) (read stderr_i)))
+      in
+      { stdout; stderr; status })
 
 type error =
   | Unsupported_syntax of Document.Syntax.t

--- a/ocaml-lsp-server/src/progress.ml
+++ b/ocaml-lsp-server/src/progress.ml
@@ -22,15 +22,16 @@ let create (client_capabilities : ClientCapabilities.t) ~report_progress
   | _ -> Disabled
 
 let end_build (t : enabled) ~message =
-  match t.token with
-  | None -> Fiber.return ()
-  | Some token ->
-    t.token <- None;
-    t.report_progress
-      (ProgressParams.create ~token
-         ~value:
-           (Server_notification.Progress.End
-              (WorkDoneProgressEnd.create ~message ())))
+  Fiber.of_thunk (fun () ->
+      match t.token with
+      | None -> Fiber.return ()
+      | Some token ->
+        t.token <- None;
+        t.report_progress
+          (ProgressParams.create ~token
+             ~value:
+               (Server_notification.Progress.End
+                  (WorkDoneProgressEnd.create ~message ()))))
 
 let end_build_if_running = function
   | Disabled -> Fiber.return ()
@@ -53,36 +54,37 @@ let start_build (t : enabled) =
   token
 
 let build_progress t (progress : Drpc.Progress.t) =
-  match t with
-  | Disabled -> Code_error.raise "progress reporting is not supported" []
-  | Enabled ({ token; report_progress; _ } as t) -> (
-    match progress with
-    | Success -> end_build t ~message:"Build finished"
-    | Failed -> end_build t ~message:"Build failed"
-    | Interrupted -> end_build t ~message:"Build interrupted"
-    | Waiting -> end_build t ~message:"Waiting for changes"
-    | In_progress { complete; remaining } ->
-      let* token =
-        match token with
-        | Some token -> Fiber.return token
-        | None ->
-          (* This can happen when we connect to dune in the middle of a
-             build. *)
-          start_build t
-      in
-      let total = complete + remaining in
-      (* The percentage is useless as it isn't monotinically increasing as the
-         spec requires, but it's the best we can do. *)
-      let percentage =
-        let fraction = float_of_int complete /. float_of_int total in
-        int_of_float (fraction *. 100.)
-      in
-      report_progress
-        (ProgressParams.create ~token
-           ~value:
-             (Server_notification.Progress.Report
-                (let message = sprintf "Building [%d/%d]" complete total in
-                 WorkDoneProgressReport.create ~percentage ~message ()))))
+  Fiber.of_thunk (fun () ->
+      match t with
+      | Disabled -> Code_error.raise "progress reporting is not supported" []
+      | Enabled ({ token; report_progress; _ } as t) -> (
+        match progress with
+        | Success -> end_build t ~message:"Build finished"
+        | Failed -> end_build t ~message:"Build failed"
+        | Interrupted -> end_build t ~message:"Build interrupted"
+        | Waiting -> end_build t ~message:"Waiting for changes"
+        | In_progress { complete; remaining } ->
+          let* token =
+            match token with
+            | Some token -> Fiber.return token
+            | None ->
+              (* This can happen when we connect to dune in the middle of a
+                 build. *)
+              start_build t
+          in
+          let total = complete + remaining in
+          (* The percentage is useless as it isn't monotinically increasing as
+             the spec requires, but it's the best we can do. *)
+          let percentage =
+            let fraction = float_of_int complete /. float_of_int total in
+            int_of_float (fraction *. 100.)
+          in
+          report_progress
+            (ProgressParams.create ~token
+               ~value:
+                 (Server_notification.Progress.Report
+                    (let message = sprintf "Building [%d/%d]" complete total in
+                     WorkDoneProgressReport.create ~percentage ~message ())))))
 
 let should_report_build_progress = function
   | Disabled -> false


### PR DESCRIPTION
If a function returns Fiber.t, it should shift all side effects into the fiber.

I've been sloppy about this before, but from now let's keep it strict. cc @ulugbekna 