### PR TITLE
chore(nix): cleaner buildInput override

### DIFF
--- a/nix/opam-selection.nix
+++ b/nix/opam-selection.nix
@@ -249,10 +249,6 @@ in
         package = "packages/dune/dune.3.3.1";
         hash = "sha256:1nc99m7yaakz8ggdjj1lafim37ahafp17v48ai0iafdvdj3pxixv";
       };
-      buildInputs = lib.optional self.pkgs.stdenv.isDarwin (with self.pkgs.darwin.apple_sdk.frameworks; [
-        Foundation
-        CoreServices
-      ]);
     };
     dune-build-info = 
     {


### PR DESCRIPTION
instead of editing generated code, override it it in our nix file

ps-id: 1b272a69-2994-4dd6-9f39-9c023001420d