### PR TITLE
hover: use `***` to print dividers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,7 +55,7 @@
 - Disable automatic completion and signature help inside comments (#1246)
 
 - Includes a new optional/configurable option to toggle syntax documentation. If
-  toggled on, allows display of sytax documentation on hover tooltips. Can be
+  toggled on, allows display of syntax documentation on hover tooltips. Can be
   controlled via environment variables and by GUI for VS code. (#1218)
 
 - For completions on labels that the LSP gets from merlin, take into account
@@ -68,6 +68,8 @@
 - Stop generating inlay hints on generated code (#1290)
 
 - Fix parenthesizing of function types in `SignatureHelp` (#1296)
+
+- Fix syntax documentation rendering (#1318)
 
 # 1.17.0
 

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -193,7 +193,7 @@ let hover_at_cursor parsetree (`Logical (cursor_line, cursor_col)) =
   in
   !result
 
-let print_dividers sections = String.concat ~sep:"\n---\n" sections
+let print_dividers sections = String.concat ~sep:"\n***\n" sections
 
 let format_as_code_block ~highlighter strings =
   sprintf "```%s\n%s\n```" highlighter (String.concat ~sep:" " strings)

--- a/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
@@ -82,7 +82,7 @@ type color = Red|Blue
     {
       "contents": {
         "kind": "plaintext",
-        "value": "type color = Red | Blue\n---\n`syntax` Variant Type: Represent's data that may take on multiple different forms.. See [Manual](https://v2.ocaml.org/releases/4.14/htmlman/typedecl.html#ss:typedefs)"
+        "value": "type color = Red | Blue\n***\n`syntax` Variant Type: Represent's data that may take on multiple different forms.. See [Manual](https://v2.ocaml.org/releases/4.14/htmlman/typedecl.html#ss:typedefs)"
       },
       "range": {
         "end": { "character": 21, "line": 1 },
@@ -129,7 +129,7 @@ type t = ..
     {
       "contents": {
         "kind": "plaintext",
-        "value": "type t = ..\n---\n`syntax` Extensible Variant Type: Can be extended with new variant constructors using `+=`.. See [Manual](https://v2.ocaml.org/releases/4.14/htmlman/extensiblevariants.html)"
+        "value": "type t = ..\n***\n`syntax` Extensible Variant Type: Can be extended with new variant constructors using `+=`.. See [Manual](https://v2.ocaml.org/releases/4.14/htmlman/extensiblevariants.html)"
       },
       "range": {
         "end": { "character": 11, "line": 1 },

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-hoverExtended.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-hoverExtended.ts
@@ -135,7 +135,7 @@ Object {
     "value": "\`\`\`ocaml
 'a -> 'a
 \`\`\`
----
+***
 This function has a nice documentation",
   },
   "range": Object {
@@ -211,7 +211,7 @@ Object {
     "value": "\`\`\`ocaml
 int -> int -> int
 \`\`\`
----
+***
 This function has a nice documentation.
 
 It performs division of two integer numbers.

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -133,7 +133,7 @@ Object {
     "value": "\`\`\`ocaml
 'a -> 'a
 \`\`\`
----
+***
 This function has a nice documentation",
   },
   "range": Object {
@@ -188,7 +188,7 @@ Object {
     "value": "\`\`\`ocaml
 'a -> 'a
 \`\`\`
----
+***
 This function has a nice documentation",
   },
   "range": Object {
@@ -263,7 +263,7 @@ Object {
     "value": "\`\`\`ocaml
 int -> int -> int
 \`\`\`
----
+***
 This function has a nice documentation.
 
 It performs division of two integer numbers.


### PR DESCRIPTION
vscode renderer treats the section before a `---` divider as a title (it is a [setext heading](https://spec.commonmark.org/0.31.2/#setext-heading-underline), see [example 59](https://spec.commonmark.org/0.31.2/#example-59)). This stayed undetected before the syntax doc PR because only code was printed before the divider.

Current behavior with `---`:
<img width="502" alt="image" src="https://github.com/ocaml/ocaml-lsp/assets/5031221/6b1c994d-44b5-4c70-af7f-a6f885f62531">

We can use stars to get a delimiter without a heading:
<img width="502" alt="image" src="https://github.com/ocaml/ocaml-lsp/assets/5031221/341da57e-cbdb-4a82-85e9-d3c01e4a17b9">

cc @PizieDust 