### PR TITLE
Only return first result for type_enclosing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@
 - Do not invoke dune at all if `--fallback-read-dot-merlin` flag is on. (#1173)
 - Fix semantic highlighting of infix operators that contain '.'. (#1186)
 - Disable highlighting unit as an enum member to fix comment highlighting bug. (#1185)
-- Improve type-on-hover efficiency by only formatting the type of the first
-  enclosing. (#1191)
+- Improve type-on-hover and type-annotate efficiency by only formatting the type
+  of the first enclosing. (#1191, #1196)
 
 ## Features
 

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -68,7 +68,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
     match context with
     | `Invalid -> None
     | `Valid ->
-      let command = Query_protocol.Type_enclosing (None, pos_start, None) in
+      let command = Query_protocol.Type_enclosing (None, pos_start, Some 0) in
       let config = Mpipeline.final_config pipeline in
       let config =
         { config with query = { config.query with verbosity = Lvl 0 } }


### PR DESCRIPTION
Occurrence is in `type-annotate` code action.

Same as https://github.com/ocaml/ocaml-lsp/pull/1191