### PR TITLE
Remove the `--fallback-read-dot-merlin` flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Breaking Change
+
+- Remove the `--fallback-read-dot-merlin` flag to `ocamllsp`, dropping support
+  for reading `.merlin`. (#1113)
+
 ## Fixes
 
 - Allow opening documents that were already open. This is a workaround for

--- a/ocaml-lsp-server/bin/main.ml
+++ b/ocaml-lsp-server/bin/main.ml
@@ -4,16 +4,9 @@ module Cli = Lsp.Cli
 let () =
   Printexc.record_backtrace true;
   let version = ref false in
-  let read_dot_merlin = ref false in
   let arg = Lsp.Cli.Arg.create () in
   let spec =
-    [ ("--version", Arg.Set version, "print version")
-    ; ( "--fallback-read-dot-merlin"
-      , Arg.Set read_dot_merlin
-      , "read Merlin config from .merlin files. The `dot-merlin-reader` \
-         package must be installed" )
-    ]
-    @ Cli.Arg.spec arg
+    ("--version", Arg.Set version, "print version") :: Cli.Arg.spec arg
   in
   let usage =
     "ocamllsp [ --stdio | --socket PORT | --port PORT | --pipe PIPE ] [ \
@@ -37,10 +30,7 @@ let () =
     print_endline version
   else
     let module Exn_with_backtrace = Stdune.Exn_with_backtrace in
-    match
-      Exn_with_backtrace.try_with
-        (Ocaml_lsp_server.run channel ~read_dot_merlin:!read_dot_merlin)
-    with
+    match Exn_with_backtrace.try_with (Ocaml_lsp_server.run channel) with
     | Ok () -> ()
     | Error exn ->
       Format.eprintf "%a@." Exn_with_backtrace.pp_uncaught exn;

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -226,8 +226,6 @@ module Dot_protocol_io =
       let write t x = write t [ x ]
     end)
 
-let should_read_dot_merlin = ref false
-
 type db =
   { running : (string, entry) Table.t
   ; pool : Fiber.Pool.t
@@ -420,12 +418,8 @@ let config (t : t) : Mconfig.t Fiber.t =
           use_entry entry
     in
     let+ dot, failures = get_config entry.process ~workdir:ctx.workdir t.path in
-
-    if !should_read_dot_merlin && dot = Config.empty then
-      Mconfig.get_external_config t.path t.initial
-    else
-      let merlin = Config.merge dot t.initial.merlin failures config_path in
-      Mconfig.normalize { t.initial with merlin }
+    let merlin = Config.merge dot t.initial.merlin failures config_path in
+    Mconfig.normalize { t.initial with merlin }
 
 module DB = struct
   type t = db

--- a/ocaml-lsp-server/src/merlin_config.mli
+++ b/ocaml-lsp-server/src/merlin_config.mli
@@ -4,8 +4,6 @@ open Import
 
 type t
 
-val should_read_dot_merlin : bool ref
-
 val config : t -> Mconfig.t Fiber.t
 
 val destroy : t -> unit Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -865,9 +865,8 @@ let stream_of_channel : Lsp.Cli.Channel.t -> _ = function
     let sockaddr = Unix.ADDR_INET (Unix.inet_addr_loopback, port) in
     socket sockaddr
 
-let run channel ~read_dot_merlin () =
+let run channel () =
   Merlin_utils.Lib_config.set_program_name "ocamllsp";
-  Merlin_config.should_read_dot_merlin := read_dot_merlin;
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
   Lev_fiber.run ~sigpipe:`Ignore (fun () ->
       let* input, output = stream_of_channel channel in

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -1,4 +1,4 @@
-val run : Lsp.Cli.Channel.t -> read_dot_merlin:bool -> unit -> unit
+val run : Lsp.Cli.Channel.t -> unit -> unit
 
 module Diagnostics = Diagnostics
 module Version = Version


### PR DESCRIPTION
Following the release of [Melange 1.0](https://github.com/ocaml/opam-repository/pull/23850), this flag is no longer needed in OCaml LSP.

This reverts commit c2751403ad55acef079a4ddfd2182371777c2749.