### PR TITLE
feature(ocamllsp): add metrics

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -51,6 +51,7 @@ possible and does not make any assumptions about IO.
   (re (>= 1.5.0))
   (ppx_yojson_conv_lib (>= "v0.14"))
   dune-rpc
+  (chrome-trace (>= 3.3.0))
   dyn
   stdune
   (fiber (>= 3.1.1))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -24,6 +24,7 @@ depends: [
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-rpc"
+  "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"
   "fiber" {>= "3.1.1"}

--- a/ocaml-lsp-server/src/dune
+++ b/ocaml-lsp-server/src/dune
@@ -5,6 +5,7 @@
   xdg
   dune-build-info
   fiber
+  chrome-trace
   lev
   lev_fiber
   lev_fiber_csexp

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -17,6 +17,7 @@ include struct
   module Pid = Pid
   module Poly = Poly
   module Result = Result
+  module Queue = Queue
 
   module String = struct
     include String
@@ -184,6 +185,8 @@ include struct
   module ServerCapabilities = ServerCapabilities
   module Server_notification = Lsp.Server_notification
   module SetTraceParams = SetTraceParams
+  module ShowDocumentParams = ShowDocumentParams
+  module ShowDocumentResult = ShowDocumentResult
   module ShowMessageParams = ShowMessageParams
   module SignatureHelp = SignatureHelp
   module SignatureHelpOptions = SignatureHelpOptions

--- a/ocaml-lsp-server/src/metrics.ml
+++ b/ocaml-lsp-server/src/metrics.ml
@@ -1,0 +1,30 @@
+open Import
+open Fiber.O
+
+let max_len = 1_000
+
+type t = { events : Chrome_trace.Event.t Queue.t }
+
+let t_var : t Fiber.Var.t = Fiber.Var.create ()
+
+let get () = Fiber.Var.get_exn t_var
+
+let report (event : Chrome_trace.Event.t) : unit Fiber.t =
+  let+ t = get () in
+  (if Queue.length t.events >= max_len then
+   let (_ : Chrome_trace.Event.t) = Queue.pop_exn t.events in
+   ());
+  Queue.push t.events event
+
+let dump () =
+  let+ t = get () in
+  let traceEvents = Queue.to_list t.events in
+  let json =
+    Chrome_trace.Output_object.create ~traceEvents ()
+    |> Chrome_trace.Output_object.to_json
+  in
+  Json.to_string (json :> Json.t)
+
+let create () = { events = Queue.create () }
+
+let with_metrics t f = Fiber.Var.set t_var t f

--- a/ocaml-lsp-server/src/metrics.mli
+++ b/ocaml-lsp-server/src/metrics.mli
@@ -1,0 +1,9 @@
+type t
+
+val create : unit -> t
+
+val with_metrics : t -> (unit -> 'a Fiber.t) -> 'a Fiber.t
+
+val report : Chrome_trace.Event.t -> unit Fiber.t
+
+val dump : unit -> string Fiber.t

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -96,7 +96,9 @@ let%expect_test "start/stop" =
           "documentFormattingProvider": true,
           "renameProvider": { "prepareProvider": true },
           "foldingRangeProvider": true,
-          "executeCommandProvider": { "commands": [ "dune/promote" ] },
+          "executeCommandProvider": {
+            "commands": [ "ocamllsp/view-metrics", "dune/promote" ]
+          },
           "selectionRangeProvider": true,
           "workspaceSymbolProvider": true,
           "workspace": {


### PR DESCRIPTION
Record metrics by instrumenting merlin requests. Introduce a custom
command to dump the metrics and show them to the user.

- [ ] Add tests
- [ ] Add name of merlin command to events
- [ ] Add request id's to events
- [ ] Record cancellation events
- [ ] Record debouncing events
- [ ] Dune rpc connection/disconnection events
- [ ] Timer information for how long it takes to poll the rpc registry.