### PR TITLE
fix(ocamllsp): Disable type annotation for functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+- Disable type annotation for functions (#1054)
+
 - Respect codeActionLiteralSupport capability (#1046)
 
 - Fix a document syncing issue when utf-16 is the position encoding (#1004)

--- a/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
+++ b/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
@@ -23,6 +23,9 @@ let check_typeable_context pipeline pos_start =
     | None -> `Invalid
   in
   match Mbrowse.enclosing pos_start [ browse ] with
+  | (_, Pattern { pat_desc = Tpat_var _; _ })
+    :: (_, Value_binding { vb_expr = { exp_desc = Texp_function _; _ }; _ })
+    :: _ -> `Invalid
   | (_, Expression e) :: _ -> is_valid e.exp_loc is_exp_constrained e.exp_extra
   | (_, Pattern { pat_desc = Typedtree.Tpat_any; pat_loc; _ })
     :: (_, Pattern { pat_desc = Typedtree.Tpat_alias _; pat_extra; _ })

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -20,6 +20,9 @@ let check_typeable_context pipeline pos_start =
     if List.exists ~f:p extras then `Invalid else `Valid
   in
   match Mbrowse.enclosing pos_start [ browse ] with
+  | (_, Pattern { pat_desc = Tpat_var _; _ })
+    :: (_, Value_binding { vb_expr = { exp_desc = Texp_function _; _ }; _ })
+    :: _ -> `Invalid
   | (_, Expression e) :: _ -> is_valid is_exp_constrained e.exp_extra
   | (_, Pattern { pat_desc = Typedtree.Tpat_any; _ })
     :: (_, Pattern { pat_desc = Typedtree.Tpat_alias _; pat_extra; _ })

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -209,6 +209,18 @@ let iiii = 3 + 4
     }
      |}]
 
+let%expect_test "does not type-annotate function" =
+  let source = {ocaml|
+let my_fun x y = 1
+|ocaml} in
+  let range =
+    let start = Position.create ~line:1 ~character:5 in
+    let end_ = Position.create ~line:1 ~character:6 in
+    Range.create ~start ~end_
+  in
+  print_code_actions source range ~filter:find_annotate_action;
+  [%expect {| No code actions |}]
+
 let%expect_test "can type-annotate an argument in a function call" =
   let source =
     {ocaml|
@@ -487,3 +499,15 @@ let x = (7 : int :> int)
       "kind": "remove type annotation",
       "title": "Remove type annotation"
     } |}]
+
+let%expect_test "does not remove type annotation from function" =
+  let source = {ocaml|
+let my_fun x y : int = 1
+|ocaml} in
+  let range =
+    let start = Position.create ~line:1 ~character:5 in
+    let end_ = Position.create ~line:1 ~character:6 in
+    Range.create ~start ~end_
+  in
+  print_code_actions source range ~filter:find_remove_annotation_action;
+  [%expect {| No code actions |}]


### PR DESCRIPTION
As discussed in #801. I've tried to fix it with #1048, but found no reasonable solution.
This PR disables type annotation for functions, which I think is better than allowing users to generate invalid code.