### PR TITLE
feature(lsp): api for absolute positions

### DIFF
--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -105,6 +105,21 @@ let apply_text_document_edits t (edits : TextEdit.t list) =
   let zipper = String_zipper.of_string text in
   { t with text = Some text; zipper }
 
+let absolute_position t pos =
+  String_zipper.goto_position t.zipper pos t.position_encoding
+  |> String_zipper.offset
+
+let absolute_range t (range : Range.t) =
+  let zipper =
+    String_zipper.goto_position t.zipper range.start t.position_encoding
+  in
+  let start = String_zipper.offset zipper in
+  let zipper =
+    String_zipper.goto_position zipper range.end_ t.position_encoding
+  in
+  let stop = String_zipper.offset zipper in
+  (start, stop)
+
 module Expert = struct
   let goto t pos =
     let zipper = String_zipper.goto_position t.zipper pos `UTF8 in

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -2,14 +2,18 @@ open Types
 
 type t
 
-val make :
-  position_encoding:[ `UTF8 | `UTF16 ] -> DidOpenTextDocumentParams.t -> t
+type encoding :=
+  [ `UTF8
+  | `UTF16
+  ]
+
+val make : position_encoding:encoding -> DidOpenTextDocumentParams.t -> t
 
 val languageId : t -> string
 
 val documentUri : t -> Uri0.t
 
-val position_encoding : t -> [ `UTF16 | `UTF8 ]
+val position_encoding : t -> encoding
 
 val version : t -> int
 
@@ -30,6 +34,16 @@ val set_version : t -> version:int -> t
     when multiple inserts are done in the same position. All the offsets are
     interpreted relative to the original document. *)
 val apply_text_document_edits : t -> TextEdit.t list -> t
+
+(** [absolute_position t pos] returns the absolute position of [pos] inside
+    [text t]. If the position is outside the bounds of the document, the offset
+    returned will be the length of the document. [pos] is interpreted with
+    [position_encoding t] *)
+val absolute_position : t -> Position.t -> int
+
+(* [absolute_range t range] same as [(absolute_position t range.start ,
+   absolute_position t range.end_)] but possibly faster *)
+val absolute_range : t -> Range.t -> int * int
 
 module Expert : sig
   (** These functions allow one to work with the underlying zipper. This gives


### PR DESCRIPTION
Text_document.absolute_{position,range} are used to extract absolute
positions in the string.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 041b8bec-57f1-401b-a3da-c1b31a5b15c0 -->