### PR TITLE
feature: add [Lsp.Cli.args]

### DIFF
--- a/lsp/src/cli.ml
+++ b/lsp/src/cli.ml
@@ -50,3 +50,15 @@ module Arg = struct
     | None, Some s, false -> Ok (Socket s)
     | _, _, _ -> Error "invalid arguments"
 end
+
+let args ?channel ?clientProcessId () =
+  let args =
+    match clientProcessId with
+    | None -> []
+    | Some pid -> ["--clientPorcessId"; string_of_int pid]
+  in
+  match channel with
+  | None -> args
+  | Some Stdio -> "--stdio" :: args
+  | Some (Pipe pipe) -> "--pipe" :: pipe :: args
+  | Some (Socket port) -> "--socket" :: socket :: args

--- a/lsp/src/cli.mli
+++ b/lsp/src/cli.mli
@@ -16,3 +16,6 @@ module Arg : sig
 
   val clientProcessId : t -> int option
 end
+
+(** generate command line arguments that can be used to spawn an lsp client  *)
+val args : ?channel:Channel.t -> ?clientProcessId:int -> unit -> string list


### PR DESCRIPTION
Can be used to encode cli args to spawn a client

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7b0feeb0-068e-4fd4-9948-36a52f36a2f3 -->