### PR TITLE
refactor: remove incorrect logging message

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -700,9 +700,7 @@ let on_notification server (notification : Client_notification.t) :
     in
     let+ () = set_diagnostics state.detached (State.diagnostics state) doc in
     state
-  | CancelRequest _ ->
-    Log.log ~section:"debug" (fun () -> Log.msg "ignoring cancellation" []);
-    Fiber.return state
+  | CancelRequest _ -> Fiber.return state
   | ChangeConfiguration req ->
     (* TODO this is wrong and we should just fetch the config from the client
        after receiving this notification *)


### PR DESCRIPTION
Logging message claims that we ignore cancellation. That is not the case
and we handle it in both rpc.ml and the individual requests that care
about it.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 3d46cda3-8ac7-4aea-8380-041a912ab1fb -->