### PR TITLE
fix(go-to-def): report error in response

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -615,7 +615,7 @@ let definition_query kind (state : State.t) uri position =
       in
       Jsonrpc.Response.Error.raise
         (Jsonrpc.Response.Error.make
-           ~code:Jsonrpc.Response.Error.Code.InternalError
+           ~code:Jsonrpc.Response.Error.Code.RequestFailed
            ~message:(sprintf "Request \"Jump to %s\" failed." kind)
            ~data:
              (`String

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -591,6 +591,7 @@ let references (state : State.t)
            { Location.uri; range }))
 
 let definition_query kind (state : State.t) uri position =
+  let* () = Fiber.return () in
   let doc = Document_store.get state.store uri in
   match Document.kind doc with
   | `Other -> Fiber.return None


### PR DESCRIPTION
fix(go-to-def): send a response with an error for failing go-to-def/go-to-decl/go-to-type-def
     rather than a notification afterwards with the error

also, should `definition_query`'s body be wrapped in `Fiber.of_thunk` ? 