### PR TITLE
Revert "add leading slash to Uri.to_path on windows"

### DIFF
--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -46,7 +46,10 @@ let to_path t =
     |> String.replace_all ~pattern:"%3D" ~with_:"="
     |> String.replace_all ~pattern:"%3F" ~with_:"?"
   in
-  Filename.concat "/" path
+  if Sys.win32 then
+    path
+  else
+    Filename.concat "/" path
 
 let of_path (path : string) =
   let path = Uri_lexer.escape_path path in


### PR DESCRIPTION
Reverts #657 as it causes issues on windows: https://ocamllabs.slack.com/archives/CQUCVSG83/p1650145510280109
