### PR TITLE
add leading slash to Uri.to_path on windows

### DIFF
--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -46,10 +46,7 @@ let to_path t =
     |> String.replace_all ~pattern:"%3D" ~with_:"="
     |> String.replace_all ~pattern:"%3F" ~with_:"?"
   in
-  if Sys.win32 then
-    path
-  else
-    Filename.concat "/" path
+  Filename.concat "/" path
 
 let of_path (path : string) =
   let path = Uri_lexer.escape_path path in


### PR DESCRIPTION
@rgrinberg as discussed on Slack. I don't see any special behaviour for the path (but only `fsPath` and `Uri.file`) on windows in the `vscode-uri` test suite: https://github.com/microsoft/vscode-uri/blob/main/src/test/uri.test.ts#L156

So I assume that's fine to add a leading `/` on windows too. I can't test it though since I don't have a windows machine.