### PR TITLE
feature(lsp): TextDocumentEdit support

### DIFF
--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -17,3 +17,10 @@ exception Invalid_utf8
 
 val apply_content_changes :
   ?version:int -> t -> TextDocumentContentChangeEvent.t list -> t
+
+val set_version : t -> version:int -> t
+
+(** Apply a list of non overlapping text edits. The order of application matters
+    when multiple inserts are done in the same position. All the offsets are
+    interpreted relative to the original document. *)
+val apply_text_document_edits : t -> TextEdit.t list -> t


### PR DESCRIPTION
Add a function to apply text document edits and use it to test diff
generation

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c3076a49-8ba4-478f-ba82-8ae9c9b2b615 -->