### PR TITLE
Do not invoke dune at all if `--fallback-read-dot-merlin` flag is on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix missing super & subscripts in markdown documentation. (#1170)
+- Do not invoke dune at all if `--fallback-read-dot-merlin` flag is on. (#1173)
 
 ## Features
 


### PR DESCRIPTION
Fix #859.

For background, internally at Meta we use [buck2](https://buck2.build/) to build ocaml code, and we have a script to automatically generate a .merlin file based on the build artifacts. I'm not asking for a buck2 integration here. I'm simply fix the issue that blocks us from switching away from the long dead `ocaml-language-server`.

I find that the flag doesn't work if the environment does not have dune installed, because it will unconditionally run some dune command before even checking the `--fallback-read-dot-merlin` flag. This PR moves the check earlier, so that when the flag is on, it fully bypasses the dune workflow.