### PR TITLE
test: disable dune rpc

### DIFF
--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -584,6 +584,8 @@ let stop (t : t) =
             String.Map.values active.instances
             |> Fiber.parallel_iter ~f:Instance.stop))
 
+let env = Sys.getenv_opt
+
 let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
     progress ~log =
   let config =
@@ -598,7 +600,7 @@ let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
     { diagnostics; progress; include_promotions; log }
   in
   let registry =
-    Registry.create (Registry.Config.create (Xdg.create ~env:Sys.getenv_opt ()))
+    Registry.create (Registry.Config.create (Xdg.create ~env ()))
   in
   ref
     (Active
@@ -609,16 +611,14 @@ let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
        ; workspaces
        })
 
-let enabled = false
-
-let create_disabled () = ref Closed
+let inside_test = true
 
 let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
     progress ~log =
-  if enabled then
+  if inside_test then
     create workspaces client_capabilities diagnostics progress ~log
   else
-    create_disabled ()
+    ref Closed
 
 let run_loop t =
   Fiber.repeat_while ~init:() ~f:(fun () ->

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -223,3 +223,16 @@ let task_if_running pool ~f =
   match running with
   | false -> Fiber.return ()
   | true -> Fiber.Pool.task pool ~f
+
+let inside_test =
+  match Sys.getenv_opt "OCAMLLSP_TEST" with
+  | Some "true" -> true
+  | None
+  | Some "false" ->
+    false
+  | Some b ->
+    Format.eprintf
+      "invalid value %S for OCAMLLSP_TEST ignored. Only true or false are \
+       allowed@."
+      b;
+    false

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -36,7 +36,7 @@ export const toURI = (s) => {
 
 export const start = (opts?: cp.SpawnOptions) => {
   let env = { ...process.env };
-  env.OCAMLLSP_TEST = "1";
+  env.OCAMLLSP_TEST = "true";
   opts = opts || { env: env };
   let childProcess = cp.spawn(serverPath, [], opts);
 


### PR DESCRIPTION
when running tests, we don't need to poll for active dune rpc sessions