### PR TITLE
fix(lev-fiber): scheduler fd leak

### DIFF
--- a/submodules/lev/lev-fiber/src/lev_fiber.ml
+++ b/submodules/lev/lev-fiber/src/lev_fiber.ml
@@ -1276,6 +1276,7 @@ let run (type a) ?(sigpipe = `Inherit)
     List.iter t.thread_workers ~f:(fun (Worker w) ->
         Worker.complete_tasks_and_stop w;
         Worker.join w);
-    Lev.Async.destroy async
+    Lev.Async.destroy async;
+    Lev.Loop.destroy lev_loop
   in
   res


### PR DESCRIPTION
running the scheduler more than once no longer leaks fd's
