### PR TITLE
fix(ocamllsp): mark mark unused preferred

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -80,7 +80,7 @@ let code_action_mark_value_unused doc (diagnostic : Diagnostic.t) =
       in
       let edit = Document.edit doc text_edit in
       CodeAction.create ~diagnostics:[ diagnostic ] ~title:"Mark as unused"
-        ~kind:CodeActionKind.QuickFix ~edit ~isPreferred:false ())
+        ~kind:CodeActionKind.QuickFix ~edit ~isPreferred:true ())
 
 (* Takes a list of contexts enclosing a binding of `name`. Returns the range of
    the most specific binding. *)

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -1080,7 +1080,7 @@ let f x =
             },
           ],
         },
-        "isPreferred": false,
+        "isPreferred": true,
         "kind": "quickfix",
         "title": "Mark as unused",
       }


### PR DESCRIPTION
it seems to be the safe default

ps-id: 887ffc90-82c6-4345-b684-392462d53828