### PR TITLE
Bump install-nix-action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         submodules: true
     - name: nix
-      uses: cachix/install-nix-action@v15
+      uses: cachix/install-nix-action@v21
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix develop -c make nix-tests
@@ -23,7 +23,7 @@ jobs:
       with:
         submodules: true
     - name: nix
-      uses: cachix/install-nix-action@v15
+      uses: cachix/install-nix-action@v21
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix develop -c make nix-fmt


### PR DESCRIPTION
Addressing CI warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: cachix/install-nix-action@v15. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.