### PR TITLE
chore: get rid of stdune in lsp

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,6 @@ possible and does not make any assumptions about IO.
   dyn
   yojson
   (ppx_yojson_conv_lib (>= "v0.14"))
-  stdune
   (uutf (>= 1.0.2))
   (odoc :with-doc)
   (ocaml (>= 4.12))))

--- a/lsp.opam
+++ b/lsp.opam
@@ -28,7 +28,6 @@ depends: [
   "dyn"
   "yojson"
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "stdune"
   "uutf" {>= "1.0.2"}
   "odoc" {with-doc}
   "ocaml" {>= "4.12"}

--- a/lsp/src/dune
+++ b/lsp/src/dune
@@ -3,7 +3,7 @@
 (library
  (name lsp)
  (public_name lsp)
- (libraries jsonrpc ppx_yojson_conv_lib stdune dyn uutf yojson)
+ (libraries jsonrpc ppx_yojson_conv_lib dyn uutf yojson)
  (lint
   (pps ppx_yojson_conv)))
 

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -9,10 +9,6 @@ module Result = struct
   end
 end
 
-(* TODO remove these last remnants of stdune once there is something public
-   available *)
-module Code_error = Stdune.Code_error
-
 let sprintf = Printf.sprintf
 
 module String = struct
@@ -204,7 +200,7 @@ module Json = struct
         t =
       match f t with
       | `Assoc xs -> `Assoc ((k, `String v) :: xs)
-      | _ -> Code_error.raise "To.literal_field" []
+      | _ -> invalid_arg "To.literal_field"
 
     let int_pair (x, y) = `List [ `Int x; `Int y ]
   end

--- a/lsp/src/snippet.ml
+++ b/lsp/src/snippet.ml
@@ -44,7 +44,7 @@ let placeholder ?index content = Tabstop (index, `Placeholder content)
 
 let choice ?index values =
   match values with
-  | [] -> Code_error.raise "choice must have non empty values" []
+  | [] -> invalid_arg "choice must have non empty values"
   | _ -> Tabstop (index, `Choice values)
 
 let variable ?(opt = `None) var = Variable (var, opt)


### PR DESCRIPTION
do not use Code_error in the lsp library