### PR TITLE
feature(olsp): warning for unused symbols are marked using `DiagnosticTag.Unnecessary`

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -128,7 +128,7 @@ let find_unused_diagnostic pos (ds : Diagnostic.t list) =
         | `Outside _ -> false
         | `Inside -> true
       in
-      in_range && Diagnostic_util.is_unused_var_warning d)
+      in_range && Diagnostic_util.is_unused_var_warning d.message)
 
 let code_action_mark doc (params : CodeActionParams.t) =
   let pos = params.range.start in

--- a/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
+++ b/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
@@ -1,5 +1,5 @@
 open Import
 
-let is_unused_var_warning (d : Diagnostic.t) =
-  String.is_prefix d.message ~prefix:"Error (warning 26)"
-  || String.is_prefix d.message ~prefix:"Error (warning 27)"
+let is_unused_var_warning s =
+  String.is_prefix s ~prefix:"Error (warning 26)"
+  || String.is_prefix s ~prefix:"Error (warning 27)"

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -196,3 +196,14 @@ let disconnect t dune =
          Table.iter dune_diagnostics ~f:(fun (uri, _) ->
              t.dirty_uris <- Uri_set.add t.dirty_uris uri);
          Table.remove t.dune dune)
+
+(* this is not inlined in [tags_of_message] for reusability *)
+let diagnostic_tags_unnecessary = Some [ DiagnosticTag.Unnecessary ]
+
+let tags_of_message ~src message =
+  match src with
+  | `Dune when String.is_prefix message ~prefix:"unused" ->
+    diagnostic_tags_unnecessary
+  | `Merlin when Diagnostic_util.is_unused_var_warning message ->
+    diagnostic_tags_unnecessary
+  | `Dune | `Merlin -> None

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -33,6 +33,9 @@ val remove :
 
 val disconnect : t -> Dune.t -> unit
 
+val tags_of_message :
+  src:[< `Dune | `Merlin ] -> string -> DiagnosticTag.t list option
+
 (** Exposed for testing *)
 
 val equal_message : string -> string -> bool

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -214,6 +214,7 @@ end = struct
                DiagnosticRelatedInformation.create ~location ~message))
     in
     let message = make_message (D.message diagnostic) in
+    let tags = Diagnostics.tags_of_message ~src:`Dune message in
     let data =
       match include_promotions with
       | false -> None
@@ -225,7 +226,7 @@ end = struct
           Some (`Assoc [ For_diff.diagnostic_data promotions ]))
     in
     Diagnostic.create ?relatedInformation ~range ?severity
-      ~source:Diagnostics.dune_source ~message ?data ()
+      ~source:Diagnostics.dune_source ~message ?tags ?data ()
 
   let progress_loop client progress =
     match Progress.should_report_build_progress progress with

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -180,6 +180,7 @@ include struct
   module Diagnostic = Diagnostic
   module DiagnosticRelatedInformation = DiagnosticRelatedInformation
   module DiagnosticSeverity = DiagnosticSeverity
+  module DiagnosticTag = DiagnosticTag
   module DidChangeConfigurationParams = DidChangeConfigurationParams
   module DidChangeWorkspaceFoldersParams = DidChangeWorkspaceFoldersParams
   module DidOpenTextDocumentParams = DidOpenTextDocumentParams

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -265,7 +265,10 @@ let set_diagnostics rpc doc =
                                  DiagnosticRelatedInformation.create ~location
                                    ~message)) )
                     in
-                    create_diagnostic ?relatedInformation ~range ~message
+                    let tags =
+                      Diagnostics.tags_of_message ~src:`Merlin message
+                    in
+                    create_diagnostic ?tags ?relatedInformation ~range ~message
                       ~severity ())
               in
               let holes_as_err_diags =


### PR DESCRIPTION
<img width="131" alt="image" src="https://user-images.githubusercontent.com/16353531/177403926-b6771cfb-3389-4a2b-a5c1-ae310c045bd6.png">

<img width="105" alt="image" src="https://user-images.githubusercontent.com/16353531/177403900-844f5d0c-a28e-4217-ba36-4cda10ba16ea.png">

Fixes #754 