### PR TITLE
fix: remove dependency on workspace_root

### DIFF
--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -82,7 +82,6 @@ let equal_message =
 type t =
   { dune :
       (Dune.t, (Drpc.Diagnostic.Id.t, Uri.t * Diagnostic.t) Table.t) Table.t
-  ; workspace_root : Uri.t Lazy.t
   ; merlin : (Uri.t, Diagnostic.t list) Table.t
   ; send : PublishDiagnosticsParams.t list -> unit Fiber.t
   ; mutable dirty_uris : Uri_set.t
@@ -90,10 +89,7 @@ type t =
   ; tags : DiagnosticTag.t list
   }
 
-let workspace_root t = Lazy.force t.workspace_root
-
-let create (capabilities : PublishDiagnosticsClientCapabilities.t option)
-    ~workspace_root send =
+let create (capabilities : PublishDiagnosticsClientCapabilities.t option) send =
   let related_information, tags =
     match capabilities with
     | None -> (false, [])
@@ -107,7 +103,6 @@ let create (capabilities : PublishDiagnosticsClientCapabilities.t option)
   ; merlin = Table.create (module Uri) 32
   ; dirty_uris = Uri_set.empty
   ; send
-  ; workspace_root
   ; related_information
   ; tags
   }

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -8,13 +8,10 @@ type t
 
 val create :
      PublishDiagnosticsClientCapabilities.t option
-  -> workspace_root:Uri.t Lazy.t
   -> (PublishDiagnosticsParams.t list -> unit Fiber.t)
   -> t
 
 val send : t -> [ `All | `One of Uri.t ] -> unit Fiber.t
-
-val workspace_root : t -> Uri.t
 
 module Dune : sig
   type t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -207,16 +207,10 @@ let on_initialize server (ip : InitializeParams.t) =
   let state : State.t = Server.state server in
   let workspaces = Workspaces.create ip in
   let diagnostics =
-    let workspace_root =
-      lazy
-        (let state = Server.state server in
-         State.workspace_root state)
-    in
     Diagnostics.create
       (let open Option.O in
       let* td = ip.capabilities.textDocument in
       td.publishDiagnostics)
-      ~workspace_root
       (function
         | [] -> Fiber.return ()
         | diagnostics ->


### PR DESCRIPTION
It wa only used in one particular case where we need a location for a
diagnostic and doesn't give us one.

Instead, we use the dune instance's directory as the location.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 5383325f-6217-4912-85eb-b604e3fbdc4b -->