### PR TITLE
Construct custom query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@
 - Kill unnecessary ocamlformat processes with sigterm rather than sigint or
   sigkill (#1343)
 
+## Features
+
+- Add custom [`ocamllsp/construct`](https://github.com/ocaml/ocaml-lsp/blob/ocaml-lsp-server/docs/ocamllsp/construct-spec.md) request (#1348)
+
 # 1.18.0
 
 ## Features

--- a/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
@@ -1,0 +1,44 @@
+# Construct Request
+
+## Description
+
+Provides commands to browse and fill typed holes (`_`). Such holes sometimes
+appear in the result of other commands like `destruct` and can also be inserted
+manually in the source. The command is already accessible via a completion hook,
+however, in certain situations, invoking `construct` on a hole via a request
+allows more control.
+
+## Client Capability
+
+There is no client capability relative to this request.
+
+## Server capability
+
+- property name: `handleConstruct`
+- property type: `boolean`
+
+## Request
+
+- method: `ocamllsp/typeEnclosing`
+- params:
+
+  ```json
+  {
+    "uri": TextDocumentIdentifier,
+    "position": Position
+    "depth?": uinteger (default value: 0)
+    "withValues?": <"local" | "none">,
+  }
+  ```
+
+## Response
+
+```json
+{
+  "position": Range,
+  "result": string[]
+}
+```
+
+The result contains the range (`position`) to be replaced (describing the hole)
+and the list of possible substitution values (`result`).

--- a/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
@@ -19,7 +19,7 @@ There is no client capability relative to this request.
 
 ## Request
 
-- method: `ocamllsp/typeEnclosing`
+- method: `ocamllsp/construct`
 - params:
 
   ```json
@@ -30,6 +30,11 @@ There is no client capability relative to this request.
     "withValues?": <"local" | "none">,
   }
   ```
+
+The `depth` parameter allows to recursively construct terms. Note that
+when `depth > 1` partial results of inferior depth will not be
+returned. The `withValues` use values from the environment (`local`)
+or not (`none`), by default, the parameter is fixed to `none`.
 
 ## Response
 

--- a/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/construct-spec.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Provides commands to browse and fill typed holes (`_`). Such holes sometimes
+Provides commands to fill typed holes (`_`). Such holes sometimes
 appear in the result of other commands like `destruct` and can also be inserted
 manually in the source. The command is already accessible via a completion hook,
 however, in certain situations, invoking `construct` on a hole via a request
@@ -33,8 +33,8 @@ There is no client capability relative to this request.
 
 The `depth` parameter allows to recursively construct terms. Note that
 when `depth > 1` partial results of inferior depth will not be
-returned. The `withValues` use values from the environment (`local`)
-or not (`none`), by default, the parameter is fixed to `none`.
+returned. The `withValues` parameter enables the use of values from
+the environment (`local`) or not (`none`), It defaults to `none`.
 
 ## Response
 

--- a/ocaml-lsp-server/src/custom_requests/custom_request.ml
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.ml
@@ -1,3 +1,4 @@
+module Construct = Req_construct
 module Hover_extended = Req_hover_extended
 module Infer_intf = Req_infer_intf
 module Merlin_call_compatible = Req_merlin_call_compatible

--- a/ocaml-lsp-server/src/custom_requests/custom_request.mli
+++ b/ocaml-lsp-server/src/custom_requests/custom_request.mli
@@ -1,5 +1,6 @@
 (** {1 Exposed Custom Request} *)
 
+module Construct = Req_construct
 module Hover_extended = Req_hover_extended
 module Infer_intf = Req_infer_intf
 module Merlin_call_compatible = Req_merlin_call_compatible

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -84,7 +84,7 @@ let with_pipeline state uri f =
   | `Merlin merlin ->
     (match Document.Merlin.kind merlin with
      | Document.Kind.Intf ->
-       (* Construct makes so sense if its called from an interface. *)
+       (* Construct makes no sense if its called from an interface. *)
        Fiber.return `Null
      | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -1,0 +1,111 @@
+open Import
+
+let capability = "handleConstruct", `Bool true
+let meth = "ocamllsp/construct"
+
+module Request_params = struct
+  type t =
+    { text_document : TextDocumentIdentifier.t
+    ; position : Position.t
+    ; depth : int option
+    ; with_values : [ `None | `Local ] option
+    }
+
+  let create ?with_values ?depth ~text_document ~position () =
+    { text_document; position; with_values; depth }
+  ;;
+
+  let yojson_of_with_values = function
+    | Some `Local -> `String "local"
+    | Some `None -> `String "none"
+    | None -> `Null
+  ;;
+
+  let yojson_of_t { text_document; position; with_values; depth } =
+    match TextDocumentIdentifier.yojson_of_t text_document with
+    | `Assoc assoc ->
+      let depth =
+        ( "depth"
+        , match depth with
+          | None -> `Null
+          | Some x -> `Int x )
+      in
+      let with_values = "withValues", yojson_of_with_values with_values in
+      let position = "position", Position.yojson_of_t position in
+      `Assoc (depth :: with_values :: position :: assoc)
+    | _ -> (* unreachable *) assert false
+  ;;
+
+  let with_values_of_yojson json =
+    let open Yojson.Safe.Util in
+    json
+    |> member "withValues"
+    |> to_string_option
+    |> Option.bind ~f:(fun value ->
+      match String.(lowercase_ascii @@ trim value) with
+      | "none" -> Some `None
+      | "local" -> Some `Local
+      | _ -> None)
+  ;;
+
+  let t_of_yojson json =
+    let open Yojson.Safe.Util in
+    let text_document = json |> TextDocumentIdentifier.t_of_yojson in
+    let position = json |> member "position" |> Position.t_of_yojson in
+    let depth = json |> member "depth" |> to_int_option in
+    let with_values = json |> with_values_of_yojson in
+    create ?with_values ?depth ~text_document ~position ()
+  ;;
+end
+
+type t =
+  { position : Range.t
+  ; result : string list
+  }
+
+let t_of_yojson json =
+  let open Yojson.Safe.Util in
+  let position = json |> member "position" |> Range.t_of_yojson in
+  let result = json |> member "result" |> to_list |> List.map ~f:to_string in
+  { position; result }
+;;
+
+let yojson_of_t { position; result } =
+  `Assoc
+    [ "position", Range.yojson_of_t position
+    ; "result", `List (List.map ~f:(fun x -> `String x) result)
+    ]
+;;
+
+let with_pipeline state uri f =
+  let doc = Document_store.get state.State.store uri in
+  match Document.kind doc with
+  | `Other -> Fiber.return `Null
+  | `Merlin merlin ->
+    (match Document.Merlin.kind merlin with
+     | Document.Kind.Intf ->
+       (* Construct makes so sense if its called from an interface. *)
+       Fiber.return `Null
+     | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
+;;
+
+let make_construct_command position with_values depth =
+  Query_protocol.Construct (position, with_values, depth)
+;;
+
+let dispatch_construct position with_values depth pipeline =
+  let position = Position.logical position in
+  let command = make_construct_command position with_values depth in
+  let pos, result = Query_commands.dispatch pipeline command in
+  yojson_of_t { position = Range.of_loc pos; result }
+;;
+
+let on_request ~params state =
+  Fiber.of_thunk (fun () ->
+    let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
+    let Request_params.{ text_document; position; with_values; depth } =
+      Request_params.t_of_yojson params
+    in
+    let uri = text_document.uri in
+    with_pipeline state uri @@ dispatch_construct position with_values depth)
+;;

--- a/ocaml-lsp-server/src/custom_requests/req_construct.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.mli
@@ -1,0 +1,22 @@
+open Import
+
+module Request_params : sig
+  type t
+
+  val create
+    :  ?with_values:[ `None | `Local ]
+    -> ?depth:int
+    -> text_document:Lsp.Types.TextDocumentIdentifier.t
+    -> position:Position.t
+    -> unit
+    -> t
+
+  val yojson_of_t : t -> Json.t
+end
+
+type t
+
+val t_of_yojson : Json.t -> t
+val capability : string * Json.t
+val meth : string
+val on_request : params:Jsonrpc.Structured.t option -> State.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -95,6 +95,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
               ; Req_merlin_call_compatible.capability
               ; Req_type_enclosing.capability
               ; Req_get_documentation.capability
+              ; Req_construct.capability
               ] )
         ]
     in
@@ -539,6 +540,7 @@ let on_request
        ; Req_type_enclosing.meth, Req_type_enclosing.on_request
        ; Req_get_documentation.meth, Req_get_documentation.on_request
        ; Req_wrapping_ast_node.meth, Req_wrapping_ast_node.on_request
+       ; Req_construct.meth, Req_construct.on_request
        ; ( Semantic_highlighting.Debug.meth_request_full
          , Semantic_highlighting.Debug.on_request_full )
        ; ( Req_hover_extended.meth

--- a/ocaml-lsp-server/test/e2e-new/construct.ml
+++ b/ocaml-lsp-server/test/e2e-new/construct.ml
@@ -1,0 +1,137 @@
+open Test.Import
+module Req = Ocaml_lsp_server.Custom_request.Construct
+
+module Util = struct
+  let call_construct ?depth ?with_values client position =
+    let uri = DocumentUri.of_path "test.ml" in
+    let text_document = TextDocumentIdentifier.create ~uri in
+    let params =
+      Req.Request_params.create ?depth ?with_values ~text_document ~position ()
+      |> Req.Request_params.yojson_of_t
+      |> Jsonrpc.Structured.t_of_yojson
+      |> Option.some
+    in
+    let req = Lsp.Client_request.UnknownRequest { meth = Req.meth; params } in
+    Client.request client req
+  ;;
+
+  let test ?depth ?with_values ~line ~character source =
+    let position = Position.create ~line ~character in
+    let request client =
+      let open Fiber.O in
+      let+ response = call_construct ?depth ?with_values client position in
+      Test.print_result response
+    in
+    Helpers.test source request
+  ;;
+end
+
+let%expect_test "Example sample from merlin 1" =
+  let source =
+    {|type r = {the_t: t; id: int}
+and t = A | B of r option
+
+let x : t = _
+|}
+  in
+  let line = 3
+  and character = 13 in
+  Util.test ~line ~character source;
+  [%expect
+    {|
+    {
+      "position": {
+        "end": { "character": 13, "line": 3 },
+        "start": { "character": 12, "line": 3 }
+      },
+      "result": [ "A", "(B _)" ]
+    } |}]
+;;
+
+let%expect_test "Example sample from merlin 2" =
+  let source =
+    {|type r = {the_t: t; id: int}
+and t = A | B of r option
+
+let x : t = B _
+|}
+  in
+  let line = 3
+  and character = 14 in
+  Util.test ~line ~character source;
+  [%expect
+    {|
+    {
+      "position": {
+        "end": { "character": 15, "line": 3 },
+        "start": { "character": 14, "line": 3 }
+      },
+      "result": [ "None", "(Some _)" ]
+    } |}]
+;;
+
+let%expect_test "Example sample from merlin 3" =
+  let source =
+    {|type r = {the_t: t; id: int}
+and t = A | B of r option
+
+let x : t = B (Some _)
+|}
+  in
+  let line = 3
+  and character = 20 in
+  Util.test ~line ~character source;
+  [%expect
+    {|
+    {
+      "position": {
+        "end": { "character": 21, "line": 3 },
+        "start": { "character": 20, "line": 3 }
+      },
+      "result": [ "{ the_t = _; id = _ }" ]
+    } |}]
+;;
+
+let%expect_test "Example sample from merlin 4" =
+  let source =
+    {|type r = {the_t: t; id: int}
+and t = A | B of r option
+
+let x : t = B (Some { the_t = _; id = _ })
+|}
+  in
+  let line = 3
+  and character = 30 in
+  Util.test ~line ~character source;
+  [%expect
+    {|
+    {
+      "position": {
+        "end": { "character": 31, "line": 3 },
+        "start": { "character": 30, "line": 3 }
+      },
+      "result": [ "A", "(B _)" ]
+    } |}]
+;;
+
+let%expect_test "Example sample from merlin 5" =
+  let source =
+    {|type r = {the_t: t; id: int}
+and t = A | B of r option
+
+let x : t = B (Some { the_t = A; id = _ })
+|}
+  in
+  let line = 3
+  and character = 38 in
+  Util.test ~line ~character source;
+  [%expect
+    {|
+    {
+      "position": {
+        "end": { "character": 39, "line": 3 },
+        "start": { "character": 38, "line": 3 }
+      },
+      "result": [ "0" ]
+    } |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -46,6 +46,7 @@
     code_actions
     completion
     completions
+    construct
     doc_to_md
     document_flow
     exit_notification

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -92,7 +92,8 @@ let%expect_test "start/stop" =
             "handleHoverExtended": true,
             "handleMerlinCallCompatible": true,
             "handleTypeEnclosing": true,
-            "handleGetDocumentation": true
+            "handleGetDocumentation": true,
+            "handleConstruct": true
           }
         },
         "foldingRangeProvider": true,


### PR DESCRIPTION
At the moment, construct is a completion hook, and in some cases accessing it via a one-off query can be useful.