### PR TITLE
Fix 'Contributing to project' section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,19 @@ git clone --recursive git@github.com:ocaml/ocaml-lsp.git
 # if you already cloned, pull submodules
 git submodule update --init --recursive
 
-# create local switch (or use global one) and install dependencies
-opam switch create . ocaml-base-compiler.4.13.0 --with-test
+# create local switch (or use global one)
+opam switch create . ocaml-base-compiler.4.13.0
 
 # don't forget to set your environment to use the local switch
 eval $(opam env)
 
+# install dependencies
+make install-test-deps
+
 # build
 make all
 
-# the ocamllsp executable can be found at _build/default/ocaml-lsp-server/src/main.exe
+# the ocamllsp executable can be found at _build/default/ocaml-lsp-server/bin/main.exe
 ```
 
 ## Tests


### PR DESCRIPTION
The current description of the 'Contributing to project' section in README.md uses `--with-test` option to install dependencies before `make all`, but in my environment, it fails due to library-not-found errors. According to https://github.com/ocaml/ocaml-lsp/commit/62872323c1b14da42a0d451fad173d4af25c379f, the dependencies should be installed by `make install-test-deps` before `make all`, and it succeeded in my environment. Also, the built executable is located at `_build/default/ocaml-lsp-server/bin/main.exe` now. This patch fixes these problems.