### PR TITLE
fix: Nix mainProgram name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,9 @@
                 dune build ${package}.install --release ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
                 runHook postBuild
               '';
+              meta = {
+                mainProgram = "ocamllsp";
+              };
             };
 
             ocaml-lsp = fast.ocaml-lsp;


### PR DESCRIPTION
Fixes `nix run`.
Before:
```
[rafal@nixos ocaml-lsp]$ nix run
error: unable to execute '/nix/store/pvlaay6869p70xsgkj2cj942ay3jvjiz-ocaml4.14.1-ocaml-lsp-server-n-a/bin/ocaml-lsp-server': No such file or directory
```

After:
```
[rafal@nixos ocaml-lsp]$ nix run . -- --help
ocamllsp [ --stdio | --socket PORT | --port PORT | --pipe PIPE ] [ --clientProcessId pid ]
  --version print version
  --fallback-read-dot-merlin read Merlin config from .merlin files. The `dot-merlin-reader` package must be installed
  --pipe set pipe path
  --socket set the port
  --port synonym for --socket
  --stdio set stdio
  --node-ipc not supported
  --clientProcessId set the pid of the lsp client
  -help  Display this list of options
  --help  Display this list of options
```