### PR TITLE
Enable dune build --watch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,9 @@ possible and does not make any assumptions about IO.
   dyn
   yojson
   (ppx_yojson_conv_lib (>= "v0.14"))
+  (cinaps :with-test)
+  (menhir (>= 20211230 :with-test))
+  (ppx_expect (>= v0.14.0 :with-test))
   (uutf (>= 1.0.2))
   (odoc :with-doc)
   (ocaml (>= 4.12))))

--- a/lsp.opam
+++ b/lsp.opam
@@ -28,6 +28,9 @@ depends: [
   "dyn"
   "yojson"
   "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "menhir" {"20211230" >= with-test}
+  "ppx_expect" {"v0.14.0" >= with-test}
   "uutf" {>= "1.0.2"}
   "odoc" {with-doc}
   "ocaml" {>= "4.12"}

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -713,10 +713,10 @@ let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
 
 let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
     progress document_store ~log =
-  if inside_test then
+  if inside_test then ref Closed
+  else
     create workspaces client_capabilities diagnostics progress document_store
       ~log
-  else ref Closed
 
 let run_loop t =
   Fiber.repeat_while ~init:() ~f:(fun () ->


### PR DESCRIPTION
See https://github.com/ocaml/ocaml-lsp/issues/690.

Note that `dune runtest` is failing on `types.ml.cinaps-corrected`, but it was failing prior to my changes as well:
```
dune runtest 2>&1|diffstat
 types.ml.cinaps-corrected |41081 ++++++++++------------------------------------------------------------------------------------------------------
 1 file changed, 3802 insertions(+), 37279 deletions(-)
```
There was also a formatting difference causing a test failure (similarly failing before my change, so I added that here as well).
`make test-ocaml test-e2e` does pass though.