### PR TITLE
fix(lsp): Substring.rindex_from

### DIFF
--- a/lsp/src/substring.ml
+++ b/lsp/src/substring.ml
@@ -85,7 +85,10 @@ let rindex_from =
     else if s.[pos] = c then Some pos
     else loop s (pos - 1) outside c
   in
-  fun t ~pos c -> loop t.base (t.pos + pos - 1) (t.pos - 1) c
+  fun t ~pos c ->
+    match loop t.base (t.pos + pos - 1) (t.pos - 1) c with
+    | None -> None
+    | Some c -> Some (c - t.pos)
 
 let get_exn t i =
   if i < t.len then t.base.[t.pos + i]

--- a/lsp/test/substring_tests.ml
+++ b/lsp/test/substring_tests.ml
@@ -153,38 +153,17 @@ let%expect_test "rindex_from" =
   [definitive]
   not found |}];
   test "\nfoo" 1;
-  [%expect
-    {|
+  [%expect {|
     [definitive]
-    0
-    [FAIL] ("foo", "\nfoo", ""):
-    3
-    [FAIL] ("a", "\nfoo", "b"):
-    1
-    [FAIL] ("\n", "\nfoo", ""):
-    1 |}];
+    0 |}];
   test "\nfoo" 2;
-  [%expect
-    {|
+  [%expect {|
     [definitive]
-    0
-    [FAIL] ("foo", "\nfoo", ""):
-    3
-    [FAIL] ("a", "\nfoo", "b"):
-    1
-    [FAIL] ("\n", "\nfoo", ""):
-    1 |}];
+    0 |}];
   test "\nfoo" 4;
-  [%expect
-    {|
+  [%expect {|
     [definitive]
-    0
-    [FAIL] ("foo", "\nfoo", ""):
-    3
-    [FAIL] ("a", "\nfoo", "b"):
-    1
-    [FAIL] ("\n", "\nfoo", ""):
-    1 |}];
+    0 |}];
   test "\nfoo" 5;
   [%expect
     {|
@@ -193,7 +172,7 @@ let%expect_test "rindex_from" =
     [FAIL] ("", "\nfoo", "baz"):
     0
     [FAIL] ("a", "\nfoo", "b"):
-    1
+    0
     [FAIL] ("", "\nfoo", "\n"):
     4 |}];
   test "" 0;


### PR DESCRIPTION
Fix the returned offset by this function. It wasn't re adjusted by the
position inside the substring.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 24c3f6b6-29ca-408e-a155-0466d05e4852 -->