### PR TITLE
feat: improve error message when can't poll dune registry

### DIFF
--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -643,7 +643,10 @@ let poll active last_error =
       | `Skip -> Fiber.return ()
       | `Print ->
         let message =
-          sprintf "failed to poll dune registry. %s" (Printexc.to_string exn)
+          sprintf
+            "failed to poll dune registry. %s \n\
+             Maybe you are not running dune in watch mode?"
+            (Printexc.to_string exn)
         in
         active.config.log ~type_:MessageType.Warning ~message
     in


### PR DESCRIPTION
The most common cause of this issue is not running `dune` in watch mode; therefore, there is no registry to be polled. The current error message doesn't make it clear that this behavior is expected.

We probably don't want to make polling conditional on existence of the socket, since the current implementation allows users to run `dune --watch` without restarting the lsp server.

Expanding the error message makes it clear that this behavior is intentional, and suggests the "fix".

See https://github.com/ocaml/ocaml-lsp/issues/802#issuecomment-1456883356