### PR TITLE
test: kill child process

### DIFF
--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -53,6 +53,10 @@ export const start = (opts?: cp.SpawnOptions) => {
 
   connection.listen();
 
+  connection.onDispose(() => {
+    childProcess.kill("SIGKILL");
+  });
+
   return connection as LanguageServer;
 };
 


### PR DESCRIPTION
That should fix the following warning:

```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```

and fix tests not finishing in CI on Linux: https://github.com/ocaml/ocaml-lsp/runs/6089594745?check_suite_focus=true
