### PR TITLE
test: remove unused timeout

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -123,32 +123,13 @@ end = struct
       let client = Client.make handler io () in
       f client
     in
-    (* TODO replace the wheel once we can cancel sleep *)
-    let waitpid wheel =
-      let* timeout = Lev_fiber.Timer.Wheel.task wheel in
-      Fiber.finalize ~finally:(fun () -> Lev_fiber.Timer.Wheel.stop wheel)
-      @@ fun () ->
-      let cancelled = ref false in
-      Fiber.fork_and_join_unit
-        (fun () ->
-          let+ timeout = Lev_fiber.Timer.Wheel.await timeout in
-          match timeout with
-          | `Ok ->
-            Unix.kill pid Sys.sigkill;
-            cancelled := true
-          | `Cancelled -> ())
-        (fun () ->
-          let* (_ : Unix.process_status) = Lev_fiber.waitpid ~pid in
-          if !cancelled then Fiber.return ()
-          else Lev_fiber.Timer.Wheel.cancel timeout)
+    let waitpid =
+      let+ (_ : Unix.process_status) = Lev_fiber.waitpid ~pid in
+      ()
     in
     Lev_fiber.run (fun () ->
-        let* wheel = Lev_fiber.Timer.Wheel.create ~delay:3.0 in
         let+ res = init
-        and+ () =
-          Fiber.all_concurrently_unit
-            [ waitpid wheel; Lev_fiber.Timer.Wheel.run wheel ]
-        in
+        and+ () = waitpid in
         res)
     |> Lev_fiber.Error.ok_exn
 end


### PR DESCRIPTION
It seems that somehow when calling `Client.stop`, the server will also halt itself. I think it might this call to `Session.stop`:

https://github.com/ocaml/ocaml-lsp/blob/cb338c754bcc99c329fb45e0c4554c387cd185f2/lsp-fiber/src/rpc.ml#L346

But I'm not sure exactly why, there is a lot of code between lsp-fiber, jsonrpc-fiber and regular fiber...