### PR TITLE
fix: server capabilities

### DIFF
--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -244,6 +244,7 @@ include struct
   module RegistrationParams = RegistrationParams
   module RenameOptions = RenameOptions
   module RenameParams = RenameParams
+  module SaveOptions = SaveOptions
   module SelectionRange = SelectionRange
   module SelectionRangeParams = SelectionRangeParams
   module SemanticTokens = SemanticTokens

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -50,7 +50,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) :
          ~openClose:true
          ~change:TextDocumentSyncKind.Incremental
          ~willSave:false
-         ~save:(`Bool true)
+         ~save:(`SaveOptions (SaveOptions.create ~includeText:false ()))
          ~willSaveWaitUntil:false
          ())
   in

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -89,7 +89,7 @@ let%expect_test "start/stop" =
           "textDocumentSync": {
             "change": 2,
             "openClose": true,
-            "save": true,
+            "save": { "includeText": false },
             "willSave": false,
             "willSaveWaitUntil": false
           },


### PR DESCRIPTION
explicitly tell the client we don't care about includeText

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 5e211f6b-2929-49e8-8479-89ccbc01b37d