### PR TITLE
refactor(uri): get rid of uri dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -48,7 +48,6 @@ possible and does not make any assumptions about IO.
  (description "An LSP server for OCaml.")
  (depends
   yojson
-  uri
   (re (>= 1.5.0))
   (ppx_yojson_conv_lib (>= "v0.14"))
   dune-rpc

--- a/lsp/src/dune
+++ b/lsp/src/dune
@@ -3,7 +3,7 @@
 (library
  (name lsp)
  (public_name lsp)
- (libraries jsonrpc ppx_yojson_conv_lib dyn uutf yojson uri)
+ (libraries jsonrpc ppx_yojson_conv_lib dyn uutf yojson)
  (lint
   (pps ppx_yojson_conv)))
 

--- a/lsp/src/uri_lexer.mll
+++ b/lsp/src/uri_lexer.mll
@@ -4,6 +4,49 @@ type t =
   ; authority : string
   ; path : string
   }
+
+let int_of_hex_char c =
+  let c = int_of_char (Char.uppercase_ascii c) - 48 in
+  if c > 9 then if c > 16 && c < 23 then c - 7 else failwith "int_of_hex_char"
+  else if c >= 0 then c
+  else failwith "int_of_hex_char"
+
+(* https://github.com/mirage/ocaml-uri/blob/master/lib/uri.ml#L318 *)
+let decode b =
+  let len = String.length b in
+  let buf = Buffer.create len in
+  let rec scan start cur =
+    if cur >= len then Buffer.add_substring buf b start (cur - start)
+    else if b.[cur] = '%' then (
+      Buffer.add_substring buf b start (cur - start);
+      let cur = cur + 1 in
+      if cur >= len then Buffer.add_char buf '%'
+      else
+        match int_of_hex_char b.[cur] with
+        | exception _ ->
+          Buffer.add_char buf '%';
+          scan cur cur
+        | highbits ->
+          let cur = cur + 1 in
+          if cur >= len then (
+            Buffer.add_char buf '%';
+            Buffer.add_char buf b.[cur - 1])
+          else
+            let start_at =
+              match int_of_hex_char b.[cur] with
+              | lowbits ->
+                Buffer.add_char buf (Char.chr ((highbits lsl 4) + lowbits));
+                cur + 1
+              | exception _ ->
+                Buffer.add_char buf '%';
+                Buffer.add_char buf b.[cur - 1];
+                cur
+            in
+            scan start_at start_at)
+    else scan start (cur + 1)
+  in
+  scan 0 0;
+  Buffer.contents buf
 }
 
 rule uri = parse
@@ -14,10 +57,10 @@ rule uri = parse
   let open Import in
   let scheme = scheme |> Option.value ~default:"file" in
   let authority =
-    authority |> Option.map Uri.pct_decode |> Option.value ~default:""
+    authority |> Option.map decode |> Option.value ~default:""
   in
   let path =
-    let path = path |> Uri.pct_decode in
+    let path = path |> decode in
     match scheme with
     | "http" | "https" | "file" ->
       String.add_prefix_if_not_exists path ~prefix:"/"

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -21,7 +21,6 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "3.0"}
   "yojson"
-  "uri"
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-rpc"


### PR DESCRIPTION
Extracted the relevant `encode`/`decode` functions from `ocaml-uri`