### PR TITLE
fix(ocamllsp): fix in pp handling the file permissions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixes
+
+- Fix file permissions used when specifying output files of pp and ppx. (#1153)
+
 # 1.16.1
 
 ## Fixes

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -878,12 +878,13 @@ let run_in_directory ~prog ~prog_is_quoted:_ ~args ~cwd ?stdin ?stdout ?stderr
   let argv = [ "sh"; "-c"; cmd ] in
   let stdin =
     match stdin with
-    | Some file -> Unix.openfile file [ Unix.O_WRONLY ] 0x664
-    | None -> Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0x777
+    | Some file -> Unix.openfile file [ Unix.O_WRONLY ] 0o664
+    | None -> Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0o777
   in
   let stdout, should_close_stdout =
     match stdout with
-    | Some file -> (Unix.openfile file [ Unix.O_WRONLY ] 0x664, true)
+    | Some file ->
+      (Unix.openfile file [ Unix.O_WRONLY; Unix.O_CREAT ] 0o664, true)
     | None ->
       (* Runned programs should never output to stdout since it is the channel
          used by LSP to communicate with the editor *)
@@ -891,7 +892,7 @@ let run_in_directory ~prog ~prog_is_quoted:_ ~args ~cwd ?stdin ?stdout ?stderr
   in
   let stderr =
     Option.map stderr ~f:(fun file ->
-        Unix.openfile file [ Unix.O_WRONLY ] 0x664)
+        Unix.openfile file [ Unix.O_WRONLY; Unix.O_CREAT ] 0o664)
   in
   let pid =
     let cwd : Spawn.Working_dir.t = Path cwd in

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -878,7 +878,7 @@ let run_in_directory ~prog ~prog_is_quoted:_ ~args ~cwd ?stdin ?stdout ?stderr
   let argv = [ "sh"; "-c"; cmd ] in
   let stdin =
     match stdin with
-    | Some file -> Unix.openfile file [ Unix.O_WRONLY ] 0o664
+    | Some file -> Unix.openfile file [ Unix.O_RDONLY ] 0o664
     | None -> Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0o777
   in
   let stdout, should_close_stdout =

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -12,6 +12,7 @@
   (deps
    %{bin:ocamlformat-rpc}
    for_ppx.ml
+   for_pp.ml
    (package ocaml-lsp-server)))
  (libraries
   stdune
@@ -32,4 +33,23 @@
   ppx_expect.config_types
   ppx_inline_test.config)
  (preprocess
-  (pps ppx_expect)))
+  (per_module
+   ((action
+     (run %{dep:for_pp.sh} %{input-file}))
+    for_pp)
+   ((pps ppx_expect)
+    action_extract
+    action_inline
+    code_actions
+    document_flow
+    for_ppx
+    hover_extended
+    metrics
+    semantic_hl_data
+    semantic_hl_helpers
+    semantic_hl_tests
+    start_stop
+    test
+    with_pp
+    with_ppx
+    workspace_change_config))))

--- a/ocaml-lsp-server/test/e2e-new/for_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/for_pp.ml
@@ -1,0 +1,1 @@
+type world

--- a/ocaml-lsp-server/test/e2e-new/for_pp.sh
+++ b/ocaml-lsp-server/test/e2e-new/for_pp.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed 's/world/universe/g' $1

--- a/ocaml-lsp-server/test/e2e-new/with_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_pp.ml
@@ -1,0 +1,71 @@
+open! Test.Import
+
+let path = Filename.concat (Sys.getcwd ()) "for_pp.ml"
+
+let uri = DocumentUri.of_path path
+
+let print_hover hover =
+  match hover with
+  | None -> print_endline "no hover response"
+  | Some hover ->
+    hover |> Hover.yojson_of_t
+    |> Yojson.Safe.pretty_to_string ~std:false
+    |> print_endline
+
+let hover_req client position =
+  Client.request
+    client
+    (TextDocumentHover
+       { HoverParams.position
+       ; textDocument = TextDocumentIdentifier.create ~uri
+       ; workDoneToken = None
+       })
+
+let%expect_test "with-pp" =
+  let position = Position.create ~line:0 ~character:9 in
+  let handler =
+    Client.Handler.make
+      ~on_notification:(fun client _notification ->
+        Client.state client;
+        Fiber.return ())
+      ()
+  in
+  let output =
+    Test.run ~handler @@ fun client ->
+    let run_client () =
+      let capabilities = ClientCapabilities.create () in
+      Client.start client (InitializeParams.create ~capabilities ())
+    in
+    let run () =
+      let* (_ : InitializeResult.t) = Client.initialized client in
+      let textDocument =
+        let text = Io.String_path.read_file path in
+        TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text
+      in
+      let* () =
+        Client.notification
+          client
+          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+      in
+      let* () =
+        let+ resp = hover_req client position in
+        print_hover resp
+      in
+      let output = [%expect.output] in
+      let* () = Client.request client Shutdown in
+      let+ () = Client.stop client in
+      output
+    in
+    Fiber.fork_and_join_unit run_client run
+  in
+  let (_ : string) = [%expect.output] in
+  print_endline output;
+  [%expect
+    {|
+    {
+      "contents": { "kind": "plaintext", "value": "type universe" },
+      "range": {
+        "end": { "character": 13, "line": 0 },
+        "start": { "character": 0, "line": 0 }
+      }
+    }|}]


### PR DESCRIPTION
Hello,
In the PR that made Merlin a dependency #1070 a bug was introduced that prevents from using preprocessor programs as https://github.com/ocaml-community/cppo.
This is because the file permissions are not provided in the right base and that the output files are currently not created if they do not exist yet.
I do not know if the addition of the flag `Unix.O_CREAT` could cause an issue with some pp or ppx.