### PR TITLE
Disable inlay hints under ghost location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@
 
 - Fix document syncing (#1278, #1280, fixes #1207)
 
+- Stop generating inlay hints on generated code (#1290)
+
 # 1.17.0
 
 ## Fixes

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -56,6 +56,8 @@ let hint_binding_iter ?(hint_let_bindings = false)
       | Texp_match (expr, cases, _) ->
         iter.expr iter expr;
         List.iter cases ~f:(case hint_pattern_variables iter)
+      (* Stop iterating when we see a ghost location to avoid annotating generated code *)
+      | _ when e.exp_loc.loc_ghost -> ()
       | _ -> I.default_iterator.expr iter e
   in
 
@@ -65,6 +67,8 @@ let hint_binding_iter ?(hint_let_bindings = false)
       | Typedtree.Tstr_value (_, vbs) ->
         List.iter vbs ~f:(fun (vb : Typedtree.value_binding) ->
             expr iter vb.vb_expr)
+      (* Stop iterating when we see a ghost location to avoid annotating generated code *)
+      | _ when item.str_loc.loc_ghost -> ()
       | _ -> I.default_iterator.structure_item iter item
   in
   let pat (type k) iter (pat : k Typedtree.general_pattern) =

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -57,7 +57,7 @@ let hint_binding_iter ?(hint_let_bindings = false)
         iter.expr iter expr;
         List.iter cases ~f:(case hint_pattern_variables iter)
       (* Stop iterating when we see a ghost location to avoid annotating generated code *)
-      | _ when e.exp_loc.loc_ghost -> ()
+      | _ when e.exp_loc.loc_ghost && not inside_test -> ()
       | _ -> I.default_iterator.expr iter e
   in
 
@@ -68,7 +68,7 @@ let hint_binding_iter ?(hint_let_bindings = false)
         List.iter vbs ~f:(fun (vb : Typedtree.value_binding) ->
             expr iter vb.vb_expr)
       (* Stop iterating when we see a ghost location to avoid annotating generated code *)
-      | _ when item.str_loc.loc_ghost -> ()
+      | _ when item.str_loc.loc_ghost && not inside_test -> ()
       | _ -> I.default_iterator.structure_item iter item
   in
   let pat (type k) iter (pat : k Typedtree.general_pattern) =


### PR DESCRIPTION
Inlay hints are both noisy and useless when applied to generated code. Examples include lots of unnecessary hints on the fields of a record definition that derives things like `sexp` or `fields`, or confusing annotations on format strings using `!`. 

All the generated code exists under typedtree nodes with ghost locations. This PR changes the inlay hint logic to stop iterating over the typedtree when it sees an expression or a structure item with a ghost location.