### PR TITLE
Fix abs_pos computing in `String_zipper.drop_until`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@
   completions that start with `?` to start with `~` when the prefix being
   completed starts with `~`. (#1277)
 
+- Fix document syncing (#1278, #1280, fixes #1207)
+
 # 1.17.0
 
 ## Fixes

--- a/lsp/src/string_zipper.ml
+++ b/lsp/src/string_zipper.ml
@@ -183,8 +183,9 @@ let rec prev_newline t =
           })
 
 let beginning_of_line t =
+  let line = t.line in
   let t = prev_newline t in
-  if is_begin t then t else advance_char t
+  if is_begin t && t.line = line then t else advance_char t
 
 let rec goto_line_backward t = function
   | 0 -> beginning_of_line t

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -248,7 +248,7 @@ let%expect_test "replace second line first line is \\n" =
   let new_doc = Text_document.apply_text_document_edits doc [ edit ] in
   new_doc |> Text_document.text |> String.escaped |> print_endline;
   [%expect {|
-    \nfochange\nfoo\nbar\nbaz\n |}]
+    \nfochangeo\nbar\nbaz\n |}]
 
 let%expect_test "get position after change" =
   let range = tuple_range (1, 2) (1, 2) in
@@ -260,4 +260,4 @@ let%expect_test "get position after change" =
   printf "pos: %d\n" pos;
   [%expect {|
     \nfochangeo\nbar\nbaz\n
-    pos: 19 |}]
+    pos: 22 |}]

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -47,7 +47,11 @@ let%expect_test "mark value in top level let" =
 let $f$ =
   let x = 1 in
   0
-|}
+|};
+  [%expect {|
+    let _f =
+      let x = 1 in
+      0 |}]
 
 let%expect_test "mark value in match" =
   mark_test `Value {|


### PR DESCRIPTION
This PR should fix a problem that occurs when editing a text document with `apply_text_document_edits`, where some text could be duplicated, as shown in #1207.