### PR TITLE
fix(lsp): Substring.{rindex,index}_from bound checks

### DIFF
--- a/lsp/src/substring.ml
+++ b/lsp/src/substring.ml
@@ -75,6 +75,8 @@ let index_from =
     else loop s (pos + 1) len c
   in
   fun t ~pos c ->
+    if pos < 0 || pos >= t.len then
+      invalid_arg "Substring.index_from: out of bounds";
     match loop t.base (t.pos + pos) (t.pos + t.len) c with
     | None -> None
     | Some pos -> Some (pos - t.pos)
@@ -86,6 +88,8 @@ let rindex_from =
     else loop s (pos - 1) outside c
   in
   fun t ~pos c ->
+    if pos < 0 || pos > t.len then
+      invalid_arg "Substring.rindex_from: out of bounds";
     match loop t.base (t.pos + pos - 1) (t.pos - 1) c with
     | None -> None
     | Some c -> Some (c - t.pos)

--- a/lsp/test/substring_tests.ml
+++ b/lsp/test/substring_tests.ml
@@ -168,13 +168,7 @@ let%expect_test "rindex_from" =
   [%expect
     {|
     [definitive]
-    exception: Invalid_argument("index out of bounds")
-    [FAIL] ("", "\nfoo", "baz"):
-    0
-    [FAIL] ("a", "\nfoo", "b"):
-    0
-    [FAIL] ("", "\nfoo", "\n"):
-    4 |}];
+    exception: Invalid_argument("Substring.rindex_from: out of bounds") |}];
   test "" 0;
   [%expect {|
     [definitive]
@@ -183,4 +177,4 @@ let%expect_test "rindex_from" =
   [%expect
     {|
     [definitive]
-    exception: Invalid_argument("index out of bounds") |}]
+    exception: Invalid_argument("Substring.rindex_from: out of bounds") |}]


### PR DESCRIPTION
Without bound checks, incorrect use will return parts of the string the
user shouldn't see.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 647f7feb-67d1-448c-b677-5c98e732297f -->