### PR TITLE
chore: windows tests

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -35,7 +35,7 @@
  (preprocess
   (per_module
    ((action
-     (run %{dep:for_pp.sh} %{input-file}))
+     (run sh %{dep:for_pp.sh} %{input-file}))
     for_pp)
    ((pps ppx_expect)
     action_extract


### PR DESCRIPTION
shell scripts cannot be executed like binaries

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: e452a5d5-63be-4786-9ff7-4c45f5767f96 -->