### PR TITLE
fix(ocamllsp): Respect codeActionLiteralSupport capability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Fixes
 
+- Respect codeActionLiteralSupport capability (#1046)
+
 - Fix a document syncing issue when utf-16 is the position encoding (#1004)
+
 - Disable "Type-annotate" action for code that is already annotated.
   ([#1037](https://github.com/ocaml/ocaml-lsp/pull/1037)), fixes
   [#1036](https://github.com/ocaml/ocaml-lsp/issues/1036)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -30,21 +30,24 @@ let view_metrics server =
 let initialize_info (client_capabilities : ClientCapabilities.t) :
     InitializeResult.t =
   let codeActionProvider =
-    let codeActionKinds =
-      Action_inferred_intf.kind :: Action_destruct.kind
-      :: List.map
-           ~f:(fun (c : Code_action.t) -> c.kind)
-           [ Action_type_annotate.t
-           ; Action_remove_type_annotation.t
-           ; Action_construct.t
-           ; Action_refactor_open.unqualify
-           ; Action_refactor_open.qualify
-           ; Action_add_rec.t
-           ; Action_inline.t
-           ]
-      |> List.sort_uniq ~compare:Poly.compare
-    in
-    `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())
+    match client_capabilities.textDocument with
+    | Some { codeAction = Some { codeActionLiteralSupport = Some _; _ }; _ } ->
+      let codeActionKinds =
+        Action_inferred_intf.kind :: Action_destruct.kind
+        :: List.map
+             ~f:(fun (c : Code_action.t) -> c.kind)
+             [ Action_type_annotate.t
+             ; Action_remove_type_annotation.t
+             ; Action_construct.t
+             ; Action_refactor_open.unqualify
+             ; Action_refactor_open.qualify
+             ; Action_add_rec.t
+             ; Action_inline.t
+             ]
+        |> List.sort_uniq ~compare:Poly.compare
+      in
+      `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())
+    | _ -> `Bool true
   in
   let textDocumentSync =
     `TextDocumentSyncOptions

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -16,7 +16,20 @@ let%expect_test "start/stop" =
           in
           WindowClientCapabilities.create ~showDocument ()
         in
-        ClientCapabilities.create ~window ()
+        let textDocument =
+          let codeAction =
+            let codeActionLiteralSupport =
+              let codeActionKind =
+                CodeActionClientCapabilities.create_codeActionKind ~valueSet:[]
+              in
+              CodeActionClientCapabilities.create_codeActionLiteralSupport
+                ~codeActionKind
+            in
+            CodeActionClientCapabilities.create ~codeActionLiteralSupport ()
+          in
+          TextDocumentClientCapabilities.create ~codeAction ()
+        in
+        ClientCapabilities.create ~window ~textDocument ()
       in
       Client.start client (InitializeParams.create ~capabilities ())
     in


### PR DESCRIPTION
Mentioned in #911.


According to [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/):
```
/**
	 * The server provides code actions. The `CodeActionOptions` return type is
	 * only valid if the client signals code action literal support via the
	 * property `textDocument.codeAction.codeActionLiteralSupport`.
	 */
	codeActionProvider?: boolean | [CodeActionOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionOptions);
```

When client doesn't support code action literal, we return boolean instead.

I didn't modify returned code actions based on kinds supported by client, because client is supposed to handle actions that it doesn't support:
```
 /**
	 * The client supports code action literals as a valid
	 * response of the `textDocument/codeAction` request.
	 *
	 * @since 3.8.0
	 */
	codeActionLiteralSupport?: {
		/**
		 * The code action kind is supported with the following value
		 * set.
		 */
		codeActionKind: {

			/**
			 * The code action kind values the client supports. When this
			 * property exists the client also guarantees that it will
			 * handle values outside its set gracefully and falls back
			 * to a default value when unknown.
			 */
			valueSet: [CodeActionKind](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind)[];
		};
	};
```