### PR TITLE
fix: Branch name in changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,7 +2,7 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:


### PR DESCRIPTION
We need to add a `no changelog` label so that this check can be skipped. Unfortunately, I don't have the necessary write access to do it on my own.