### PR TITLE
fix(lsp): goto_line_backward abs_pos

### DIFF
--- a/lsp/src/string_zipper.ml
+++ b/lsp/src/string_zipper.ml
@@ -292,7 +292,7 @@ let drop_until from until =
       | [] -> empty
       | current :: left ->
         let rel_pos = Substring.length current in
-        let abs_pos = from.rel_pos + rel_pos in
+        let abs_pos = from.abs_pos + rel_pos in
         { from with right; left; current; rel_pos; abs_pos })
 
 let add_buffer_between b start stop =

--- a/lsp/test/string_zipper_tests.ml
+++ b/lsp/test/string_zipper_tests.ml
@@ -173,4 +173,4 @@ let%expect_test "drop_until bug" =
     "foo\nbar\n|" |}];
   printfn "abs_pos: %d" (String_zipper.Private.reflect t).abs_pos;
   [%expect {|
-    abs_pos: 16 |}]
+    abs_pos: 8 |}]


### PR DESCRIPTION
fix book-keeping of [abs_pos] in [String_zipper.goto_line_backward]