### PR TITLE
chore: revert incorrect changes to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ bench: ##
 
 .PHONY: test-ocaml
 test-ocaml: ## Run the unit tests
-	# FIXME: Find another approach to prevent competing test runs from causing errors
-	dune build  -j 1 @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
+	dune build @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
 
 .PHONY: promote
 promote:
@@ -106,6 +105,5 @@ coverage-deps:
 
 .PHONY: test-coverage
 test-coverage:
-	# FIXME: Find another approach to prevent competing test runs from causing errors
-	dune build -j 1 --instrument-with bisect_ppx --force @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
+	dune build --instrument-with bisect_ppx --force @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
 	bisect-ppx-report send-to Coveralls


### PR DESCRIPTION
@xvw your original is still flaky even with your workaround. Your workaround also makes the tests way slower for everyone. Let's keep the test suite in a healthy state.