### PR TITLE
fix(lsp): make write take list of strings

### DIFF
--- a/lsp-fiber/src/fiber_io.ml
+++ b/lsp-fiber/src/fiber_io.ml
@@ -28,9 +28,9 @@ module Io =
         | Ok s -> Some s
         | Error (`Partial_eof _) -> None
 
-      let write oc s =
+      let write oc strings =
         Fiber.of_thunk (fun () ->
-            Lio.Writer.add_string oc s;
+            List.iter strings ~f:(Lio.Writer.add_string oc);
             Fiber.return ())
     end)
 

--- a/lsp/src/io.ml
+++ b/lsp/src/io.ml
@@ -50,7 +50,7 @@ end) (Chan : sig
 
   val read_exactly : input -> int -> string option Io.t
 
-  val write : output -> string -> unit Io.t
+  val write : output -> string list -> unit Io.t
 end) =
 struct
   open Io.O
@@ -112,6 +112,5 @@ struct
     let data = Json.to_string json in
     let content_length = String.length data in
     let header = Header.create ~content_length () in
-    let* () = Chan.write chan (Header.to_string header) in
-    Chan.write chan data
+    Chan.write chan [ Header.to_string header; data ]
 end

--- a/lsp/src/io.mli
+++ b/lsp/src/io.mli
@@ -23,7 +23,7 @@ end) (Chan : sig
 
   val read_exactly : input -> int -> string option Io.t
 
-  val write : output -> string -> unit Io.t
+  val write : output -> string list -> unit Io.t
 end) : sig
   val read : Chan.input -> Jsonrpc.Packet.t option Io.t
 


### PR DESCRIPTION
So that we don't have to assume that writes aren't interleaved.

cc @ddickstein

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>