### PR TITLE
fix(ocamllsp): allow interleaved writes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 - Allow cancellation of workspace symbols requests (#777)
 
+- Fix unintentionally interleaved jsonrpc IO that would corrupt the session
+  (#786)
+
+- Ignore `SIGPIPE` . (#788)
+
 # 1.12.3
 
 ## Fixes


### PR DESCRIPTION
The proper way to do this is just to wait for the last write to
complete, but this is a hot fix.

ps-id: cb0e6c1e-91eb-42fe-9432-99db28a5512e