### PR TITLE
fix(semantic-hl): properly highlight longidents with spaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 - Support utf-8 position encoding clients (#919)
 
+## Fixes
+
+- Fix semantic highlighting of "long identifiers," e.g., `Foo.Bar.x` (#TODO)
+
 # 1.14.2
 
 ## Fixes

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
@@ -1,0 +1,108 @@
+open Test.Import
+
+type token =
+  { delta_line : int
+  ; delta_char : int
+  ; len : int
+  ; type_ : int
+  ; mods : int
+  }
+
+let tokens encoded_tokens =
+  Array.init
+    (Array.length encoded_tokens / 5)
+    ~f:(fun i ->
+      let ix = i * 5 in
+      { delta_line = encoded_tokens.(ix)
+      ; delta_char = encoded_tokens.(ix + 1)
+      ; len = encoded_tokens.(ix + 2)
+      ; type_ = encoded_tokens.(ix + 3)
+      ; mods = encoded_tokens.(ix + 4)
+      })
+
+let modifiers ~(legend : string array) (encoded_mods : int) =
+  let rec loop encoded_mods i acc =
+    if encoded_mods = 0 then acc
+    else
+      let k = Stdlib.Int.logand encoded_mods 1 in
+      let new_val = Stdlib.Int.shift_right encoded_mods 1 in
+      if k = 0 then loop new_val (i + 1) acc
+      else loop new_val (i + 1) (legend.(k) :: acc)
+  in
+  loop encoded_mods 0 [] |> List.rev
+
+let annotate_src_with_tokens ~(legend : SemanticTokensLegend.t)
+    ~(encoded_tokens : int array) ~(annot_mods : bool) (src : string) : string =
+  let token_types = legend.SemanticTokensLegend.tokenTypes |> Array.of_list in
+  let token_mods =
+    legend.SemanticTokensLegend.tokenModifiers |> Array.of_list
+  in
+  let src_ix = ref 0 in
+  let tokens = Array.Iter.create (tokens encoded_tokens) in
+  let token = ref @@ Array.Iter.next_exn tokens in
+  let token_id = ref 0 in
+  let line = ref !token.delta_line in
+  let character = ref !token.delta_char in
+  let src_len = String.length src in
+  let b = Buffer.create src_len in
+  while !src_ix < src_len do
+    if !line = 0 && !character = 0 then (
+      Printf.bprintf
+        b
+        "<%s%s-%d>"
+        token_types.(!token.type_)
+        (if annot_mods then
+         "|" ^ String.concat ~sep:"," (modifiers ~legend:token_mods !token.mods)
+        else "")
+        !token_id;
+      Buffer.add_substring b src !src_ix !token.len;
+      src_ix := !src_ix + !token.len;
+      Printf.bprintf b "</%d>" !token_id;
+      match Array.Iter.next tokens with
+      | None ->
+        (* copy the rest of src *)
+        Buffer.add_substring b src !src_ix (src_len - !src_ix);
+        src_ix := src_len
+      | Some next_token ->
+        incr token_id;
+        character := next_token.delta_char - !token.len;
+        token := next_token;
+        line := !token.delta_line)
+    else
+      let ch = src.[!src_ix] in
+      (match ch with
+      | '\n' ->
+        decr line;
+        character := !token.delta_char
+      | _ -> decr character);
+      Buffer.add_char b ch;
+      incr src_ix
+  done;
+  Buffer.to_bytes b |> Bytes.to_string
+
+(* for tests below *)
+let legend =
+  SemanticTokensLegend.create ~tokenModifiers:[] ~tokenTypes:[ "var"; "mod" ]
+
+let%expect_test "annotate single-line src" =
+  annotate_src_with_tokens
+    ~legend
+    ~encoded_tokens:[| 0; 4; 3; 0; 0 |]
+    ~annot_mods:false
+    {|let foo = bar|}
+  |> print_endline;
+  [%expect {| let <var-0>foo</0> = bar |}]
+
+let%expect_test "annotate multi-line src" =
+  annotate_src_with_tokens
+    ~legend
+    ~encoded_tokens:
+      [| 0; 4; 3; 0; 0; 0; 6; 3; 0; 0; 1; 4; 3; 0; 0; 0; 6; 3; 1; 0 |]
+    ~annot_mods:false
+    {|let foo = bar
+let jar = dar|}
+  |> print_endline;
+  [%expect
+    {|
+    let <var-0>foo</0> = <var-1>bar</1>
+    let <var-2>jar</2> = <mod-3>dar</3> |}]

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.mli
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.mli
@@ -1,0 +1,8 @@
+open Test.Import
+
+val annotate_src_with_tokens :
+     legend:SemanticTokensLegend.t
+  -> encoded_tokens:int array
+  -> annot_mods:bool
+  -> string
+  -> string

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -688,8 +688,7 @@ let%expect_test "tokens for ocaml_lsp_server.ml" =
       }
     ] |}]
 
-let%expect_test "FIXME: highlighting longidents with space between identifiers"
-    =
+let%expect_test "highlighting longidents with space between identifiers" =
   test_semantic_tokens_full
   @@ String.trim {|
 let foo = Bar.jar
@@ -700,10 +699,10 @@ let joo = Bar.   jar
     {|
     let <variable|-0>foo</0> = <namespace|-1>Bar</1>.<variable|-2>jar</2>
 
-    let <variable|-3>joo</3> = <namespace|-4>Bar</4>.<variable|-5>   </5>jar |}]
+    let <variable|-3>joo</3> = <namespace|-4>Bar</4>.   <variable|-5>jar</5> |}]
 
-let%expect_test "FIXME: highlighting longidents with space between identifiers \
-                 and infix fns" =
+let%expect_test "highlighting longidents with space between identifiers and \
+                 infix fns" =
   test_semantic_tokens_full
   @@ String.trim {|
 Bar.(+) ;;
@@ -716,10 +715,24 @@ Bar. ( + ) ;;
     |};
   [%expect
     {|
-    <namespace|-0>Bar</0>.<variable|-1>(</1>+) ;;
+    <namespace|-0>Bar</0>.<variable|-1>(+)</1> ;;
 
-    <namespace|-2>Bar</2>.<variable|-3>(</3> + ) ;;
+    <namespace|-2>Bar</2>.<namespace|-3>(</3> <namespace|-4>+</4> <variable|-5>)</5> ;;
 
-    <namespace|-4>Bar</4>.<variable|-5> </5>(+) ;;
+    <namespace|-6>Bar</6>. <variable|-7>(+)</7> ;;
 
-    <namespace|-6>Bar</6>.<variable|-7> </7>( + ) ;; |}]
+    <namespace|-8>Bar</8>. <namespace|-9>(</9> <namespace|-10>+</10> <variable|-11>)</11> ;; |}]
+
+let%expect_test "longidents in records" =
+  test_semantic_tokens_full
+  @@ String.trim
+       {|
+module M = struct type r = { foo : int ; bar : string } end
+
+let x = { M . foo = 0 ; bar = "bar"}
+      |};
+  [%expect
+    {|
+    module <namespace|definition-0>M</0> = struct type <struct|definition-1>r</1> = { <property|-2>foo</2> : <type|-3>int</3> ; <property|-4>bar</4> : <type|-5>string</5> } end
+
+    let <variable|-6>x</6> = { <namespace|-7>M</7> . <property|-8>foo</8> = <number|-9>0</9> ; <property|-10>bar</10> = <string|-11>"bar"</11>} |}]

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -687,3 +687,39 @@ let%expect_test "tokens for ocaml_lsp_server.ml" =
         "modifiers": []
       }
     ] |}]
+
+let%expect_test "FIXME: highlighting longidents with space between identifiers"
+    =
+  test_semantic_tokens_full
+  @@ String.trim {|
+let foo = Bar.jar
+
+let joo = Bar.   jar
+  |};
+  [%expect
+    {|
+    let <variable|-0>foo</0> = <namespace|-1>Bar</1>.<variable|-2>jar</2>
+
+    let <variable|-3>joo</3> = <namespace|-4>Bar</4>.<variable|-5>   </5>jar |}]
+
+let%expect_test "FIXME: highlighting longidents with space between identifiers \
+                 and infix fns" =
+  test_semantic_tokens_full
+  @@ String.trim {|
+Bar.(+) ;;
+
+Bar.( + ) ;;
+
+Bar. (+) ;;
+
+Bar. ( + ) ;;
+    |};
+  [%expect
+    {|
+    <namespace|-0>Bar</0>.<variable|-1>(</1>+) ;;
+
+    <namespace|-2>Bar</2>.<variable|-3>(</3> + ) ;;
+
+    <namespace|-4>Bar</4>.<variable|-5> </5>(+) ;;
+
+    <namespace|-6>Bar</6>.<variable|-7> </7>( + ) ;; |}]

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -25,6 +25,39 @@ module Import = struct
         in
         List.rev (take [] n l)
     end
+
+    module Array = struct
+      include Array
+
+      module Iter : sig
+        type 'a t
+
+        val create : 'a array -> 'a t
+
+        val has_next : 'a t -> bool
+
+        val next : 'a t -> 'a option
+
+        val next_exn : 'a t -> 'a
+      end = struct
+        type 'a t =
+          { contents : 'a array
+          ; mutable ix : int
+          }
+
+        let create contents = { contents; ix = 0 }
+
+        let has_next t = t.ix < Array.length t.contents
+
+        let next_exn t =
+          let { contents; ix } = t in
+          let v = contents.(ix) in
+          t.ix <- ix + 1;
+          v
+
+        let next t = if has_next t then Some (next_exn t) else None
+      end
+    end
   end
 
   include Fiber.O


### PR DESCRIPTION
Based on #931 

Fixes incorrect highlighting for longidents with spaces - see #808