### PR TITLE
feature: support --clientProcessId argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 
 - Fix the type of DocumentSelector in cram document registration (#1068)
 
+- Accept the `--clientProcessId` command line argument. (#1074)
+
 ## Features
 - Add "Remove type annotation" code action. (#1039)
 

--- a/lsp/src/cli.ml
+++ b/lsp/src/cli.ml
@@ -11,10 +11,18 @@ module Arg = struct
     ; mutable port : int option
     ; mutable stdio : bool
     ; mutable spec : (string * Arg.spec * string) list
+    ; mutable clientProcessId : int option
     }
 
   let create () =
-    let t = { pipe = None; port = None; stdio = false; spec = [] } in
+    let t =
+      { pipe = None
+      ; port = None
+      ; stdio = false
+      ; spec = []
+      ; clientProcessId = None
+      }
+    in
     let spec =
       [ ("--pipe", Arg.String (fun p -> t.pipe <- Some p), "set pipe path")
       ; ("--socket", Arg.Int (fun p -> t.port <- Some p), "set port")
@@ -22,6 +30,9 @@ module Arg = struct
       ; ( "--node-ipc"
         , Arg.Unit (fun () -> raise @@ Arg.Bad "node-ipc isn't supported")
         , "not supported" )
+      ; ( "--clientProcessId"
+        , Arg.Int (fun pid -> t.clientProcessId <- Some pid)
+        , "set the pid of the lsp client" )
       ]
     in
     t.spec <- spec;
@@ -29,7 +40,10 @@ module Arg = struct
 
   let spec t = t.spec
 
-  let read { pipe; port; stdio; spec = _ } : (Channel.t, string) result =
+  let clientProcessId t = t.clientProcessId
+
+  let read { pipe; port; stdio; spec = _; clientProcessId = _ } :
+      (Channel.t, string) result =
     match (pipe, port, stdio) with
     | None, None, _ -> Ok Stdio
     | Some p, None, false -> Ok (Pipe p)

--- a/lsp/src/cli.mli
+++ b/lsp/src/cli.mli
@@ -13,4 +13,6 @@ module Arg : sig
   val spec : t -> (string * Arg.spec * string) list
 
   val read : t -> (Channel.t, string) result
+
+  val clientProcessId : t -> int option
 end

--- a/ocaml-lsp-server/bin/main.ml
+++ b/ocaml-lsp-server/bin/main.ml
@@ -16,7 +16,8 @@ let () =
     @ Cli.Arg.spec arg
   in
   let usage =
-    "ocamllsp [ --stdio | --socket SOCKET --port PORT | --pipe PIPE ]"
+    "ocamllsp [ --stdio | --socket SOCKET --port PORT | --pipe PIPE ] [ \
+     --clientProcessId pid ]"
   in
   Arg.parse
     spec


### PR DESCRIPTION
It does nothing for now, but it's in the standard so it's better to at
least explicitly ignore it.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 35ce0575-f2a8-47b6-a0fb-97cf408d86cd -->