### PR TITLE
[WIP] Upgrade Omd to 2.0.0~alpha3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@ possible and does not make any assumptions about IO.
   (ppx_expect (and (>= v0.15.0) :with-test))
   (ocamlformat (and :with-test (= 0.24.1)))
   (ocamlc-loc (and (>= 3.5.0) (< 3.7.0)))
-  (omd (and (>= 1.3.2) (< 2.0.0~alpha1)))
+  (omd (>= 2.0.0~alpha3))
   (octavius (>= 1.2.2))
   (uutf (>= 1.0.2))
   (pp (>= 1.1.2))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_expect" {>= "v0.15.0" & with-test}
   "ocamlformat" {with-test & = "0.24.1"}
   "ocamlc-loc" {>= "3.5.0" & < "3.7.0"}
-  "omd" {>= "1.3.2" & < "2.0.0~alpha1"}
+  "omd" {>= "2.0.0~alpha3"}
   "octavius" {>= "1.2.2"}
   "uutf" {>= "1.0.2"}
   "pp" {>= "1.1.2"}


### PR DESCRIPTION
Alternative to #1088 which upgrades to Omd 2.0.0~alpha3. Unfortunately, Omd 2 doesn't support printing to Markdown yet, and the upgrade can't be completed until it does.

cc @tatchi @ddickstein