### PR TITLE
support settings through `didChangeConfiguration` notification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 ## Features
 
 - Add "Remove type annotation" code action. (#1039)
+- Support settings through `didChangeConfiguration` notification (#1103)
 
 # 1.15.1
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The server supports the following LSP requests (inexhaustive list):
 - [x] `textDocument/prepareRename`
 - [x] `textDocument/foldingRange`
 - [x] `textDocument/selectionRange`
+- [x] `workspace/didChangeConfiguration`
 - [x] `workspace/symbol`
 
 Note that degrees of support for each LSP request are varying.
@@ -336,8 +337,8 @@ make all
 
 ### Changelog
 
-User-visible changes should come with an entry in the changelog under the appropriate part of 
-the **unreleased** section. PR that doesn't provide an entry will fail CI check. This behavior 
+User-visible changes should come with an entry in the changelog under the appropriate part of
+the **unreleased** section. PR that doesn't provide an entry will fail CI check. This behavior
 can be overridden by using the "no changelog" label, which is used for changes that are not user-visible.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ The server supports the following LSP requests (inexhaustive list):
 
 Note that degrees of support for each LSP request are varying.
 
+## Configuration
+
+[Read more about configurations supported by ocamllsp](./ocaml-lsp-server/docs/ocamllsp/config.md)
+
 ### Semantic highlighting
 
 > since OCaml-LSP 1.15.0 (since version `1.15.0-4.14` for OCaml 4, `1.15.0-5.0` for OCaml 5)

--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -1,0 +1,21 @@
+# Configuration
+
+The ocamllsp support the folowing configuration. These configurations are sent through the [`didChangeConfiguration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration) notification.
+
+```ts
+interface config {
+  /**
+  * Enable Extended Hover
+  * @default false
+  * @since 1.16
+  */
+  extendedHover: { enable : boolean }
+
+  /**
+  * Disable CodeLens
+  * @default true
+  * @since 1.16
+  */
+  codelens: { enable : boolean }
+}
+```

--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -5,14 +5,14 @@ The ocamllsp support the folowing configuration. These configurations are sent t
 ```ts
 interface config {
   /**
-  * Enable Extended Hover
+  * Enable/Disabe Extended Hover
   * @default false
   * @since 1.16
   */
   extendedHover: { enable : boolean }
 
   /**
-  * Disable CodeLens
+  * Enable/Disable CodeLens
   * @default true
   * @since 1.16
   */

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -2,7 +2,7 @@ open Import
 open Import.Json.Conv
 
 module Lens = struct
-  type t = { enable : bool Json.Nullable_option.t [@default Some true] }
+  type t = { enable : bool [@default true] }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
@@ -20,9 +20,7 @@ module Lens = struct
            | "enable" -> (
              match Ppx_yojson_conv_lib.( ! ) enable_field with
              | Ppx_yojson_conv_lib.Option.None ->
-               let fvalue =
-                 Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-               in
+               let fvalue = bool_of_yojson _field_yojson in
                enable_field := Ppx_yojson_conv_lib.Option.Some fvalue
              | Ppx_yojson_conv_lib.Option.Some _ ->
                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -48,7 +46,7 @@ module Lens = struct
            let enable_value = Ppx_yojson_conv_lib.( ! ) enable_field in
            { enable =
                (match enable_value with
-               | Ppx_yojson_conv_lib.Option.None -> Some true
+               | Ppx_yojson_conv_lib.Option.None -> true
                | Ppx_yojson_conv_lib.Option.Some v -> v)
            }))
      | _ as yojson ->
@@ -64,7 +62,7 @@ module Lens = struct
      | { enable = v_enable } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = Json.Nullable_option.yojson_of_t yojson_of_bool v_enable in
+         let arg = yojson_of_bool v_enable in
          ("enable", arg) :: bnds
        in
        `Assoc bnds
@@ -76,7 +74,7 @@ module Lens = struct
 end
 
 module ExtendedHover = struct
-  type t = { enable : bool Json.Nullable_option.t [@default Some false] }
+  type t = { enable : bool [@default false] }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
@@ -94,9 +92,7 @@ module ExtendedHover = struct
            | "enable" -> (
              match Ppx_yojson_conv_lib.( ! ) enable_field with
              | Ppx_yojson_conv_lib.Option.None ->
-               let fvalue =
-                 Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-               in
+               let fvalue = bool_of_yojson _field_yojson in
                enable_field := Ppx_yojson_conv_lib.Option.Some fvalue
              | Ppx_yojson_conv_lib.Option.Some _ ->
                duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -122,7 +118,7 @@ module ExtendedHover = struct
            let enable_value = Ppx_yojson_conv_lib.( ! ) enable_field in
            { enable =
                (match enable_value with
-               | Ppx_yojson_conv_lib.Option.None -> Some false
+               | Ppx_yojson_conv_lib.Option.None -> false
                | Ppx_yojson_conv_lib.Option.Some v -> v)
            }))
      | _ as yojson ->
@@ -138,7 +134,7 @@ module ExtendedHover = struct
      | { enable = v_enable } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = Json.Nullable_option.yojson_of_t yojson_of_bool v_enable in
+         let arg = yojson_of_bool v_enable in
          ("enable", arg) :: bnds
        in
        `Assoc bnds
@@ -153,7 +149,7 @@ type t =
   { codelens : Lens.t Json.Nullable_option.t
         [@default None] [@yojson_drop_default ( = )]
   ; extended_hover : ExtendedHover.t Json.Nullable_option.t
-        [@default None] [@key "extendedHover"] [@yojson_drop_default ( = )]
+        [@key "extendedHover"] [@default None] [@yojson_drop_default ( = )]
   }
 [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -259,3 +255,8 @@ let yojson_of_t =
 let _ = yojson_of_t
 
 [@@@end]
+
+let default =
+  { codelens = Some { enable = true }
+  ; extended_hover = Some { enable = false }
+  }

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -1,0 +1,261 @@
+open Import
+open Import.Json.Conv
+
+module Lens = struct
+  type t = { enable : bool Json.Nullable_option.t [@default Some true] }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "ocaml-lsp-server/src/config_data.ml.Lens.t" in
+     function
+     | `Assoc field_yojsons as yojson -> (
+       let enable_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+           | "enable" -> (
+             match Ppx_yojson_conv_lib.( ! ) enable_field with
+             | Ppx_yojson_conv_lib.Option.None ->
+               let fvalue =
+                 Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+               in
+               enable_field := Ppx_yojson_conv_lib.Option.Some fvalue
+             | Ppx_yojson_conv_lib.Option.Some _ ->
+               duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+           | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       match Ppx_yojson_conv_lib.( ! ) duplicates with
+       | _ :: _ ->
+         Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+           _tp_loc
+           (Ppx_yojson_conv_lib.( ! ) duplicates)
+           yojson
+       | [] -> (
+         match Ppx_yojson_conv_lib.( ! ) extra with
+         | _ :: _ ->
+           Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+             _tp_loc
+             (Ppx_yojson_conv_lib.( ! ) extra)
+             yojson
+         | [] ->
+           let enable_value = Ppx_yojson_conv_lib.( ! ) enable_field in
+           { enable =
+               (match enable_value with
+               | Ppx_yojson_conv_lib.Option.None -> Some true
+               | Ppx_yojson_conv_lib.Option.Some v -> v)
+           }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom
+         _tp_loc
+         yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { enable = v_enable } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = Json.Nullable_option.yojson_of_t yojson_of_bool v_enable in
+         ("enable", arg) :: bnds
+       in
+       `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
+module ExtendedHover = struct
+  type t = { enable : bool Json.Nullable_option.t [@default Some false] }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "ocaml-lsp-server/src/config_data.ml.ExtendedHover.t" in
+     function
+     | `Assoc field_yojsons as yojson -> (
+       let enable_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+           | "enable" -> (
+             match Ppx_yojson_conv_lib.( ! ) enable_field with
+             | Ppx_yojson_conv_lib.Option.None ->
+               let fvalue =
+                 Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+               in
+               enable_field := Ppx_yojson_conv_lib.Option.Some fvalue
+             | Ppx_yojson_conv_lib.Option.Some _ ->
+               duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+           | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       match Ppx_yojson_conv_lib.( ! ) duplicates with
+       | _ :: _ ->
+         Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+           _tp_loc
+           (Ppx_yojson_conv_lib.( ! ) duplicates)
+           yojson
+       | [] -> (
+         match Ppx_yojson_conv_lib.( ! ) extra with
+         | _ :: _ ->
+           Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+             _tp_loc
+             (Ppx_yojson_conv_lib.( ! ) extra)
+             yojson
+         | [] ->
+           let enable_value = Ppx_yojson_conv_lib.( ! ) enable_field in
+           { enable =
+               (match enable_value with
+               | Ppx_yojson_conv_lib.Option.None -> Some false
+               | Ppx_yojson_conv_lib.Option.Some v -> v)
+           }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom
+         _tp_loc
+         yojson
+      : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { enable = v_enable } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = Json.Nullable_option.yojson_of_t yojson_of_bool v_enable in
+         ("enable", arg) :: bnds
+       in
+       `Assoc bnds
+      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
+type t =
+  { codelens : Lens.t Json.Nullable_option.t
+        [@default None] [@yojson_drop_default ( = )]
+  ; extended_hover : ExtendedHover.t Json.Nullable_option.t
+        [@default None] [@key "extendedHover"] [@yojson_drop_default ( = )]
+  }
+[@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+let _ = fun (_ : t) -> ()
+
+let t_of_yojson =
+  (let _tp_loc = "ocaml-lsp-server/src/config_data.ml.t" in
+   function
+   | `Assoc field_yojsons as yojson -> (
+     let codelens_field = ref Ppx_yojson_conv_lib.Option.None
+     and extended_hover_field = ref Ppx_yojson_conv_lib.Option.None
+     and duplicates = ref []
+     and extra = ref [] in
+     let rec iter = function
+       | (field_name, _field_yojson) :: tail ->
+         (match field_name with
+         | "codelens" -> (
+           match Ppx_yojson_conv_lib.( ! ) codelens_field with
+           | Ppx_yojson_conv_lib.Option.None ->
+             let fvalue =
+               Json.Nullable_option.t_of_yojson Lens.t_of_yojson _field_yojson
+             in
+             codelens_field := Ppx_yojson_conv_lib.Option.Some fvalue
+           | Ppx_yojson_conv_lib.Option.Some _ ->
+             duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+         | "extendedHover" -> (
+           match Ppx_yojson_conv_lib.( ! ) extended_hover_field with
+           | Ppx_yojson_conv_lib.Option.None ->
+             let fvalue =
+               Json.Nullable_option.t_of_yojson
+                 ExtendedHover.t_of_yojson
+                 _field_yojson
+             in
+             extended_hover_field := Ppx_yojson_conv_lib.Option.Some fvalue
+           | Ppx_yojson_conv_lib.Option.Some _ ->
+             duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+         | _ -> ());
+         iter tail
+       | [] -> ()
+     in
+     iter field_yojsons;
+     match Ppx_yojson_conv_lib.( ! ) duplicates with
+     | _ :: _ ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+         _tp_loc
+         (Ppx_yojson_conv_lib.( ! ) duplicates)
+         yojson
+     | [] -> (
+       match Ppx_yojson_conv_lib.( ! ) extra with
+       | _ :: _ ->
+         Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+           _tp_loc
+           (Ppx_yojson_conv_lib.( ! ) extra)
+           yojson
+       | [] ->
+         let codelens_value, extended_hover_value =
+           ( Ppx_yojson_conv_lib.( ! ) codelens_field
+           , Ppx_yojson_conv_lib.( ! ) extended_hover_field )
+         in
+         { codelens =
+             (match codelens_value with
+             | Ppx_yojson_conv_lib.Option.None -> None
+             | Ppx_yojson_conv_lib.Option.Some v -> v)
+         ; extended_hover =
+             (match extended_hover_value with
+             | Ppx_yojson_conv_lib.Option.None -> None
+             | Ppx_yojson_conv_lib.Option.Some v -> v)
+         }))
+   | _ as yojson ->
+     Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom
+       _tp_loc
+       yojson
+    : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+
+let _ = t_of_yojson
+
+let yojson_of_t =
+  (function
+   | { codelens = v_codelens; extended_hover = v_extended_hover } ->
+     let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+     let bnds =
+       if None = v_extended_hover then bnds
+       else
+         let arg =
+           (Json.Nullable_option.yojson_of_t ExtendedHover.yojson_of_t)
+             v_extended_hover
+         in
+         let bnd = ("extendedHover", arg) in
+         bnd :: bnds
+     in
+     let bnds =
+       if None = v_codelens then bnds
+       else
+         let arg =
+           (Json.Nullable_option.yojson_of_t Lens.yojson_of_t) v_codelens
+         in
+         let bnd = ("codelens", arg) in
+         bnd :: bnds
+     in
+     `Assoc bnds
+    : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+
+let _ = yojson_of_t
+
+[@@@end]

--- a/ocaml-lsp-server/src/configuration.ml
+++ b/ocaml-lsp-server/src/configuration.ml
@@ -17,12 +17,7 @@ let default () =
     in
     Lev_fiber.Timer.Wheel.create ~delay
   in
-  let data =
-    Config_data.
-      { codelens = Some { enable = Some true }
-      ; extended_hover = Some { enable = Some false }
-      }
-  in
+  let data = Config_data.default in
   { wheel; data }
 
 let update t { DidChangeConfigurationParams.settings } =

--- a/ocaml-lsp-server/src/configuration.mli
+++ b/ocaml-lsp-server/src/configuration.mli
@@ -1,6 +1,9 @@
 open Import
 
-type t
+type t =
+  { wheel : Lev_fiber.Timer.Wheel.t
+  ; data : Config_data.t
+  }
 
 val default : unit -> t Fiber.t
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -600,7 +600,7 @@ let on_request :
   | TextDocumentHover req ->
     let mode =
       match state.configuration.data.extended_hover with
-      | Some { enable = Some true } -> Hover_req.Extended_variable
+      | Some { enable = true } -> Hover_req.Extended_variable
       | Some _ | None -> Hover_req.Default
     in
     later (fun (_ : State.t) () -> Hover_req.handle rpc req mode) ()
@@ -608,8 +608,8 @@ let on_request :
   | TextDocumentCodeLensResolve codeLens -> now codeLens
   | TextDocumentCodeLens req -> (
     match state.configuration.data.codelens with
-    | Some { enable = Some true } -> later text_document_lens req
-    | None | Some _ -> now [])
+    | Some { enable = true } | None -> later text_document_lens req
+    | Some _ -> now [])
   | TextDocumentHighlight req -> later highlight req
   | DocumentSymbol { textDocument = { uri }; _ } -> later document_symbol uri
   | TextDocumentDeclaration { textDocument = { uri }; position } ->

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -598,12 +598,18 @@ let on_request :
   | TextDocumentColor _ -> now []
   | TextDocumentColorPresentation _ -> now []
   | TextDocumentHover req ->
-    later
-      (fun (_ : State.t) () -> Hover_req.handle rpc req Hover_req.Default)
-      ()
+    let mode =
+      match state.configuration.data.extended_hover with
+      | Some { enable = Some true } -> Hover_req.Extended_variable
+      | Some _ | None -> Hover_req.Default
+    in
+    later (fun (_ : State.t) () -> Hover_req.handle rpc req mode) ()
   | TextDocumentReferences req -> later references req
   | TextDocumentCodeLensResolve codeLens -> now codeLens
-  | TextDocumentCodeLens req -> later text_document_lens req
+  | TextDocumentCodeLens req -> (
+    match state.configuration.data.codelens with
+    | Some { enable = Some true } -> later text_document_lens req
+    | None | Some _ -> now [])
   | TextDocumentHighlight req -> later highlight req
   | DocumentSymbol { textDocument = { uri }; _ } -> later document_symbol uri
   | TextDocumentDeclaration { textDocument = { uri }; position } ->
@@ -702,8 +708,6 @@ let on_notification server (notification : Client_notification.t) :
     state
   | CancelRequest _ -> Fiber.return state
   | ChangeConfiguration req ->
-    (* TODO this is wrong and we should just fetch the config from the client
-       after receiving this notification *)
     let+ configuration = Configuration.update state.configuration req in
     { state with configuration }
   | DidSaveTextDocument { textDocument = { uri }; _ } -> (

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -1,0 +1,122 @@
+open Test.Import
+
+let client_capabilities = ClientCapabilities.create ()
+
+let uri = DocumentUri.of_path "test.ml"
+
+let test text req =
+  let handler =
+    Client.Handler.make
+      ~on_notification:(fun client _notification ->
+        Client.state client;
+        Fiber.return ())
+      ()
+  in
+  Test.run ~handler (fun client ->
+      let run_client () =
+        Client.start
+          client
+          (InitializeParams.create ~capabilities:client_capabilities ())
+      in
+      let run () =
+        let* (_ : InitializeResult.t) = Client.initialized client in
+        let textDocument =
+          TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text
+        in
+        let* () =
+          Client.notification
+            client
+            (TextDocumentDidOpen
+               (DidOpenTextDocumentParams.create ~textDocument))
+        in
+        let* () = req client in
+        let* () = Client.request client Shutdown in
+        Client.stop client
+      in
+      Fiber.fork_and_join_unit run_client run)
+
+let change_config client params =
+  Client.notification client (ChangeConfiguration params)
+
+let codelens client textDocument =
+  Client.request
+    client
+    (TextDocumentCodeLens
+       { textDocument; workDoneToken = None; partialResultToken = None })
+
+let%expect_test "disable codelens" =
+  let source = {ocaml|
+let string = "Hello"
+|ocaml} in
+
+  let req client =
+    let text_document = TextDocumentIdentifier.create ~uri in
+    let* () =
+      change_config
+        client
+        (DidChangeConfigurationParams.create
+           ~settings:
+             (`Assoc [ ("codelens", `Assoc [ ("enable", `Bool false) ]) ]))
+    in
+
+    let* resp_codelens_disabled = codelens client text_document in
+
+    print_endline
+      ("CodeLens found: " ^ string_of_int (List.length resp_codelens_disabled));
+
+    Fiber.return ()
+  in
+
+  test source req;
+  [%expect {| CodeLens found: 0 |}]
+
+let%expect_test "enable hover extended" =
+  let source =
+    {ocaml|
+type foo = int option
+
+let foo_value : foo = Some 1
+|ocaml}
+  in
+
+  let position = Position.create ~line:3 ~character:4 in
+
+  let req client =
+    let* resp = Hover_extended.hover client position in
+
+    let () = Hover_extended.print_hover resp in
+
+    let* () =
+      change_config
+        client
+        (DidChangeConfigurationParams.create
+           ~settings:
+             (`Assoc [ ("extendedHover", `Assoc [ ("enable", `Bool true) ]) ]))
+    in
+
+    (* The first hover request has verbosity = 0 *)
+    let* _ = Hover_extended.hover client position in
+
+    (* The second hover request has verbosity = 1 *)
+    let* resp = Hover_extended.hover client position in
+
+    let () = Hover_extended.print_hover resp in
+    Fiber.return ()
+  in
+  test source req;
+  [%expect
+    {|
+    {
+      "contents": { "kind": "plaintext", "value": "foo" },
+      "range": {
+        "end": { "character": 13, "line": 3 },
+        "start": { "character": 4, "line": 3 }
+      }
+    }
+    {
+      "contents": { "kind": "plaintext", "value": "int option" },
+      "range": {
+        "end": { "character": 13, "line": 3 },
+        "start": { "character": 4, "line": 3 }
+      }
+    } |}]


### PR DESCRIPTION
This PR add support to enable/disable settings through `didChangeConfiguration` notification.

## Settings

- CodeLens
- Extended Hover

## Example using Neovim

```lua
require('lspconfig').ocamllsp.setup {
  cmd = {'ocamllsp'},
  on_attach = on_attach,
  settings = {
    extendedHover = { 
      enable = true 
    },
    codelens = {
      enable = false
    }
  },
  capabilities = capabilities,
}
```

Close #1102 