### PR TITLE
Fix parens around function types in signature help

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@
 
 - Stop generating inlay hints on generated code (#1290)
 
+- Fix parenthesizing of function types in `SignatureHelp` (#1296)
+
 # 1.17.0
 
 ## Fixes

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -59,8 +59,7 @@ let rec type_is_arrow ty =
 
 (* surround function types in parentheses *)
 let pp_parameter_type env ppf ty =
-  if type_is_arrow ty
-  then Format.fprintf ppf "(%a)" (pp_type env) ty
+  if type_is_arrow ty then Format.fprintf ppf "(%a)" (pp_type env) ty
   else pp_type env ppf ty
 
 (* print parameter labels and types *)

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -50,11 +50,18 @@ let pp_type env ppf ty =
   Printtyp.wrap_printing_env env ~verbosity:(Lvl 0) (fun () ->
       Printtyp.shared_type_scheme ppf ty)
 
+let rec type_is_arrow ty =
+  match Types.get_desc ty with
+  | Tarrow _ -> true
+  | Tlink ty -> type_is_arrow ty
+  | Tpoly (ty, _) -> type_is_arrow ty
+  | _ -> false
+
 (* surround function types in parentheses *)
 let pp_parameter_type env ppf ty =
-  match Types.get_desc ty with
-  | Tarrow _ -> Format.fprintf ppf "(%a)" (pp_type env) ty
-  | _ -> pp_type env ppf ty
+  if type_is_arrow ty
+  then Format.fprintf ppf "(%a)" (pp_type env) ty
+  else pp_type env ppf ty
 
 (* print parameter labels and types *)
 let pp_parameter env label ppf ty =


### PR DESCRIPTION
Fix the algorithm that decides when to wrap a signature hint with parens.

Testing
-------
Ran the LSP locally and confirmed this correctly surrounds function argument types with parens.