### PR TITLE
fix(ocamllsp): workspace symbols fallback to _build folder

### DIFF
--- a/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
@@ -120,6 +120,7 @@ describe("workspace/symbol", () => {
         "lib_x 12 /workspace_symbol_A/lib/lib.ml 6:0 6:14",
         "user 15 /workspace_symbol_A/lib/lib.ml 3:0 5:1",
         "name 7 /workspace_symbol_A/lib/lib.ml 4:2 4:14",
+        "hello 12 /workspace_symbol_A/lib/gen.ml 0:0 0:19",
         "t 15 /workspace_symbol_A/lib/LibTypes.mli 0:0 0:15",
         "x 12 /workspace_symbol_A/vendor/vendored_lib.ml 0:0 0:9",
       ]
@@ -200,6 +201,7 @@ describe("workspace/symbol", () => {
         "lib_x 12 /workspace_symbol_A/lib/lib.ml 6:0 6:14",
         "user 15 /workspace_symbol_A/lib/lib.ml 3:0 5:1",
         "name 7 /workspace_symbol_A/lib/lib.ml 4:2 4:14",
+        "hello 12 /workspace_symbol_A/lib/gen.ml 0:0 0:19",
         "t 15 /workspace_symbol_A/lib/LibTypes.mli 0:0 0:15",
         "x 12 /workspace_symbol_A/vendor/vendored_lib.ml 0:0 0:9",
         "workspace_B 12 /workspace_symbol_B/main.ml 0:0 0:31",

--- a/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/workspace-symbol.test.ts
@@ -120,7 +120,7 @@ describe("workspace/symbol", () => {
         "lib_x 12 /workspace_symbol_A/lib/lib.ml 6:0 6:14",
         "user 15 /workspace_symbol_A/lib/lib.ml 3:0 5:1",
         "name 7 /workspace_symbol_A/lib/lib.ml 4:2 4:14",
-        "hello 12 /workspace_symbol_A/lib/gen.ml 0:0 0:19",
+        "hello 12 /workspace_symbol_A/_build/default/lib/gen.ml 0:0 0:19",
         "t 15 /workspace_symbol_A/lib/LibTypes.mli 0:0 0:15",
         "x 12 /workspace_symbol_A/vendor/vendored_lib.ml 0:0 0:9",
       ]
@@ -201,7 +201,7 @@ describe("workspace/symbol", () => {
         "lib_x 12 /workspace_symbol_A/lib/lib.ml 6:0 6:14",
         "user 15 /workspace_symbol_A/lib/lib.ml 3:0 5:1",
         "name 7 /workspace_symbol_A/lib/lib.ml 4:2 4:14",
-        "hello 12 /workspace_symbol_A/lib/gen.ml 0:0 0:19",
+        "hello 12 /workspace_symbol_A/_build/default/lib/gen.ml 0:0 0:19",
         "t 15 /workspace_symbol_A/lib/LibTypes.mli 0:0 0:15",
         "x 12 /workspace_symbol_A/vendor/vendored_lib.ml 0:0 0:9",
         "workspace_B 12 /workspace_symbol_B/main.ml 0:0 0:31",

--- a/ocaml-lsp-server/test/e2e/__tests__/workspace_symbol_A/lib/dune
+++ b/ocaml-lsp-server/test/e2e/__tests__/workspace_symbol_A/lib/dune
@@ -4,5 +4,11 @@
  (flags :standard -w -32-38-27-34)
  (name lib))
 
-
 (copy_files# ../vendor/*.ml{,i})
+
+(rule
+ (target gen.ml)
+ (action
+  (with-stdout-to
+   %{target}
+   (echo "let hello = \"world\""))))


### PR DESCRIPTION
It checks that the `uri` exist and otherwise fallback to the `_build` folder. This might be the case for generated files (that only exist in the `_build` folder.

Before:

https://github.com/ocaml/ocaml-lsp/assets/5595092/10f65cf6-b048-4058-a0d1-e95ea4c0f136

After:

https://github.com/ocaml/ocaml-lsp/assets/5595092/4e23f045-b25b-400c-91cd-302de3e8e7d1




