### PR TITLE
chore(nix): remove ocaml version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         localPackages = {
           jsonrpc = "*";
           lsp = "*";
-          ocaml-base-compiler = "4.14.0";
+          ocaml-lsp-server = "*";
         };
         devPackages = {
           menhir = "*";


### PR DESCRIPTION
let nix select it as the constraint in the opam file should determine it correctly.

ps-id: 28865dc9-fc77-4624-9109-f3503fdf8a1e