### PR TITLE
fix: kill dune ocaml-merlin in a friendlier way

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Fixes
 
+- Kill unnecessary `$ dune ocaml-merlin` with SIGTERM rather than SIGKILL
+  (#1124)
+
 - Refactor comment parsing to use `odoc-parser` and `cmarkit` instead of
   `octavius` and `omd` (#1088)
 

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -442,6 +442,6 @@ module DB = struct
     let* () = Fiber.return () in
     Table.iter t.running ~f:(fun running ->
         let pid = Pid.to_int running.process.pid in
-        Unix.kill pid Sys.sigkill);
+        Unix.kill pid Sys.sigterm);
     Fiber.Pool.stop t.pool
 end


### PR DESCRIPTION
kill didn't use to work because of buggy versions of `dune ocaml-version`. Those have been fixed, so sigterm should work fine.