### PR TITLE
refactor(olsp): extract code actions computation into a separate file

### DIFF
--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -1,0 +1,96 @@
+open Import
+open Fiber.O
+
+module Code_action_error = struct
+  type t =
+    | Initial
+    | Need_merlin_extend of string
+    | Exn of Exn_with_backtrace.t
+
+  let empty = Initial
+
+  let combine x y =
+    match (x, y) with
+    | Initial, _ -> y (* [Initial] cedes to any *)
+    | _, Initial -> x
+    | Exn _, _ -> x (* [Exn] takes over any *)
+    | _, Exn _ -> y
+    | Need_merlin_extend _, Need_merlin_extend _ -> y
+end
+
+module Code_action_error_monoid = struct
+  type t = Code_action_error.t
+
+  include Stdune.Monoid.Make (Code_action_error)
+end
+
+let compute server (params : CodeActionParams.t) =
+  let state : State.t = Server.state server in
+  let doc =
+    let uri = params.textDocument.uri in
+    let store = state.store in
+    Document_store.get_opt store uri
+  in
+  let dune_actions =
+    Dune.code_actions (State.dune state) params.textDocument.uri
+  in
+  let actions = function
+    | [] -> None
+    | xs -> Some (List.map ~f:(fun a -> `CodeAction a) xs)
+  in
+  match doc with
+  | None -> Fiber.return (Reply.now (actions dune_actions), state)
+  | Some doc -> (
+    match Document.syntax doc with
+    | Ocamllex | Menhir | Cram | Dune ->
+      let state : State.t = Server.state server in
+      Fiber.return (Reply.now (actions dune_actions), state)
+    | Ocaml | Reason ->
+      let reply () =
+        let code_action (ca : Code_action.t) =
+          match params.context.only with
+          | Some set when not (List.mem set ca.kind ~equal:Poly.equal) ->
+            Fiber.return None
+          | Some _ | None -> (
+            let+ res =
+              Fiber.map_reduce_errors
+                ~on_error:(fun (exn : Exn_with_backtrace.t) ->
+                  match exn.exn with
+                  | Merlin_extend.Extend_main.Handshake.Error error ->
+                    Fiber.return (Code_action_error.Need_merlin_extend error)
+                  | _ -> Fiber.return (Code_action_error.Exn exn))
+                (module Code_action_error_monoid)
+                (fun () -> ca.run doc params)
+            in
+            match res with
+            | Ok res -> res
+            | Error Initial -> assert false
+            | Error (Need_merlin_extend _) -> None
+            | Error (Exn exn) -> Exn_with_backtrace.reraise exn)
+        in
+        let+ code_action_results =
+          (* XXX this is a really bad use of resources. we should be batching
+             all the merlin related work *)
+          Fiber.parallel_map ~f:code_action
+            [ Action_destruct.t state
+            ; Action_inferred_intf.t state
+            ; Action_type_annotate.t
+            ; Action_construct.t
+            ; Action_refactor_open.unqualify
+            ; Action_refactor_open.qualify
+            ; Action_add_rec.t
+            ; Action_mark_remove_unused.mark
+            ; Action_mark_remove_unused.remove
+            ]
+        in
+        List.filter_opt code_action_results
+        |> List.append dune_actions |> actions
+      in
+      let later f =
+        Fiber.return
+          ( Reply.later (fun k ->
+                let* resp = f () in
+                k resp)
+          , state )
+      in
+      later reply)

--- a/ocaml-lsp-server/src/code_actions.mli
+++ b/ocaml-lsp-server/src/code_actions.mli
@@ -1,0 +1,6 @@
+open Import
+
+val compute :
+     State.t Server.t
+  -> CodeActionParams.t
+  -> ([> `CodeAction of CodeAction.t ] list option Reply.t * State.t) Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -318,100 +318,6 @@ let on_initialize server (ip : InitializeParams.t) =
   in
   (resp, state)
 
-module Code_action_error = struct
-  type t =
-    | Initial
-    | Need_merlin_extend of string
-    | Exn of Exn_with_backtrace.t
-
-  let empty = Initial
-
-  let combine x y =
-    match (x, y) with
-    | Initial, _ -> y (* [Initial] cedes to any *)
-    | _, Initial -> x
-    | Exn _, _ -> x (* [Exn] takes over any *)
-    | _, Exn _ -> y
-    | Need_merlin_extend _, Need_merlin_extend _ -> y
-end
-
-module Code_action_error_monoid = struct
-  type t = Code_action_error.t
-
-  include Stdune.Monoid.Make (Code_action_error)
-end
-
-let code_action server (params : CodeActionParams.t) =
-  let state : State.t = Server.state server in
-  let doc =
-    let uri = params.textDocument.uri in
-    let store = state.store in
-    Document_store.get_opt store uri
-  in
-  let dune_actions =
-    Dune.code_actions (State.dune state) params.textDocument.uri
-  in
-  let actions = function
-    | [] -> None
-    | xs -> Some (List.map ~f:(fun a -> `CodeAction a) xs)
-  in
-  match doc with
-  | None -> Fiber.return (Reply.now (actions dune_actions), state)
-  | Some doc -> (
-    match Document.syntax doc with
-    | Ocamllex | Menhir | Cram | Dune ->
-      let state : State.t = Server.state server in
-      Fiber.return (Reply.now (actions dune_actions), state)
-    | Ocaml | Reason ->
-      let reply () =
-        let code_action (ca : Code_action.t) =
-          match params.context.only with
-          | Some set when not (List.mem set ca.kind ~equal:Poly.equal) ->
-            Fiber.return None
-          | Some _ | None -> (
-            let+ res =
-              Fiber.map_reduce_errors
-                ~on_error:(fun (exn : Exn_with_backtrace.t) ->
-                  match exn.exn with
-                  | Merlin_extend.Extend_main.Handshake.Error error ->
-                    Fiber.return (Code_action_error.Need_merlin_extend error)
-                  | _ -> Fiber.return (Code_action_error.Exn exn))
-                (module Code_action_error_monoid)
-                (fun () -> ca.run doc params)
-            in
-            match res with
-            | Ok res -> res
-            | Error Initial -> assert false
-            | Error (Need_merlin_extend _) -> None
-            | Error (Exn exn) -> Exn_with_backtrace.reraise exn)
-        in
-        let+ code_action_results =
-          (* XXX this is a really bad use of resources. we should be batching
-             all the merlin related work *)
-          Fiber.parallel_map ~f:code_action
-            [ Action_destruct.t state
-            ; Action_inferred_intf.t state
-            ; Action_type_annotate.t
-            ; Action_construct.t
-            ; Action_refactor_open.unqualify
-            ; Action_refactor_open.qualify
-            ; Action_add_rec.t
-            ; Action_mark_remove_unused.mark
-            ; Action_mark_remove_unused.remove
-            ]
-        in
-        List.filter_opt code_action_results
-        |> List.append dune_actions |> actions
-      in
-      let later f =
-        Fiber.return
-          ( Reply.later (fun k ->
-                let* resp = f () in
-                k resp)
-          , state )
-      in
-      later reply)
-
 module Formatter = struct
   let jsonrpc_error (e : Ocamlformat.error) =
     let message = Ocamlformat.message e in
@@ -876,7 +782,7 @@ let on_request :
           in
           Compl.resolve doc ci resolve Document.doc_comment ~markdown)
       ()
-  | CodeAction params -> code_action server params
+  | CodeAction params -> Code_actions.compute server params
   | TextDocumentColor _ -> now []
   | TextDocumentColorPresentation _ -> now []
   | TextDocumentHover req ->


### PR DESCRIPTION
This PR is nothing more than just moving code around. 

Why? 

1. I am experimenting with how code actions' merlin work could be run at once rather than in different fibers (related [comment](https://github.com/ocaml/ocaml-lsp/blob/bd0c6402bbd2373333e833ea7c7b4f08112877fa/ocaml-lsp-server/src/ocaml_lsp_server.ml#L407-L408)) [*]
2. Some of the code is code action-specific, so having a separate module offers good separation of concern 
3. `ocaml_lsp_server.ml` is already big, let's lighten it when we can


[*] There are two things I'd like to mention about refactoring code actions: 

1. Code actions can be split by two properties: 
    1) Whether they are offered only in presence of certain diagnostics. For example, quick fix code actions that are aimed at changing code only when a certain diagnostic is present, e.g., code actions fixing "unused" warnings. As a result, we need a mechanism that allows iterate through diagnostics present in the code action context and find code actions that are applicable to them. For warnings (dune reports warnings as errors though), if we could send warning number in the diagnostics metadata, that would be helpful to quickly find related code actions. 
   2) Whether they use merlin. So far I think a code action that needs merlin work can be represented as such 

```ocaml
type code_action =
  | Action :
      { merlin_work :
          Mpipeline.t -> CodeActionParams.t -> ('a, Exn_with_backtrace.t) result
      ; mutable merlin_result : ('a, Exn_with_backtrace.t) result
      ; compute_code_actions :
             ('a, Exn_with_backtrace.t) result
          -> CodeActionParams.t
          -> CodeAction.t list
      }
      -> c
```

then we could compute code actions: 

```ocaml
let compute_all_code_actions server (params : CodeActionParams.t) cs =
  let state : State.t = Server.state server in
  let doc =
    let uri = params.textDocument.uri in
    let store = state.store in
    Document_store.get store uri
  in
  let+ () =
    Document.with_pipeline_exn doc (fun pipeline ->
        List.iter cs ~f:(fun (Code_action.Action c) ->
            c.merlin_result <- c.merlin_work pipeline params))
  in
  List.concat_map cs ~f:(fun (Code_action.Action c) ->
      c.compute_code_actions c.merlin_result params)
```