### PR TITLE
use ppxlib 0.26.0 (alternative to #687)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all:
 # results in a conflict
 .PHONY: install-test-deps
 install-test-deps:
-	opam install 'menhir>20211230' cinaps 'ppx_expect>=v0.14.0' \
+	opam install 'menhir>20211230' cinaps 'ppx_expect>=v0.14.0' 'ppxlib=0.26.0' \
 		ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat) ocamlformat-rpc
 
 .PHONY: dev


### PR DESCRIPTION
Alternative to #687. This one make it so that sexplib0 `0.15.0` is installed on all platforms (instead of version `0.14.0` like in #687). 

Not sure which one is the best, the most important thing is that all platforms use the same version