### PR TITLE
flake: remove flake-utils dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Remove `flake-utils` Nix Flake dependency
+
 ## Features
 
 - Introduce a configuration option to control dune diagnostics. The option is

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1700856099,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,130 +1,84 @@
 {
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, flake-utils, nixpkgs, ... }@inputs:
+  outputs = { self, nixpkgs, ... }@inputs:
     let
       package = "ocaml-lsp-server";
-      overlay = final: prev: {
-        ${package} = prev.${package}.overrideAttrs (_: {
-          # Do not add share/nix-support, so that dependencies from
-          # the scope don't leak into dependent derivations
-          doNixSupport = false;
-        });
-        dune-release = prev.dune-release.overrideAttrs (_: {
-          doCheck = false;
-        });
-        ocamlPackages = prev.ocamlPackages.overrideScope' (oself: osuper:
-          let
-            fixPreBuild = o: {
-              propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.pp ];
-              preBuild = ''
-                rm -r vendor/csexp vendor/pp
-              '';
-            };
-          in
-          {
-            dyn = osuper.dyn.overrideAttrs fixPreBuild;
-            dune-private-libs = osuper.dune-private-libs.overrideAttrs fixPreBuild;
-            dune-glob = osuper.dune-glob.overrideAttrs fixPreBuild;
-            dune-action-plugin = osuper.dune-action-plugin.overrideAttrs fixPreBuild;
-            dune-rpc = osuper.dune-rpc.overrideAttrs fixPreBuild;
-            stdune = osuper.stdune.overrideAttrs fixPreBuild;
-          });
-      };
-      lspPackage = pkgs:
-        with pkgs.ocamlPackages;
-        buildDunePackage {
-          pname = package;
-          version = "n/a";
-          src = ./.;
-          duneVersion = "3";
-          buildInputs = [
-            ocamlc-loc
-            astring
-            camlp-streams
-            dune-build-info
-            re
-            dune-rpc
-            chrome-trace
-            dyn
-            fiber
-            xdg
-            ordering
-            spawn
-            pp
-            csexp
-            ocamlformat-rpc-lib
-            stdune
-            yojson
-            ppx_yojson_conv_lib
-            uutf
-            merlin-lib
-          ];
-          propagatedBuildInputs = [ ];
-          doCheck = false;
-          buildPhase = ''
-            runHook preBuild
-            dune build ${package}.install --release ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
-            runHook postBuild
-          '';
-          meta = {
-            mainProgram = "ocamllsp";
-          };
-        };
+
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        overlays = builtins.attrValues self.overlays;
+      });
     in
     {
-      overlays.default = (final: prev: {
-        ocamlPackages = prev.ocamlPackages.overrideScope (oself: osuper:
-          with oself;
+      overlays = {
+        default = final: prev: {
+          ${package} = prev.${package}.overrideAttrs (_: {
+            # Do not add share/nix-support, so that dependencies from
+            # the scope don't leak into dependent derivations
+            doNixSupport = false;
+          });
 
-          {
-            ocaml-lsp = lspPackage final;
-          }
-        );
-      });
-    } // (flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { overlays = [ overlay ]; inherit system; };
-        inherit (pkgs.ocamlPackages) buildDunePackage;
-        fast = rec {
-
-          jsonrpc = buildDunePackage {
-            pname = "jsonrpc";
-            version = "n/a";
-            src = ./.;
-            duneVersion = "3";
-            propagatedBuildInputs = with pkgs.ocamlPackages; [ ];
+          dune-release = prev.dune-release.overrideAttrs (_: {
             doCheck = false;
-          };
+          });
 
-          lsp = buildDunePackage {
-            pname = "lsp";
-            version = "n/a";
-            src = ./.;
-            duneVersion = "3";
-            propagatedBuildInputs = with pkgs.ocamlPackages; [
-              jsonrpc
-              yojson
-              stdune
-              ppx_yojson_conv_lib
-              uutf
-            ];
-            checkInputs = with pkgs.ocamlPackages; [ cinaps ppx_expect ];
-            doCheck = false;
-          };
+          ocamlPackages = prev.ocamlPackages.overrideScope' (oself: osuper:
+            let
+              fixPreBuild = o: {
+                propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.pp ];
+                preBuild = ''
+                  rm -r vendor/csexp vendor/pp
+                '';
+              };
+            in
+            {
+              dyn = osuper.dyn.overrideAttrs fixPreBuild;
+              dune-private-libs = osuper.dune-private-libs.overrideAttrs fixPreBuild;
+              dune-glob = osuper.dune-glob.overrideAttrs fixPreBuild;
+              dune-action-plugin = osuper.dune-action-plugin.overrideAttrs fixPreBuild;
+              dune-rpc = osuper.dune-rpc.overrideAttrs fixPreBuild;
+              stdune = osuper.stdune.overrideAttrs fixPreBuild;
+              ocaml-lsp = self.packages.${prev.system}.ocaml-lsp;
+            });
+        };
+
+        ocaml-lsp-only = final: prev: {
+          ocamlPackages = prev.ocamlPackages.overrideScope' (_: _: {
+            ocaml-lsp = self.packages.${prev.system}.ocaml-lsp;
+          });
+        };
+      };
+
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          inherit (pkgs.ocamlPackages) buildDunePackage;
+        in
+        {
+          # we have a package without opam2nix for easy consumption for nix users
+          default = self.packages.${system}.ocaml-lsp;
 
           ocaml-lsp = buildDunePackage {
-            pname = "ocaml-lsp";
+            pname = package;
             version = "n/a";
             src = ./.;
             duneVersion = "3";
-            checkInputs = with pkgs.ocamlPackages; [ ppx_expect ];
-            propagatedBuildInputs = with pkgs.ocamlPackages; [
+            buildInputs = with pkgs.ocamlPackages; [
               ocamlc-loc
-              octavius
+              astring
+              camlp-streams
               dune-build-info
               re
               dune-rpc
@@ -141,43 +95,70 @@
               yojson
               ppx_yojson_conv_lib
               uutf
-              lsp
-              astring
-              camlp-streams
               merlin-lib
+            ] ++ [
+              self.packages.${system}.lsp
             ];
+            propagatedBuildInputs = [ ];
+            doCheck = false;
+            buildPhase = ''
+              runHook preBuild
+              dune build ${package}.install --release ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+              runHook postBuild
+            '';
+            meta = {
+              mainProgram = "ocamllsp";
+            };
+          };
+
+          # stub builds
+          jsonrpc = buildDunePackage {
+            pname = "jsonrpc";
+            version = "n/a";
+            src = ./.;
+            duneVersion = "3";
+            propagatedBuildInputs = with pkgs.ocamlPackages; [ ];
             doCheck = false;
           };
-        };
-      in
-      {
-        packages =
-          rec {
-            # we have a package without opam2nix for easy consumption for nix users
-            default = lspPackage pkgs;
 
-            ocaml-lsp = fast.ocaml-lsp;
+          lsp = buildDunePackage {
+            pname = "lsp";
+            version = "n/a";
+            src = ./.;
+            duneVersion = "3";
+            propagatedBuildInputs = with pkgs.ocamlPackages; [
+              yojson
+              stdune
+              ppx_yojson_conv_lib
+              uutf
+            ] ++ [
+              self.packages.${system}.jsonrpc
+            ];
+            checkInputs = with pkgs.ocamlPackages; [ cinaps ppx_expect ];
+            doCheck = false;
           };
+        });
 
-        devShells = {
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system}; in {
           default = pkgs.mkShell {
-            buildInputs = (with pkgs;
-              [
-                # dev tools
-                ocamlformat_0_26_1
-                yarn
+            name = package;
+            inputsFrom = builtins.attrValues self.packages.${system};
+            buildInputs = with pkgs; [
+              # dev tools
+              ocamlformat_0_26_1
+              yarn
 
-                ocamlPackages.ppx_expect
-                ocamlPackages.utop
-                ocamlPackages.cinaps
-                ocamlPackages.ppx_yojson_conv
-              ]);
-            inputsFrom = [ fast.ocaml-lsp fast.jsonrpc fast.lsp ];
+              ocamlPackages.ppx_expect
+              ocamlPackages.utop
+              ocamlPackages.cinaps
+              ocamlPackages.ppx_yojson_conv
+            ];
           };
 
           release = pkgs.mkShell {
             buildInputs = [ pkgs.dune-release ];
           };
-        };
-      }));
+        });
+  };
 }


### PR DESCRIPTION
By inlining the for loop from the utility library, downstream consumers do not need to pull in any additional dependencies & bloat their flake.lock files. Some additional reorganizing due to inlining as well—with the net effect of more lines deleted than added.