### PR TITLE
disable ofmt rpc for files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 
 - Semantic highlighting support is enabled by default (#933)
 
-- Re-enable `ocamlformat-rpc` for code formatting (#920)
+- Re-enable `ocamlformat-rpc` for formatting code snippets (but not files) (#920, #939)
 
   One needs to have either `ocamlformat` version > 0.21.0 or, otherwise,
   `ocamlformat-rpc` package installed.

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -316,10 +316,6 @@ module Formatter = struct
     match Document.kind doc with
     | `Merlin _ -> (
       let* res =
-        let* res = Ocamlformat_rpc.format_doc state.ocamlformat_rpc doc in
-        match res with
-        | Ok res -> Fiber.return @@ Ok res
-        | Error _ ->
           let* cancel = Server.cancel_token () in
           Ocamlformat.run doc cancel
       in


### PR DESCRIPTION
- fix(ofmt-rpc): disable ofmt-rpc for formatting files because it doesn't respect missing .ocamlformat and formats projects using default config
- refactor(formatter): cleaner error handling
