### PR TITLE
Update JSON syntax in toMatchInlineSnapshot

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/completionItem-resolve.test.ts
@@ -55,7 +55,7 @@ describe("textDocument/completion", () => {
     );
 
     expect(response).toMatchInlineSnapshot(`
-      Object {
+      {
         "documentation": "[map2 f [a1; ...; an] [b1; ...; bn]] is
          [[f a1 b1; ...; f an bn]].
          @raise Invalid_argument if the two lists are determined
@@ -76,7 +76,7 @@ describe("textDocument/completion", () => {
     );
 
     expect(response).toMatchInlineSnapshot(`
-      Object {
+      {
         "documentation": "[find_all] is another name for {!filter}.",
         "label": "find_all",
       }
@@ -103,7 +103,7 @@ describe("textDocument/completion", () => {
     );
 
     expect(response).toMatchInlineSnapshot(`
-      Object {
+      {
         "documentation": "documentation for [Inner]",
         "label": "Inner",
       }

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-typedHoles.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-typedHoles.ts
@@ -42,7 +42,7 @@ let u = 1
     );
 
     let r = await sendTypedHolesReq();
-    expect(r).toMatchInlineSnapshot(`Array []`);
+    expect(r).toMatchInlineSnapshot(`[]`);
   });
 
   it("one hole", async () => {
@@ -54,13 +54,13 @@ let k = match () with () -> _
 
     let r = await sendTypedHolesReq();
     expect(r).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "end": Object {
+      [
+        {
+          "end": {
             "character": 29,
             "line": 0,
           },
-          "start": Object {
+          "start": {
             "character": 28,
             "line": 0,
           },
@@ -80,33 +80,33 @@ let u =
     );
     let r = await sendTypedHolesReq();
     expect(r).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "end": Object {
+      [
+        {
+          "end": {
             "character": 31,
             "line": 2,
           },
-          "start": Object {
+          "start": {
             "character": 30,
             "line": 2,
           },
         },
-        Object {
-          "end": Object {
+        {
+          "end": {
             "character": 37,
             "line": 1,
           },
-          "start": Object {
+          "start": {
             "character": 36,
             "line": 1,
           },
         },
-        Object {
-          "end": Object {
+        {
+          "end": {
             "character": 49,
             "line": 1,
           },
-          "start": Object {
+          "start": {
             "character": 48,
             "line": 1,
           },

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-wrappingAstNode.test.ts
@@ -73,12 +73,12 @@ end
         let k = 1
     */
     expect(r).toMatchInlineSnapshot(`
-      Object {
-        "end": Object {
+      {
+        "end": {
           "character": 9,
           "line": 0,
         },
-        "start": Object {
+        "start": {
           "character": 0,
           "line": 0,
         },
@@ -95,12 +95,12 @@ end
         whole `code_snippet_0`
     */
     expect(r).toMatchInlineSnapshot(`
-      Object {
-        "end": Object {
+      {
+        "end": {
           "character": 3,
           "line": 8,
         },
-        "start": Object {
+        "start": {
           "character": 0,
           "line": 0,
         },
@@ -123,12 +123,12 @@ end
         end
     */
     expect(r).toMatchInlineSnapshot(`
-      Object {
-        "end": Object {
+      {
+        "end": {
           "character": 3,
           "line": 8,
         },
-        "start": Object {
+        "start": {
           "character": 0,
           "line": 2,
         },
@@ -146,12 +146,12 @@ end
           b + 1
     */
     expect(r).toMatchInlineSnapshot(`
-      Object {
-        "end": Object {
+      {
+        "end": {
           "character": 9,
           "line": 5,
         },
-        "start": Object {
+        "start": {
           "character": 2,
           "line": 3,
         },
@@ -172,12 +172,12 @@ end
         let c = 2
     */
     expect(r).toMatchInlineSnapshot(`
-      Object {
-        "end": Object {
+      {
+        "end": {
           "character": 11,
           "line": 7,
         },
-        "start": Object {
+        "start": {
           "character": 2,
           "line": 3,
         },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeAction.test.ts
@@ -107,17 +107,17 @@ let f (x : t) = x
     let end = Types.Position.create(2, 17);
     let actions = await codeAction("file:///test.ml", start, end);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "command": Object {
-            "arguments": Array [
-              Object {
-                "inRange": Object {
-                  "end": Object {
+      [
+        {
+          "command": {
+            "arguments": [
+              {
+                "inRange": {
+                  "end": {
                     "character": 54,
                     "line": 2,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 16,
                     "line": 2,
                   },
@@ -128,25 +128,25 @@ let f (x : t) = x
             "command": "ocaml.next-hole",
             "title": "Jump to Next Hole",
           },
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
-                "edits": Array [
-                  Object {
+          "edit": {
+            "documentChanges": [
+              {
+                "edits": [
+                  {
                     "newText": "match x with | Foo _ -> _ | Bar _ -> _",
-                    "range": Object {
-                      "end": Object {
+                    "range": {
+                      "end": {
                         "character": 17,
                         "line": 2,
                       },
-                      "start": Object {
+                      "start": {
                         "character": 16,
                         "line": 2,
                       },
                     },
                   },
                 ],
-                "textDocument": Object {
+                "textDocument": {
                   "uri": "file:///test.ml",
                   "version": 0,
                 },
@@ -157,26 +157,26 @@ let f (x : t) = x
           "kind": "destruct",
           "title": "Destruct",
         },
-        Object {
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
-                "edits": Array [
-                  Object {
+        {
+          "edit": {
+            "documentChanges": [
+              {
+                "edits": [
+                  {
                     "newText": "(x : t)",
-                    "range": Object {
-                      "end": Object {
+                    "range": {
+                      "end": {
                         "character": 17,
                         "line": 2,
                       },
-                      "start": Object {
+                      "start": {
                         "character": 16,
                         "line": 2,
                       },
                     },
                   },
                 ],
-                "textDocument": Object {
+                "textDocument": {
                   "uri": "file:///test.ml",
                   "version": 0,
                 },
@@ -187,17 +187,17 @@ let f (x : t) = x
           "kind": "type-annotate",
           "title": "Type-annotate",
         },
-        Object {
-          "command": Object {
-            "arguments": Array [
+        {
+          "command": {
+            "arguments": [
               "file:///test.mli",
             ],
             "command": "ocamllsp/open-related-source",
             "title": "Create test.mli",
           },
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
+          "edit": {
+            "documentChanges": [
+              {
                 "kind": "create",
                 "uri": "file:///test.mli",
               },
@@ -224,28 +224,28 @@ let f (x : t) = x
     let end = Types.Position.create(0, 0);
     let actions = (await codeAction("file:///test.mli", start, end)) ?? [];
     expect(findInferredAction(actions)).toMatchInlineSnapshot(`
-      Object {
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+      {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "type t = Foo of int | Bar of bool
       val f : t -> t
       ",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 0,
                       "line": 0,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 0,
                       "line": 0,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///test.mli",
                 "version": 0,
               },
@@ -272,17 +272,17 @@ let f (x : t) = x
         Types.TextDocumentEdit.is(a) ? a.edits : null,
       ),
     ).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
+      [
+        [
+          {
             "newText": "val x : int
       ",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 0,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 0,
                 "line": 0,
               },
@@ -306,26 +306,26 @@ let f x = Foo x
     let end = Types.Position.create(2, 7);
     let actions = (await codeAction("file:///test.ml", start, end)) ?? [];
     expect(findAnnotateAction(actions)).toMatchInlineSnapshot(`
-      Object {
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+      {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "(x : int)",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 7,
                       "line": 2,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 6,
                       "line": 2,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///test.ml",
                 "version": 0,
               },
@@ -350,26 +350,26 @@ let iiii = 3 + 4
     let end = Types.Position.create(0, 5);
     let actions = (await codeAction("file:///test.ml", start, end)) ?? [];
     expect(findAnnotateAction(actions)).toMatchInlineSnapshot(`
-      Object {
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+      {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "(iiii : int)",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 8,
                       "line": 0,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 4,
                       "line": 0,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///test.ml",
                 "version": 0,
               },
@@ -397,26 +397,26 @@ let () =
     let end = Types.Position.create(3, 16);
     let actions = (await codeAction("file:///test.ml", start, end)) ?? [];
     expect(findAnnotateAction(actions)).toMatchInlineSnapshot(`
-      Object {
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+      {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "(i : int)",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 16,
                       "line": 3,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 15,
                       "line": 3,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///test.ml",
                 "version": 0,
               },
@@ -443,26 +443,26 @@ let f (x : t) = x
     let end = Types.Position.create(2, 17);
     let actions = (await codeAction("file:///test.ml", start, end)) ?? [];
     expect(findAnnotateAction(actions)).toMatchInlineSnapshot(`
-      Object {
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+      {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "(x : t)",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 17,
                       "line": 2,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 16,
                       "line": 2,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///test.ml",
                 "version": 0,
               },
@@ -489,18 +489,18 @@ type x =
     let end = Types.Position.create(2, 6);
     let actions = await codeAction("file:///test.ml", start, end);
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "command": Object {
-            "arguments": Array [
+      [
+        {
+          "command": {
+            "arguments": [
               "file:///test.mli",
             ],
             "command": "ocamllsp/open-related-source",
             "title": "Create test.mli",
           },
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
+          "edit": {
+            "documentChanges": [
+              {
                 "kind": "create",
                 "uri": "file:///test.mli",
               },
@@ -527,27 +527,27 @@ let x = _
       [];
 
     expect(actions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
-                "edits": Array [
-                  Object {
+      [
+        {
+          "edit": {
+            "documentChanges": [
+              {
+                "edits": [
+                  {
                     "newText": "(_ : 'a)",
-                    "range": Object {
-                      "end": Object {
+                    "range": {
+                      "end": {
                         "character": 9,
                         "line": 0,
                       },
-                      "start": Object {
+                      "start": {
                         "character": 8,
                         "line": 0,
                       },
                     },
                   },
                 ],
-                "textDocument": Object {
+                "textDocument": {
                   "uri": "file:///test.ml",
                   "version": 0,
                 },
@@ -558,25 +558,25 @@ let x = _
           "kind": "type-annotate",
           "title": "Type-annotate",
         },
-        Object {
-          "command": Object {
+        {
+          "command": {
             "command": "editor.action.triggerSuggest",
             "title": "Trigger Suggest",
           },
           "kind": "construct",
           "title": "Construct an expression",
         },
-        Object {
-          "command": Object {
-            "arguments": Array [
+        {
+          "command": {
+            "arguments": [
               "file:///test.mli",
             ],
             "command": "ocamllsp/open-related-source",
             "title": "Create test.mli",
           },
-          "edit": Object {
-            "documentChanges": Array [
-              Object {
+          "edit": {
+            "documentChanges": [
+              {
                 "kind": "create",
                 "uri": "file:///test.mli",
               },
@@ -594,8 +594,8 @@ let x = _
     );
 
     expect(construct_actions).toMatchInlineSnapshot(`
-      Object {
-        "command": Object {
+      {
+        "command": {
           "command": "editor.action.triggerSuggest",
           "title": "Trigger Suggest",
         },
@@ -656,32 +656,32 @@ let x = _
     });
 
     expect(specificCodeActions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "edit": Object {
-            "changes": Object {
-              "file:///test.ml": Array [
-                Object {
+      [
+        {
+          "edit": {
+            "changes": {
+              "file:///test.ml": [
+                {
                   "newText": "f",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 11,
                       "line": 7,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 8,
                       "line": 7,
                     },
                   },
                 },
-                Object {
+                {
                   "newText": "a",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 15,
                       "line": 7,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 12,
                       "line": 7,
                     },
@@ -716,32 +716,32 @@ let x = _
     });
 
     expect(specificCodeActions).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "edit": Object {
-            "changes": Object {
-              "file:///test.ml": Array [
-                Object {
+      [
+        {
+          "edit": {
+            "changes": {
+              "file:///test.ml": [
+                {
                   "newText": "M.f",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 9,
                       "line": 7,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 8,
                       "line": 7,
                     },
                   },
                 },
-                Object {
+                {
                   "newText": "M.a",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 11,
                       "line": 7,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 10,
                       "line": 7,
                     },
@@ -779,16 +779,16 @@ let needs_rec x = 1 + (needs_rec x)
 
     let actions = (await codeAction(uri, start, end, context)) ?? [];
     expect(findAddRecAnnotation(actions)).toMatchInlineSnapshot(`
-      Object {
-        "diagnostics": Array [
-          Object {
+      {
+        "diagnostics": [
+          {
             "message": "Unbound value",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 32,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
@@ -797,25 +797,25 @@ let needs_rec x = 1 + (needs_rec x)
             "source": "ocamllsp",
           },
         ],
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "rec ",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 4,
                       "line": 0,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 4,
                       "line": 0,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///missing-rec-1.ml",
                 "version": 0,
               },
@@ -852,16 +852,16 @@ let outer =
 
     let actions = (await codeAction(uri, start, end, context)) ?? [];
     expect(findAddRecAnnotation(actions)).toMatchInlineSnapshot(`
-      Object {
-        "diagnostics": Array [
-          Object {
+      {
+        "diagnostics": [
+          {
             "message": "Unbound value",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 14,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 9,
                 "line": 2,
               },
@@ -870,25 +870,25 @@ let outer =
             "source": "ocamllsp",
           },
         ],
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "rec ",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 6,
                       "line": 1,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 6,
                       "line": 1,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///missing-rec-2.ml",
                 "version": 0,
               },
@@ -926,16 +926,16 @@ let outer =
 
     let actions = (await codeAction(uri, start, end, context)) ?? [];
     expect(findAddRecAnnotation(actions)).toMatchInlineSnapshot(`
-      Object {
-        "diagnostics": Array [
-          Object {
+      {
+        "diagnostics": [
+          {
             "message": "Unbound value",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 14,
                 "line": 3,
               },
-              "start": Object {
+              "start": {
                 "character": 9,
                 "line": 3,
               },
@@ -944,25 +944,25 @@ let outer =
             "source": "ocamllsp",
           },
         ],
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "rec ",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 6,
                       "line": 1,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 6,
                       "line": 1,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///missing-rec-3.ml",
                 "version": 0,
               },
@@ -1042,16 +1042,16 @@ let f x =
 
     let actions = (await codeAction(uri, start, end, context)) ?? [];
     expect(findMarkUnused(actions)).toMatchInlineSnapshot(`
-      Object {
-        "diagnostics": Array [
-          Object {
+      {
+        "diagnostics": [
+          {
             "message": "Error (warning 26): unused variable",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 7,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 6,
                 "line": 1,
               },
@@ -1060,25 +1060,25 @@ let f x =
             "source": "ocamllsp",
           },
         ],
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "_",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 6,
                       "line": 1,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 6,
                       "line": 1,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///mark-unused-variable.ml",
                 "version": 0,
               },
@@ -1118,16 +1118,16 @@ let f x =
 
     let actions = (await codeAction(uri, start, end, context)) ?? [];
     expect(findRemoveUnused(actions)).toMatchInlineSnapshot(`
-      Object {
-        "diagnostics": Array [
-          Object {
+      {
+        "diagnostics": [
+          {
             "message": "Error (warning 26): unused variable",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 7,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 6,
                 "line": 1,
               },
@@ -1136,25 +1136,25 @@ let f x =
             "source": "ocamllsp",
           },
         ],
-        "edit": Object {
-          "documentChanges": Array [
-            Object {
-              "edits": Array [
-                Object {
+        "edit": {
+          "documentChanges": [
+            {
+              "edits": [
+                {
                   "newText": "",
-                  "range": Object {
-                    "end": Object {
+                  "range": {
+                    "end": {
                       "character": 2,
                       "line": 5,
                     },
-                    "start": Object {
+                    "start": {
                       "character": 2,
                       "line": 1,
                     },
                   },
                 },
               ],
-              "textDocument": Object {
+              "textDocument": {
                 "uri": "file:///remove-unused-variable.ml",
                 "version": 0,
               },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-completion.test.ts
@@ -99,17 +99,17 @@ g ~f:ig
 
     let items = await queryCompletion(Types.Position.create(1, 7));
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "ignore",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "ignore",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 7,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 5,
                 "line": 1,
               },
@@ -129,17 +129,17 @@ g ~f:M.ig
 
     let items = await queryCompletion(Types.Position.create(2, 9));
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "igfoo",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "igfoo",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 9,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 7,
                 "line": 2,
               },
@@ -158,17 +158,17 @@ g ?f:ig
 
     let items = await queryCompletion(Types.Position.create(1, 7));
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "ignore",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "ignore",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 7,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 5,
                 "line": 1,
               },
@@ -188,17 +188,17 @@ g ?f:M.ig
 
     let items = await queryCompletion(Types.Position.create(2, 9));
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "igfoo",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "igfoo",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 9,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 7,
                 "line": 2,
               },
@@ -238,33 +238,33 @@ g ?f:M.ig
     let items = await queryCompletion(Types.Position.create(5, 13));
 
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "somenum",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "somenum",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 13,
                 "line": 5,
               },
-              "start": Object {
+              "start": {
                 "character": 13,
                 "line": 5,
               },
             },
           },
         },
-        Object {
+        {
           "label": "somestring",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "somestring",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 13,
                 "line": 5,
               },
-              "start": Object {
+              "start": {
                 "character": 13,
                 "line": 5,
               },
@@ -283,49 +283,49 @@ g ?f:M.ig
 
     let items = await queryCompletion(Types.Position.create(1, 11));
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": ">>|",
-          "textEdit": Object {
+          "textEdit": {
             "newText": ">>|",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 11,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 10,
                 "line": 1,
               },
             },
           },
         },
-        Object {
+        {
           "label": ">",
-          "textEdit": Object {
+          "textEdit": {
             "newText": ">",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 11,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 10,
                 "line": 1,
               },
             },
           },
         },
-        Object {
+        {
           "label": ">=",
-          "textEdit": Object {
+          "textEdit": {
             "newText": ">=",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 11,
                 "line": 1,
               },
-              "start": Object {
+              "start": {
                 "character": 10,
                 "line": 1,
               },
@@ -381,81 +381,81 @@ g ?f:M.ig
     let items = (await queryCompletion(Types.Position.create(4, 12))) ?? [];
     let items_top5 = items.slice(0, 5);
     expect(items_top5).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "somenum",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "somenum",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 12,
                 "line": 4,
               },
-              "start": Object {
+              "start": {
                 "character": 12,
                 "line": 4,
               },
             },
           },
         },
-        Object {
+        {
           "label": "x",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "x",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 12,
                 "line": 4,
               },
-              "start": Object {
+              "start": {
                 "character": 12,
                 "line": 4,
               },
             },
           },
         },
-        Object {
+        {
           "label": "y",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "y",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 12,
                 "line": 4,
               },
-              "start": Object {
+              "start": {
                 "character": 12,
                 "line": 4,
               },
             },
           },
         },
-        Object {
+        {
           "label": "max_int",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "max_int",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 12,
                 "line": 4,
               },
-              "start": Object {
+              "start": {
                 "character": 12,
                 "line": 4,
               },
             },
           },
         },
-        Object {
+        {
           "label": "min_int",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "min_int",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 12,
                 "line": 4,
               },
-              "start": Object {
+              "start": {
                 "character": 12,
                 "line": 4,
               },
@@ -472,81 +472,81 @@ g ?f:M.ig
     let items = (await queryCompletion(Types.Position.create(0, 24))) ?? [];
     let items_top5 = items.slice(0, 10);
     expect(items_top5).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "~+",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "~+",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 24,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
             },
           },
         },
-        Object {
+        {
           "label": "~+.",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "~+.",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 24,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
             },
           },
         },
-        Object {
+        {
           "label": "~-",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "~-",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 24,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
             },
           },
         },
-        Object {
+        {
           "label": "~-.",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "~-.",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 24,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
             },
           },
         },
-        Object {
+        {
           "label": "~f",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "~f",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 24,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 23,
                 "line": 0,
               },
@@ -583,17 +583,17 @@ let u = f \`Str
     let items = await queryCompletion(Position.create(2, 15));
 
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "\`String",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "\`String",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 15,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 11,
                 "line": 2,
               },
@@ -614,17 +614,17 @@ let u = f \`In
     let items = await queryCompletion(Position.create(2, 14));
 
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "\`Int",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "\`Int",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 14,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 11,
                 "line": 2,
               },
@@ -645,17 +645,17 @@ let x : t = \`I
     let items = await queryCompletion(Position.create(2, 15));
 
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "\`Int",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "\`Int",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 15,
                 "line": 2,
               },
-              "start": Object {
+              "start": {
                 "character": 13,
                 "line": 2,
               },
@@ -678,17 +678,17 @@ let u : int = _
     );
 
     expect(items).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "label": "0",
-          "textEdit": Object {
+          "textEdit": {
             "newText": "0",
-            "range": Object {
-              "end": Object {
+            "range": {
+              "end": {
                 "character": 15,
                 "line": 0,
               },
-              "start": Object {
+              "start": {
                 "character": 14,
                 "line": 0,
               },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-diagnostics.ts
@@ -36,29 +36,29 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "message": "This comment contains an unterminated string literal",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 2,
                     "line": 0,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 0,
                     "line": 0,
                   },
                 },
-                "relatedInformation": Array [
-                  Object {
-                    "location": Object {
-                      "range": Object {
-                        "end": Object {
+                "relatedInformation": [
+                  {
+                    "location": {
+                      "range": {
+                        "end": {
                           "character": 4,
                           "line": 0,
                         },
-                        "start": Object {
+                        "start": {
                           "character": 3,
                           "line": 0,
                         },
@@ -91,16 +91,16 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "message": "Warning 26: unused variable x.",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 7,
                     "line": 1,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 6,
                     "line": 1,
                   },
@@ -130,17 +130,17 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "message": "Alert deprecated: X.x
           do not use",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 19,
                     "line": 6,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 16,
                     "line": 6,
                   },
@@ -174,9 +174,9 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "message": "Signature mismatch:
           Modules do not match:
             sig val x : int end
@@ -184,25 +184,25 @@ describe("textDocument/diagnostics", () => {
             sig val x : unit end
           Values do not match: val x : int is not included in val x : unit
           The type int is not compatible with the type unit",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 3,
                     "line": 4,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 6,
                     "line": 2,
                   },
                 },
-                "relatedInformation": Array [
-                  Object {
-                    "location": Object {
-                      "range": Object {
-                        "end": Object {
+                "relatedInformation": [
+                  {
+                    "location": {
+                      "range": {
+                        "end": {
                           "character": 14,
                           "line": 2,
                         },
-                        "start": Object {
+                        "start": {
                           "character": 2,
                           "line": 2,
                         },
@@ -211,14 +211,14 @@ describe("textDocument/diagnostics", () => {
                     },
                     "message": "Expected declaration",
                   },
-                  Object {
-                    "location": Object {
-                      "range": Object {
-                        "end": Object {
+                  {
+                    "location": {
+                      "range": {
+                        "end": {
                           "character": 7,
                           "line": 4,
                         },
-                        "start": Object {
+                        "start": {
                           "character": 6,
                           "line": 4,
                         },
@@ -255,8 +255,8 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [],
+          {
+            "diagnostics": [],
             "uri": "file:///test.ml",
           }
         `);
@@ -278,17 +278,17 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type int",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 15,
                     "line": 0,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 14,
                     "line": 0,
                   },
@@ -318,17 +318,17 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type int",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 16,
                     "line": 0,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 15,
                     "line": 0,
                   },
@@ -336,14 +336,14 @@ describe("textDocument/diagnostics", () => {
                 "severity": 1,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "message": "Warning 26: unused variable b.",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 5,
                     "line": 1,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 4,
                     "line": 1,
                   },
@@ -351,15 +351,15 @@ describe("textDocument/diagnostics", () => {
                 "severity": 2,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type string",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 44,
                     "line": 1,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 43,
                     "line": 1,
                   },
@@ -367,15 +367,15 @@ describe("textDocument/diagnostics", () => {
                 "severity": 1,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type string",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 58,
                     "line": 1,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 57,
                     "line": 1,
                   },
@@ -407,16 +407,16 @@ describe("textDocument/diagnostics", () => {
           `"textDocument/publishDiagnostics"`,
         );
         expect(params).toMatchInlineSnapshot(`
-          Object {
-            "diagnostics": Array [
-              Object {
+          {
+            "diagnostics": [
+              {
                 "message": "This expression has type unit but an expression was expected of type int",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 42,
                     "line": 1,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 40,
                     "line": 1,
                   },
@@ -424,15 +424,15 @@ describe("textDocument/diagnostics", () => {
                 "severity": 1,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type 'a",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 12,
                     "line": 3,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 11,
                     "line": 3,
                   },
@@ -440,15 +440,15 @@ describe("textDocument/diagnostics", () => {
                 "severity": 1,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "code": "hole",
                 "message": "This typed hole should be replaced with an expression of type 'a",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 12,
                     "line": 4,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 11,
                     "line": 4,
                   },
@@ -456,14 +456,14 @@ describe("textDocument/diagnostics", () => {
                 "severity": 1,
                 "source": "ocamllsp",
               },
-              Object {
+              {
                 "message": "This expression has type string but an expression was expected of type int",
-                "range": Object {
-                  "end": Object {
+                "range": {
+                  "end": {
                     "character": 9,
                     "line": 5,
                   },
-                  "start": Object {
+                  "start": {
                     "character": 6,
                     "line": 5,
                   },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -47,15 +47,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 4,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 9,
           "endLine": 4,
           "kind": "region",
@@ -76,22 +76,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 3,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 3,
           "kind": "region",
           "startCharacter": 5,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 6,
           "endLine": 2,
           "kind": "region",
@@ -110,8 +110,8 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 6,
           "endLine": 2,
           "kind": "region",
@@ -135,22 +135,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 29,
           "endLine": 7,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 7,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 7,
           "kind": "region",
@@ -171,15 +171,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 7,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 3,
           "kind": "region",
@@ -205,29 +205,29 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 2,
           "kind": "region",
           "startCharacter": 5,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 4,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 19,
           "startLine": 4,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 7,
           "kind": "region",
@@ -253,22 +253,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 21,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 4,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 4,
         },
-        Object {
+        {
           "endCharacter": 21,
           "endLine": 8,
           "kind": "region",
@@ -295,29 +295,29 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 1,
           "endLine": 3,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 15,
           "endLine": 9,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 5,
         },
-        Object {
+        {
           "endCharacter": 11,
           "endLine": 7,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 6,
         },
-        Object {
+        {
           "endCharacter": 15,
           "endLine": 9,
           "kind": "region",
@@ -356,50 +356,50 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 21,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 21,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 6,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 21,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 7,
         },
-        Object {
+        {
           "endCharacter": 15,
           "endLine": 20,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 8,
         },
-        Object {
+        {
           "endCharacter": 13,
           "endLine": 18,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 9,
         },
-        Object {
+        {
           "endCharacter": 12,
           "endLine": 16,
           "kind": "region",
@@ -419,8 +419,8 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 4,
           "endLine": 3,
           "kind": "region",
@@ -441,8 +441,8 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 4,
           "endLine": 3,
           "kind": "region",
@@ -464,15 +464,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 3,
           "kind": "region",
@@ -496,22 +496,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 18,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 5,
           "kind": "region",
@@ -537,22 +537,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 4,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 25,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 7,
           "kind": "region",
@@ -576,22 +576,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 14,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 20,
           "endLine": 5,
           "kind": "region",
@@ -615,8 +615,8 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 6,
           "kind": "region",
@@ -641,15 +641,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 8,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 33,
           "endLine": 4,
           "kind": "region",
@@ -674,15 +674,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 4,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 4,
           "kind": "region",
@@ -704,15 +704,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 9,
           "endLine": 3,
           "kind": "region",
@@ -749,36 +749,36 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 6,
           "endLine": 20,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 2,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 6,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 14,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 12,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 18,
           "kind": "region",
@@ -801,15 +801,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 8,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 9,
           "endLine": 3,
           "kind": "region",
@@ -840,36 +840,36 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 8,
           "endLine": 13,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 8,
           "endLine": 13,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 2,
         },
-        Object {
+        {
           "endCharacter": 8,
           "endLine": 13,
           "kind": "region",
           "startCharacter": 13,
           "startLine": 8,
         },
-        Object {
+        {
           "endCharacter": 29,
           "endLine": 11,
           "kind": "region",
@@ -894,15 +894,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 7,
           "endLine": 7,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 5,
           "kind": "region",
@@ -976,148 +976,148 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 16,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 56,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 7,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 56,
           "kind": "region",
           "startCharacter": 11,
           "startLine": 7,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 18,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 8,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 18,
           "kind": "region",
           "startCharacter": 18,
           "startLine": 8,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 14,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 9,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 14,
           "kind": "region",
           "startCharacter": 16,
           "startLine": 9,
         },
-        Object {
+        {
           "endCharacter": 11,
           "endLine": 13,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 10,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 31,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 20,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 31,
           "kind": "region",
           "startCharacter": 13,
           "startLine": 20,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 30,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 21,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 30,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 22,
         },
-        Object {
+        {
           "endCharacter": 31,
           "endLine": 26,
           "kind": "region",
           "startCharacter": 12,
           "startLine": 23,
         },
-        Object {
+        {
           "endCharacter": 30,
           "endLine": 30,
           "kind": "region",
           "startCharacter": 14,
           "startLine": 27,
         },
-        Object {
+        {
           "endCharacter": 9,
           "endLine": 55,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 33,
         },
-        Object {
+        {
           "endCharacter": 11,
           "endLine": 53,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 34,
         },
-        Object {
+        {
           "endCharacter": 10,
           "endLine": 42,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 38,
         },
-        Object {
+        {
           "endCharacter": 25,
           "endLine": 47,
           "kind": "region",
           "startCharacter": 6,
           "startLine": 45,
         },
-        Object {
+        {
           "endCharacter": 11,
           "endLine": 53,
           "kind": "region",
@@ -1140,22 +1140,22 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 40,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 40,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 9,
           "endLine": 3,
           "kind": "region",
@@ -1177,15 +1177,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
@@ -1212,36 +1212,36 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 9,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 9,
           "kind": "region",
           "startCharacter": 19,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 2,
         },
-        Object {
+        {
           "endCharacter": 47,
           "endLine": 7,
           "kind": "region",
@@ -1263,29 +1263,29 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 3,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 16,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 3,
           "kind": "region",
           "startCharacter": 2,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 3,
           "kind": "region",
@@ -1308,15 +1308,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 5,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 5,
           "kind": "region",
@@ -1338,15 +1338,15 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 5,
           "endLine": 4,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 5,
           "endLine": 4,
           "kind": "region",
@@ -1372,29 +1372,29 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 8,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 8,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 10,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 8,
           "kind": "region",
           "startCharacter": 5,
           "startLine": 3,
         },
-        Object {
+        {
           "endCharacter": 35,
           "endLine": 7,
           "kind": "region",
@@ -1418,36 +1418,36 @@ describe("textDocument/foldingRange", () => {
 
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
+      [
+        {
           "endCharacter": 7,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 0,
           "startLine": 0,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 10,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 18,
           "startLine": 1,
         },
-        Object {
+        {
           "endCharacter": 7,
           "endLine": 6,
           "kind": "region",
           "startCharacter": 4,
           "startLine": 2,
         },
-        Object {
+        {
           "endCharacter": 11,
           "endLine": 5,
           "kind": "region",

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -304,19 +304,19 @@ describe("textDocument/hover", () => {
     });
 
     expect(hover1).toMatchInlineSnapshot(`
-      Object {
-        "contents": Object {
+      {
+        "contents": {
           "kind": "markdown",
           "value": "\`\`\`ocaml
       type s = t
       \`\`\`",
         },
-        "range": Object {
-          "end": Object {
+        "range": {
+          "end": {
             "character": 14,
             "line": 1,
           },
-          "start": Object {
+          "start": {
             "character": 0,
             "line": 1,
           },
@@ -330,19 +330,19 @@ describe("textDocument/hover", () => {
     });
 
     expect(hover2).toMatchInlineSnapshot(`
-      Object {
-        "contents": Object {
+      {
+        "contents": {
           "kind": "markdown",
           "value": "\`\`\`ocaml
       type 'a fib = ('a -> unit) -> unit
       \`\`\`",
         },
-        "range": Object {
-          "end": Object {
+        "range": {
+          "end": {
             "character": 34,
             "line": 2,
           },
-          "start": Object {
+          "start": {
             "character": 0,
             "line": 2,
           },
@@ -372,17 +372,17 @@ let x : foo = 1
     });
 
     expect(result).toMatchInlineSnapshot(`
-      Object {
-        "contents": Object {
+      {
+        "contents": {
           "kind": "plaintext",
           "value": "foo",
         },
-        "range": Object {
-          "end": Object {
+        "range": {
+          "end": {
             "character": 5,
             "line": 2,
           },
-          "start": Object {
+          "start": {
             "character": 4,
             "line": 2,
           },
@@ -448,19 +448,19 @@ let x : foo = 1
     });
 
     expect(hoverOverK).toMatchInlineSnapshot(`
-      Object {
-        "contents": Object {
+      {
+        "contents": {
           "kind": "markdown",
           "value": "\`\`\`ocaml
       unit
       \`\`\`",
         },
-        "range": Object {
-          "end": Object {
+        "range": {
+          "end": {
             "character": 5,
             "line": 24,
           },
-          "start": Object {
+          "start": {
             "character": 4,
             "line": 24,
           },
@@ -487,19 +487,19 @@ let x : foo = 1
 
     // now the same hover as before comes with unrelated documentation
     expect(buggedHoverOverK).toMatchInlineSnapshot(`
-      Object {
-        "contents": Object {
+      {
+        "contents": {
           "kind": "markdown",
           "value": "\`\`\`ocaml
       unit
       \`\`\`",
         },
-        "range": Object {
-          "end": Object {
+        "range": {
+          "end": {
             "character": 5,
             "line": 24,
           },
-          "start": Object {
+          "start": {
             "character": 4,
             "line": 24,
           },

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
@@ -202,30 +202,30 @@ let () = bar ~foo
     let result = await query(Types.Position.create(0, 4), "ident");
 
     expect(result).toMatchInlineSnapshot(`
-      Object {
-        "changes": Object {
-          "file:///test.ml": Array [
-            Object {
+      {
+        "changes": {
+          "file:///test.ml": [
+            {
               "newText": "ident",
-              "range": Object {
-                "end": Object {
+              "range": {
+                "end": {
                   "character": 7,
                   "line": 0,
                 },
-                "start": Object {
+                "start": {
                   "character": 4,
                   "line": 0,
                 },
               },
             },
-            Object {
+            {
               "newText": ":ident",
-              "range": Object {
-                "end": Object {
+              "range": {
+                "end": {
                   "character": 17,
                   "line": 4,
                 },
-                "start": Object {
+                "start": {
                   "character": 17,
                   "line": 4,
                 },
@@ -256,30 +256,30 @@ ignore (bar ?foo ())
     let result = await query(Types.Position.create(0, 4), "sunit");
 
     expect(result).toMatchInlineSnapshot(`
-      Object {
-        "changes": Object {
-          "file:///test.ml": Array [
-            Object {
+      {
+        "changes": {
+          "file:///test.ml": [
+            {
               "newText": "sunit",
-              "range": Object {
-                "end": Object {
+              "range": {
+                "end": {
                   "character": 7,
                   "line": 0,
                 },
-                "start": Object {
+                "start": {
                   "character": 4,
                   "line": 0,
                 },
               },
             },
-            Object {
+            {
               "newText": ":sunit",
-              "range": Object {
-                "end": Object {
+              "range": {
+                "end": {
                   "character": 16,
                   "line": 5,
                 },
-                "start": Object {
+                "start": {
                   "character": 16,
                   "line": 5,
                 },

--- a/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
@@ -83,7 +83,7 @@ describe("workspace/symbol", () => {
     });
 
     expect(symbols.map(toTestResult)).toMatchInlineSnapshot(`
-      Array [
+      [
         "stack_of_ints 5 /workspace_symbol_A/bin/a.ml 51:0 65:5",
         "size 6 /workspace_symbol_A/bin/a.ml 64:11 64:15",
         "peek 6 /workspace_symbol_A/bin/a.ml 62:11 62:15",
@@ -138,7 +138,7 @@ describe("workspace/symbol", () => {
     });
 
     expect(symbols.map(toTestResult)).toMatchInlineSnapshot(`
-      Array [
+      [
         "a_i 12 /workspace_symbol_A/bin/a.ml 22:0 24:7",
         "a_arr 12 /workspace_symbol_A/bin/a.ml 18:0 18:14",
         "a_u 12 /workspace_symbol_A/bin/a.ml 16:0 16:15",
@@ -163,7 +163,7 @@ describe("workspace/symbol", () => {
     });
 
     expect(symbols.map(toTestResult)).toMatchInlineSnapshot(`
-      Array [
+      [
         "stack_of_ints 5 /workspace_symbol_A/bin/a.ml 51:0 65:5",
         "size 6 /workspace_symbol_A/bin/a.ml 64:11 64:15",
         "peek 6 /workspace_symbol_A/bin/a.ml 62:11 62:15",


### PR DESCRIPTION
Remove Object and Array keywords from strings passed
to toMatchInlineSnapshot(). Now looking like regular
JSON syntax.
