### PR TITLE
fix: refresh merlin configs after dune build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Tag "unused code" and "deprecated" warnings, allowing clients to better
   display them. (#848)
 
+- Refresh merlin configuration after every dune build in watch mode (#853)
+
 ## Fixes
 
 - Respect `showDocument` capabilities. Do not offer commands or code actions

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -190,6 +190,20 @@ let get_semantic_tokens_cache : t -> Uri.t -> semantic_tokens_cache option =
   let doc = get' t uri in
   doc.semantic_tokens_cache
 
+let change_all t ~f =
+  let all =
+    Table.foldi ~init:[] t.db ~f:(fun uri doc acc -> (uri, doc) :: acc)
+  in
+  Fiber.parallel_iter all ~f:(fun (uri, doc) ->
+      let+ doc =
+        match doc.document with
+        | None -> Fiber.return doc
+        | Some document ->
+          let+ document = f document in
+          { doc with document = Some document }
+      in
+      Table.set t.db uri doc)
+
 let close_all t =
   Fiber.of_thunk (fun () ->
       let docs = Table.fold t.db ~init:[] ~f:(fun doc acc -> doc :: acc) in

--- a/ocaml-lsp-server/src/document_store.mli
+++ b/ocaml-lsp-server/src/document_store.mli
@@ -28,4 +28,6 @@ val get_semantic_tokens_cache : t -> Uri.t -> semantic_tokens_cache option
 
 val close_document : t -> Uri.t -> unit Fiber.t
 
+val change_all : t -> f:(Document.t -> Document.t Fiber.t) -> unit Fiber.t
+
 val close_all : t -> unit Fiber.t


### PR DESCRIPTION
When dune finishes a build, merlin configuration might not be correct and it's useful to reload it and give users fresh diagnostics. Of course, this requires us throwing away some diagnostic work that isn't necessarily stale, but it's better to be slow than give false positives to the user.