### PR TITLE
Add code action for inlining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Code action for inlining let bindings within a module or expression. (#847)
+
 - Tag "unused code" and "deprecated" warnings, allowing clients to better
   display them. (#848)
 

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -82,14 +82,14 @@ let compute server (params : CodeActionParams.t) =
           Fiber.parallel_map
             ~f:code_action
             [ Action_destruct.t state
-            ; Action_inferred_intf.t state
-            ; Action_type_annotate.t
+            ; Action_inferred_intf.t state (* ; Action_type_annotate.t *)
             ; Action_construct.t
             ; Action_refactor_open.unqualify
             ; Action_refactor_open.qualify
             ; Action_add_rec.t
             ; Action_mark_remove_unused.mark
             ; Action_mark_remove_unused.remove
+            ; Action_inline.t
             ]
         in
         List.concat

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -82,7 +82,8 @@ let compute server (params : CodeActionParams.t) =
           Fiber.parallel_map
             ~f:code_action
             [ Action_destruct.t state
-            ; Action_inferred_intf.t state (* ; Action_type_annotate.t *)
+            ; Action_inferred_intf.t state
+            ; Action_type_annotate.t
             ; Action_construct.t
             ; Action_refactor_open.unqualify
             ; Action_refactor_open.qualify

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -76,8 +76,8 @@ let iter_inline_edits pipeline task k =
           match (label, m_arg_expr) with
           (* handle the labeled argument shorthand `f ~x` when inlining `x` *)
           | ( Asttypes.Labelled name
-            , Some { exp_desc = Texp_ident (Pident name', { loc; _ }, _); _ } )
-            when String.equal name (Ident.name name') ->
+            , Some { exp_desc = Texp_ident (Pident id, { loc; _ }, _); _ } )
+            when Ident.same task.ident id ->
             let newText = sprintf "%s:%s" name newText in
             let textedit = TextEdit.create ~newText ~range:(Range.of_loc loc) in
             k textedit

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -310,6 +310,10 @@ let inlined_text pipeline task =
   let expr = strip_attribute "merlin.loc" expr in
   Format.asprintf "(%a)" Pprintast.expression expr
 
+(** [inline_edits pipeline task] returns a list of inlining edits and an
+    optional error value. An error will be generated if any of the potential
+    inlinings is not allowed due to shadowing. The successful edits will still
+    be returned *)
 let inline_edits pipeline task =
   let module I = Ocaml_typing.Tast_iterator in
   let open Option.O in

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -3,8 +3,8 @@ open Import
 let action_title = "Inline"
 
 type inline_task =
-  { ident : Ident.t
-  ; body : Typedtree.expression  (** the expression to inline *)
+  { inlined_var : Ident.t
+  ; inlined_expr : Typedtree.expression  (** the expression to inline *)
   ; context : Typedtree.expression  (** where to perform inlining *)
   }
 
@@ -25,7 +25,7 @@ let find_inline_task pipeline pos =
     (Mpipeline.get_lexing_pos pipeline (Position.logical pos))
     [ browse ]
   |> List.find_map ~f:(function
-       | ( _
+       | ( (_ : Ocaml_typing.Env.t)
          , Browse_raw.Expression
              { exp_desc =
                  Texp_let
@@ -39,35 +39,34 @@ let find_inline_task pipeline pos =
              ; _
              } )
          when contains s.loc pos ->
-         Some { ident = id; body = vb_expr; context = rhs }
+         Some { inlined_var = id; inlined_expr = vb_expr; context = rhs }
        | _ -> None)
 
 let find_parsetree_loc pipeline loc k =
-  let expr_iter (iter : Ocaml_parsing.Ast_iterator.iterator)
-      (expr : Parsetree.expression) =
-    if expr.pexp_loc = loc then k expr
-    else Ocaml_parsing.Ast_iterator.default_iterator.expr iter expr
+  let expr_iter (iter : Ast_iterator.iterator) (expr : Parsetree.expression) =
+    if Loc.compare expr.pexp_loc loc = 0 then k expr
+    else Ast_iterator.default_iterator.expr iter expr
   in
-  let iterator =
-    { Ocaml_parsing.Ast_iterator.default_iterator with expr = expr_iter }
-  in
-  match Mpipeline.reader_parsetree pipeline with
+  let iterator = { Ast_iterator.default_iterator with expr = expr_iter } in
+  match Mpipeline.ppx_parsetree pipeline with
   | `Implementation s -> iterator.structure iterator s
-  | _ -> ()
+  | `Interface _ -> ()
 
 let inlined_text pipeline task =
   let ret = ref None in
-  find_parsetree_loc pipeline task.body.exp_loc (fun expr ->
+  find_parsetree_loc pipeline task.inlined_expr.exp_loc (fun expr ->
       ret :=
         Some (Format.asprintf "(%a)" Ocaml_parsing.Pprintast.expression expr));
   Option.value_exn !ret
 
 (** Iterator over the text edits performed by the inlining task. *)
-let iter_inline_edits pipeline task k =
+let inline_edits pipeline task =
   let newText = inlined_text pipeline task in
   let make_edit newText loc =
     TextEdit.create ~newText ~range:(Range.of_loc loc)
   in
+  let edits = Queue.create () in
+  let insert_edit newText loc = Queue.push edits (make_edit newText loc) in
 
   let expr_iter (iter : Ocaml_typing.Tast_iterator.iterator)
       (expr : Typedtree.expression) =
@@ -80,40 +79,42 @@ let iter_inline_edits pipeline task k =
           (* handle the labeled argument shorthand `f ~x` when inlining `x` *)
           | ( Asttypes.Labelled name
             , Some { exp_desc = Texp_ident (Pident id, { loc; _ }, _); _ } )
-            when Ident.same task.ident id ->
+            when Ident.same task.inlined_var id ->
             let newText = sprintf "%s:%s" name newText in
-            k (make_edit newText loc)
+            insert_edit newText loc
           | _, m_expr -> Option.iter m_expr ~f:(iter.expr iter))
-    | Texp_ident (Pident id, { loc; _ }, _) when Ident.same task.ident id ->
-      k (make_edit newText loc)
+    | Texp_ident (Pident id, { loc; _ }, _) when Ident.same task.inlined_var id
+      -> insert_edit newText loc
     | _ -> Ocaml_typing.Tast_iterator.default_iterator.expr iter expr
   in
   let iterator =
     { Ocaml_typing.Tast_iterator.default_iterator with expr = expr_iter }
   in
-  iterator.expr iterator task.context
+  iterator.expr iterator task.context;
+  Queue.to_list edits
 
 let code_action doc (params : CodeActionParams.t) =
-  Document.with_pipeline_exn doc (fun pipeline ->
-      let m_inline_task = find_inline_task pipeline params.range.start in
-      Option.map m_inline_task ~f:(fun task ->
-          let edits = Queue.create () in
-          iter_inline_edits pipeline task (Queue.push edits);
-
-          let edit =
-            let version = Document.version doc in
-            let textDocument =
-              OptionalVersionedTextDocumentIdentifier.create
-                ~uri:params.textDocument.uri ~version ()
-            in
-            let edit =
-              TextDocumentEdit.create ~textDocument
-                ~edits:
-                  (Queue.to_list edits |> List.map ~f:(fun e -> `TextEdit e))
-            in
-            WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-          in
-          CodeAction.create ~title:action_title
-            ~kind:CodeActionKind.RefactorInline ~edit ~isPreferred:false ()))
+  let open Fiber.O in
+  let* m_edits =
+    Document.with_pipeline_exn doc (fun pipeline ->
+        find_inline_task pipeline params.range.start
+        |> Option.map ~f:(inline_edits pipeline))
+  in
+  Option.map m_edits ~f:(fun edits ->
+      let edit =
+        let version = Document.version doc in
+        let textDocument =
+          OptionalVersionedTextDocumentIdentifier.create
+            ~uri:params.textDocument.uri ~version ()
+        in
+        let edit =
+          TextDocumentEdit.create ~textDocument
+            ~edits:(List.map edits ~f:(fun e -> `TextEdit e))
+        in
+        WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+      in
+      CodeAction.create ~title:action_title ~kind:CodeActionKind.RefactorInline
+        ~edit ~isPreferred:false ())
+  |> Fiber.return
 
 let t = { Code_action.kind = RefactorInline; run = code_action }

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -28,8 +28,8 @@ let check_shadowing (inlined_expr : Typedtree.expression) new_env =
         match find_path_by_name ident new_env with
         | Some path' ->
           if not (Path.same path path') then
-            raise (Env_mismatch (ident, `Shadowed))
-        | None -> raise (Env_mismatch (ident, `Unbound)))
+            raise_notrace (Env_mismatch (ident, `Shadowed))
+        | None -> raise_notrace (Env_mismatch (ident, `Unbound)))
     | _ -> I.default_iterator.expr iter expr
   in
   let iter = { I.default_iterator with expr = expr_iter } in
@@ -69,7 +69,8 @@ let find_inline_task typedtree pos =
               }
             ]
           , _ )
-        when contains loc pos -> raise (Found { inlined_var; inlined_expr })
+        when contains loc pos ->
+        raise_notrace (Found { inlined_var; inlined_expr })
       | _ -> I.default_iterator.expr iter expr
   in
   let structure_item_iter (iter : I.iterator) (item : Typedtree.structure_item)
@@ -83,7 +84,8 @@ let find_inline_task typedtree pos =
               ; _
               }
             ] )
-        when contains loc pos -> raise (Found { inlined_var; inlined_expr })
+        when contains loc pos ->
+        raise_notrace (Found { inlined_var; inlined_expr })
       | _ -> I.default_iterator.structure_item iter item
   in
   let iterator =
@@ -101,7 +103,7 @@ let find_parsetree_loc pipeline loc =
   let exception Found of Parsetree.expression in
   try
     let expr_iter (iter : Ast_iterator.iterator) (expr : Parsetree.expression) =
-      if Loc.compare expr.pexp_loc loc = 0 then raise (Found expr)
+      if Loc.compare expr.pexp_loc loc = 0 then raise_notrace (Found expr)
       else Ast_iterator.default_iterator.expr iter expr
     in
     let iterator = { Ast_iterator.default_iterator with expr = expr_iter } in

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -112,6 +112,93 @@ let strip_attribute attr_name expr =
   let mapper = { M.default_mapper with expr = expr_map } in
   mapper.expr mapper expr
 
+(** [uses expr path] returns the number of uses of [path] in [expr]. *)
+let uses expr path =
+  let module I = Ocaml_typing.Tast_iterator in
+  let count = ref 0 in
+  let expr_iter (iter : I.iterator) (expr : Typedtree.expression) =
+    match expr.exp_desc with
+    | Texp_ident (path', _, _) when Path.same path path' -> incr count
+    | _ -> I.default_iterator.expr iter expr
+  in
+  let iterator = { I.default_iterator with expr = expr_iter } in
+  iterator.expr iterator expr;
+  !count
+
+let subst task =
+  let module M = Ocaml_typing.Tast_mapper in
+  let expr_map (map : M.mapper) (expr : Typedtree.expression) =
+    match expr.exp_desc with
+    | Texp_ident (Pident id, _, _) when Ident.same task.inlined_var id ->
+      task.inlined_expr
+    | _ -> M.default.expr map expr
+  in
+  let mapper = { M.default with expr = expr_map } in
+  mapper.expr mapper task.context
+
+(** Rough check for pure expressions. Identifiers and constants are pure. *)
+let is_pure (expr : Typedtree.expression) =
+  match expr.exp_desc with
+  | Texp_ident _ | Texp_constant _ -> true
+  | _ -> false
+
+let rec beta_reduce (app : Typedtree.expression) =
+  let untype_expression = Ocaml_typing.Untypeast.untype_expression in
+  match app.exp_desc with
+  | Texp_apply
+      ( { exp_desc =
+            Texp_function
+              { arg_label = Nolabel
+              ; cases =
+                  [ { c_lhs = { pat_desc = pat; _ }
+                    ; c_guard = None
+                    ; c_rhs = body
+                    }
+                  ]
+              ; _
+              }
+        ; _
+        }
+      , (Nolabel, Some arg) :: args' ) -> (
+    let body =
+      if List.is_empty args' then body
+      else { app with exp_desc = Texp_apply (body, args') }
+    in
+    match pat with
+    | Tpat_any -> beta_reduce body
+    | Tpat_var (param, _) ->
+      let n_uses = uses body (Path.Pident param) in
+      Printf.eprintf "uses: %d\n%!" n_uses;
+      Out_channel.flush stderr;
+      if n_uses = 0 then Ocaml_typing.Untypeast.untype_expression body
+      else if n_uses = 1 || is_pure arg then
+        beta_reduce
+          (subst { inlined_var = param; inlined_expr = arg; context = body })
+      else
+        (* if the parameter is used multiple times in the body, introduce a let
+           binding so that the parameter is evaluated only once *)
+        let module H = Ocaml_parsing.Ast_helper in
+        let body = untype_expression body in
+        let arg = untype_expression arg in
+        H.Exp.let_
+          Nonrecursive
+          [ H.Vb.mk
+              (H.Pat.var { txt = Ident.name param; loc = !H.default_loc })
+              arg
+          ]
+          body
+    | _ -> untype_expression app)
+  | _ -> untype_expression app
+
+module Test = struct
+  let z =
+    let k = 1 in
+    let f y = y + k in
+    let k = 2 in
+    let y = 2 in
+    f y
+end
+
 let inlined_text pipeline task =
   let open Option.O in
   let+ expr = find_parsetree_loc pipeline task.inlined_expr.exp_loc in
@@ -137,6 +224,7 @@ let inline_edits pipeline task =
       false
   in
 
+  (* inlining into an argument context has some special cases *)
   let arg_iter env (iter : I.iterator) (label : Asttypes.arg_label)
       (m_arg_expr : Typedtree.expression option) =
     match (label, m_arg_expr) with
@@ -159,11 +247,27 @@ let inline_edits pipeline task =
     | _, m_expr -> Option.iter m_expr ~f:(iter.expr iter)
   in
 
+  let apply_iter env (iter : I.iterator) (func : Typedtree.expression) args =
+    iter.expr iter func;
+    List.iter args ~f:(fun (l, e) -> arg_iter env iter l e)
+  in
+
   let expr_iter (iter : I.iterator) (expr : Typedtree.expression) =
     match expr.exp_desc with
-    | Texp_apply (func, args) ->
-      iter.expr iter func;
-      List.iter args ~f:(fun (l, e) -> arg_iter expr.exp_env iter l e)
+    (* when inlining into an application context, attempt to beta reduce the
+       result *)
+    | Texp_apply ({ exp_desc = Texp_ident (Pident id, _, _); _ }, args)
+      when Ident.same task.inlined_var id && not_shadowed expr.exp_env ->
+      let reduced_expr =
+        beta_reduce
+          { expr with exp_desc = Texp_apply (task.inlined_expr, args) }
+      in
+      let newText =
+        Format.asprintf "(%a)" Pprintast.expression
+        @@ strip_attribute "merlin.loc" reduced_expr
+      in
+      insert_edit newText expr.exp_loc
+    | Texp_apply (func, args) -> apply_iter expr.exp_env iter func args
     | Texp_ident (Pident id, { loc; _ }, _)
       when Ident.same task.inlined_var id && not_shadowed expr.exp_env ->
       insert_edit newText loc

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -50,7 +50,7 @@ let find_parsetree_loc pipeline loc =
       else Ast_iterator.default_iterator.expr iter expr
     in
     let iterator = { Ast_iterator.default_iterator with expr = expr_iter } in
-    (match Mpipeline.ppx_parsetree pipeline with
+    (match Mpipeline.reader_parsetree pipeline with
     | `Implementation s -> iterator.structure iterator s
     | `Interface _ -> ());
     None

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -75,20 +75,6 @@ let iter_inline_edits task k =
   in
   iterator.expr iterator task.context
 
-module Test = struct
-  let f x y = x + y
-
-  let g y = f y y
-
-  let h g x = g x
-
-  let j x = h g x
-
-  let test () =
-    let y x = x + 1 in
-    y 0 + 2
-end
-
 let code_action doc (params : CodeActionParams.t) =
   let open Fiber.O in
   let+ m_inline_task =

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -1,0 +1,104 @@
+open Import
+
+let action_title = "Inline"
+
+let log str =
+  let ch =
+    open_out_gen [ Open_wronly; Open_append ] 0o744 "/home/feser/ocamllsp.log"
+  in
+  output_string ch str;
+  flush ch;
+  close_out ch
+
+type inline_task =
+  { ident : Ident.t
+  ; body : Typedtree.expression  (** the expression to inline *)
+  ; context : Typedtree.expression  (** where to perform inlining *)
+  }
+
+let find_inline_task pipeline pos =
+  let contains loc pos =
+    match Position.compare_inclusion pos (Range.of_loc loc) with
+    | `Outside _ -> false
+    | `Inside -> true
+  in
+
+  (* Find most enclosing nonrecursive let binding *)
+  let browse =
+    Mpipeline.typer_result pipeline
+    |> Mtyper.get_typedtree |> Mbrowse.of_typedtree
+  in
+
+  Mbrowse.enclosing
+    (Mpipeline.get_lexing_pos pipeline (Position.logical pos))
+    [ browse ]
+  |> List.find_map ~f:(function
+       | ( _
+         , Browse_raw.Expression
+             { exp_desc =
+                 Texp_let
+                   ( Nonrecursive
+                   , [ { vb_pat = { pat_desc = Tpat_var (id, s); _ }
+                       ; vb_expr
+                       ; _
+                       }
+                     ]
+                   , rhs )
+             ; _
+             } )
+         when contains s.loc pos ->
+         Some { ident = id; body = vb_expr; context = rhs }
+       | _ -> None)
+
+let iter_ident_locs id expr k =
+  let expr_iter iter (expr : Typedtree.expression) =
+    match expr.exp_desc with
+    | Texp_ident (Pident id', { loc; _ }, _) when Ident.same id id' -> k loc
+    | _ -> Ocaml_typing.Tast_iterator.default_iterator.expr iter expr
+  in
+  let iterator =
+    { Ocaml_typing.Tast_iterator.default_iterator with expr = expr_iter }
+  in
+  iterator.expr iterator expr
+
+let iter_inline_edits task k =
+  iter_ident_locs task.ident task.context (fun loc ->
+      let textedit = TextEdit.create ~newText:"??" ~range:(Range.of_loc loc) in
+      k textedit)
+
+module Test = struct
+  let f x y = x + y
+
+  let g y = f y y
+
+  let h g x = g x
+
+  let j x = h g x
+end
+
+let code_action doc (params : CodeActionParams.t) =
+  let open Fiber.O in
+  let+ m_inline_task =
+    Document.with_pipeline_exn doc (fun pipeline ->
+        find_inline_task pipeline params.range.start)
+  in
+  Option.map m_inline_task ~f:(fun task ->
+      let edits = Queue.create () in
+      iter_inline_edits task (Queue.push edits);
+
+      let edit =
+        let version = Document.version doc in
+        let textDocument =
+          OptionalVersionedTextDocumentIdentifier.create
+            ~uri:params.textDocument.uri ~version ()
+        in
+        let edit =
+          TextDocumentEdit.create ~textDocument
+            ~edits:(Queue.to_list edits |> List.map ~f:(fun e -> `TextEdit e))
+        in
+        WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+      in
+      CodeAction.create ~title:action_title ~kind:CodeActionKind.RefactorInline
+        ~edit ~isPreferred:false ())
+
+let t = { Code_action.kind = RefactorInline; run = code_action }

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -210,11 +210,4 @@ let code_action doc (params : CodeActionParams.t) =
         Some action)
   |> Fiber.return
 
-module Test = struct
-  let x =
-    let k = 0 in
-    let f ?(k = 1) ~j () = k + j in
-    f ~j:0 ~k ()
-end
-
 let t = { Code_action.kind = RefactorInline; run = code_action }

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -118,7 +118,6 @@ let inlined_text pipeline task =
   let expr = strip_attribute "merlin.loc" expr in
   Format.asprintf "(%a)" Pprintast.expression expr
 
-(** Iterator over the text edits performed by the inlining task. *)
 let inline_edits pipeline task =
   let module I = Ocaml_typing.Tast_iterator in
   let open Option.O in

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -44,7 +44,10 @@ let string_of_error (ident, reason) =
     | `Unbound -> "unbound"
     | `Shadowed -> "shadowed"
   in
-  Format.asprintf "'%a' is %s in inlining context" Pprintast.longident ident
+  Format.asprintf
+    "'%a' is %s in inlining context"
+    Pprintast.longident
+    ident
     reason
 
 let find_inline_task pipeline pos =
@@ -64,22 +67,22 @@ let find_inline_task pipeline pos =
     (Mpipeline.get_lexing_pos pipeline (Position.logical pos))
     [ browse ]
   |> List.find_map ~f:(function
-       | ( (_ : Ocaml_typing.Env.t)
-         , Browse_raw.Expression
-             { exp_desc =
-                 Texp_let
-                   ( Nonrecursive
-                   , [ { vb_pat = { pat_desc = Tpat_var (id, s); _ }
-                       ; vb_expr
-                       ; _
-                       }
-                     ]
-                   , rhs )
-             ; _
-             } )
-         when contains s.loc pos ->
-         Some { inlined_var = id; inlined_expr = vb_expr; context = rhs }
-       | _ -> None)
+         | ( (_ : Ocaml_typing.Env.t)
+           , Browse_raw.Expression
+               { exp_desc =
+                   Texp_let
+                     ( Nonrecursive
+                     , [ { vb_pat = { pat_desc = Tpat_var (id, s); _ }
+                         ; vb_expr
+                         ; _
+                         }
+                       ]
+                     , rhs )
+               ; _
+               } )
+           when contains s.loc pos ->
+           Some { inlined_var = id; inlined_expr = vb_expr; context = rhs }
+         | _ -> None)
 
 let find_parsetree_loc pipeline loc =
   let exception Found of Parsetree.expression in
@@ -183,8 +186,10 @@ let code_action doc (params : CodeActionParams.t) =
       | [], None -> None
       | [], Some error ->
         let action =
-          CodeAction.create ~title:action_title
-            ~kind:CodeActionKind.RefactorInline ~isPreferred:false
+          CodeAction.create
+            ~title:action_title
+            ~kind:CodeActionKind.RefactorInline
+            ~isPreferred:false
             ~disabled:
               (CodeAction.create_disabled ~reason:(string_of_error error))
             ()
@@ -195,17 +200,24 @@ let code_action doc (params : CodeActionParams.t) =
           let version = Document.version doc in
           let textDocument =
             OptionalVersionedTextDocumentIdentifier.create
-              ~uri:params.textDocument.uri ~version ()
+              ~uri:params.textDocument.uri
+              ~version
+              ()
           in
           let edit =
-            TextDocumentEdit.create ~textDocument
+            TextDocumentEdit.create
+              ~textDocument
               ~edits:(List.map edits ~f:(fun e -> `TextEdit e))
           in
           WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
         in
         let action =
-          CodeAction.create ~title:action_title
-            ~kind:CodeActionKind.RefactorInline ~edit ~isPreferred:false ()
+          CodeAction.create
+            ~title:action_title
+            ~kind:CodeActionKind.RefactorInline
+            ~edit
+            ~isPreferred:false
+            ()
         in
         Some action)
   |> Fiber.return

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -302,14 +302,6 @@ let rec beta_reduce (uses : Uses.t) (paths : Paths.t)
     )
   | _ -> app
 
-module Test = struct
-  type t = { x : int }
-
-  let z =
-    let f (y : int) (z : int) a = y + z + a in
-    f 2 0
-end
-
 let inlined_text pipeline task =
   let open Option.O in
   let+ expr = find_parsetree_loc pipeline task.inlined_expr.exp_loc in

--- a/ocaml-lsp-server/src/code_actions/action_inline.mli
+++ b/ocaml-lsp-server/src/code_actions/action_inline.mli
@@ -1,0 +1,1 @@
+val t : Code_action.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -110,6 +110,7 @@ module Ast_iterator = Ocaml_parsing.Ast_iterator
 module Asttypes = Ocaml_parsing.Asttypes
 module Cmt_format = Ocaml_typing.Cmt_format
 module Ident = Ocaml_typing.Ident
+module Env = Ocaml_typing.Env
 
 module Loc = struct
   include Ocaml_parsing.Location

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -113,8 +113,33 @@ module Ident = Ocaml_typing.Ident
 module Env = Ocaml_typing.Env
 
 module Loc = struct
-  include Ocaml_parsing.Location
-  include Ocaml_parsing.Location_aux
+  module T = struct
+    include Ocaml_parsing.Location
+    include Ocaml_parsing.Location_aux
+  end
+
+  include T
+
+  module Map = Map.Make (struct
+    include T
+
+    let compare x x' = Ordering.of_int (compare x x')
+
+    let position_to_dyn (pos : Lexing.position) =
+      Dyn.Record
+        [ ("pos_fname", Dyn.String pos.pos_fname)
+        ; ("pos_lnum", Dyn.Int pos.pos_lnum)
+        ; ("pos_bol", Dyn.Int pos.pos_bol)
+        ; ("pos_cnum", Dyn.Int pos.pos_cnum)
+        ]
+
+    let to_dyn loc =
+      Dyn.Record
+        [ ("loc_start", position_to_dyn loc.loc_start)
+        ; ("loc_end", position_to_dyn loc.loc_end)
+        ; ("loc_ghost", Dyn.Bool loc.loc_ghost)
+        ]
+  end)
 end
 
 module Longident = Ocaml_parsing.Longident

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -119,6 +119,7 @@ end
 module Longident = Ocaml_parsing.Longident
 module Parsetree = Ocaml_parsing.Parsetree
 module Path = Ocaml_typing.Path
+module Pprintast = Ocaml_parsing.Pprintast
 module Typedtree = Ocaml_typing.Typedtree
 module Types = Ocaml_typing.Types
 module Warnings = Ocaml_utils.Warnings

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -33,13 +33,12 @@ let initialize_info (client_capabilities : ClientCapabilities.t) :
       Action_inferred_intf.kind :: Action_destruct.kind
       :: List.map
            ~f:(fun (c : Code_action.t) -> c.kind)
-           [ (* Action_type_annotate.t *)
-             (* ; Action_construct.t *)
-             (* ; Action_refactor_open.unqualify *)
-             (* ; Action_refactor_open.qualify *)
-             (* ; Action_add_rec.t *)
-             (* ; *)
-             Action_inline.t
+           [ Action_type_annotate.t
+           ; Action_construct.t
+           ; Action_refactor_open.unqualify
+           ; Action_refactor_open.qualify
+           ; Action_add_rec.t
+           ; Action_inline.t
            ]
       |> List.sort_uniq ~compare:Poly.compare
     in

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -38,6 +38,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) :
            ; Action_refactor_open.unqualify
            ; Action_refactor_open.qualify
            ; Action_add_rec.t
+           ; Action_inline.t
            ]
       |> List.sort_uniq ~compare:Poly.compare
     in

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -33,12 +33,13 @@ let initialize_info (client_capabilities : ClientCapabilities.t) :
       Action_inferred_intf.kind :: Action_destruct.kind
       :: List.map
            ~f:(fun (c : Code_action.t) -> c.kind)
-           [ Action_type_annotate.t
-           ; Action_construct.t
-           ; Action_refactor_open.unqualify
-           ; Action_refactor_open.qualify
-           ; Action_add_rec.t
-           ; Action_inline.t
+           [ (* Action_type_annotate.t *)
+             (* ; Action_construct.t *)
+             (* ; Action_refactor_open.unqualify *)
+             (* ; Action_refactor_open.qualify *)
+             (* ; Action_add_rec.t *)
+             (* ; *)
+             Action_inline.t
            ]
       |> List.sort_uniq ~compare:Poly.compare
     in

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -1,20 +1,10 @@
 open Test.Import
 open Code_actions
 
-let find_mapi ~f l =
-  let rec k i = function
-    | [] -> None
-    | x :: xs -> (
-      match f i x with
-      | Some x' -> Some x'
-      | None -> k (i + 1) xs)
-  in
-  k 0 l
-
 let parse_cursor src =
   let cursor =
     String.split_lines src
-    |> find_mapi ~f:(fun lnum line ->
+    |> List.find_mapi ~f:(fun lnum line ->
            match String.index line '$' with
            | Some cnum -> Some (Position.create ~character:cnum ~line:lnum)
            | None -> None)
@@ -25,16 +15,9 @@ let parse_cursor src =
         | c -> Some c)
   , Range.create ~start:cursor ~end_:cursor )
 
-let rec take n l =
-  if n = 0 then []
-  else
-    match l with
-    | [] -> failwith "list shorter than n"
-    | x :: xs -> x :: take (n - 1) xs
-
 let offset_of_position src (pos : Position.t) =
   let line_offset =
-    String.split_lines src |> take pos.line
+    String.split_lines src |> List.take pos.line
     |> List.fold_left ~init:0 ~f:(fun s l -> s + String.length l)
   in
   line_offset + pos.line (* account for line endings *) + pos.character

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -133,7 +133,8 @@ let _ =
   let $x = 0 in
   (fun ~x -> x) ~x:(x + 1)
 |};
-  [%expect {|
+  [%expect
+    {|
     let _ =
       let x = 0 in
       (fun ~x -> x) ~x:((0) + 1) |}]
@@ -144,7 +145,8 @@ let _ =
   let $x = 0 in
   (fun ?(x = 1) -> x) ~x:(x + 1)
 |};
-  [%expect {|
+  [%expect
+    {|
     let _ =
       let x = 0 in
       (fun ?(x = 1) -> x) ~x:((0) + 1) |}]
@@ -311,18 +313,28 @@ let _ =
       let f 1 = 2 in
       (let 1 = 2 in 2) |}]
 
-(* TODO *)
 let%expect_test "" =
   inline_test {|
 let _ =
   let $f (x, y) = x + y in
   f (1, 2)
 |};
+  [%expect {|
+    let _ =
+      let f (x, y) = x + y in
+      (1 + 2) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f (x, y) = x + y + y in
+  f (1, 2 + 3)
+|};
   [%expect
     {|
     let _ =
-      let f (x, y) = x + y in
-      (let (x, y) = (1, 2) in x + y) |}]
+      let f (x, y) = x + y + y in
+      (let y = 2 + 3 in (1 + y) + y) |}]
 
 (* TODO *)
 let%expect_test "" =

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -125,11 +125,29 @@ let _ =
   let $x = Some 0 in
   (fun ?(x = 2) -> x) ?x
 |};
-  [%expect
-    {|
+  [%expect {| |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = 0 in
+  (fun ~x -> x) ~x:(x + 1)
+|};
+  [%expect {|
     let _ =
-      let x = 0 + 1 in
-      (fun ?(x = 2) -> x) ~x:(0 + 1) |}]
+      let x = 0 in
+      (fun ~x -> x) ~x:((0) + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = 0 in
+  (fun ?(x = 1) -> x) ~x:(x + 1)
+|};
+  [%expect {|
+    let _ =
+      let x = 0 in
+      (fun ?(x = 1) -> x) ~x:((0) + 1) |}]
 
 let%expect_test "" =
   inline_test {|

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -87,6 +87,53 @@ let _ =
 let%expect_test "" =
   inline_test {|
 let _ =
+  let $x = 0 + 1 in
+  (fun x -> x) x
+|};
+  [%expect {|
+    let _ =
+      let x = 0 + 1 in
+      (fun x -> x) (0 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = 0 + 1 in
+  (fun ~x -> x) ~x
+|};
+  [%expect
+    {|
+    let _ =
+      let x = 0 + 1 in
+      (fun ~x -> x) ~x:(0 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = 0 + 1 in
+  (fun ?(x = 2) -> x) ~x
+|};
+  [%expect
+    {|
+    let _ =
+      let x = 0 + 1 in
+      (fun ?(x = 2) -> x) ~x:(0 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = Some 0 in
+  (fun ?(x = 2) -> x) ?x
+|};
+  [%expect
+    {|
+    let _ =
+      let x = 0 + 1 in
+      (fun ?(x = 2) -> x) ~x:(0 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
   let $f x = x in
   f 1
 |};
@@ -181,12 +228,12 @@ let _ =
   let $f (x : int) = x + 1 in
   f 0
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f (x : int) = x + 1 in
       (0 + 1) |}]
 
+(* TODO *)
 let%expect_test "" =
   inline_test {|
 let _ =
@@ -205,8 +252,7 @@ let _ =
   let $f : int -> int = fun x -> x in
   f 0
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f : int -> int = fun x -> x in
       (0) |}]
@@ -242,12 +288,12 @@ let _ =
   let $f 1 = 2 in
   f 2
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f 1 = 2 in
       (let 1 = 2 in 2) |}]
 
+(* TODO *)
 let%expect_test "" =
   inline_test {|
 let _ =
@@ -260,6 +306,7 @@ let _ =
       let f (x, y) = x + y in
       (let (x, y) = (1, 2) in x + y) |}]
 
+(* TODO *)
 let%expect_test "" =
   inline_test
     {|
@@ -275,6 +322,7 @@ let _ =
       let f { x; y } = x + y in
       (let { x; y } = { x = 1; y = 1 } in x + y) |}]
 
+(* TODO *)
 let%expect_test "" =
   inline_test
     {|
@@ -296,8 +344,7 @@ let _ =
   let $f x = [%test] x in
   f 1
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f x = [%test] x in
       (([%test ]) 1) |}]
@@ -308,8 +355,7 @@ let _ =
   let $f x = x in
   [%test] (f 1)
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f x = x in
       [%test] (1) |}]
@@ -320,8 +366,7 @@ let _ =
   let $f x = (* test comment *) x in
   f 1
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f x = (* test comment *) x in
       (1) |}]
@@ -332,8 +377,34 @@ let _ =
   let $f x = x in
   (* test comment *) f 1
 |};
-  [%expect
-    {|
+  [%expect {|
     let _ =
       let f x = x in
       (* test comment *) (1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let $f x = x
+let g y = f y
+|};
+  [%expect {|
+    let f x = x
+    let g y = (y) |}]
+
+(* TODO *)
+let%expect_test "" =
+  inline_test
+    {|
+module M = struct
+  let $f x = x
+  let g y = f y
+end
+let h = M.f
+|};
+  [%expect
+    {|
+    module M = struct
+      let f x = x
+      let g y = (y)
+    end
+    let h = M.f |}]

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -315,7 +315,7 @@ let _ =
       let f (x : int) = x + 1 in
       (0 + 1) |}]
 
-(* TODO *)
+(* TODO: allow beta reduction with locally abstract types *)
 let%expect_test "" =
   inline_test {|
 let _ =
@@ -352,7 +352,7 @@ let _ =
       let f = function Some x -> x | None -> 0 in
       ((function | Some x -> x | None -> 0) (Some 1)) |}]
 
-(* TODO *)
+(* TODO: allow beta reduction with `as` *)
 let%expect_test "" =
   inline_test {|
 let _ =
@@ -430,7 +430,7 @@ let _ =
       let f { x; y } = x + y in
       (let { x; y } = { x = 1; y = 1 } in x + y) |}]
 
-(* TODO *)
+(* TODO: beta reduce record literals as with tuples *)
 let%expect_test "" =
   inline_test
     {|

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -104,7 +104,8 @@ let _ =
   let y = 0 in
   x y + 1
 |};
-  [%expect {|
+  [%expect
+    {|
     let _ =
       let y = 1 in
       let x y = y in
@@ -150,7 +151,8 @@ let _ =
   end in
   x
 |};
-  [%expect {|
+  [%expect
+    {|
     module M = struct
       let y = 1
     end

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -1,0 +1,339 @@
+open Test.Import
+open Code_actions
+
+let find_mapi ~f l =
+  let rec k i = function
+    | [] -> None
+    | x :: xs -> (
+      match f i x with
+      | Some x' -> Some x'
+      | None -> k (i + 1) xs)
+  in
+  k 0 l
+
+let parse_cursor src =
+  let cursor =
+    String.split_lines src
+    |> find_mapi ~f:(fun lnum line ->
+           match String.index line '$' with
+           | Some cnum -> Some (Position.create ~character:cnum ~line:lnum)
+           | None -> None)
+    |> Option.value_exn
+  in
+  ( String.filter_map src ~f:(function
+        | '$' -> None
+        | c -> Some c)
+  , Range.create ~start:cursor ~end_:cursor )
+
+let rec take n l =
+  if n = 0 then []
+  else
+    match l with
+    | [] -> failwith "list shorter than n"
+    | x :: xs -> x :: take (n - 1) xs
+
+let offset_of_position src (pos : Position.t) =
+  let line_offset =
+    String.split_lines src |> take pos.line
+    |> List.fold_left ~init:0 ~f:(fun s l -> s + String.length l)
+  in
+  line_offset + pos.line (* account for line endings *) + pos.character
+
+let apply_edit (edit : TextEdit.t) src =
+  let start_offset = offset_of_position src edit.range.start in
+  let end_offset = offset_of_position src edit.range.end_ in
+  let start = String.take src start_offset in
+  let end_ = String.drop src end_offset in
+  start ^ edit.newText ^ end_
+
+let apply_inline_action src range =
+  let open Option.O in
+  let code_actions = ref None in
+  iter_code_actions src range (fun ca -> code_actions := Some ca);
+  let* m_code_actions = !code_actions in
+  let* code_actions = m_code_actions in
+  let* { documentChanges; _ } =
+    List.find_map code_actions ~f:(function
+        | `CodeAction { kind = Some RefactorInline; edit = Some edit; _ } ->
+          Some edit
+        | _ -> None)
+  in
+  let+ documentChanges in
+  let edits =
+    List.filter_map documentChanges ~f:(function
+        | `TextDocumentEdit e -> Some e
+        | _ -> None)
+  in
+  match edits with
+  | [] -> src
+  | [ { edits = [ `TextEdit e ]; _ } ] -> apply_edit e src
+  | _ -> failwith "expected one edit"
+
+let inline_test src =
+  let src, range = parse_cursor src in
+  Option.iter (apply_inline_action src range) ~f:print_string
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $x = 0 in
+  x + 1
+|};
+  [%expect {|
+    let _ =
+      let x = 0 in
+      (0) + 1 |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = x in
+  f 1
+|};
+  [%expect {|
+    let _ =
+      let f x = x in
+      (1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f _ = 0 in
+  f 1
+|};
+  [%expect {|
+    let _ =
+      let f _ = 0 in
+      (0) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = x + x in
+  f 1
+|};
+  [%expect {|
+    let _ =
+      let f x = x + x in
+      (1 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = x + x in
+  f (g 1)
+|};
+  [%expect
+    {|
+    let _ =
+      let f x = x + x in
+      (let x = g 1 in x + x) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x y = x + y in
+  f 0
+|};
+  [%expect {|
+    let _ =
+      let f x y = x + y in
+      (fun y -> 0 + y) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x ~y = x + y in
+  f ~y:0
+|};
+  [%expect
+    {|
+    let _ =
+      let f x ~y = x + y in
+      ((fun x ~y -> x + y) ~y:0) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f ~x y = x + y in
+  f ~x:0
+|};
+  [%expect {|
+    let _ =
+      let f ~x y = x + y in
+      (fun y -> 0 + y) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f ~x ~y = x + y in
+  f ~y:0
+|};
+  [%expect
+    {|
+    let _ =
+      let f ~x ~y = x + y in
+      (fun ~x -> x + 0) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f (x : int) = x + 1 in
+  f 0
+|};
+  [%expect
+    {|
+    let _ =
+      let f (x : int) = x + 1 in
+      (0 + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f (type a) (x : a) = x in
+  f 0
+|};
+  [%expect
+    {|
+    let _ =
+      let f (type a) (x : a) = x in
+      ((fun (type a) -> fun (x : a) -> x) 0) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f : int -> int = fun x -> x in
+  f 0
+|};
+  [%expect
+    {|
+    let _ =
+      let f : int -> int = fun x -> x in
+      (0) |}]
+
+let%expect_test "" =
+  inline_test
+    {|
+let _ =
+  let $f = function Some x -> x | None -> 0 in
+  f (Some 1)
+|};
+  [%expect
+    {|
+    let _ =
+      let f = function Some x -> x | None -> 0 in
+      ((function | Some x -> x | None -> 0) (Some 1)) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f (x as y) = y + 1 in
+  f 1
+|};
+  [%expect
+    {|
+    let _ =
+      let f (x as y) = y + 1 in
+      (let x as y = 1 in y + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f 1 = 2 in
+  f 2
+|};
+  [%expect
+    {|
+    let _ =
+      let f 1 = 2 in
+      (let 1 = 2 in 2) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f (x, y) = x + y in
+  f (1, 2)
+|};
+  [%expect
+    {|
+    let _ =
+      let f (x, y) = x + y in
+      (let (x, y) = (1, 2) in x + y) |}]
+
+let%expect_test "" =
+  inline_test
+    {|
+type t = { x : int; y : int }
+let _ =
+  let $f { x; y } = x + y in
+  f { x = 1; y = 1 }
+|};
+  [%expect
+    {|
+    type t = { x : int; y : int }
+    let _ =
+      let f { x; y } = x + y in
+      (let { x; y } = { x = 1; y = 1 } in x + y) |}]
+
+let%expect_test "" =
+  inline_test
+    {|
+type t = { x : int; y : int }
+let _ =
+  let $f { x; _ } = x + 1 in
+  f { x = 1; y = 1 }
+|};
+  [%expect
+    {|
+    type t = { x : int; y : int }
+    let _ =
+      let f { x; _ } = x + 1 in
+      (let { x;_} = { x = 1; y = 1 } in x + 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = [%test] x in
+  f 1
+|};
+  [%expect
+    {|
+    let _ =
+      let f x = [%test] x in
+      (([%test ]) 1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = x in
+  [%test] (f 1)
+|};
+  [%expect
+    {|
+    let _ =
+      let f x = x in
+      [%test] (1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = (* test comment *) x in
+  f 1
+|};
+  [%expect
+    {|
+    let _ =
+      let f x = (* test comment *) x in
+      (1) |}]
+
+let%expect_test "" =
+  inline_test {|
+let _ =
+  let $f x = x in
+  (* test comment *) f 1
+|};
+  [%expect
+    {|
+    let _ =
+      let f x = x in
+      (* test comment *) (1) |}]

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -1,54 +1,47 @@
 open Test.Import
 
-let%expect_test "code actions" =
-  let source = {ocaml|
-let foo = 123
-|ocaml} in
+let iter_code_actions ?(path = "foo.ml") source range k =
   let handler =
     Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) ()
   in
-  ( Test.run ~handler @@ fun client ->
-    let run_client () =
-      let capabilities =
-        let window =
-          let showDocument =
-            ShowDocumentClientCapabilities.create ~support:true
-          in
-          WindowClientCapabilities.create ~showDocument ()
+  Test.run ~handler @@ fun client ->
+  let run_client () =
+    let capabilities =
+      let window =
+        let showDocument =
+          ShowDocumentClientCapabilities.create ~support:true
         in
-        ClientCapabilities.create ~window ()
+        WindowClientCapabilities.create ~showDocument ()
       in
-      Client.start client (InitializeParams.create ~capabilities ())
+      ClientCapabilities.create ~window ()
     in
-    let run =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let uri = DocumentUri.of_path "foo.ml" in
-      let* () =
-        let textDocument =
-          TextDocumentItem.create
-            ~uri
-            ~languageId:"ocaml"
-            ~version:0
-            ~text:source
-        in
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    Client.start client (InitializeParams.create ~capabilities ())
+  in
+  let run =
+    let* (_ : InitializeResult.t) = Client.initialized client in
+    let uri = DocumentUri.of_path path in
+    let* () =
+      let textDocument =
+        TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:source
       in
-      let+ resp =
-        let range =
-          let start = Position.create ~line:1 ~character:5 in
-          let end_ = Position.create ~line:1 ~character:7 in
-          Range.create ~start ~end_
-        in
-        let context = CodeActionContext.create ~diagnostics:[] () in
-        let request =
-          let textDocument = TextDocumentIdentifier.create ~uri in
-          CodeActionParams.create ~textDocument ~range ~context ()
-        in
-        Client.request client (CodeAction request)
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let+ resp =
+      let context = CodeActionContext.create ~diagnostics:[] () in
+      let request =
+        let textDocument = TextDocumentIdentifier.create ~uri in
+        CodeActionParams.create ~textDocument ~range ~context ()
       in
-      match resp with
+      Client.request client (CodeAction request)
+    in
+    k resp
+  in
+  Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client)
+
+let print_code_actions ?(path = "foo.ml") source range =
+  iter_code_actions ~path source range (function
       | None -> print_endline "no code actions"
       | Some code_actions ->
         print_endline "Code actions:";
@@ -58,10 +51,18 @@ let foo = 123
               | `Command command -> Command.yojson_of_t command
               | `CodeAction ca -> CodeAction.yojson_of_t ca
             in
-            Yojson.Safe.pretty_to_string ~std:false json |> print_endline)
-    in
-    Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client)
-  );
+            Yojson.Safe.pretty_to_string ~std:false json |> print_endline))
+
+let%expect_test "code actions" =
+  let source = {ocaml|
+let foo = 123
+|ocaml} in
+  let range =
+    let start = Position.create ~line:1 ~character:5 in
+    let end_ = Position.create ~line:1 ~character:7 in
+    Range.create ~start ~end_
+  in
+  print_code_actions source range;
   [%expect
     {|
     Code actions:

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -35,8 +35,8 @@ let%expect_test "start/stop" =
         "capabilities": {
           "codeActionProvider": {
             "codeActionKinds": [
-              "quickfix", "construct", "destruct", "inferred_intf",
-              "put module name in identifiers",
+              "quickfix", "refactor.inline", "construct", "destruct",
+              "inferred_intf", "put module name in identifiers",
               "remove module name from identifiers", "type-annotate"
             ]
           },

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -1,5 +1,32 @@
 module Import = struct
-  include Stdune
+  include struct
+    include Stdune
+
+    module List = struct
+      include List
+
+      let find_mapi ~f l =
+        let rec k i = function
+          | [] -> None
+          | x :: xs -> (
+            match f i x with
+            | Some x' -> Some x'
+            | None -> (k [@tailcall]) (i + 1) xs)
+        in
+        k 0 l
+
+      let take n l =
+        let rec take acc n l =
+          if n = 0 then acc
+          else
+            match l with
+            | [] -> failwith "list shorter than n"
+            | x :: xs -> (take [@tailcall]) (x :: acc) (n - 1) xs
+        in
+        List.rev (take [] n l)
+    end
+  end
+
   include Fiber.O
   module Client = Lsp_fiber.Client
   include Lsp.Types


### PR DESCRIPTION
This PR adds an inlining code action for non-top-level let bindings. For example,
```ocaml
let test y =
  let x = y + 1 in
      ^
  x + 2
```
turns into 
```ocaml
let test y =
  let x = y + 1 in
  (y + 1) + 2
```
after inlining.

Caveats:
- The inlining context can shadow bindings in the body, which changes the meaning of the inlined code. I.e., this transformation isn't sound. We should at least be able to use Merlin to detect this and block the action, but I'm not sure how.
- Right now I'm using `Untypeast` followed by `Pprintast` to turn the body of the let into a string. This means that comments are stripped and the inlined code contains expanded PPXes. This should be fixable by using the source code the body, but it requires a bit more care when inlining functions.
- The original definition is not removed. It should be unused after inlining, so it'll be a target for the "remove unused" action.