### PR TITLE
feature: add --port as a synonym to --socket

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 
 - Accept the `--clientProcessId` command line argument. (#1074)
 
+- Accept `--port` as a synonym for `--socket`. (#1075)
+
 ## Features
 - Add "Remove type annotation" code action. (#1039)
 

--- a/lsp/src/cli.mli
+++ b/lsp/src/cli.mli
@@ -1,18 +1,34 @@
+(** Handling of standard lsp server command line arguments *)
+
 module Channel : sig
+  (** The channel the server shold use to listen for connections *)
+
   type t =
     | Stdio
-    | Pipe of string
-    | Socket of int
+    | Pipe of string  (** A path to the unix domain socket or windows pipe *)
+    | Socket of int  (** A tcp connection on localhost with the port number *)
 end
 
 module Arg : sig
+  (** Parsing of the standard commnad line arguments using [Stdlib.Arg] *)
+
   type t
 
+  (** [create ()] create a new record for arguments *)
   val create : unit -> t
 
+  (** [spec t] returns the spec that should be provided to [Stdlib.Arg] to
+      populate [t] using the interpreted cli args *)
   val spec : t -> (string * Arg.spec * string) list
 
-  val read : t -> (Channel.t, string) result
+  (** [channel t] return the channel if correctly supplied. An error if the
+      arguments were provided incorrectly. *)
+  val channel : t -> (Channel.t, string) result
 
+  (** Return the process id of the client used to run the lsp server if it was
+      provided *)
   val clientProcessId : t -> int option
 end
+
+(** generate command line arguments that can be used to spawn an lsp client *)
+val args : ?channel:Channel.t -> ?clientProcessId:int -> unit -> string list

--- a/ocaml-lsp-server/bin/main.ml
+++ b/ocaml-lsp-server/bin/main.ml
@@ -16,7 +16,7 @@ let () =
     @ Cli.Arg.spec arg
   in
   let usage =
-    "ocamllsp [ --stdio | --socket SOCKET --port PORT | --pipe PIPE ] [ \
+    "ocamllsp [ --stdio | --socket PORT | --port PORT | --pipe PIPE ] [ \
      --clientProcessId pid ]"
   in
   Arg.parse
@@ -24,7 +24,7 @@ let () =
     (fun _ -> raise @@ Arg.Bad "anonymous arguments aren't allowed")
     usage;
   let channel =
-    match Cli.Arg.read arg with
+    match Cli.Arg.channel arg with
     | Ok c -> c
     | Error s ->
       Format.eprintf "%s@.%!" s;


### PR DESCRIPTION
cc @ddickstein. The spec is quite confusing about this:

> socket: uses a socket as the communication channel. The port is passed as next arg or with --port=.

So I believe that makes `--port` a synonym.