### PR TITLE
feature: disable code lens by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Fixes
 
+- Disable code lens by default. The support can be re-enabled by explicitly
+  setting it in the configuration. (#1134)
+
 - Fix initilization of `ocamlformat-rpc` in some edge cases when ocamlformat is
   initialized concurrently (#1132)
 

--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -1,11 +1,15 @@
 # Configuration
 
-The ocamllsp support the folowing configuration. These configurations are sent through the [`didChangeConfiguration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration) notification.
+The ocamllsp support the folowing configurations.
+
+These configurations are sent through the
+[`didChangeConfiguration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration)
+notification.
 
 ```ts
 interface config {
   /**
-  * Enable/Disabe Extended Hover
+  * Enable/Disable Extended Hover
   * @default false
   * @since 1.16
   */
@@ -13,7 +17,7 @@ interface config {
 
   /**
   * Enable/Disable CodeLens
-  * @default true
+  * @default false
   * @since 1.16
   */
   codelens: { enable : boolean }

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -257,6 +257,6 @@ let _ = yojson_of_t
 [@@@end]
 
 let default =
-  { codelens = Some { enable = true }
+  { codelens = Some { enable = false }
   ; extended_hover = Some { enable = false }
   }

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -609,8 +609,8 @@ let on_request :
   | TextDocumentCodeLensResolve codeLens -> now codeLens
   | TextDocumentCodeLens req -> (
     match state.configuration.data.codelens with
-    | Some { enable = true } | None -> later text_document_lens req
-    | Some _ -> now [])
+    | Some { enable = true } -> later text_document_lens req
+    | _ -> now [])
   | TextDocumentHighlight req -> later highlight req
   | DocumentSymbol { textDocument = { uri }; _ } -> later document_symbol uri
   | TextDocumentDeclaration { textDocument = { uri }; position } ->

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeLens.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-codeLens.test.ts
@@ -28,6 +28,11 @@ describe("textDocument/references", () => {
 
   beforeEach(async () => {
     languageServer = await LanguageServer.startAndInitialize();
+    languageServer.sendNotification("workspace/didChangeConfiguration", {
+      settings: {
+        codelens: { enable: true },
+      },
+    });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This feature seems to annoy quite a few users so we disable it by
default. It can be enabled through configuration.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 4dd3b3fc-5f88-48df-b6a9-8792dde164b4 -->