### PR TITLE
Show parsed ocamlformat syntax error message

### DIFF
--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -77,7 +77,15 @@ let message = function
   | Unknown_extension uri ->
     Printf.sprintf "Unable to format. File %s has an unknown extension"
       (Uri.to_path uri)
-  | Unexpected_result { message } -> message
+  | Unexpected_result { message } -> (
+    match String.split message ~on:'\n' with
+    | l0 :: l1 :: _ when String.is_suffix l0 ~suffix:"(syntax error)" -> (
+      match String.split l1 ~on:',' with
+      | [ _file; line; chars ] ->
+        sprintf "Syntax error: %s, %s. Formatting failed" line
+          (String.drop_suffix_if_exists chars ~suffix:":")
+      | _ -> message)
+    | _ :: _ | [] -> message)
 
 type formatter =
   | Reason of Document.Kind.t


### PR DESCRIPTION
The biggest quality of life improvement in editing ocaml code on vscode achievable in 8 lines IMHO

before: 

<img width="488" alt="image" src="https://user-images.githubusercontent.com/16353531/173451338-93d595e2-2d22-4e52-a88c-a78d0c8fcb1a.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/16353531/173451344-30ab0be9-8786-42cf-8f2b-08084304caab.png">

after: 

<img width="496" alt="image" src="https://user-images.githubusercontent.com/16353531/173451355-092989e4-4496-4c18-9515-021169bb9902.png">

---

Better solutions exist where we 
- add a custom notification if client supports to add a button to the pop-up to jump to the error 
- add a status bar item in vscode that shows the formatting didn't succeed and clicking on the item, one can jump to the place of error 