### PR TITLE
fix: document updates when char out of range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- Fix document syncing for ranges that span an entire line (#927)
+
 ## Features
 
 - Re-enable `ocamlformat-rpc` for code formatting (#920)

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -71,7 +71,8 @@ let find_offset_16 ~utf8 ~utf16_range:range =
   let utf16_codepoints_buf = Bytes.create utf16_codepoint_size in
   let enc = Uutf.encoder `UTF_16LE `Manual in
   let rec find_char line char =
-    if char = 0 || Uutf.decoder_line dec = line then Uutf.decoder_byte_count dec
+    if char = 0 || Uutf.decoder_line dec = line + 2 then
+      Uutf.decoder_byte_count dec
     else
       match Uutf.decode dec with
       | `Await -> raise Invalid_utf8
@@ -92,7 +93,7 @@ let find_offset_16 ~utf8 ~utf16_range:range =
         find_char line char
   in
   let rec find_pos (pos : Position.t) =
-    if Uutf.decoder_line dec - 1 = pos.line then
+    if Uutf.decoder_line dec = pos.line + 1 then
       find_char pos.line pos.character
     else
       match Uutf.decode dec with

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -106,6 +106,6 @@ let%expect_test "beyond max char" =
   test "foo\nbar\n" range ~change:"baz\n";
   [%expect {|
     UTF16:
-    baz\n
+    baz\nbar\n
     UTF8:
     baz\nbar\n |}]


### PR DESCRIPTION
out of range character positions should be interpreted as end of line

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 0f832289-ff9e-40a5-ac43-a917419c72dd