### PR TITLE
fix(semantic highlighting): use preprocessed source to highlight long identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@
   ([#1037](https://github.com/ocaml/ocaml-lsp/pull/1037)), fixes
   [#1036](https://github.com/ocaml/ocaml-lsp/issues/1036)
 
+- Fix semantic highlighting of long identifiers when using preprocessors
+  ([#1049](https://github.com/ocaml/ocaml-lsp/pull/1049), fixes
+  [#1034](https://github.com/ocaml/ocaml-lsp/issues/1034))
+
 ## Features
 - Add "Remove type annotation" code action. (#1039)
 

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -860,7 +860,7 @@ let compute_tokens doc =
     Document.Merlin.with_pipeline_exn
       ~name:"semantic highlighting"
       doc
-      (fun p -> (Mpipeline.reader_parsetree p, Mpipeline.raw_source p))
+      (fun p -> (Mpipeline.reader_parsetree p, Mpipeline.input_source p))
   in
   let module Fold = Parsetree_fold (struct
     let source = Msource.text source


### PR DESCRIPTION
Hello,

This PR follows up and solves issue #1034 where usage of preprocessors breaks semantic highlighting.

After a few minutes of investigation with @thierry-martinez we saw that, in order to parse long identifiers (e.g. `Foo.Bar.x`), ocaml-lsp reads again the source pre-preprocessor (`raw_source`) to semantic highlight the tokens in long identifiers (following PR #932).

The problem is that locations in the AST do not correspond to the ones in `raw_source`, but to the ones in `source`.

I'm not sure this modification could cause issues, but this source is only used to retrieve the source code of long identifiers. All tests still pass.