### PR TITLE
fix: ocamlformat-rpc initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Fixes
 
+- Fix initilization of `ocamlformat-rpc` in some edge cases when ocamlformat is
+  initialized concurrently (#1132)
+
 - Kill unnecessary `$ dune ocaml-merlin` with SIGTERM rather than SIGKILL
   (#1124)
 


### PR DESCRIPTION
if [get_process] is alled concurrently, the ivar might be filled twice.

Fixes #1115

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: d5c77719-29a5-4b46-92e8-c09f6453ba56 -->