### PR TITLE
Do not rely on global yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ release: ## Release on Opam
 	dune-release opam submit
 
 .PHONY: nix-tests
-nix-tests:
+nix-tests: $(YARN)
 	(cd $(TEST_E2E_DIR) && $(PWD)/$(YARN) --frozen-lockfile)
 	make test
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ To run tests execute:
 $ make test
 ```
 
-Note that tests require [Node.js](https://nodejs.org/en/) and
-[Yarn](https://yarnpkg.com/lang/en/) installed.
+Note that tests require [Node.js](https://nodejs.org/en/) installed.
 
 ## Relationship to Other Tools
 

--- a/ocaml-lsp-server/test/run_test_e2e.ml
+++ b/ocaml-lsp-server/test/run_test_e2e.ml
@@ -1,7 +1,7 @@
 let () =
   let cmd =
     Filename.quote_command
-      "yarn"
+      "ocaml-lsp-server/test/e2e/node_modules/yarn/bin/yarn"
       [ "--cwd"; "ocaml-lsp-server/test/e2e"; "test" ]
   in
   Sys.command cmd |> exit

--- a/ocaml-lsp-server/test/run_test_e2e.ml
+++ b/ocaml-lsp-server/test/run_test_e2e.ml
@@ -1,7 +1,10 @@
 let () =
+  let yarn =
+    [ "ocaml-lsp-server"; "test"; "e2e"; "node_modules"; "yarn"; "bin"; "yarn" ]
+  in
   let cmd =
     Filename.quote_command
-      "ocaml-lsp-server/test/e2e/node_modules/yarn/bin/yarn"
+      (String.concat Filename.dir_sep yarn)
       [ "--cwd"; "ocaml-lsp-server/test/e2e"; "test" ]
   in
   Sys.command cmd |> exit


### PR DESCRIPTION
Install yarn (https://yarnpkg.com) in ocaml-lsp-server/test/e2e using npm --no-save --no-package-lock. Change Makefile targets and run_test_e2e in order to use project yarn. Introduce Makefile dependencies making sure yarn installation takes place before targets requiring yarn.

In Ubuntu and Debian, package cmdtest installs unrelated (python) /usr/bin/yarn and /bin/yarn which conflicts with globally installed (nodejs) yarn. Using a project-installed yarn resolves this issue. Incidentally, it reduces the contributor-facing dependencies to Node.js/npm.