### PR TITLE
fix: client capabilities and diagnostics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 
 - Do not offer diagnostic tags unless the client supports them (#909)
 
+- Do not attach extra data to diagnostics unless the client supports this
+  (#910)
+
 # 1.14.1
 
 ## Fixes

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -774,6 +774,12 @@ let create workspaces (client_capabilities : ClientCapabilities.t) diagnostics
     progress document_store ~log =
   let config =
     let include_promotions =
+      (let open Option.O in
+      let* td = client_capabilities.textDocument in
+      let* diagnostics = td.publishDiagnostics in
+      diagnostics.dataSupport)
+      |> Option.value ~default:false
+      &&
       match client_capabilities.experimental with
       | Some (`Assoc xs) -> (
         match List.assoc xs (fst view_promotion_capability) with


### PR DESCRIPTION
check for dataSupport before using the data field of diagnostics

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 6a6537f4-ab79-499d-a915-3e3e122614b6