### PR TITLE
test: refactor e2e tests

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/TextDocument.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/TextDocument.test.ts
@@ -1,106 +1,123 @@
 import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("TextDocument: incremental sync", () => {
   let languageServer: LanguageServer.LanguageServer;
 
   async function getDoc(languageServer: LanguageServer.LanguageServer) {
-    let result = await languageServer.sendRequest("debug/textDocument/get", {
-      textDocument: Types.TextDocumentIdentifier.create(
-        "file:///test-document.txt",
-      ),
-      position: Types.Position.create(0, 0),
-    });
+    let result: string = await languageServer.sendRequest(
+      "debug/textDocument/get",
+      {
+        textDocument: Types.TextDocumentIdentifier.create(
+          "file:///test-document.txt",
+        ),
+        position: Types.Position.create(0, 0),
+      },
+    );
     return result;
   }
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("Manages unicode character ranges correctly", async () => {
     languageServer = await LanguageServer.startAndInitialize();
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        outdent`
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          outdent`
           let x = 4
           let y = "a𐐀b"
         `,
-      ),
-    });
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 1, character: 10 },
-            end: { line: 1, character: 12 },
+        ),
+      },
+    );
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 1, character: 10 },
+              end: { line: 1, character: 12 },
+            },
+            text: "",
           },
-          text: "",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual('let x = 4\nlet y = "ab"');
   });
 
   it("updates in the middle of the line", async () => {
     languageServer = await LanguageServer.startAndInitialize();
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        "let x = 1;\n\nlet y = 2;",
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          "let x = 1;\n\nlet y = 2;",
+        ),
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 2, character: 5 },
-            end: { line: 2, character: 5 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 2, character: 5 },
+              end: { line: 2, character: 5 },
+            },
+            rangeLength: 0,
+            text: "1",
           },
-          rangeLength: 0,
-          text: "1",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y1 = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 2, character: 5 },
-            end: { line: 2, character: 6 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 2, character: 5 },
+              end: { line: 2, character: 6 },
+            },
+            rangeLength: 1,
+            text: "",
           },
-          rangeLength: 1,
-          text: "",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
   });
@@ -108,33 +125,39 @@ describe("TextDocument: incremental sync", () => {
   it("updates in at the start of the line", async () => {
     languageServer = await LanguageServer.startAndInitialize();
 
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        "let x = 1;\n\nlet y = 2;",
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          "let x = 1;\n\nlet y = 2;",
+        ),
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 1, character: 0 },
-            end: { line: 1, character: 0 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 1, character: 0 },
+              end: { line: 1, character: 0 },
+            },
+            rangeLength: 0,
+            text: "s",
           },
-          rangeLength: 0,
-          text: "s",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\ns\nlet y = 2;");
   });
@@ -142,33 +165,39 @@ describe("TextDocument: incremental sync", () => {
   it("update when inserting a line", async () => {
     languageServer = await LanguageServer.startAndInitialize();
 
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        "let x = 1;\n\nlet y = 2;",
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          "let x = 1;\n\nlet y = 2;",
+        ),
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 0, character: 10 },
-            end: { line: 0, character: 10 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 0, character: 10 },
+              end: { line: 0, character: 10 },
+            },
+            rangeLength: 0,
+            text: "\nlet x = 1;",
           },
-          rangeLength: 0,
-          text: "\nlet x = 1;",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual(
       "let x = 1;\nlet x = 1;\n\nlet y = 2;",
@@ -178,33 +207,39 @@ describe("TextDocument: incremental sync", () => {
   it("update when inserting a line at the end of the doc", async () => {
     languageServer = await LanguageServer.startAndInitialize();
 
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        "let x = 1;\n\nlet y = 2;",
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          "let x = 1;\n\nlet y = 2;",
+        ),
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 2, character: 10 },
-            end: { line: 2, character: 10 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 2, character: 10 },
+              end: { line: 2, character: 10 },
+            },
+            rangeLength: 0,
+            text: "\nlet y = 2;",
           },
-          rangeLength: 0,
-          text: "\nlet y = 2;",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual(
       "let x = 1;\n\nlet y = 2;\nlet y = 2;",
@@ -214,64 +249,75 @@ describe("TextDocument: incremental sync", () => {
   it("update when deleting a line", async () => {
     languageServer = await LanguageServer.startAndInitialize();
 
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test-document.txt",
-        "ocaml",
-        0,
-        "let x = 1;\n\nlet y = 2;",
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test-document.txt",
+          "ocaml",
+          0,
+          "let x = 1;\n\nlet y = 2;",
+        ),
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("let x = 1;\n\nlet y = 2;");
 
-    languageServer.sendNotification("textDocument/didChange", {
-      textDocument: Types.VersionedTextDocumentIdentifier.create(
-        "file:///test-document.txt",
-        1,
-      ),
-      contentChanges: [
-        {
-          range: {
-            start: { line: 0, character: 0 },
-            end: { line: 1, character: 0 },
+    languageServer.sendNotification(
+      Protocol.DidChangeTextDocumentNotification.type,
+      {
+        textDocument: Types.VersionedTextDocumentIdentifier.create(
+          "file:///test-document.txt",
+          1,
+        ),
+        contentChanges: [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 1, character: 0 },
+            },
+            rangeLength: 11,
+            text: "",
           },
-          rangeLength: 11,
-          text: "",
-        },
-      ],
-    });
+        ],
+      },
+    );
 
     expect(await getDoc(languageServer)).toEqual("\nlet y = 2;");
   });
 });
 
 describe("TextDocument", () => {
-  let languageServer;
+  let languageServer: LanguageServer.LanguageServer;
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   describe("didOpen", () => {
     it("stores text document", async () => {
       languageServer = await LanguageServer.startAndInitialize();
-      languageServer.sendNotification("textDocument/didOpen", {
-        textDocument: Types.TextDocumentItem.create(
-          "file:///test-document.txt",
-          "ocaml",
-          0,
-          "Hello, World!",
-        ),
-      });
+      languageServer.sendNotification(
+        Protocol.DidOpenTextDocumentNotification.type,
+        {
+          textDocument: Types.TextDocumentItem.create(
+            "file:///test-document.txt",
+            "ocaml",
+            0,
+            "Hello, World!",
+          ),
+        },
+      );
 
-      let result = await languageServer.sendRequest("debug/textDocument/get", {
-        textDocument: Types.TextDocumentIdentifier.create(
-          "file:///test-document.txt",
-        ),
-        position: Types.Position.create(0, 0),
-      });
+      let result: string = await languageServer.sendRequest(
+        "debug/textDocument/get",
+        {
+          textDocument: Types.TextDocumentIdentifier.create(
+            "file:///test-document.txt",
+          ),
+          position: Types.Position.create(0, 0),
+        },
+      );
 
       expect(result).toEqual("Hello, World!");
     });
@@ -280,29 +326,38 @@ describe("TextDocument", () => {
   describe("didChange", () => {
     it("updates text document", async () => {
       languageServer = await LanguageServer.startAndInitialize();
-      languageServer.sendNotification("textDocument/didOpen", {
-        textDocument: Types.TextDocumentItem.create(
-          "file:///test-document.txt",
-          "ocaml",
-          0,
-          "Hello, World!",
-        ),
-      });
+      languageServer.sendNotification(
+        Protocol.DidOpenTextDocumentNotification.type,
+        {
+          textDocument: Types.TextDocumentItem.create(
+            "file:///test-document.txt",
+            "ocaml",
+            0,
+            "Hello, World!",
+          ),
+        },
+      );
 
-      languageServer.sendNotification("textDocument/didChange", {
-        textDocument: Types.VersionedTextDocumentIdentifier.create(
-          "file:///test-document.txt",
-          1,
-        ),
-        contentChanges: [{ text: "Hello again!" }],
-      });
+      languageServer.sendNotification(
+        Protocol.DidChangeTextDocumentNotification.type,
+        {
+          textDocument: Types.VersionedTextDocumentIdentifier.create(
+            "file:///test-document.txt",
+            1,
+          ),
+          contentChanges: [{ text: "Hello again!" }],
+        },
+      );
 
-      let result = await languageServer.sendRequest("debug/textDocument/get", {
-        textDocument: Types.TextDocumentIdentifier.create(
-          "file:///test-document.txt",
-        ),
-        position: Types.Position.create(0, 0),
-      });
+      let result: string = await languageServer.sendRequest(
+        "debug/textDocument/get",
+        {
+          textDocument: Types.TextDocumentIdentifier.create(
+            "file:///test-document.txt",
+          ),
+          position: Types.Position.create(0, 0),
+        },
+      );
 
       expect(result).toEqual("Hello again!");
     });

--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -1,20 +1,24 @@
 import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
+import * as Protocol from "vscode-languageserver-protocol";
 
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/completion", () => {
-  let languageServer: LanguageServer.LanguageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function queryCompletionItemResolve(
@@ -38,7 +42,6 @@ describe("textDocument/completion", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("can get documentation for the end of document", async () => {

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-inferIntf.ts
@@ -1,20 +1,24 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
+import * as Protocol from "vscode-languageserver-protocol";
 
 import * as Types from "vscode-languageserver-types";
 
 describe("ocamllsp/inferIntf", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source, name) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///" + name,
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string, name: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          LanguageServer.toURI(name),
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   beforeEach(async () => {
@@ -23,7 +27,6 @@ describe("ocamllsp/inferIntf", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   async function inferIntf(name: string) {
@@ -34,7 +37,7 @@ describe("ocamllsp/inferIntf", () => {
   }
 
   it("can infer module interfaces", async () => {
-    await openDocument(
+    openDocument(
       outdent`
 type t = Foo of int | Bar of bool
 

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-switchImplIntf.ts
@@ -4,14 +4,18 @@ import * as path from "path";
 import { DocumentUri, TextDocumentItem } from "vscode-languageserver-types";
 import { URI } from "vscode-uri";
 import * as LanguageServer from "./../src/LanguageServer";
+import * as Protocol from "vscode-languageserver-protocol";
 
 describe("ocamllsp/switchImplIntf", () => {
-  let languageServer: LanguageServer.LanguageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(documentUri: DocumentUri) {
-    languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: TextDocumentItem.create(documentUri, "ocaml", 0, ""),
-    });
+  function openDocument(documentUri: DocumentUri) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: TextDocumentItem.create(documentUri, "ocaml", 0, ""),
+      },
+    );
   }
 
   /* sends request "ocamllsp/switchImplIntf" */
@@ -31,7 +35,6 @@ describe("ocamllsp/switchImplIntf", () => {
   afterEach(async () => {
     await fs.rm(testWorkspacePath, { recursive: true });
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   let createPathForFile = (filename: string) =>

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-typedHoles.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-typedHoles.ts
@@ -1,20 +1,23 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("ocamllsp/typedHoles", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function sendTypedHolesReq() {
@@ -29,11 +32,10 @@ describe("ocamllsp/typedHoles", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("empty when no holes in file", async () => {
-    await openDocument(
+    openDocument(
       outdent`
 let u = 1
 `,
@@ -44,7 +46,7 @@ let u = 1
   });
 
   it("one hole", async () => {
-    await openDocument(
+    openDocument(
       outdent`
 let k = match () with () -> _
 `,
@@ -68,7 +70,7 @@ let k = match () with () -> _
   });
 
   it("several holes", async () => {
-    await openDocument(
+    openDocument(
       outdent`
 let u =
   let i = match Some 1 with None -> _ | Some -> _ in

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
@@ -1,21 +1,24 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 import { Position } from "vscode-languageserver-types";
 
 describe("ocamllsp/wrappingAstNode", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function sendWrappingAstNodeRequest({
@@ -37,11 +40,10 @@ describe("ocamllsp/wrappingAstNode", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("empty document", async () => {
-    await openDocument(
+    openDocument(
       outdent`
 `,
     );
@@ -63,7 +65,7 @@ end
   `;
 
   it("when on a toplevel let binding", async () => {
-    await openDocument(code_snippet_0);
+    openDocument(code_snippet_0);
 
     let r = await sendWrappingAstNodeRequest({ line: 0, character: 5 });
 
@@ -85,7 +87,7 @@ end
   });
 
   it("in between toplevel bindings (let and module def)", async () => {
-    await openDocument(code_snippet_0);
+    openDocument(code_snippet_0);
 
     let r = await sendWrappingAstNodeRequest({ line: 1, character: 0 });
 
@@ -107,7 +109,7 @@ end
   });
 
   it("on keyword struct", async () => {
-    await openDocument(code_snippet_0);
+    openDocument(code_snippet_0);
 
     let r = await sendWrappingAstNodeRequest({ line: 2, character: 14 });
 
@@ -135,7 +137,7 @@ end
   });
 
   it("on `b`'s let-binding (nested let-binding in a module def)", async () => {
-    await openDocument(code_snippet_0);
+    openDocument(code_snippet_0);
     let r = await sendWrappingAstNodeRequest({ line: 4, character: 10 });
 
     /* given range corresponds to:
@@ -158,7 +160,7 @@ end
   });
 
   it("between `a`'s and `c`'s let-bindings in a module def", async () => {
-    await openDocument(code_snippet_0);
+    openDocument(code_snippet_0);
 
     let r = await sendWrappingAstNodeRequest({ line: 6, character: 0 });
 

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeLens.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeLens.test.ts
@@ -1,20 +1,23 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/references", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function query() {
@@ -29,11 +32,10 @@ describe("textDocument/references", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("returns codeLens for a module", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let string = "Hello"
 

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-declaration.test.ts
@@ -4,9 +4,11 @@ import * as child_process from "child_process";
 import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
 import { testUri } from "./../src/LanguageServer";
+import * as Protocol from "vscode-languageserver-protocol";
+import { isNotNullable } from "../src/utils";
 
 describe("textDocument/declaration", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
   let testWorkspacePath = path.join(__dirname, "declaration_files/");
 
@@ -19,26 +21,39 @@ describe("textDocument/declaration", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
-  async function openDocument(filepath) {
+  async function openDocument(filepath: string) {
     let source = await fs.readFile(filepath);
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        testUri(filepath),
-        "ocaml",
-        0,
-        source.toString(),
-      ),
-    });
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          testUri(filepath),
+          "ocaml",
+          0,
+          source.toString(),
+        ),
+      },
+    );
   }
 
-  async function queryDeclaration(filepath, position) {
-    return await languageServer.sendRequest("textDocument/declaration", {
-      textDocument: Types.TextDocumentIdentifier.create(testUri(filepath)),
-      position,
-    });
+  async function queryDeclaration(filepath: string, position: Types.Position) {
+    let result = await languageServer.sendRequest(
+      Protocol.DeclarationRequest.type,
+      {
+        textDocument: Types.TextDocumentIdentifier.create(testUri(filepath)),
+        position,
+      },
+    );
+
+    if (result === null) return [];
+
+    result = Array.isArray(result) ? result : [result];
+
+    return result
+      .map((location) => (Types.Location.is(location) ? location : null))
+      .filter(isNotNullable);
   }
 
   it("returns location of a declaration", async () => {

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
@@ -1,21 +1,24 @@
 import outdent from "outdent";
 import * as rpc from "vscode-jsonrpc/node";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/diagnostics", () => {
-  let languageServer: rpc.MessageConnection = null;
+  let languageServer: rpc.MessageConnection;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   beforeEach(async () => {
@@ -24,7 +27,6 @@ describe("textDocument/diagnostics", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("has related diagnostics", async () => {
@@ -76,7 +78,7 @@ describe("textDocument/diagnostics", () => {
         resolve(null);
       }),
     );
-    await openDocument(outdent`
+    openDocument(outdent`
 (* " *)
     `);
     await receivedDiganostics;
@@ -113,7 +115,7 @@ describe("textDocument/diagnostics", () => {
         resolve(null);
       }),
     );
-    await openDocument(outdent`
+    openDocument(outdent`
       let () =
         let x = 123 in
         ()
@@ -153,7 +155,7 @@ describe("textDocument/diagnostics", () => {
         resolve(null);
       }),
     );
-    await openDocument(outdent`
+    openDocument(outdent`
       module X : sig
         val x : unit
         [@@ocaml.deprecated "do not use"]
@@ -236,7 +238,7 @@ describe("textDocument/diagnostics", () => {
         resolve(null);
       }),
     );
-    await openDocument(outdent`
+    openDocument(outdent`
       module X : sig
         val x : unit
       end = struct
@@ -262,7 +264,7 @@ describe("textDocument/diagnostics", () => {
       }),
     );
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
     `);
 
@@ -302,7 +304,7 @@ describe("textDocument/diagnostics", () => {
       }),
     );
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let a : int = _
     `);
 
@@ -389,7 +391,7 @@ describe("textDocument/diagnostics", () => {
       }),
     );
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let _a : int = _ in
       let b : string = match Some 1 with None -> _ | Some _ -> _ in
       ()
@@ -477,7 +479,7 @@ describe("textDocument/diagnostics", () => {
       }),
     );
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let _u =
         let _i = List.map (fun i -> i) [1; 2; ()] in
         let b = 234 in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-documentHighlight.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-documentHighlight.test.ts
@@ -1,20 +1,23 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/references", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function query(position: Types.Position) {
@@ -30,11 +33,10 @@ describe("textDocument/references", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("highlight references in a file", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let sum = num + 13
       let sum2 = sum + num

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-documentSymbol.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-documentSymbol.ts
@@ -1,20 +1,23 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/documentSymbol", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function query() {
@@ -25,12 +28,11 @@ describe("textDocument/documentSymbol", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("returns a list of symbol infos", async () => {
     languageServer = await LanguageServer.startAndInitialize();
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let string = "Hello"
 
@@ -114,7 +116,7 @@ describe("textDocument/documentSymbol", () => {
         },
       },
     });
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let string = "Hello"
 

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-references.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-references.test.ts
@@ -1,24 +1,27 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/references", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function query(position: Types.Position) {
-    return await languageServer.sendRequest("textDocument/references", {
+    return await languageServer.sendRequest(Protocol.ReferencesRequest.type, {
       textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
       position,
       context: { includeDeclaration: false },
@@ -31,11 +34,10 @@ describe("textDocument/references", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("finds references in a file", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let sum = num + 13
       let sum2 = sum + num

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
@@ -1,25 +1,28 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/rename", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function query(position: Types.Position, newNameOpt?: string) {
     let newName = newNameOpt ? newNameOpt : "new_num";
-    return await languageServer.sendRequest("textDocument/rename", {
+    return await languageServer.sendRequest(Protocol.RenameRequest.type, {
       textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
       position,
       newName,
@@ -27,15 +30,17 @@ describe("textDocument/rename", () => {
   }
 
   async function query_prepare(position: Types.Position) {
-    return await languageServer.sendRequest("textDocument/prepareRename", {
-      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
-      position,
-    });
+    return await languageServer.sendRequest(
+      Protocol.PrepareRenameRequest.type,
+      {
+        textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+        position,
+      },
+    );
   }
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("can reject invalid rename request", async () => {
@@ -45,7 +50,7 @@ describe("textDocument/rename", () => {
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let num = num + 13
       let num2 = num
@@ -62,7 +67,7 @@ describe("textDocument/rename", () => {
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let num = num + 13
       let num2 = num
@@ -82,7 +87,7 @@ describe("textDocument/rename", () => {
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let num = num + 13
       let num2 = num
@@ -131,7 +136,7 @@ describe("textDocument/rename", () => {
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
       let num = 42
       let num = num + 13
       let num2 = num
@@ -186,7 +191,7 @@ describe("textDocument/rename", () => {
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
 let foo x = x
 
 let bar ~foo = foo ()
@@ -239,7 +244,7 @@ let () = bar ~foo
       },
     });
 
-    await openDocument(outdent`
+    openDocument(outdent`
 let foo = Some ()
 
 let bar ?foo () = foo

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
@@ -1,10 +1,10 @@
 import outdent from "outdent";
 import * as LanguageServer from "../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 describe("textDocument/selectionRange", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
   beforeEach(async () => {
     languageServer = await LanguageServer.startAndInitialize();
@@ -12,29 +12,34 @@ describe("textDocument/selectionRange", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function selectionRange(positions: Types.Position[]) {
-    return await languageServer.sendRequest("textDocument/selectionRange", {
-      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
-      positions: positions,
-    });
+    return await languageServer.sendRequest(
+      Protocol.SelectionRangeRequest.type,
+      {
+        textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+        positions: positions,
+      },
+    );
   }
 
   it("returns a selection range for modules", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       let foo a b =
         let min_ab = min a b in
         let max_ab = max a b in

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -1,6 +1,6 @@
 import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
-
+import * as Protocol from "vscode-languageserver-protocol";
 import * as Types from "vscode-languageserver-types";
 
 const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0")
@@ -8,24 +8,30 @@ const describe_opt = LanguageServer.ocamlVersionGEq("4.08.0")
   : xdescribe;
 
 describe_opt("textDocument/completion", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        "file:///test.ml",
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          "file:///test.ml",
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
-  async function querySignatureHelp(position) {
-    return await languageServer.sendRequest("textDocument/signatureHelp", {
-      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
-      position,
-    });
+  async function querySignatureHelp(position: Types.Position) {
+    return await languageServer.sendRequest(
+      Protocol.SignatureHelpRequest.type,
+      {
+        textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+        position,
+      },
+    );
   }
 
   beforeEach(async () => {
@@ -49,7 +55,6 @@ describe_opt("textDocument/completion", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("can provide signature help after a function-type value", async () => {

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-typeDefinition.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-typeDefinition.test.ts
@@ -2,26 +2,42 @@ import outdent from "outdent";
 import * as LanguageServer from "./../src/LanguageServer";
 import * as Types from "vscode-languageserver-types";
 import { testUri } from "./../src/LanguageServer";
+import * as Protocol from "vscode-languageserver-protocol";
+import { isNotNullable } from "../src/utils";
 
 describe("textDocument/definition", () => {
-  let languageServer = null;
+  let languageServer: LanguageServer.LanguageServer;
 
-  async function openDocument(source: string) {
-    await languageServer.sendNotification("textDocument/didOpen", {
-      textDocument: Types.TextDocumentItem.create(
-        testUri("file.ml"),
-        "ocaml",
-        0,
-        source,
-      ),
-    });
+  function openDocument(source: string) {
+    languageServer.sendNotification(
+      Protocol.DidOpenTextDocumentNotification.type,
+      {
+        textDocument: Types.TextDocumentItem.create(
+          testUri("file.ml"),
+          "ocaml",
+          0,
+          source,
+        ),
+      },
+    );
   }
 
   async function queryDefinition(position: Types.Position) {
-    return await languageServer.sendRequest("textDocument/typeDefinition", {
-      textDocument: Types.TextDocumentIdentifier.create(testUri("file.ml")),
-      position,
-    });
+    let result = await languageServer.sendRequest(
+      Protocol.TypeDefinitionRequest.type,
+      {
+        textDocument: Types.TextDocumentIdentifier.create(testUri("file.ml")),
+        position,
+      },
+    );
+
+    if (result === null) return [];
+
+    result = Array.isArray(result) ? result : [result];
+
+    return result
+      .map((location) => (Types.Location.is(location) ? location : null))
+      .filter(isNotNullable);
   }
 
   beforeEach(async () => {
@@ -30,11 +46,10 @@ describe("textDocument/definition", () => {
 
   afterEach(async () => {
     await LanguageServer.exit(languageServer);
-    languageServer = null;
   });
 
   it("returns location of a type definition", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       (* type we are jumping on *)
       type t = T of int
 
@@ -52,7 +67,7 @@ describe("textDocument/definition", () => {
   });
 
   it("ignores names in values namespace", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       (* type we are jumping on *)
       type t = T of int
 
@@ -71,7 +86,7 @@ describe("textDocument/definition", () => {
   });
 
   it("ignores names in values namespace (cursor on same named value)", async () => {
-    await openDocument(outdent`
+    openDocument(outdent`
       (* type we are jumping on *)
       type t = T of int
 

--- a/ocaml-lsp-server/test/e2e/jest.config.js
+++ b/ocaml-lsp-server/test/e2e/jest.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('@jest/types').Config.ProjectConfig}
+ */
 module.exports = {
   preset: "ts-jest",
   roots: ["<rootDir>"],

--- a/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
+++ b/ocaml-lsp-server/test/e2e/src/LanguageServer.ts
@@ -28,10 +28,8 @@ let serverPath = path.join(
 
 export type LanguageServer = rpc.MessageConnection;
 
-let prefix = process.platform === "win32" ? "file:///" : "file://";
-
-export const toURI = (s) => {
-  return prefix + s;
+export const toURI = (s: string) => {
+  return URI.parse(s).toString();
 };
 
 export const start = (opts?: cp.SpawnOptions) => {
@@ -41,11 +39,11 @@ export const start = (opts?: cp.SpawnOptions) => {
   let childProcess = cp.spawn(serverPath, [], opts);
 
   let connection = rpc.createMessageConnection(
-    new rpc.StreamMessageReader(childProcess.stdout),
-    new rpc.StreamMessageWriter(childProcess.stdin),
+    new rpc.StreamMessageReader(childProcess.stdout!),
+    new rpc.StreamMessageWriter(childProcess.stdin!),
   );
 
-  childProcess.stderr.on("data", (d) => {
+  childProcess.stderr!.on("data", (d) => {
     if (process.env.OCAMLLSP_TEST_DEBUG) {
       console.log("Received data: " + d);
     }
@@ -94,7 +92,10 @@ export const testUri = (file: string) => {
   return URI.file(file).toString();
 };
 
-export const toEqualUri = function (received: string, expected: string) {
+export const toEqualUri: jest.CustomMatcher = function (
+  received: string,
+  expected: string,
+) {
   const obj = this;
 
   const options = {

--- a/ocaml-lsp-server/test/e2e/src/utils.ts
+++ b/ocaml-lsp-server/test/e2e/src/utils.ts
@@ -1,0 +1,3 @@
+export const isNotNullable = <T>(
+  x: T | null | undefined,
+): x is NonNullable<T> => x !== null && x !== undefined;

--- a/ocaml-lsp-server/test/e2e/tsconfig.json
+++ b/ocaml-lsp-server/test/e2e/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "esModuleInterop": true,
     "lib": ["es2015"]
   }


### PR DESCRIPTION
* Update TS to the latest version
* Turn on TS strict flag
* Avoid using string for request type (use `vscode-languageserver-protocol` instead)
* Remove unnecessary `await`