### PR TITLE
feature(dune): annotate dune diagnostics with pid

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -50,7 +50,7 @@ possible and does not make any assumptions about IO.
   yojson
   (re (>= 1.5.0))
   (ppx_yojson_conv_lib (>= "v0.14"))
-  dune-rpc
+  (dune-rpc (>= 3.4.0))
   (chrome-trace (>= 3.3.0))
   dyn
   stdune

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -23,7 +23,7 @@ depends: [
   "yojson"
   "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
-  "dune-rpc"
+  "dune-rpc" {>= "3.4.0"}
   "chrome-trace" {>= "3.3.0"}
   "dyn"
   "stdune"

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -2,6 +2,8 @@ open Import
 
 val ocamllsp_source : string
 
+val dune_source : string
+
 type t
 
 val create :
@@ -16,7 +18,7 @@ val workspace_root : t -> Uri.t
 module Dune : sig
   type t
 
-  val gen : unit -> t
+  val gen : Pid.t -> t
 end
 
 val set :

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -224,8 +224,8 @@ end = struct
           let promotions = List.map promotions ~f:For_diff.Diff.of_promotion in
           Some (`Assoc [ For_diff.diagnostic_data promotions ]))
     in
-    Diagnostic.create ?relatedInformation ~range ?severity ~source:"dune"
-      ~message ?data ()
+    Diagnostic.create ?relatedInformation ~range ?severity
+      ~source:Diagnostics.dune_source ~message ?data ()
 
   let progress_loop client progress =
     match Progress.should_report_build_progress progress with
@@ -407,7 +407,7 @@ end = struct
       t.state <- Connected (session, where);
       Fiber.return (Ok ())
 
-  let run ({ config; _ } as t) =
+  let run ({ config; source; _ } as t) =
     let* () = Fiber.return () in
     let session, where =
       match t.state with
@@ -421,7 +421,8 @@ end = struct
       ; finish
       ; promotions = String.Map.empty
       ; client = None
-      ; diagnostics_id = Diagnostics.Dune.gen ()
+      ; diagnostics_id =
+          Diagnostics.Dune.gen (Pid.of_int (Registry.Dune.pid source))
       ; id = Id.gen ()
       }
     in


### PR DESCRIPTION
when we are connected to more than one dune instance, we annotate them
with a pid so it's clear to the user

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 4b487e5f-cd4d-42f2-ae20-b02059f4b5c4