### PR TITLE
chore: update constraints on uutf in lsp

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@ possible and does not make any assumptions about IO.
   yojson
   (ppx_yojson_conv_lib (>= "v0.14"))
   stdune
-  uutf
+  (uutf (>= 1.0.2))
   (odoc :with-doc)
   (ocaml (>= 4.12))))
 

--- a/lsp.opam
+++ b/lsp.opam
@@ -29,7 +29,7 @@ depends: [
   "yojson"
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "stdune"
-  "uutf"
+  "uutf" {>= "1.0.2"}
   "odoc" {with-doc}
   "ocaml" {>= "4.12"}
 ]


### PR DESCRIPTION
the constraints for lsp and ocaml-lsp-server must match as
ocaml-lsp-server only uses uutf through the lsp package.