### PR TITLE
fix(lsp): text edit application

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@
 
 - Fix semantic highlighting of "long identifiers," e.g., `Foo.Bar.x` (#932)
 
+- Fix syncing of document contents. Previously, whole line edits would
+  incorrectly eat the newline characters. (#971)
+
 # 1.14.2
 
 ## Fixes

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -107,7 +107,7 @@ let%expect_test "replace first line" =
 
 let%expect_test "beyond max char" =
   let range = tuple_range (0, 0) (0, 100) in
-  test "foo\nbar\n" range ~change:"baz\n";
+  test "foo\nbar\n" range ~change:"baz";
   [%expect {|
     UTF16:
     baz\nbar\n
@@ -124,9 +124,9 @@ let%expect_test "entire line without newline" =
   test "xxx\n" (tuple_range (0, 0) (0, 4)) ~change:"baz";
   [%expect {|
     UTF16:
-    baz
+    baz\n
     UTF8:
-    baz |}];
+    baz\n |}];
   test "xxx\n" (tuple_range (0, 0) (1, 0)) ~change:"baz";
   [%expect {|
     UTF16:


### PR DESCRIPTION
Do not eat newlines when applying edits past the newline character.

Any edit where the character position goes beyond the newline char
should be truncated to right before the newline.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

ps-id: ae5e0adc-18a7-450d-be78-589c4995e3d6