### PR TITLE
fix(lsp): move LogTrace to the correct location

### DIFF
--- a/lsp/src/client_notification.ml
+++ b/lsp/src/client_notification.ml
@@ -17,7 +17,6 @@ type t =
   | Exit
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
-  | LogTrace of LogTraceParams.t
   | SetTrace of SetTraceParams.t
   | UnknownNotification of Jsonrpc.Notification.t
 
@@ -35,7 +34,6 @@ let method_ = function
   | DidCreateFiles _ -> "workspace/didCreateFiles"
   | DidDeleteFiles _ -> "workspace/didDeleteFiles"
   | DidRenameFiles _ -> "workspace/didRenameFiles"
-  | LogTrace _ -> "$/logTrace"
   | SetTrace _ -> "$/setTrace"
   | CancelRequest _ -> Cancel_request.meth_
   | WorkDoneProgressCancel _ -> "window/workDoneProgress/cancel"
@@ -66,7 +64,6 @@ let yojson_of_t = function
   | CancelRequest params -> Some (Cancel_request.yojson_of_t params)
   | WorkDoneProgressCancel params ->
     Some (WorkDoneProgressCancelParams.yojson_of_t params)
-  | LogTrace params -> Some (LogTraceParams.yojson_of_t params)
   | SetTrace params -> Some (SetTraceParams.yojson_of_t params)
   | UnknownNotification n -> (n.params :> Json.t option)
 
@@ -133,9 +130,6 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
       Json.message_params params WorkDoneProgressCancelParams.t_of_yojson
     in
     WorkDoneProgressCancel params
-  | "$/logTrace" ->
-    let+ params = Json.message_params params LogTraceParams.t_of_yojson in
-    LogTrace params
   | "$/setTrace" ->
     let+ params = Json.message_params params SetTraceParams.t_of_yojson in
     SetTrace params

--- a/lsp/src/client_notification.mli
+++ b/lsp/src/client_notification.mli
@@ -17,7 +17,6 @@ type t =
   | Exit
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
-  | LogTrace of LogTraceParams.t
   | SetTrace of SetTraceParams.t
   | UnknownNotification of Jsonrpc.Notification.t
 

--- a/lsp/src/server_notification.ml
+++ b/lsp/src/server_notification.ml
@@ -26,6 +26,7 @@ type t =
   | PublishDiagnostics of PublishDiagnosticsParams.t
   | ShowMessage of ShowMessageParams.t
   | LogMessage of LogMessageParams.t
+  | LogTrace of LogTraceParams.t
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t
@@ -35,6 +36,7 @@ let method_ = function
   | ShowMessage _ -> "window/showMessage"
   | PublishDiagnostics _ -> "textDocument/publishDiagnostics"
   | LogMessage _ -> "window/logMessage"
+  | LogTrace _ -> "$/logTrace"
   | TelemetryNotification _ -> "telemetry/event"
   | CancelRequest _ -> Cancel_request.meth_
   | WorkDoneProgress _ -> "$/progress"
@@ -42,6 +44,7 @@ let method_ = function
 
 let yojson_of_t = function
   | LogMessage params -> Some (LogMessageParams.yojson_of_t params)
+  | LogTrace params -> Some (LogTraceParams.yojson_of_t params)
   | ShowMessage params -> Some (ShowMessageParams.yojson_of_t params)
   | PublishDiagnostics params ->
     Some (PublishDiagnosticsParams.yojson_of_t params)

--- a/lsp/src/server_notification.mli
+++ b/lsp/src/server_notification.mli
@@ -12,6 +12,7 @@ type t =
   | PublishDiagnostics of PublishDiagnosticsParams.t
   | ShowMessage of ShowMessageParams.t
   | LogMessage of LogMessageParams.t
+  | LogTrace of LogTraceParams.t
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -729,7 +729,6 @@ let on_notification server (notification : Client_notification.t) :
   | DidCreateFiles _
   | DidDeleteFiles _
   | DidRenameFiles _
-  | LogTrace _
   | WillSaveTextDocument _
   | Initialized
   | WorkDoneProgressCancel _


### PR DESCRIPTION
It's sent by the server to the client rather than the other way around.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cca71bc4-fba5-4d44-a733-7b0ed0eb33e2 -->