### PR TITLE
fix(ocamllsp): disable root discovery in release builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Fix a document syncing issue when utf-16 is the position encoding (#1004)
 
+- Disable root discovery in release build (#1035, fix #1029)
+
 # 1.15.1
 
 ## Fixes

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -54,5 +54,7 @@ build: [
     jobs
     "ocaml-lsp-server.install"
     "--release"
+    "--root"
+    "."
   ]
 ]

--- a/ocaml-lsp-server.opam.template
+++ b/ocaml-lsp-server.opam.template
@@ -7,5 +7,7 @@ build: [
     jobs
     "ocaml-lsp-server.install"
     "--release"
+    "--root"
+    "."
   ]
 ]


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 858f165c-85ed-4f61-b8ff-bfe92dbd2ce1 -->