### PR TITLE
feature: add command to dump a document

### DIFF
--- a/ocaml-lsp-server/src/document_text_command.ml
+++ b/ocaml-lsp-server/src/document_text_command.ml
@@ -1,0 +1,28 @@
+open Import
+open Fiber.O
+
+let command_name = "ocamllsp/show-document-text"
+
+let command_run server store args =
+  let uri =
+    match args with
+    | Some [ `String arg ] -> arg
+    | _ -> assert false
+  in
+  let doc =
+    Document_store.get store (Uri.t_of_yojson (`String uri)) |> Document.text
+  in
+  let uri, chan =
+    Filename.open_temp_file
+      (sprintf "ocamllsp-document.%d" (Unix.getpid ()))
+      (Filename.extension uri)
+  in
+  output_string chan doc;
+  close_out_noerr chan;
+  let req =
+    let uri = Uri.of_path uri in
+    Server_request.ShowDocumentRequest
+      (ShowDocumentParams.create ~uri ~takeFocus:true ())
+  in
+  let+ { ShowDocumentResult.success = _ } = Server.request server req in
+  ()

--- a/ocaml-lsp-server/src/document_text_command.mli
+++ b/ocaml-lsp-server/src/document_text_command.mli
@@ -1,0 +1,6 @@
+open Import
+
+val command_name : string
+
+val command_run :
+  _ Server.t -> Document_store.t -> Json.t list option -> unit Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -103,6 +103,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) :
             window.showDocument)
         then
           view_metrics_command_name :: Action_open_related.command_name
+          :: Document_text_command.command_name
           :: Merlin_config_command.command_name :: Dune.commands
         else Dune.commands
       in
@@ -601,6 +602,15 @@ let on_request :
         (fun state server ->
           let store = state.store in
           let+ () = Merlin_config_command.command_run server store in
+          `Null)
+        server
+    else if String.equal command.command Document_text_command.command_name then
+      later
+        (fun state server ->
+          let store = state.store in
+          let+ () =
+            Document_text_command.command_run server store command.arguments
+          in
           `Null)
         server
     else if String.equal command.command view_metrics_command_name then

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -64,7 +64,8 @@ let%expect_test "start/stop" =
           "executeCommandProvider": {
             "commands": [
               "ocamllsp/view-metrics", "ocamllsp/open-related-source",
-              "ocamllsp/show-merlin-config", "dune/promote"
+              "ocamllsp/show-document-text", "ocamllsp/show-merlin-config",
+              "dune/promote"
             ]
           },
           "experimental": {


### PR DESCRIPTION
@copy would you mind reproducing the bug with this PR and running:

```
:lua = vim.lsp.buf.execute_command({
    command = "ocamllsp/show-document-text",
    arguments = {
      vim.uri_from_bufnr(vim.api.nvim_get_current_buf())
    },
})
```

This command should open a file with the contents of the currently opened document as the lsp server sees it. If the result is different, it's a syncing issue. Otherwise, it must be something else.