### PR TITLE
Ignore unknown config tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Features
+
+- Ignore unknown tags in merlin configuration to improve forward compatibility
+  with Dune. (#883)
+
 # 1.14.0
 
 ## Features

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -110,7 +110,10 @@ module Config = struct
       | `STDLIB path -> ({ config with stdlib = Some path }, errors)
       | `READER reader -> ({ config with reader }, errors)
       | `EXCLUDE_QUERY_DIR -> ({ config with exclude_query_dir = true }, errors)
-      | `UNKNOWN_TAG s -> (config, sprintf "Unknown tag %S" s :: errors)
+      | `UNKNOWN_TAG _ ->
+        (* For easier forward compatibility we ignore unknown configuration tags
+           when they are provided by dune *)
+        (config, errors)
       | `ERROR_MSG str -> (config, str :: errors))
 
   let postprocess =


### PR DESCRIPTION
In Merlin we decided to ignore unknown configuration tags when the provider is Dune.
This allows for easier forward compatibility if the protocol gets extended (with, for example, a new tag).

Since this part of the configuration management is re-implemented in ocaml-lsp-server this PR re-apply that Merlin change.