### PR TITLE
Fix uri to_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 - Improve type-on-hover and type-annotate efficiency by only formatting the type
   of the first enclosing. (#1191, #1196)
 
+- Fix the encoding of URI's to match how vscode does it (#1197)
+
 ## Features
 
 - Display text of references in doc strings (#1166)

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -96,7 +96,8 @@ let to_string { scheme; authority; path } =
     Buffer.add_string buff scheme;
     Buffer.add_char buff ':');
 
-  if authority = "file" || scheme = "file" then Buffer.add_string buff "//";
+  if (not (String.is_empty authority)) || scheme = "file" then
+    Buffer.add_string buff "//";
 
   (*TODO: implement full logic:
     https://github.com/microsoft/vscode-uri/blob/96acdc0be5f9d5f2640e1c1f6733bbf51ec95177/src/uri.ts#L605 *)

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -216,6 +216,7 @@ let%expect_test "of_string -> to_string" =
     ; ""
     ; "file://LöC%2FAL/host:8080/projects/"
     ; "file:///pro%2Fjects/"
+    ; "vscode://mount/test.ml"
     ];
   [%expect
     {|
@@ -230,6 +231,7 @@ let%expect_test "of_string -> to_string" =
      -> file:///
     file://LöC%2FAL/host:8080/projects/ -> file://l%C3%B6c%2Fal/host%3A8080/projects/
     file:///pro%2Fjects/ -> file:///pro/jects/
+    vscode://mount/test.ml -> vscode://mount/test.ml
     Windows:
     file://shares/pröjects/c%23/#l12 -> file://shares/pr%C3%B6jects/c%23/
     file://sh%c3%a4res/path -> file://sh%C3%A4res/path
@@ -241,6 +243,7 @@ let%expect_test "of_string -> to_string" =
      -> file:///
     file://LöC%2FAL/host:8080/projects/ -> file://l%C3%B6c%2Fal/host%3A8080/projects/
     file:///pro%2Fjects/ -> file:///pro/jects/
+    vscode://mount/test.ml -> vscode://mount/test.ml
     |}]
 
 let%expect_test "of_string -> to_path" =


### PR DESCRIPTION
The current implementation is not the same as `uri.ts`

see https://github.com/microsoft/vscode-uri/blob/96acdc0be5f9d5f2640e1c1f6733bbf51ec95177/src/uri.ts#L601

the ts code just checks if authority is empty, while ocaml code checks if authority is "file"
