### PR TITLE
chore: remove result dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -61,7 +61,6 @@ possible and does not make any assumptions about IO.
   (uutf (>= 1.0.2))
   (pp (>= 1.1.2))
   (csexp (>= 1.5))
-  (result (>= 1.5))
   (ocamlformat-rpc-lib (>= 0.21.0))
   (odoc :with-doc)
   (ocaml (and (>= 4.13) (< 4.14)))))

--- a/lsp-fiber/src/dune
+++ b/lsp-fiber/src/dune
@@ -8,6 +8,5 @@
   jsonrpc_fiber
   lsp
   ppx_yojson_conv_lib
-  result
   stdune
   yojson))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -36,7 +36,6 @@ depends: [
   "uutf" {>= "1.0.2"}
   "pp" {>= "1.1.2"}
   "csexp" {>= "1.5"}
-  "result" {>= "1.5"}
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.13" & < "4.14"}


### PR DESCRIPTION
we don't need it because merlin dropped it