### PR TITLE
Mitigate ocaml/ocaml#11737 (windows-only)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Respect the client's completion item resolve capability (#925)
 
+- Disable polling for dune's watch mode on Windows and OCaml 4.14.0 (#935)
+
 ## Features
 
 - Semantic highlighting support is enabled by default (#TODO)


### PR DESCRIPTION
# Description 

 See #929. 

With this PR, we do not start the inifinite loop that is watching the "dune/rpc" file on windows. 

This loop exists to communicate with dune in watch mode... which is not yet supported on windows (although it should be supported "soonish" when https://github.com/ocaml/dune/pull/6087 will be merged). So, in practice, on windows, this loop is basically an infinite thread doing nothing but failing calls to `Unix.stat`. That is exactly what's needed to trigger ocaml/ocaml#11737.

Note: even with this PR, the ocaml bug could still lead to a segfault each time we do a Unix.stat on non-existing file. But 
with this PR, it should be harder to trigger. 

This PR should be reverted as soon as all supported compilers have ocaml/ocaml#11737 (> 4.14.0 ?) which, hopefully, should happen before #6087 is merged (or we will need another way to avoid this problem). 
