### PR TITLE
Disable trigger-character completions and signature help in comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 
 - Correctly accept the `--clientProcessId` flag. (#1242)
 
+- Disable automatic completion and signature help inside comments (#1246)
+
 # 1.17.0
 
 ## Fixes

--- a/ocaml-lsp-server/src/check_for_comments.ml
+++ b/ocaml-lsp-server/src/check_for_comments.ml
@@ -1,0 +1,16 @@
+open Import
+
+let position_in_comment ~position ~merlin =
+  let loc_contains_position (_, (loc : Loc.t)) =
+    let start = Position.of_lexical_position loc.loc_start in
+    let end_ = Position.of_lexical_position loc.loc_end in
+    match Option.both start end_ with
+    | Some (start, end_) -> (
+      let range = Range.create ~start ~end_ in
+      match Position.compare_inclusion position range with
+      | `Inside -> true
+      | `Outside _ -> false)
+    | None -> false
+  in
+  Document.Merlin.with_pipeline_exn ~name:"get-comments" merlin (fun pipeline ->
+      Mpipeline.reader_comments pipeline |> List.exists ~f:loc_contains_position)

--- a/ocaml-lsp-server/src/check_for_comments.mli
+++ b/ocaml-lsp-server/src/check_for_comments.mli
@@ -1,0 +1,3 @@
+(** Returns [true] if [position] occurs inside a comment in the document *)
+val position_in_comment :
+  position:Position.t -> merlin:Document.Merlin.t -> bool Fiber.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -108,6 +108,7 @@ module Asttypes = Ocaml_parsing.Asttypes
 module Cmt_format = Ocaml_typing.Cmt_format
 module Ident = Ocaml_typing.Ident
 module Env = Ocaml_typing.Env
+module Merlin_parsing = Ocaml_parsing
 
 module Loc = struct
   module T = struct

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -197,11 +197,17 @@ let run (state : State.t)
     Fiber.return help
   | `Merlin merlin -> (
     let* application_signature =
-      Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-          let typer = Mpipeline.typer_result pipeline in
-          let pos = Mpipeline.get_lexing_pos pipeline pos in
-          let node = Mtyper.node_at typer pos in
-          application_signature node ~prefix)
+      let* inside_comment =
+        Check_for_comments.position_in_comment ~position ~merlin
+      in
+      match inside_comment with
+      | true -> Fiber.return None
+      | false ->
+        Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
+            let typer = Mpipeline.typer_result pipeline in
+            let pos = Mpipeline.get_lexing_pos pipeline pos in
+            let node = Mtyper.node_at typer pos in
+            application_signature node ~prefix)
     in
     match application_signature with
     | None ->

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-signatureHelp.ts
@@ -327,7 +327,7 @@ describe_opt("textDocument/completion", () => {
     `,
     );
 
-    let items = await querySignatureHelp(Types.Position.create(23, 13));
+    let items = await querySignatureHelp(Types.Position.create(80, 13));
     expect(items).toMatchObject({
       activeSignature: 0,
       activeParameter: 0,


### PR DESCRIPTION
When the user requests signature help or completions via a trigger character, do not provide a repsonse if the request was generated from within a comment. This reduces unhelpful noise when writing comments.