### PR TITLE
stop server on exit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   This enables more lsp features for non-.ml/.mli files. Though it still
   depends on merlin's support. (#1237)
 
+- Stop server when exit notification is received (#1239)
+
 # 1.17.0
 
 ## Fixes

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -13,6 +13,10 @@ type init =
 
 type hover_extended = { mutable history : (Uri.t * Position.t * int) option }
 
+type shutdown_status =
+  | Shutdown_received
+  | Shutdown_not_received
+
 type t =
   { store : Document_store.t
   ; merlin : Document.Single_pipeline.t
@@ -25,6 +29,7 @@ type t =
   ; symbols_thread : Lev_fiber.Thread.t Lazy_fiber.t
   ; wheel : Lev_fiber.Timer.Wheel.t
   ; hover_extended : hover_extended
+  ; shutdown_status : shutdown_status
   }
 
 let create ~store ~merlin ~detached ~configuration ~ocamlformat_rpc
@@ -40,6 +45,7 @@ let create ~store ~merlin ~detached ~configuration ~ocamlformat_rpc
   ; symbols_thread
   ; wheel
   ; hover_extended = { history = None }
+  ; shutdown_status = Shutdown_not_received
   }
 
 let wheel t = t.wheel

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -19,6 +19,10 @@ type hover_extended =
             is not specific by the client. *)
   }
 
+type shutdown_status =
+  | Shutdown_received
+  | Shutdown_not_received
+
 type t =
   { store : Document_store.t
   ; merlin : Document.Single_pipeline.t
@@ -31,6 +35,7 @@ type t =
   ; symbols_thread : Lev_fiber.Thread.t Lazy_fiber.t
   ; wheel : Lev_fiber.Timer.Wheel.t
   ; hover_extended : hover_extended
+  ; shutdown_status : shutdown_status
   }
 
 val create :


### PR DESCRIPTION
I noticed that the vscode extension was stopping [only the client but not the server](https://github.com/ocamllabs/vscode-ocaml-platform/blob/bb60961679f248963204a71853e28e2454931d62/src/extension_instance.ml#L84-L90). This can potentially leave server processes hanging.

The protocol [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit) is clear:

> A notification to ask the server to exit its process. The server should exit with `success` code 0 if the shutdown request has been received before; otherwise with `error` code 1.