### PR TITLE
bug fixes for destruct-line edge cases

### DIFF
--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -37,6 +37,8 @@ include struct
     let hd t = List.hd t
 
     let filter t ~f = List.filter t ~f
+
+    let tl t = List.tl t
   end
 
   module Map = Map
@@ -57,6 +59,12 @@ include struct
     let chop_suffix_if_exists = Base.String.chop_suffix_if_exists
 
     let substr_index_exn = Base.String.substr_index_exn
+
+    let substr_index = Base.String.substr_index
+
+    let prefix = Base.String.prefix
+
+    let lfindi = Base.String.lfindi
 
     (**Filters a string keeping any chars for which f returns true and
        discarding those for which it returns false*)


### PR DESCRIPTION
Fixed a bug where destruct-line would sometimes fail to provide the "-> _" on the
right-hand side of cases when Merlin split its response across multiple lines.

Used the opportunity to clean up how the reply gets formatted: it now relies on fewer
fragile regular expressions and should generally be a bit easier to read.

Testing also led to the discovery of some bad behavior on case-lines where the lhs is
a hole, but the cursor isn't on the hole. This was fixed by adding `OffsetHole` to the
`statement_kind` variants.

Testing
-------
Updated the expect-tests for long variant names, offset-holes, and hole-spacing.
Importantly, the tests called "destruct strips parentheses even on long lines" and
"destruct a case with a hole but not on the hole" confirm the bug-fixes.