### PR TITLE
Display text of references in doc strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Display text of references in doc strings (#1166)
+
 # 1.16.2
 
 ## Fixes

--- a/ocaml-lsp-server/src/doc_to_md.ml
+++ b/ocaml-lsp-server/src/doc_to_md.ml
@@ -90,7 +90,7 @@ and inline_element_list_to_inlines inlines =
 
 let rec nestable_block_element_to_block
     (nestable :
-       Odoc_parser.Ast.nestable_block_element Odoc_parser.Loc.with_location) =
+      Odoc_parser.Ast.nestable_block_element Odoc_parser.Loc.with_location) =
   match nestable with
   | { value = `Paragraph text; location } ->
     let inline = inline_element_list_to_inlines text in

--- a/ocaml-lsp-server/src/doc_to_md.ml
+++ b/ocaml-lsp-server/src/doc_to_md.ml
@@ -61,9 +61,13 @@ let rec inline_element_to_inline
     let text = inline_element_list_to_inlines inlines in
     let meta = loc_to_meta location in
     style_inline ~meta style text
-  | { value = `Reference (_kind, _ref, _inlines); location = _location } ->
+  | { value = `Reference (kind, ref, inlines); location } ->
     (* TODO: add support for references *)
-    Inline.Break (Inline.Break.make `Hard, Meta.none)
+    let meta = loc_to_meta location in
+    begin match kind with
+      | `Simple -> Inline.Code_span (Inline.Code_span.of_string ref.value, meta)
+      | `With_text -> inline_element_list_to_inlines inlines
+    end
   | { value = `Link (link, inlines); location } ->
     let text = inline_element_list_to_inlines inlines in
     let ref =
@@ -86,7 +90,7 @@ and inline_element_list_to_inlines inlines =
 
 let rec nestable_block_element_to_block
     (nestable :
-      Odoc_parser.Ast.nestable_block_element Odoc_parser.Loc.with_location) =
+       Odoc_parser.Ast.nestable_block_element Odoc_parser.Loc.with_location) =
   match nestable with
   | { value = `Paragraph text; location } ->
     let inline = inline_element_list_to_inlines text in

--- a/ocaml-lsp-server/src/doc_to_md.ml
+++ b/ocaml-lsp-server/src/doc_to_md.ml
@@ -61,13 +61,12 @@ let rec inline_element_to_inline
     let text = inline_element_list_to_inlines inlines in
     let meta = loc_to_meta location in
     style_inline ~meta style text
-  | { value = `Reference (kind, ref, inlines); location } ->
+  | { value = `Reference (kind, ref, inlines); location } -> (
     (* TODO: add support for references *)
     let meta = loc_to_meta location in
-    begin match kind with
-      | `Simple -> Inline.Code_span (Inline.Code_span.of_string ref.value, meta)
-      | `With_text -> inline_element_list_to_inlines inlines
-    end
+    match kind with
+    | `Simple -> Inline.Code_span (Inline.Code_span.of_string ref.value, meta)
+    | `With_text -> inline_element_list_to_inlines inlines)
   | { value = `Link (link, inlines); location } ->
     let text = inline_element_list_to_inlines inlines in
     let ref =

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -254,6 +254,8 @@ describe_opt("textDocument/completion", () => {
       
           External links: {{:https://ocaml.org/} OCaml's official website}
       
+          Cross-references: {!List.length} {{!List.length} Replacement text}
+      
           {3 Inline Formatting}
       
           {b Bold}, {i Italic}, {e Emphasize}, {^ Superscript}, {_ Subscript}, and [inline code]
@@ -357,6 +359,8 @@ describe_opt("textDocument/completion", () => {
               #### Links and Cross-references
               
               External links: [OCaml's official website](https://ocaml.org/)
+              
+              Cross-references: \`List.length\` Replacement text
               
               #### Inline Formatting
               


### PR DESCRIPTION
This PR does not add support for cross-references, but Doc_to_md now outputs the text of the reference, instead of a line break as it does currently.