### PR TITLE
fix: odoc-parser constraints

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,7 @@ possible and does not make any assumptions about IO.
   ordering
   dune-build-info
   spawn
-  (odoc-parser (>= 2.0.0))
+  (odoc-parser (and (>= 2.0.0) (< 2.3.0)))
   (ppx_expect (and (>= v0.15.0) :with-test))
   (ocamlformat (and :with-test (= 0.24.1)))
   (ocamlc-loc (>= 3.7.0))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -32,7 +32,7 @@ depends: [
   "ordering"
   "dune-build-info"
   "spawn"
-  "odoc-parser" {>= "2.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "ppx_expect" {>= "v0.15.0" & with-test}
   "ocamlformat" {with-test & = "0.24.1"}
   "ocamlc-loc" {>= "3.7.0"}


### PR DESCRIPTION
we aren't compatible with 2.3.0

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 7902a176-de20-4d3a-ae54-5274fb424611 -->