### PR TITLE
refactor(lsp): reuse zipper

### DIFF
--- a/lsp/src/string_zipper.ml
+++ b/lsp/src/string_zipper.ml
@@ -44,7 +44,7 @@ let length =
     let init = List.fold_left ~init ~f left in
     List.fold_left ~init ~f right
 
-let to_string t =
+let to_string_and_pos t =
   let dst = Bytes.make (length t) '\000' in
   let dst_pos = ref 0 in
   let f sub =
@@ -52,9 +52,19 @@ let to_string t =
     dst_pos := !dst_pos + Substring.length sub
   in
   List.iter (List.rev t.left) ~f;
+  let final_pos = t.rel_pos + !dst_pos in
   f t.current;
   List.iter t.right ~f;
-  Bytes.unsafe_to_string dst
+  (Bytes.unsafe_to_string dst, final_pos, t.line)
+
+let to_string t =
+  let s, _, _ = to_string_and_pos t in
+  s
+
+let squash t =
+  let str, rel_pos, line = to_string_and_pos t in
+  let current = Substring.of_string str in
+  ({ left = []; right = []; rel_pos; line; current }, str)
 
 let empty = of_string ""
 

--- a/lsp/src/string_zipper.mli
+++ b/lsp/src/string_zipper.mli
@@ -8,6 +8,8 @@ exception Invalid_utf of invalid_utf
 
 val of_string : string -> t
 
+val squash : t -> t * string
+
 val to_string : t -> string
 
 val to_string_debug : t -> string

--- a/lsp/test/string_zipper_tests.ml
+++ b/lsp/test/string_zipper_tests.ml
@@ -140,3 +140,13 @@ let%expect_test "drop_until" =
   let t = String_zipper.drop_until t t in
   printfn "%S" (String_zipper.to_string_debug t);
   [%expect {| "123\n|" |}]
+
+let%expect_test "squashing" =
+  let str = "foo\nbar" in
+  let t = String_zipper.of_string str in
+  let t = String_zipper.goto_line t 1 in
+  let t, str' = String_zipper.squash t in
+  assert (String.equal str str');
+  printfn "squashing: %S" (String_zipper.to_string_debug t);
+  [%expect {|
+    squashing: "foo\n|bar" |}]


### PR DESCRIPTION
Reuse the zipper between different update requests

To reuse the zipper effectively, we "squash" into a single string since
we need the string anyway.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 571d8441-4e1f-460b-a67d-b93a2a99e140 -->