### PR TITLE
test(ocamllsp): debug env vars

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -1,6 +1,7 @@
 (env
  (_
   (env-vars
+   (OCAMLLSP_TEST true)
    (LEV_DEBUG 1))))
 
 (library
@@ -9,6 +10,7 @@
   (enabled_if
    (= %{os_type} Unix))
   (deps
+   %{bin:ocamlformat-rpc}
    (package ocaml-lsp-server)))
  (libraries
   stdune

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -119,12 +119,4 @@ let%expect_test "start/stop" =
       }
       client: shutting down server
 
-      notifications received:
-      {
-        "params": {
-          "message": "Unable to find 'ocamlformat-rpc' binary. Types on hover may not be well-formatted. You need to install either 'ocamlformat' of version > 0.21.0 or, otherwise, 'ocamlformat-rpc' package.",
-          "type": 3
-        },
-        "method": "window/showMessage",
-        "jsonrpc": "2.0"
-      } |}]
+      notifications received: |}]

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -81,14 +81,16 @@ end = struct
   let bin =
     Bin.which "ocamllsp" ~path:_PATH |> Option.value_exn |> Path.to_string
 
-  let env = [ "OCAMLLSP_TEST=true" ]
-
   let run ?(extra_env = []) ?handler f =
     let stdin_i, stdin_o = Unix.pipe ~cloexec:true () in
     let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
     let pid =
+      let env =
+        let current = Unix.environment () in
+        Array.to_list current @ extra_env |> Spawn.Env.of_list
+      in
       Spawn.spawn
-        ~env:(Spawn.Env.of_list (extra_env @ env))
+        ~env
         ~prog:bin
         ~argv:[ bin ]
         ~stdin:stdin_i


### PR DESCRIPTION
do not override env vars when launching ocamllsp. only add debug
environment variables

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: 6c9e69d2-4250-4b29-afb2-cfc1d39c2ce5