### PR TITLE
Specify `-index 0` in type-enclosing queries.

### DIFF
--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -289,7 +289,7 @@ module Merlin = struct
 
   let type_enclosing doc pos verbosity =
     with_pipeline_exn doc (fun pipeline ->
-        let command = Query_protocol.Type_enclosing (None, pos, None) in
+        let command = Query_protocol.Type_enclosing (None, pos, Some 0) in
         let pipeline =
           match verbosity with
           | 0 -> pipeline


### PR DESCRIPTION
This change greatly improves performances in some cases where Merlin would spend a lot of time formatting big types that were discarded by ocaml-lsp anyway.

This fixes type-enclosing taking 10s in Irmin:
```
❯ ocamlmerlin single type-enclosing -position 146:39 -filename src/irmin-pack/mem/irmin_pack_mem.ml <src/irmin-pack/mem/irmin_pack_mem.ml | jq '.timing'
{
  "clock": 11399,
  "cpu": 11321,
  "query": 11153,
  "pp": 0,
  "reader": 1,
  "ppx": 23,
  "typer": 144,
  "error": 0
}
```

```
❯ ocamlmerlin single type-enclosing -position 146:39 -filename src/irmin-pack/mem/irmin_pack_mem.ml -index 0 <src/irmin-pack/mem/irmin_pack_mem.ml | jq '.timing'
{
  "clock": 238,
  "cpu": 183,
  "query": 17,
  "pp": 0,
  "reader": 1,
  "ppx": 22,
  "typer": 142,
  "error": 0
}
```

This does not fix every issue on Irmin's codebase: hovering on some modules causes `ocaml-lsp` to hang at 100% cpu.
This happens for example with this query, which is instantaneous in Merlin:
```
❯ ocamlmerlin single type-enclosing -position 43:40 -index 0 -filename src/irmin-pack/mem/irmin_pack_mem.ml <src/irmin-pack/mem/irmin_pack_mem.ml | jq '.timing'
{
  "clock": 263,
  "cpu": 207,
  "query": 40,
  "pp": 0,
  "reader": 1,
  "ppx": 23,
  "typer": 144,
  "error": 0
}
```

Cancellation is not working and the process must be manually killed.

I will open an issue for this, it is independent from the problem solved by that PR that should increase performance without drawbacks in many cases.