### PR TITLE
Global pass on Custom_request

### DIFF
--- a/ocaml-lsp-server/src/custom_requests/custom_request.ml
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.ml
@@ -1,30 +1,7 @@
-open Import
-
-type 't req_params_spec =
-  { params_schema : Jsonrpc.Structured.t
-  ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
-  }
-
-let of_jsonrpc_params_exn spec params =
-  let raise_invalid_params ?data ~message () =
-    Jsonrpc.Response.Error.raise
-    @@ Jsonrpc.Response.Error.make
-         ?data
-         ~code:Jsonrpc.Response.Error.Code.InvalidParams
-         ~message
-         ()
-  in
-  match params with
-  | None -> raise_invalid_params ~message:"Expected params but received none" ()
-  | Some params ->
-    (match spec.of_jsonrpc_params params with
-     | Some t -> t
-     | None ->
-       let error_json =
-         `Assoc
-           [ "params_expected", (spec.params_schema :> Json.t)
-           ; "params_received", (params :> Json.t)
-           ]
-       in
-       raise_invalid_params ~message:"Unexpected parameter format" ~data:error_json ())
-;;
+module Hover_extended = Req_hover_extended
+module Infer_intf = Req_infer_intf
+module Merlin_call_compatible = Req_merlin_call_compatible
+module Switch_impl_intf = Req_switch_impl_intf
+module Typed_holes = Req_typed_holes
+module Type_enclosing = Req_type_enclosing
+module Wrapping_ast_node = Req_wrapping_ast_node

--- a/ocaml-lsp-server/src/custom_requests/custom_request.mli
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.mli
@@ -1,13 +1,9 @@
-type 't req_params_spec =
-  { params_schema : Jsonrpc.Structured.t
-  (** used to document the structure of the params; example:
-      [`Assoc [ "uri" , `String "<Uri>" ]]; *)
-  ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
-  (** parses given structured JSON if it's of the expected schema;
-      otherwise, return [None] *)
-  }
+(** {1 Exposed Custom Request} *)
 
-val of_jsonrpc_params_exn
-  :  'req_params req_params_spec
-  -> Jsonrpc.Structured.t option
-  -> 'req_params
+module Hover_extended = Req_hover_extended
+module Infer_intf = Req_infer_intf
+module Merlin_call_compatible = Req_merlin_call_compatible
+module Switch_impl_intf = Req_switch_impl_intf
+module Typed_holes = Req_typed_holes
+module Type_enclosing = Req_type_enclosing
+module Wrapping_ast_node = Req_wrapping_ast_node

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
@@ -156,8 +156,8 @@ module Request_params = struct
   ;;
 
   let of_jsonrpc_params_exn params : t =
-    let params_spec = { Custom_request.params_schema; of_jsonrpc_params } in
-    Custom_request.of_jsonrpc_params_exn params_spec params
+    let params_spec = Util.{ params_schema; of_jsonrpc_params } in
+    Util.of_jsonrpc_params_exn params_spec params
   ;;
 end
 

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
@@ -14,6 +14,9 @@ module Request_params = struct
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
+  let create ?verbosity ~text_document ~cursor_position () =
+    { text_document; cursor_position; verbosity }
+
   let _ = fun (_ : t) -> ()
 
   let t_of_yojson =

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.ml
@@ -16,6 +16,7 @@ module Request_params = struct
 
   let create ?verbosity ~text_document ~cursor_position () =
     { text_document; cursor_position; verbosity }
+  ;;
 
   let _ = fun (_ : t) -> ()
 
@@ -159,6 +160,10 @@ module Request_params = struct
     Custom_request.of_jsonrpc_params_exn params_spec params
   ;;
 end
+
+type t = Hover.t
+
+let t_of_yojson = Hover.t_of_yojson
 
 let on_request ~(params : Jsonrpc.Structured.t option) (server : State.t Server.t) =
   let { Request_params.text_document; cursor_position; verbosity } =

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
@@ -13,6 +13,10 @@ module Request_params : sig
   val yojson_of_t : t -> Json.t
 end
 
+type t
+
+val t_of_yojson : Json.t -> t
+
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t Server.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
@@ -3,8 +3,8 @@ open Import
 module Request_params : sig
   type t
 
-  val create :
-       ?verbosity:int
+  val create
+    :  ?verbosity:int
     -> text_document:Lsp.Types.TextDocumentIdentifier.t
     -> cursor_position:Position.t
     -> unit
@@ -16,7 +16,6 @@ end
 type t
 
 val t_of_yojson : Json.t -> t
-
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t Server.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_hover_extended.mli
@@ -1,5 +1,18 @@
 open Import
 
+module Request_params : sig
+  type t
+
+  val create :
+       ?verbosity:int
+    -> text_document:Lsp.Types.TextDocumentIdentifier.t
+    -> cursor_position:Position.t
+    -> unit
+    -> t
+
+  val yojson_of_t : t -> Json.t
+end
+
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t Server.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.ml
@@ -5,46 +5,14 @@ let meth = "ocamllsp/merlinCallCompatible"
 
 module Request_params = struct
   type t =
-    { uri : Uri.t
+    { text_document : TextDocumentIdentifier.t
     ; result_as_sexp : bool
     ; command : string
     ; args : string list
     }
 
-  let expected =
-    `Assoc
-      [ "uri", `String "<DocumentUri>"
-      ; "resultAsSexp?", `String "<true | false>"
-      ; "command", `String "<MerlinCommand>"
-      ; "args?", `String "<string | bool | float | int | intLit>[] | Object"
-      ]
-  ;;
-
-  let as_sexp_of_yojson params =
-    match List.assoc_opt "resultAsSexp" params with
-    | Some (`Bool value) -> value
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, it is assumed that
-         the result is not requested in the form of Sexp *)
-      false
-  ;;
-
-  let command_of_yojson params =
-    match List.assoc_opt "command" params with
-    | Some (`String command_name) -> Some command_name
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, we refuse to build
-         the parameter, [command] is mandatory. *)
-      None
-  ;;
-
-  let uri_of_yojson params =
-    match List.assoc_opt "uri" params with
-    | Some uri -> Some (Uri.t_of_yojson uri)
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, we refuse to build
-         the parameter, [uri] is mandatory. *)
-      None
+  let create ~text_document ~result_as_sexp ~command ~args =
+    { text_document; result_as_sexp; command; args }
   ;;
 
   let stringish_of_yojson
@@ -89,45 +57,48 @@ module Request_params = struct
     List.rev args
   ;;
 
-  let args_of_yojson params =
-    match List.assoc_opt "args" params with
-    | Some (`List args) -> args_of_yojson_list args
-    | Some (`Assoc args) -> args_of_yojson_assoc args
-    | _ ->
-      (* If args is not a list or is absent, it should fail. *)
-      None
+  let args_of_yojson json =
+    let open Yojson.Safe.Util in
+    match to_option (member "args") json with
+    | Some (`List args) -> args |> args_of_yojson_list |> Option.value ~default:[]
+    | Some (`Assoc args) -> args |> args_of_yojson_assoc |> Option.value ~default:[]
+    | _ -> []
   ;;
 
-  let t_of_yojson = function
-    | `Assoc params ->
-      let result_as_sexp = as_sexp_of_yojson params in
-      let open Option.O in
-      let* command = command_of_yojson params in
-      let* args = args_of_yojson params in
-      let* uri = uri_of_yojson params in
-      Some { result_as_sexp; command; args; uri }
-    | _ -> None
+  let t_of_yojson json =
+    let open Yojson.Safe.Util in
+    let result_as_sexp = json |> member "resultAsSexp" |> to_bool in
+    let command = json |> member "command" |> to_string in
+    let args = args_of_yojson json in
+    let text_document = TextDocumentIdentifier.t_of_yojson json in
+    { text_document; result_as_sexp; command; args }
+  ;;
+
+  let yojson_of_t { text_document; result_as_sexp; command; args } =
+    match TextDocumentIdentifier.yojson_of_t text_document with
+    | `Assoc assoc ->
+      let result_as_sexp = "resultAsSexp", `Bool result_as_sexp in
+      let command = "command", `String command in
+      let args = "args", `List (List.map ~f:(fun x -> `String x) args) in
+      `Assoc (result_as_sexp :: command :: args :: assoc)
+    | _ -> (* unreachable *) assert false
   ;;
 end
 
-let raise_invalid_params ?data ~message () =
-  let open Jsonrpc.Response.Error in
-  raise @@ make ?data ~code:Code.InvalidParams ~message ()
+type t =
+  { result_as_sexp : bool
+  ; result : string
+  }
+
+let yojson_of_t { result_as_sexp; result } =
+  `Assoc [ "resultAsSexp", `Bool result_as_sexp; "result", `String result ]
 ;;
 
-let from_structured_json_exn = function
-  | None -> raise_invalid_params ~message:"Expected params but received none" ()
-  | Some params ->
-    (match Request_params.t_of_yojson params with
-     | Some params -> params
-     | None ->
-       let data =
-         `Assoc
-           [ "expectedParams", Request_params.expected
-           ; "receivedParams", (params :> Json.t)
-           ]
-       in
-       raise_invalid_params ~data ~message:"Unexpected params format" ())
+let t_of_yojson json =
+  let open Yojson.Safe.Util in
+  let result_as_sexp = json |> member "resultAsSexp" |> to_bool in
+  let result = json |> member "result" |> to_string in
+  { result_as_sexp; result }
 ;;
 
 let with_pipeline state uri specs raw_args cmd_args f =
@@ -150,6 +121,11 @@ let with_pipeline state uri specs raw_args cmd_args f =
     Document.Merlin.with_configurable_pipeline_exn ~config merlin (f args)
 ;;
 
+let raise_invalid_params ?data ~message () =
+  let open Jsonrpc.Response.Error in
+  raise @@ make ?data ~code:Code.InvalidParams ~message ()
+;;
+
 let perform_query action params pipeline =
   let action () = action pipeline params in
   let class_, output =
@@ -165,19 +141,22 @@ let perform_query action params pipeline =
 
 let on_request ~params state =
   Fiber.of_thunk (fun () ->
-    let Request_params.{ result_as_sexp; command; args; uri } =
-      from_structured_json_exn params
+    let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
+    let Request_params.{ result_as_sexp; command; args; text_document } =
+      Request_params.t_of_yojson params
     in
     match Merlin_commands.New_commands.(find_command command all_commands) with
     | Merlin_commands.New_commands.Command (_name, _doc, specs, params, action) ->
       let open Fiber.O in
+      let uri = text_document.uri in
       let+ json = with_pipeline state uri specs args params @@ perform_query action in
       let result =
         if result_as_sexp
         then Merlin_utils.(json |> Sexp.of_json |> Sexp.to_string)
         else json |> Yojson.Basic.to_string
       in
-      `Assoc [ "resultAsSexp", `Bool result_as_sexp; "result", `String result ]
+      let result = { result_as_sexp; result } in
+      yojson_of_t result
     | exception Not_found ->
       let data = `Assoc [ "command", `String command ] in
       raise_invalid_params ~data ~message:"Unexpected command name" ())

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
@@ -1,5 +1,22 @@
 open Import
 
+module Request_params : sig
+  type t
+
+  val create :
+       text_document:TextDocumentIdentifier.t
+    -> result_as_sexp:bool
+    -> command:string
+    -> args:string list
+    -> t
+
+  val yojson_of_t : t -> Json.t
+end
+
+type t
+
+val t_of_yojson : Json.t -> t
+
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
@@ -3,8 +3,8 @@ open Import
 module Request_params : sig
   type t
 
-  val create :
-       text_document:TextDocumentIdentifier.t
+  val create
+    :  text_document:TextDocumentIdentifier.t
     -> result_as_sexp:bool
     -> command:string
     -> args:string list
@@ -16,7 +16,6 @@ end
 type t
 
 val t_of_yojson : Json.t -> t
-
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -55,6 +55,15 @@ type t =
   ; enclosings : Range.t list
   }
 
+let t_of_yojson json =
+  let open Yojson.Safe.Util in
+  let index = json |> member "index" |> to_int in
+  let type_ = json |> member "type" |> to_string in
+  let enclosings =
+    json |> member "enclosings" |> to_list |> List.map ~f:Range.t_of_yojson
+  in
+  { index; type_; enclosings }
+
 let yojson_of_t { index; type_; enclosings } =
   `Assoc
     [ "index", `Int index

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -63,6 +63,7 @@ let t_of_yojson json =
     json |> member "enclosings" |> to_list |> List.map ~f:Range.t_of_yojson
   in
   { index; type_; enclosings }
+;;
 
 let yojson_of_t { index; type_; enclosings } =
   `Assoc

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -1,5 +1,4 @@
 open Import
-module TextDocumentPositionParams = Lsp.Types.TextDocumentPositionParams
 
 let capability = "handleTypeEnclosing", `Bool true
 let meth = "ocamllsp/typeEnclosing"
@@ -31,45 +30,22 @@ module Request_params = struct
     { text_document; index; at; verbosity }
   ;;
 
-  let json_error json = Json.error "invalid Req_type_enclosing.Request_params" json
-
-  let index_of_yojson json params =
-    match List.assoc_opt "index" params with
-    | Some (`Int index) -> index
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, we refuse to build
-         the parameter, [index] is mandatory. *)
-      json_error json
+  let at_of_yojson json =
+    let open Yojson.Safe.Util in
+    let at = json |> member "at" in
+    try `Position (Position.t_of_yojson at) with
+    | _ -> `Range (Range.t_of_yojson at)
   ;;
 
-  let verbosity_of_yojson params =
-    match List.assoc_opt "verbosity" params with
-    | Some (`Int verbosity) -> verbosity
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, it is assumed that
-         the we ask for a verbosity level set to 0. *)
-      0
-  ;;
-
-  let at_of_yojson json params =
-    match List.assoc_opt "at" params with
-    | Some at ->
-      (try `Position (Position.t_of_yojson at) with
-       | _ -> `Range (Range.t_of_yojson at))
-    | _ ->
-      (* If the parameter is incorrectly formatted or missing, we refuse to build
-         the parameter, [at] is mandatory. *)
-      json_error json
-  ;;
-
-  let t_of_yojson = function
-    | `Assoc params as json ->
-      let verbosity = verbosity_of_yojson params in
-      let at = at_of_yojson json params in
-      let index = index_of_yojson json params in
-      let text_document = TextDocumentIdentifier.t_of_yojson json in
-      { index; at; verbosity; text_document }
-    | json -> json_error json
+  let t_of_yojson json =
+    let open Yojson.Safe.Util in
+    let verbosity =
+      json |> member "verbosity" |> to_int_option |> Option.value ~default:0
+    in
+    let at = at_of_yojson json in
+    let index = json |> member "index" |> to_int in
+    let text_document = TextDocumentIdentifier.t_of_yojson json in
+    { index; at; verbosity; text_document }
   ;;
 end
 

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.mli
@@ -16,6 +16,8 @@ end
 
 type t
 
+val t_of_yojson : Json.t -> t
+
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.mli
@@ -17,7 +17,6 @@ end
 type t
 
 val t_of_yojson : Json.t -> t
-
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
@@ -4,14 +4,12 @@ module Request_params : sig
   type t
 
   val create : Uri.t -> t
-
   val yojson_of_t : t -> Json.t
 end
 
 type t
 
 val t_of_yojson : Json.t -> t
-
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.mli
@@ -1,5 +1,17 @@
 open Import
 
+module Request_params : sig
+  type t
+
+  val create : Uri.t -> t
+
+  val yojson_of_t : t -> Json.t
+end
+
+type t
+
+val t_of_yojson : Json.t -> t
+
 val capability : string * Json.t
 val meth : string
 val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml
@@ -24,8 +24,8 @@ module Request_params = struct
   ;;
 
   let of_jsonrpc_params_exn params : t =
-    let params_spec = { Custom_request.params_schema; of_jsonrpc_params } in
-    Custom_request.of_jsonrpc_params_exn params_spec params
+    let params_spec = Util.{ params_schema; of_jsonrpc_params } in
+    Util.of_jsonrpc_params_exn params_spec params
   ;;
 end
 

--- a/ocaml-lsp-server/src/custom_requests/util.ml
+++ b/ocaml-lsp-server/src/custom_requests/util.ml
@@ -1,0 +1,32 @@
+open Import
+
+type 't req_params_spec =
+  { params_schema : Jsonrpc.Structured.t
+  ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
+  }
+
+let of_jsonrpc_params_exn spec params =
+  let raise_invalid_params ?data ~message () =
+    Jsonrpc.Response.Error.raise
+    @@ Jsonrpc.Response.Error.make
+         ?data
+         ~code:Jsonrpc.Response.Error.Code.InvalidParams
+         ~message
+         ()
+  in
+  match params with
+  | None -> raise_invalid_params ~message:"Expected params but received none" ()
+  | Some params -> (
+    match spec.of_jsonrpc_params params with
+    | Some t -> t
+    | None ->
+      let error_json =
+        `Assoc
+          [ ("params_expected", (spec.params_schema :> Json.t))
+          ; ("params_received", (params :> Json.t))
+          ]
+      in
+      raise_invalid_params
+        ~message:"Unexpected parameter format"
+        ~data:error_json
+        ())

--- a/ocaml-lsp-server/src/custom_requests/util.ml
+++ b/ocaml-lsp-server/src/custom_requests/util.ml
@@ -16,17 +16,15 @@ let of_jsonrpc_params_exn spec params =
   in
   match params with
   | None -> raise_invalid_params ~message:"Expected params but received none" ()
-  | Some params -> (
-    match spec.of_jsonrpc_params params with
-    | Some t -> t
-    | None ->
-      let error_json =
-        `Assoc
-          [ ("params_expected", (spec.params_schema :> Json.t))
-          ; ("params_received", (params :> Json.t))
-          ]
-      in
-      raise_invalid_params
-        ~message:"Unexpected parameter format"
-        ~data:error_json
-        ())
+  | Some params ->
+    (match spec.of_jsonrpc_params params with
+     | Some t -> t
+     | None ->
+       let error_json =
+         `Assoc
+           [ "params_expected", (spec.params_schema :> Json.t)
+           ; "params_received", (params :> Json.t)
+           ]
+       in
+       raise_invalid_params ~message:"Unexpected parameter format" ~data:error_json ())
+;;

--- a/ocaml-lsp-server/src/custom_requests/util.mli
+++ b/ocaml-lsp-server/src/custom_requests/util.mli
@@ -1,0 +1,11 @@
+type 't req_params_spec =
+  { params_schema : Jsonrpc.Structured.t
+        (** used to document the structure of the params; example:
+            [`Assoc [ "uri" , `String "<Uri>" ]]; *)
+  ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
+        (** parses given structured JSON if it's of the expected schema;
+            otherwise, return [None] *)
+  }
+
+val of_jsonrpc_params_exn :
+  'req_params req_params_spec -> Jsonrpc.Structured.t option -> 'req_params

--- a/ocaml-lsp-server/src/custom_requests/util.mli
+++ b/ocaml-lsp-server/src/custom_requests/util.mli
@@ -1,11 +1,13 @@
 type 't req_params_spec =
   { params_schema : Jsonrpc.Structured.t
-        (** used to document the structure of the params; example:
-            [`Assoc [ "uri" , `String "<Uri>" ]]; *)
+  (** used to document the structure of the params; example:
+      [`Assoc [ "uri" , `String "<Uri>" ]]; *)
   ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
-        (** parses given structured JSON if it's of the expected schema;
-            otherwise, return [None] *)
+  (** parses given structured JSON if it's of the expected schema;
+      otherwise, return [None] *)
   }
 
-val of_jsonrpc_params_exn :
-  'req_params req_params_spec -> Jsonrpc.Structured.t option -> 'req_params
+val of_jsonrpc_params_exn
+  :  'req_params req_params_spec
+  -> Jsonrpc.Structured.t option
+  -> 'req_params

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -948,3 +948,5 @@ let run channel ~read_dot_merlin () =
     start (Lsp_fiber.Fiber_io.make input output))
   |> Lev_fiber.Error.ok_exn
 ;;
+
+module Custom_request = Custom_request

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -5,3 +5,4 @@ module Version = Version
 module Position = Position
 module Doc_to_md = Doc_to_md
 module Testing = Testing
+module Custom_request = Custom_request

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -250,3 +250,7 @@ let apply_edits src edits =
   List.fold_left edits ~init:src ~f:(fun src (new_text, start, end_) ->
     String.take src start ^ new_text ^ String.drop src end_)
 ;;
+
+let print_result result =
+  result |> Yojson.Safe.pretty_to_string ~std:false |> print_endline
+;;


### PR DESCRIPTION
The patch proposes a global pass on Custom Requests by trying to impose the `module Request_params` structure, which proposes a creation function (and projection in Yojson), and a `type t` at the module toplevel (with a conversion function from Yojson). 

- What's more, parameter deserialization relies on Yojson's API to get close to what derivation would give.
- The `Custom_request` module is exposed by `Ocaml_lsp_server` for use from, for example, tests (and also from a JavaScript client, ie: vscode).
- Some requests have been modified very little to avoid introducing breaking-changes.

I'm obviously open to feedback!