### PR TITLE
fix(ocamllex): do not raise exceptions on signatureHelp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Respect `showDocument` capabilities. Do not offer commands or code actions
   that rely on this request without client support. (#836)
 
+- Fix signatureHelp on .mll files: avoid "Document.dune" exceptions
+
 # 1.13.1
 
 ## Fixes

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -471,11 +471,13 @@ let signature_help (state : State.t)
   in
   (* TODO use merlin resources efficiently and do everything in 1 thread *)
   let* application_signature =
-    Document.with_pipeline_exn doc (fun pipeline ->
-        let typer = Mpipeline.typer_result pipeline in
-        let pos = Mpipeline.get_lexing_pos pipeline pos in
-        let node = Mtyper.node_at typer pos in
-        Merlin_analysis.Signature_help.application_signature node ~prefix)
+    if Document.is_merlin doc then
+      Document.with_pipeline_exn doc (fun pipeline ->
+          let typer = Mpipeline.typer_result pipeline in
+          let pos = Mpipeline.get_lexing_pos pipeline pos in
+          let node = Mtyper.node_at typer pos in
+          Merlin_analysis.Signature_help.application_signature node ~prefix)
+    else Fiber.return None
   in
   match application_signature with
   | None ->


### PR DESCRIPTION
As soon as I open a .mll file (with filetype set to ocamllex in NeoVim) the LSP
server sends a continuous stream "Document.dune" exceptions.
I currently have to turn off Lsp (using :LspStop) to be able to keep
editing.

Instead of raising an exception just return an empty result for
filetypes where signatureHelp is not implemented yet.

It'd probably be better to not advertise the capability, but not sure if
that is doable by filetype...