### PR TITLE
fix: merlin document safety

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_construct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_construct.ml
@@ -5,8 +5,9 @@ let action_kind = "construct"
 
 let code_action doc (params : CodeActionParams.t) =
   match Document.kind doc with
-  | `Other | `Merlin Intf -> Fiber.return None
-  | `Merlin Impl ->
+  | `Other -> Fiber.return None
+  | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
+  | `Merlin merlin ->
     let pos = Position.logical params.range.Range.end_ in
     (* we want this predicate to quickly eliminate prefixes that don't fit to be
        a hole *)
@@ -17,7 +18,7 @@ let code_action doc (params : CodeActionParams.t) =
     if not (Typed_hole.can_be_hole prefix) then Fiber.return None
     else
       let+ structures =
-        Document.with_pipeline_exn doc (fun pipeline ->
+        Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
             let typedtree =
               let typer = Mpipeline.typer_result pipeline in
               Mtyper.get_typedtree typer

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -40,14 +40,15 @@ let code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText)
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
   let uri = params.textDocument.uri in
   match Document.kind doc with
-  | `Other | `Merlin Intf -> Fiber.return None
-  | `Merlin Impl -> (
+  | `Other -> Fiber.return None
+  | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
+  | `Merlin merlin -> (
     let command =
       let start = Position.logical params.range.start in
       let finish = Position.logical params.range.end_ in
       Query_protocol.Case_analysis (start, finish)
     in
-    let* res = Document.dispatch doc command in
+    let* res = Document.Merlin.dispatch merlin command in
     match res with
     | Ok (loc, newText) ->
       let+ newText =

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -26,8 +26,9 @@ let code_action_of_intf doc intf range =
 
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
   match Document.kind doc with
-  | `Other | `Merlin Impl -> Fiber.return None
-  | `Merlin Intf -> (
+  | `Other -> Fiber.return None
+  | `Merlin m when Document.Merlin.kind m = Impl -> Fiber.return None
+  | `Merlin _ -> (
     let* intf = Inference.infer_intf state doc in
     match intf with
     | None -> Fiber.return None

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -403,53 +403,58 @@ let inline_edits pipeline task =
 
 let code_action doc (params : CodeActionParams.t) =
   let open Option.O in
-  Document.with_pipeline_exn doc (fun pipeline ->
-      let* typedtree =
-        match Mtyper.get_typedtree (Mpipeline.typer_result pipeline) with
-        | `Interface _ -> None
-        | `Implementation x -> Some x
-      in
-      let* task = find_inline_task typedtree params.range.start in
-      inline_edits pipeline task)
-  |> Fiber.map ~f:(fun m_edits ->
-         let* edits, m_error = m_edits in
-         match (edits, m_error) with
-         | [], None -> None
-         | [], Some error ->
-           let action =
-             CodeAction.create
-               ~title:action_title
-               ~kind:CodeActionKind.RefactorInline
-               ~isPreferred:false
-               ~disabled:
-                 (CodeAction.create_disabled ~reason:(string_of_error error))
-               ()
-           in
-           Some action
-         | _ :: _, (Some _ | None) ->
-           let edit =
-             let version = Document.version doc in
-             let textDocument =
-               OptionalVersionedTextDocumentIdentifier.create
-                 ~uri:params.textDocument.uri
-                 ~version
+  match Document.kind doc with
+  | `Other -> Fiber.return None
+  | `Merlin merlin ->
+    Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
+        let* typedtree =
+          match Mtyper.get_typedtree (Mpipeline.typer_result pipeline) with
+          | `Interface _ -> None
+          | `Implementation x -> Some x
+        in
+        let* task = find_inline_task typedtree params.range.start in
+        inline_edits pipeline task)
+    |> Fiber.map ~f:(fun m_edits ->
+           let* edits, m_error = m_edits in
+           match (edits, m_error) with
+           | [], None -> None
+           | [], Some error ->
+             let action =
+               CodeAction.create
+                 ~title:action_title
+                 ~kind:CodeActionKind.RefactorInline
+                 ~isPreferred:false
+                 ~disabled:
+                   (CodeAction.create_disabled ~reason:(string_of_error error))
                  ()
              in
+             Some action
+           | _ :: _, (Some _ | None) ->
              let edit =
-               TextDocumentEdit.create
-                 ~textDocument
-                 ~edits:(List.map edits ~f:(fun e -> `TextEdit e))
+               let version = Document.version doc in
+               let textDocument =
+                 OptionalVersionedTextDocumentIdentifier.create
+                   ~uri:params.textDocument.uri
+                   ~version
+                   ()
+               in
+               let edit =
+                 TextDocumentEdit.create
+                   ~textDocument
+                   ~edits:(List.map edits ~f:(fun e -> `TextEdit e))
+               in
+               WorkspaceEdit.create
+                 ~documentChanges:[ `TextDocumentEdit edit ]
+                 ()
              in
-             WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-           in
-           let action =
-             CodeAction.create
-               ~title:action_title
-               ~kind:CodeActionKind.RefactorInline
-               ~edit
-               ~isPreferred:false
-               ()
-           in
-           Some action)
+             let action =
+               CodeAction.create
+                 ~title:action_title
+                 ~kind:CodeActionKind.RefactorInline
+                 ~edit
+                 ~isPreferred:false
+                 ()
+             in
+             Some action)
 
 let t = { Code_action.kind = RefactorInline; run = code_action }

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -71,7 +71,7 @@ let rec mark_value_unused_edit name contexts =
 
 let code_action_mark_value_unused doc (diagnostic : Diagnostic.t) =
   let open Option.O in
-  Document.with_pipeline_exn doc (fun pipeline ->
+  Document.Merlin.with_pipeline_exn (Document.merlin_exn doc) (fun pipeline ->
       let var_name = slice doc diagnostic.range in
       let pos = diagnostic.range.start in
       let+ text_edit =
@@ -125,10 +125,9 @@ let code_action_remove_range doc (diagnostic : Diagnostic.t) range =
 
 (* Create a code action that removes the value mentioned in [diagnostic]. *)
 let code_action_remove_value doc pos (diagnostic : Diagnostic.t) =
-  Document.with_pipeline_exn doc (fun pipeline ->
+  Document.Merlin.with_pipeline_exn (Document.merlin_exn doc) (fun pipeline ->
       let var_name = slice doc diagnostic.range in
-      enclosing_pos pipeline pos
-      |> List.map ~f:(fun (_, x) -> x)
+      enclosing_pos pipeline pos |> List.map ~f:snd
       |> enclosing_value_binding_range var_name
       |> Option.map ~f:(fun range ->
              code_action_remove_range doc diagnostic range))

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
@@ -3,30 +3,33 @@ open Fiber.O
 
 let code_action (mode : [ `Qualify | `Unqualify ]) (action_kind : string) doc
     (params : CodeActionParams.t) =
-  let+ res =
-    let command =
-      let pos_start = Position.logical params.range.start in
-      Query_protocol.Refactor_open (mode, pos_start)
-    in
-    Document.dispatch_exn doc command
-  in
-  match res with
-  | [] -> None
-  | changes ->
-    let code_action =
-      let edit : WorkspaceEdit.t =
-        let edits =
-          List.map changes ~f:(fun (newText, loc) ->
-              { TextEdit.newText; range = Range.of_loc loc })
-        in
-        let uri = params.textDocument.uri in
-        WorkspaceEdit.create ~changes:[ (uri, edits) ] ()
+  match Document.kind doc with
+  | `Other -> Fiber.return None
+  | `Merlin doc -> (
+    let+ res =
+      let command =
+        let pos_start = Position.logical params.range.start in
+        Query_protocol.Refactor_open (mode, pos_start)
       in
-      let kind = CodeActionKind.Other action_kind in
-      let title = String.capitalize_ascii action_kind in
-      CodeAction.create ~title ~kind ~edit ~isPreferred:false ()
+      Document.Merlin.dispatch_exn doc command
     in
-    Some code_action
+    match res with
+    | [] -> None
+    | changes ->
+      let code_action =
+        let edit : WorkspaceEdit.t =
+          let edits =
+            List.map changes ~f:(fun (newText, loc) ->
+                { TextEdit.newText; range = Range.of_loc loc })
+          in
+          let uri = params.textDocument.uri in
+          WorkspaceEdit.create ~changes:[ (uri, edits) ] ()
+        in
+        let kind = CodeActionKind.Other action_kind in
+        let title = String.capitalize_ascii action_kind in
+        CodeAction.create ~title ~kind ~edit ~isPreferred:false ()
+      in
+      Some code_action)
 
 let unqualify =
   let action_kind = "remove module name from identifiers" in

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -19,10 +19,10 @@ val complete :
 
 (** creates a server response for ["completionItem/resolve"] *)
 val resolve :
-     Document.t
+     Document.Merlin.t
   -> CompletionItem.t
   -> Resolve.t
-  -> (Document.t -> [> `Logical of int * int ] -> string option Fiber.t)
+  -> (Document.Merlin.t -> [> `Logical of int * int ] -> string option Fiber.t)
   -> markdown:bool
   -> CompletionItem.t Fiber.t
 

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
@@ -62,7 +62,9 @@ let on_request ~(params : Jsonrpc.Structured.t option) (state : State.t) =
                   (Uri.to_string uri))
              ()
       | Some doc ->
-        let+ holes = Document.dispatch_exn doc Holes in
+        let+ holes =
+          Document.Merlin.dispatch_exn (Document.merlin_exn doc) Holes
+        in
         Json.yojson_of_list
           (fun (loc, _type) -> loc |> Range.of_loc |> Range.yojson_of_t)
           holes)

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -34,34 +34,42 @@ let on_request ~params state =
         Request_params.of_jsonrpc_params_exn params
       in
       let doc = Document_store.get state.State.store text_document_uri in
-      let pos = Position.logical cursor_position in
-      let+ node =
-        Document.with_pipeline_exn doc (fun pipeline ->
-            let typer = Mpipeline.typer_result pipeline in
-            let pos = Mpipeline.get_lexing_pos pipeline pos in
-            let enclosing_nodes (* from smallest node to largest *) =
-              Mbrowse.enclosing
-                pos
-                [ Mbrowse.of_typedtree (Mtyper.get_typedtree typer) ]
-            in
-            let loc_of_structure_item { Typedtree.str_loc; _ } = str_loc in
-            let find_fst_structure_item_or_structure = function
-              | _, Browse_raw.Structure_item (str_item, _) ->
-                Some (loc_of_structure_item str_item)
-              | _, Structure { str_items; _ } -> (
-                match str_items with
-                | [] -> None
-                | hd :: rest ->
-                  let last = List.last rest |> Option.value ~default:hd in
-                  let { Loc.loc_start; _ } = loc_of_structure_item hd in
-                  let { Loc.loc_end; _ } = loc_of_structure_item last in
-                  Some { Loc.loc_start; loc_end; loc_ghost = false })
-              | _ -> None
-            in
-            List.find_map
-              enclosing_nodes
-              ~f:find_fst_structure_item_or_structure)
-      in
-      match node with
-      | None -> `Null
-      | Some loc -> Range.of_loc loc |> Range.yojson_of_t)
+      match Document.kind doc with
+      | `Other ->
+        Jsonrpc.Response.Error.raise
+          (Jsonrpc.Response.Error.make
+             ~code:InvalidRequest
+             ~message:"not a merlin document"
+             ())
+      | `Merlin doc -> (
+        let pos = Position.logical cursor_position in
+        let+ node =
+          Document.Merlin.with_pipeline_exn doc (fun pipeline ->
+              let typer = Mpipeline.typer_result pipeline in
+              let pos = Mpipeline.get_lexing_pos pipeline pos in
+              let enclosing_nodes (* from smallest node to largest *) =
+                Mbrowse.enclosing
+                  pos
+                  [ Mbrowse.of_typedtree (Mtyper.get_typedtree typer) ]
+              in
+              let loc_of_structure_item { Typedtree.str_loc; _ } = str_loc in
+              let find_fst_structure_item_or_structure = function
+                | _, Browse_raw.Structure_item (str_item, _) ->
+                  Some (loc_of_structure_item str_item)
+                | _, Structure { str_items; _ } -> (
+                  match str_items with
+                  | [] -> None
+                  | hd :: rest ->
+                    let last = List.last rest |> Option.value ~default:hd in
+                    let { Loc.loc_start; _ } = loc_of_structure_item hd in
+                    let { Loc.loc_end; _ } = loc_of_structure_item last in
+                    Some { Loc.loc_start; loc_end; loc_ghost = false })
+                | _ -> None
+              in
+              List.find_map
+                enclosing_nodes
+                ~f:find_fst_structure_item_or_structure)
+        in
+        match node with
+        | None -> `Null
+        | Some loc -> Range.of_loc loc |> Range.yojson_of_t))

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -277,7 +277,8 @@ let extract_related_errors uri raw_message =
     (string_of_message message, related)
   | _ -> (raw_message, None)
 
-let merlin_diagnostics diagnostics doc =
+let merlin_diagnostics diagnostics merlin =
+  let doc = Document.Merlin.to_doc merlin in
   let uri = Document.uri doc in
   let create_diagnostic = Diagnostic.create ~source:ocamllsp_source in
   let open Fiber.O in
@@ -285,7 +286,7 @@ let merlin_diagnostics diagnostics doc =
     let command =
       Query_protocol.Errors { lexing = true; parsing = true; typing = true }
     in
-    Document.with_pipeline_exn doc (fun pipeline ->
+    Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
         match Query_commands.dispatch pipeline command with
         | exception Merlin_extend.Extend_main.Handshake.Error error ->
           let message =

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -36,7 +36,7 @@ val disconnect : t -> Dune.t -> unit
 val tags_of_message :
   src:[< `Dune | `Merlin ] -> string -> DiagnosticTag.t list option
 
-val merlin_diagnostics : t -> Document.t -> unit Fiber.t
+val merlin_diagnostics : t -> Document.Merlin.t -> unit Fiber.t
 
 (** Exposed for testing *)
 

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -22,8 +22,6 @@ module Kind : sig
     | Impl
 end
 
-val kind : t -> [ `Merlin of Kind.t | `Other ]
-
 val syntax : t -> Syntax.t
 
 val make :
@@ -33,25 +31,52 @@ val make :
   -> DidOpenTextDocumentParams.t
   -> t Fiber.t
 
-val timer : t -> Lev_fiber.Timer.Wheel.task
-
 val uri : t -> Uri.t
 
 val text : t -> string
 
 val source : t -> Msource.t
 
-val with_pipeline_exn : t -> (Mpipeline.t -> 'a) -> 'a Fiber.t
+module Merlin : sig
+  type doc := t
+
+  type t
+
+  val source : t -> Msource.t
+
+  val timer : t -> Lev_fiber.Timer.Wheel.task
+
+  val with_pipeline_exn : t -> (Mpipeline.t -> 'a) -> 'a Fiber.t
+
+  val dispatch :
+    t -> 'a Query_protocol.t -> ('a, Exn_with_backtrace.t) result Fiber.t
+
+  val dispatch_exn : t -> 'a Query_protocol.t -> 'a Fiber.t
+
+  val doc_comment :
+    t -> Msource.position -> (* doc string *) string option Fiber.t
+
+  type type_enclosing =
+    { loc : Loc.t
+    ; typ : string
+    ; doc : string option
+    }
+
+  val type_enclosing : t -> Msource.position -> type_enclosing option Fiber.t
+
+  val kind : t -> Kind.t
+
+  val to_doc : t -> doc
+end
+
+val kind : t -> [ `Merlin of Merlin.t | `Other ]
+
+val merlin_exn : t -> Merlin.t
 
 val version : t -> int
 
 val update_text :
   ?version:int -> t -> TextDocumentContentChangeEvent.t list -> t
-
-val dispatch :
-  t -> 'a Query_protocol.t -> ('a, Exn_with_backtrace.t) result Fiber.t
-
-val dispatch_exn : t -> 'a Query_protocol.t -> 'a Fiber.t
 
 val close : t -> unit Fiber.t
 
@@ -62,14 +87,3 @@ val close : t -> unit Fiber.t
 val get_impl_intf_counterparts : Uri.t -> Uri.t list
 
 val edit : t -> TextEdit.t -> WorkspaceEdit.t
-
-val doc_comment :
-  t -> Msource.position -> (* doc string *) string option Fiber.t
-
-type type_enclosing =
-  { loc : Loc.t
-  ; typ : string
-  ; doc : string option
-  }
-
-val type_enclosing : t -> Msource.position -> type_enclosing option Fiber.t

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -50,8 +50,8 @@ let symbols_of_outline uri outline =
 let run (client_capabilities : ClientCapabilities.t) doc uri =
   match Document.kind doc with
   | `Other -> Fiber.return None
-  | `Merlin _ ->
-    let+ outline = Document.dispatch_exn doc Outline in
+  | `Merlin doc ->
+    let+ outline = Document.Merlin.dispatch_exn doc Outline in
     Some
       (match
          Option.value

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -259,10 +259,10 @@ end = struct
                       Document_store.change_all document_store ~f:(fun doc ->
                           match Document.kind doc with
                           | `Other -> Fiber.return doc
-                          | `Merlin _ ->
+                          | `Merlin merlin ->
                             let doc = Document.update_text doc [] in
                             let+ () =
-                              Diagnostics.merlin_diagnostics diagnostics doc
+                              Diagnostics.merlin_diagnostics diagnostics merlin
                             in
                             doc)
                     in

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -303,9 +303,12 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
 let compute (state : State.t) (params : FoldingRangeParams.t) =
   Fiber.of_thunk (fun () ->
       let doc = Document_store.get state.store params.textDocument.uri in
-      let+ ranges =
-        Document.with_pipeline_exn doc (fun pipeline ->
-            let parsetree = Mpipeline.reader_parsetree pipeline in
-            fold_over_parsetree parsetree)
-      in
-      Some ranges)
+      match Document.kind doc with
+      | `Other -> Fiber.return None
+      | `Merlin m ->
+        let+ ranges =
+          Document.Merlin.with_pipeline_exn m (fun pipeline ->
+              let parsetree = Mpipeline.reader_parsetree pipeline in
+              fold_over_parsetree parsetree)
+        in
+        Some ranges)

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -34,46 +34,50 @@ let handle server { HoverParams.textDocument = { uri }; position; _ } =
         let store = state.store in
         Document_store.get store uri
       in
-      let pos = Position.logical position in
-      let* type_enclosing = Document.type_enclosing doc pos in
-      match type_enclosing with
-      | None -> Fiber.return None
-      | Some { Document.loc; typ; doc = documentation } ->
-        let syntax = Document.syntax doc in
-        let+ typ =
-          (* We ask Ocamlformat to format this type *)
-          let* result =
-            Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ
-          in
-          match result with
-          | Ok v ->
-            (* OCamlformat adds an unnecessay newline at the end of the type *)
-            Fiber.return (String.trim v)
-          | Error `No_process -> Fiber.return typ
-          | Error (`Msg message) ->
-            (* We log OCamlformat errors and display the unformated type *)
-            let+ () =
-              let message =
-                sprintf
-                  "An error occured while querying ocamlformat:\n\
-                   Input type: %s\n\n\
-                   Answer: %s"
-                  typ
-                  message
-              in
-              State.log_msg server ~type_:Warning ~message
+      match Document.kind doc with
+      | `Other -> Fiber.return None
+      | `Merlin merlin -> (
+        let pos = Position.logical position in
+        let* type_enclosing = Document.Merlin.type_enclosing merlin pos in
+        match type_enclosing with
+        | None -> Fiber.return None
+        | Some { Document.Merlin.loc; typ; doc = documentation } ->
+          let syntax = Document.syntax doc in
+          let+ typ =
+            (* We ask Ocamlformat to format this type *)
+            let* result =
+              Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ
             in
-            typ
-        in
-        let contents =
-          let markdown =
-            let client_capabilities = State.client_capabilities state in
-            ClientCapabilities.markdown_support
-              client_capabilities
-              ~field:(fun td ->
-                Option.map td.hover ~f:(fun h -> h.contentFormat))
+            match result with
+            | Ok v ->
+              (* OCamlformat adds an unnecessay newline at the end of the
+                 type *)
+              Fiber.return (String.trim v)
+            | Error `No_process -> Fiber.return typ
+            | Error (`Msg message) ->
+              (* We log OCamlformat errors and display the unformated type *)
+              let+ () =
+                let message =
+                  sprintf
+                    "An error occured while querying ocamlformat:\n\
+                     Input type: %s\n\n\
+                     Answer: %s"
+                    typ
+                    message
+                in
+                State.log_msg server ~type_:Warning ~message
+              in
+              typ
           in
-          format_contents ~syntax ~markdown ~typ ~doc:documentation
-        in
-        let range = Range.of_loc loc in
-        Some (Hover.create ~contents ~range ()))
+          let contents =
+            let markdown =
+              let client_capabilities = State.client_capabilities state in
+              ClientCapabilities.markdown_support
+                client_capabilities
+                ~field:(fun td ->
+                  Option.map td.hover ~f:(fun h -> h.contentFormat))
+            in
+            format_contents ~syntax ~markdown ~typ ~doc:documentation
+          in
+          let range = Range.of_loc loc in
+          Some (Hover.create ~contents ~range ())))

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -7,12 +7,12 @@ let infer_intf_for_impl doc =
     Code_error.raise
       "expected an implementation document, got a non merlin document"
       []
-  | `Merlin Intf ->
+  | `Merlin m when Document.Merlin.kind m = Intf ->
     Code_error.raise
       "expected an implementation document, got an interface instead"
       []
-  | `Merlin Impl ->
-    Document.with_pipeline_exn doc (fun pipeline ->
+  | `Merlin doc ->
+    Document.Merlin.with_pipeline_exn doc (fun pipeline ->
         let typer = Mpipeline.typer_result pipeline in
         let sig_ : Types.signature =
           let typedtree = Mtyper.get_typedtree typer in
@@ -65,9 +65,9 @@ let infer_intf (state : State.t) doc =
   match Document.kind doc with
   | `Other ->
     Code_error.raise "the provided document is not a merlin source." []
-  | `Merlin Impl ->
+  | `Merlin m when Document.Merlin.kind m = Impl ->
     Code_error.raise "the provided document is not an interface." []
-  | `Merlin Intf ->
+  | `Merlin _ ->
     Fiber.of_thunk (fun () ->
         let intf_uri = Document.uri doc in
         let impl_uri =

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -136,7 +136,7 @@ let formatter doc =
     Ok
       (Reason
          (match Document.kind doc with
-         | `Merlin i -> i
+         | `Merlin m -> Document.Merlin.kind m
          | `Other -> Code_error.raise "unable to format non merlin document" []))
 
 let exec cancel bin args stdin =


### PR DESCRIPTION
only use merlin features on merlin sources. enforce this with the type
system

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: dedef00c-ebda-4e88-b85d-258bc07144e1