### PR TITLE
chore: remove ocamlformat-rpc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
           ppx_yojson_conv = "*";
           cinaps = "*";
           ppx_expect = "*";
-          ocamlformat-rpc = "*";
           ocamlfind = "1.9.2";
           dune-release = "*";
         };


### PR DESCRIPTION
it's been moved into ocamlformat

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 9b44bd8a-0de4-4019-864e-75553ff1d3f9