### PR TITLE
fix(ocamllsp): ignore sigpipe

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -1069,4 +1069,4 @@ let start () =
 let run ~read_dot_merlin () =
   Merlin_config.should_read_dot_merlin := read_dot_merlin;
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
-  Lev_fiber.run start
+  Lev_fiber.run ~sigpipe:`Ignore start


### PR DESCRIPTION
Sub processes such as ocamlformat-rpc, refmt (heaven forbid) might crash
on us. We should not terminate the server because of that.

ps-id: ab654253-9786-4ea6-96d2-260389712b47