### PR TITLE
feat(ocamllsp): support Pexp_ifthenelse folding ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   called `duneDiganostics` and it may be set to `{ enable: false }` to disable
   diagnostics. (#1221)
 
+- Support folding of `ifthenelse` expressions (#1031)
+
 # 1.17.0
 
 ## Fixes

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -188,11 +188,13 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
             let lident_range = Range.of_loc lident.Asttypes.loc in
             let expr_range = Range.of_loc expr.Parsetree.pexp_loc in
             push { Range.start = lident_range.end_; end_ = expr_range.end_ })
-      | Pexp_ifthenelse (if_expr, then_expr, else_expr) -> 
-        let loc = { if_expr.pexp_loc with loc_end = then_expr.pexp_loc.loc_end } in
+      | Pexp_ifthenelse (if_expr, then_expr, else_expr) ->
+        let loc =
+          { if_expr.pexp_loc with loc_end = then_expr.pexp_loc.loc_end }
+        in
         Range.of_loc loc |> push;
         self.expr self then_expr;
-        Option.iter else_expr ~f:(self.expr self);
+        Option.iter else_expr ~f:(self.expr self)
       | Pexp_apply _
       | Pexp_while _
       | Pexp_for _

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -188,6 +188,11 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
             let lident_range = Range.of_loc lident.Asttypes.loc in
             let expr_range = Range.of_loc expr.Parsetree.pexp_loc in
             push { Range.start = lident_range.end_; end_ = expr_range.end_ })
+      | Pexp_ifthenelse (if_expr, then_expr, else_expr) -> 
+        let loc = { if_expr.pexp_loc with loc_end = then_expr.pexp_loc.loc_end } in
+        Range.of_loc loc |> push;
+        self.expr self then_expr;
+        Option.iter else_expr ~f:(self.expr self);
       | Pexp_apply _
       | Pexp_while _
       | Pexp_for _
@@ -202,7 +207,6 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
       | Pexp_fun _
       | Pexp_poly _
       | Pexp_sequence _
-      | Pexp_ifthenelse _
       | Pexp_constraint _
       | Pexp_function _
       | Pexp_newtype _

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -758,6 +758,13 @@ describe("textDocument/foldingRange", () => {
           "startLine": 0,
         },
         Object {
+          "endCharacter": 6,
+          "endLine": 10,
+          "kind": "region",
+          "startCharacter": 5,
+          "startLine": 1,
+        },
+        Object {
           "endCharacter": 29,
           "endLine": 4,
           "kind": "region",
@@ -1481,6 +1488,20 @@ describe("textDocument/foldingRange", () => {
     let result = await foldingRange();
     expect(result).toMatchInlineSnapshot(`
       Array [
+        Object {
+          "endCharacter": 54,
+          "endLine": 3,
+          "kind": "region",
+          "startCharacter": 3,
+          "startLine": 0,
+        },
+        Object {
+          "endCharacter": 42,
+          "endLine": 2,
+          "kind": "region",
+          "startCharacter": 5,
+          "startLine": 1,
+        },
         Object {
           "endCharacter": 6,
           "endLine": 8,

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-foldingRange.test.ts
@@ -1457,4 +1457,45 @@ describe("textDocument/foldingRange", () => {
       ]
     `);
   });
+
+  it("returns folding ranges for Pexp_ifthenelse", async () => {
+    openDocument(outdent`
+    if tool_name = "ocamldep" then
+      if is_self_reference ~input_name ~loc lid then
+        {type_decl with ptype_manifest = None}
+      else {type_decl with ptype_manifest = Some manifest}
+    else
+      let x =
+        let () = Stdlib.print_endline "one" in
+        let () = Stdlib.print_endline "two" in
+        ()
+      in
+      let y =
+        let () = Stdlib.print_endline "one" in
+        let () = Stdlib.print_endline "two" in
+        ()
+      in
+      ()
+    `);
+
+    let result = await foldingRange();
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "endCharacter": 6,
+          "endLine": 8,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 5,
+        },
+        Object {
+          "endCharacter": 6,
+          "endLine": 13,
+          "kind": "region",
+          "startCharacter": 2,
+          "startLine": 10,
+        },
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
Support folding ranges for `ifthenelse` expressions. 

Before:

https://user-images.githubusercontent.com/5595092/218944712-f71cbd25-ae60-410f-8bd1-f1c06394b2f5.mov

After:

https://user-images.githubusercontent.com/5595092/218944755-c5fb89cf-5d74-4279-8af8-d23091fab810.mov


As you can see in the video above, we can collapse the entire `if` expression but not the `else`. This is because we don't have the start location of the `else` keyword. We only have the location of the whole `expression` inside the `else`. We can add this location to the ranges, but it doesn't appear next to the `else`.

https://user-images.githubusercontent.com/5595092/218945059-2f85fb6b-8536-4afd-9c6f-a8b05c5c10f4.mov

Also, it makes it impossible to collapse only the first expression inside the `else`.


