### PR TITLE
unite all olsp env var handling

### DIFF
--- a/ocaml-lsp-server/src/configuration.ml
+++ b/ocaml-lsp-server/src/configuration.ml
@@ -8,7 +8,7 @@ let wheel t = t.wheel
 let default () =
   let+ wheel =
     let delay =
-      match Sys.getenv_opt "OCAMLLSP_TEST" with
+      match Env_vars._TEST () with
       | None -> 0.25
       | Some _ -> 0.0
     in

--- a/ocaml-lsp-server/src/env_vars.ml
+++ b/ocaml-lsp-server/src/env_vars.ml
@@ -1,0 +1,19 @@
+open Stdune.Option.O
+
+let _TEST () : bool option =
+  let+ v = Sys.getenv_opt "OCAMLLSP_TEST" in
+  match v with
+  | "true" -> true
+  | "false" -> false
+  | unexpected_val ->
+    Format.eprintf
+      "invalid value %S for OCAMLLSP_TEST ignored. Only true or false are \
+       allowed@."
+      unexpected_val;
+    false
+
+let _IS_HOVER_EXTENDED () : bool option =
+  let* v = Sys.getenv_opt "OCAMLLSP_HOVER_IS_EXTENDED" in
+  match v with
+  | "true" | "1" -> Some true
+  | _ -> Some false

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -8,9 +8,9 @@ type mode =
 
 (* possibly overwrite the default mode using an environment variable *)
 let environment_mode =
-  match Sys.getenv_opt "OCAMLLSP_HOVER_IS_EXTENDED" with
-  | Some ("true" | "1") -> Extended_variable
-  | _ -> Default
+  match Env_vars._IS_HOVER_EXTENDED () with
+  | Some true -> Extended_variable
+  | Some false | None -> Default
 
 let format_contents ~syntax ~markdown ~typ ~doc =
   (* TODO for vscode, we should just use the language id. But that will not work

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -305,13 +305,4 @@ let task_if_running pool ~f =
   | false -> Fiber.return ()
   | true -> Fiber.Pool.task pool ~f
 
-let inside_test =
-  match Sys.getenv_opt "OCAMLLSP_TEST" with
-  | Some "true" -> true
-  | None | Some "false" -> false
-  | Some b ->
-    Format.eprintf
-      "invalid value %S for OCAMLLSP_TEST ignored. Only true or false are \
-       allowed@."
-      b;
-    false
+let inside_test = Env_vars._TEST () |> Option.value ~default:false


### PR DESCRIPTION
The commit comment explains why. 

Ideally, we would write a config file for env vars, from which we could generate both `Env_vars` module and documentation for README, but that seems unnecessary right now. 

I can also shadow `Sys.getenv` and `Sys.getenv_opt` with empty functions, if we want to ensure people use `Env_vars` rather than those by `Sys` module.