### PR TITLE
selection_range: use merlin enclosing query instead of shape

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fix fd leak in running external processes for preprocessing (#1349)
 - Fix prefix parsing for completion of object methods (#1363, fixes #1358)
+- Remove some duplicates in the `selectionRange` answers (#1368)
 
 
 # 1.19.0

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
@@ -148,4 +148,550 @@ Array [
 ]
 `);
   });
+
+  it("returns a selection range for more complex documents", async () => {
+    openDocument(outdent`
+      type _ typ =
+        | TInt : int typ
+        | TBool : bool typ
+      module M = struct
+        type t
+        let f (_ : _ typ) = ()
+      end
+        `);
+
+    let result = await selectionRange([Types.Position.create(5, 23)]);
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "parent": Object {
+      "parent": Object {
+        "parent": Object {
+          "parent": Object {
+            "parent": Object {
+              "parent": Object {
+                "parent": Object {
+                  "parent": Object {
+                    "range": Object {
+                      "end": Object {
+                        "character": 3,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "character": 0,
+                        "line": 0,
+                      },
+                    },
+                  },
+                  "range": Object {
+                    "end": Object {
+                      "character": 3,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "character": 0,
+                      "line": 3,
+                    },
+                  },
+                },
+                "range": Object {
+                  "end": Object {
+                    "character": 3,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "character": 0,
+                    "line": 3,
+                  },
+                },
+              },
+              "range": Object {
+                "end": Object {
+                  "character": 3,
+                  "line": 6,
+                },
+                "start": Object {
+                  "character": 11,
+                  "line": 3,
+                },
+              },
+            },
+            "range": Object {
+              "end": Object {
+                "character": 24,
+                "line": 5,
+              },
+              "start": Object {
+                "character": 2,
+                "line": 4,
+              },
+            },
+          },
+          "range": Object {
+            "end": Object {
+              "character": 24,
+              "line": 5,
+            },
+            "start": Object {
+              "character": 2,
+              "line": 5,
+            },
+          },
+        },
+        "range": Object {
+          "end": Object {
+            "character": 24,
+            "line": 5,
+          },
+          "start": Object {
+            "character": 2,
+            "line": 5,
+          },
+        },
+      },
+      "range": Object {
+        "end": Object {
+          "character": 24,
+          "line": 5,
+        },
+        "start": Object {
+          "character": 8,
+          "line": 5,
+        },
+      },
+    },
+    "range": Object {
+      "end": Object {
+        "character": 24,
+        "line": 5,
+      },
+      "start": Object {
+        "character": 22,
+        "line": 5,
+      },
+    },
+  },
+]
+`)});
+
+  it("returns a selection range for functors", async () => {
+    openDocument(outdent`
+module M = Map.Make (struct
+  type t = { o: < rank : int > }
+  let compare a b = a.o#rank - b.o#rank
+end)`);
+
+  let result = await selectionRange([Types.Position.create(2, 26)]);
+  expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "parent": Object {
+      "parent": Object {
+        "parent": Object {
+          "parent": Object {
+            "parent": Object {
+              "parent": Object {
+                "parent": Object {
+                  "parent": Object {
+                    "parent": Object {
+                      "parent": Object {
+                        "parent": Object {
+                          "range": Object {
+                            "end": Object {
+                              "character": 4,
+                              "line": 3,
+                            },
+                            "start": Object {
+                              "character": 0,
+                              "line": 0,
+                            },
+                          },
+                        },
+                        "range": Object {
+                          "end": Object {
+                            "character": 4,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "character": 0,
+                            "line": 0,
+                          },
+                        },
+                      },
+                      "range": Object {
+                        "end": Object {
+                          "character": 4,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "character": 0,
+                          "line": 0,
+                        },
+                      },
+                    },
+                    "range": Object {
+                      "end": Object {
+                        "character": 4,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "character": 11,
+                        "line": 0,
+                      },
+                    },
+                  },
+                  "range": Object {
+                    "end": Object {
+                      "character": 3,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "character": 21,
+                      "line": 0,
+                    },
+                  },
+                },
+                "range": Object {
+                  "end": Object {
+                    "character": 39,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "character": 2,
+                    "line": 1,
+                  },
+                },
+              },
+              "range": Object {
+                "end": Object {
+                  "character": 39,
+                  "line": 2,
+                },
+                "start": Object {
+                  "character": 2,
+                  "line": 2,
+                },
+              },
+            },
+            "range": Object {
+              "end": Object {
+                "character": 39,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 2,
+                "line": 2,
+              },
+            },
+          },
+          "range": Object {
+            "end": Object {
+              "character": 39,
+              "line": 2,
+            },
+            "start": Object {
+              "character": 14,
+              "line": 2,
+            },
+          },
+        },
+        "range": Object {
+          "end": Object {
+            "character": 39,
+            "line": 2,
+          },
+          "start": Object {
+            "character": 20,
+            "line": 2,
+          },
+        },
+      },
+      "range": Object {
+        "end": Object {
+          "character": 28,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 20,
+          "line": 2,
+        },
+      },
+    },
+    "range": Object {
+      "end": Object {
+        "character": 28,
+        "line": 2,
+      },
+      "start": Object {
+        "character": 23,
+        "line": 2,
+      },
+    },
+  },
+]
+`)});
+
+it("returns a reasonable selection range for ill-typed modules", async () => {
+  openDocument(outdent`
+module M = struct
+    let f x : int = string_of_int x
+end`);
+
+let result = await selectionRange([Types.Position.create(1, 34)]);
+expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "parent": Object {
+      "parent": Object {
+        "parent": Object {
+          "parent": Object {
+            "parent": Object {
+              "parent": Object {
+                "parent": Object {
+                  "parent": Object {
+                    "parent": Object {
+                      "range": Object {
+                        "end": Object {
+                          "character": 3,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "character": 0,
+                          "line": 0,
+                        },
+                      },
+                    },
+                    "range": Object {
+                      "end": Object {
+                        "character": 3,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "character": 0,
+                        "line": 0,
+                      },
+                    },
+                  },
+                  "range": Object {
+                    "end": Object {
+                      "character": 3,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "character": 0,
+                      "line": 0,
+                    },
+                  },
+                },
+                "range": Object {
+                  "end": Object {
+                    "character": 3,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "character": 11,
+                    "line": 0,
+                  },
+                },
+              },
+              "range": Object {
+                "end": Object {
+                  "character": 35,
+                  "line": 1,
+                },
+                "start": Object {
+                  "character": 4,
+                  "line": 1,
+                },
+              },
+            },
+            "range": Object {
+              "end": Object {
+                "character": 35,
+                "line": 1,
+              },
+              "start": Object {
+                "character": 4,
+                "line": 1,
+              },
+            },
+          },
+          "range": Object {
+            "end": Object {
+              "character": 35,
+              "line": 1,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 1,
+            },
+          },
+        },
+        "range": Object {
+          "end": Object {
+            "character": 35,
+            "line": 1,
+          },
+          "start": Object {
+            "character": 10,
+            "line": 1,
+          },
+        },
+      },
+      "range": Object {
+        "end": Object {
+          "character": 35,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 20,
+          "line": 1,
+        },
+      },
+    },
+    "range": Object {
+      "end": Object {
+        "character": 35,
+        "line": 1,
+      },
+      "start": Object {
+        "character": 20,
+        "line": 1,
+      },
+    },
+  },
+]
+`)});
+
+it("returns a reasonable selection range in the presence of syntax errors", async () => {
+  openDocument(outdent`
+module M = struct
+    let f x : int = string_of_int x
+ed`);
+
+let result = await selectionRange([Types.Position.create(1, 34)]);
+expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "parent": Object {
+      "parent": Object {
+        "parent": Object {
+          "parent": Object {
+            "parent": Object {
+              "parent": Object {
+                "parent": Object {
+                  "parent": Object {
+                    "parent": Object {
+                      "range": Object {
+                        "end": Object {
+                          "character": 2,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "character": 0,
+                          "line": 0,
+                        },
+                      },
+                    },
+                    "range": Object {
+                      "end": Object {
+                        "character": 2,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "character": 0,
+                        "line": 0,
+                      },
+                    },
+                  },
+                  "range": Object {
+                    "end": Object {
+                      "character": 2,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "character": 0,
+                      "line": 0,
+                    },
+                  },
+                },
+                "range": Object {
+                  "end": Object {
+                    "character": 2,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "character": 11,
+                    "line": 0,
+                  },
+                },
+              },
+              "range": Object {
+                "end": Object {
+                  "character": 2,
+                  "line": 2,
+                },
+                "start": Object {
+                  "character": 4,
+                  "line": 1,
+                },
+              },
+            },
+            "range": Object {
+              "end": Object {
+                "character": 2,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 4,
+                "line": 1,
+              },
+            },
+          },
+          "range": Object {
+            "end": Object {
+              "character": 2,
+              "line": 2,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 1,
+            },
+          },
+        },
+        "range": Object {
+          "end": Object {
+            "character": 2,
+            "line": 2,
+          },
+          "start": Object {
+            "character": 10,
+            "line": 1,
+          },
+        },
+      },
+      "range": Object {
+        "end": Object {
+          "character": 2,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 20,
+          "line": 1,
+        },
+      },
+    },
+    "range": Object {
+      "end": Object {
+        "character": 2,
+        "line": 2,
+      },
+      "start": Object {
+        "character": 20,
+        "line": 1,
+      },
+    },
+  },
+]
+`)});
 });

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-selectionRange.test.ts
@@ -55,30 +55,6 @@ Array [
         "parent": Object {
           "parent": Object {
             "parent": Object {
-              "parent": Object {
-                "parent": Object {
-                  "range": Object {
-                    "end": Object {
-                      "character": 17,
-                      "line": 3,
-                    },
-                    "start": Object {
-                      "character": 0,
-                      "line": 0,
-                    },
-                  },
-                },
-                "range": Object {
-                  "end": Object {
-                    "character": 17,
-                    "line": 3,
-                  },
-                  "start": Object {
-                    "character": 0,
-                    "line": 0,
-                  },
-                },
-              },
               "range": Object {
                 "end": Object {
                   "character": 17,
@@ -170,30 +146,6 @@ Array [
           "parent": Object {
             "parent": Object {
               "parent": Object {
-                "parent": Object {
-                  "parent": Object {
-                    "range": Object {
-                      "end": Object {
-                        "character": 3,
-                        "line": 6,
-                      },
-                      "start": Object {
-                        "character": 0,
-                        "line": 0,
-                      },
-                    },
-                  },
-                  "range": Object {
-                    "end": Object {
-                      "character": 3,
-                      "line": 6,
-                    },
-                    "start": Object {
-                      "character": 0,
-                      "line": 3,
-                    },
-                  },
-                },
                 "range": Object {
                   "end": Object {
                     "character": 3,
@@ -201,7 +153,7 @@ Array [
                   },
                   "start": Object {
                     "character": 0,
-                    "line": 3,
+                    "line": 0,
                   },
                 },
               },
@@ -211,19 +163,19 @@ Array [
                   "line": 6,
                 },
                 "start": Object {
-                  "character": 11,
+                  "character": 0,
                   "line": 3,
                 },
               },
             },
             "range": Object {
               "end": Object {
-                "character": 24,
-                "line": 5,
+                "character": 3,
+                "line": 6,
               },
               "start": Object {
-                "character": 2,
-                "line": 4,
+                "character": 11,
+                "line": 3,
               },
             },
           },
@@ -234,7 +186,7 @@ Array [
             },
             "start": Object {
               "character": 2,
-              "line": 5,
+              "line": 4,
             },
           },
         },
@@ -293,72 +245,36 @@ Array [
               "parent": Object {
                 "parent": Object {
                   "parent": Object {
-                    "parent": Object {
-                      "parent": Object {
-                        "parent": Object {
-                          "range": Object {
-                            "end": Object {
-                              "character": 4,
-                              "line": 3,
-                            },
-                            "start": Object {
-                              "character": 0,
-                              "line": 0,
-                            },
-                          },
-                        },
-                        "range": Object {
-                          "end": Object {
-                            "character": 4,
-                            "line": 3,
-                          },
-                          "start": Object {
-                            "character": 0,
-                            "line": 0,
-                          },
-                        },
-                      },
-                      "range": Object {
-                        "end": Object {
-                          "character": 4,
-                          "line": 3,
-                        },
-                        "start": Object {
-                          "character": 0,
-                          "line": 0,
-                        },
-                      },
-                    },
                     "range": Object {
                       "end": Object {
                         "character": 4,
                         "line": 3,
                       },
                       "start": Object {
-                        "character": 11,
+                        "character": 0,
                         "line": 0,
                       },
                     },
                   },
                   "range": Object {
                     "end": Object {
-                      "character": 3,
+                      "character": 4,
                       "line": 3,
                     },
                     "start": Object {
-                      "character": 21,
+                      "character": 11,
                       "line": 0,
                     },
                   },
                 },
                 "range": Object {
                   "end": Object {
-                    "character": 39,
-                    "line": 2,
+                    "character": 3,
+                    "line": 3,
                   },
                   "start": Object {
-                    "character": 2,
-                    "line": 1,
+                    "character": 21,
+                    "line": 0,
                   },
                 },
               },
@@ -369,7 +285,7 @@ Array [
                 },
                 "start": Object {
                   "character": 2,
-                  "line": 2,
+                  "line": 1,
                 },
               },
             },
@@ -446,73 +362,25 @@ Array [
         "parent": Object {
           "parent": Object {
             "parent": Object {
-              "parent": Object {
-                "parent": Object {
-                  "parent": Object {
-                    "parent": Object {
-                      "range": Object {
-                        "end": Object {
-                          "character": 3,
-                          "line": 2,
-                        },
-                        "start": Object {
-                          "character": 0,
-                          "line": 0,
-                        },
-                      },
-                    },
-                    "range": Object {
-                      "end": Object {
-                        "character": 3,
-                        "line": 2,
-                      },
-                      "start": Object {
-                        "character": 0,
-                        "line": 0,
-                      },
-                    },
-                  },
-                  "range": Object {
-                    "end": Object {
-                      "character": 3,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "character": 0,
-                      "line": 0,
-                    },
-                  },
-                },
-                "range": Object {
-                  "end": Object {
-                    "character": 3,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "character": 11,
-                    "line": 0,
-                  },
-                },
-              },
               "range": Object {
                 "end": Object {
-                  "character": 35,
-                  "line": 1,
+                  "character": 3,
+                  "line": 2,
                 },
                 "start": Object {
-                  "character": 4,
-                  "line": 1,
+                  "character": 0,
+                  "line": 0,
                 },
               },
             },
             "range": Object {
               "end": Object {
-                "character": 35,
-                "line": 1,
+                "character": 3,
+                "line": 2,
               },
               "start": Object {
-                "character": 4,
-                "line": 1,
+                "character": 11,
+                "line": 0,
               },
             },
           },
@@ -555,7 +423,7 @@ Array [
         "line": 1,
       },
       "start": Object {
-        "character": 20,
+        "character": 34,
         "line": 1,
       },
     },
@@ -578,62 +446,14 @@ Array [
         "parent": Object {
           "parent": Object {
             "parent": Object {
-              "parent": Object {
-                "parent": Object {
-                  "parent": Object {
-                    "parent": Object {
-                      "range": Object {
-                        "end": Object {
-                          "character": 2,
-                          "line": 2,
-                        },
-                        "start": Object {
-                          "character": 0,
-                          "line": 0,
-                        },
-                      },
-                    },
-                    "range": Object {
-                      "end": Object {
-                        "character": 2,
-                        "line": 2,
-                      },
-                      "start": Object {
-                        "character": 0,
-                        "line": 0,
-                      },
-                    },
-                  },
-                  "range": Object {
-                    "end": Object {
-                      "character": 2,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "character": 0,
-                      "line": 0,
-                    },
-                  },
-                },
-                "range": Object {
-                  "end": Object {
-                    "character": 2,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "character": 11,
-                    "line": 0,
-                  },
-                },
-              },
               "range": Object {
                 "end": Object {
                   "character": 2,
                   "line": 2,
                 },
                 "start": Object {
-                  "character": 4,
-                  "line": 1,
+                  "character": 0,
+                  "line": 0,
                 },
               },
             },
@@ -643,8 +463,8 @@ Array [
                 "line": 2,
               },
               "start": Object {
-                "character": 4,
-                "line": 1,
+                "character": 11,
+                "line": 0,
               },
             },
           },
@@ -683,11 +503,11 @@ Array [
     },
     "range": Object {
       "end": Object {
-        "character": 2,
-        "line": 2,
+        "character": 35,
+        "line": 1,
       },
       "start": Object {
-        "character": 20,
+        "character": 34,
         "line": 1,
       },
     },


### PR DESCRIPTION
@awilliambauer @pitag-ha I looked at the server answer to the `selectionRange` query after our discussion earlier today, and I noticed that they were, in fact, duplicated ranges:

```
[Trace - 17:40:29] Received response 'textDocument/selectionRange - (20)' in 6ms.
Result: [
    {
        "parent": {
            "parent": {
                "parent": {
                    "parent": {
                        "parent": {
                            "parent": {
                                "parent": {
                                    "parent": {
                                        "parent": {
                                            "parent": {
                                                "range": {
                                                    "end": {
                                                        "character": 38,
                                                        "line": 968
                                                    },
                                                    "start": {
                                                        "character": 0,
                                                        "line": 0
                                                    }
                                                }
                                            },
                                            "range": {
                                                "end": {
                                                    "character": 26,
                                                    "line": 409
                                                },
                                                "start": {
                                                    "character": 0,
                                                    "line": 379
                                                }
                                            }
                                        },
                                        "range": {
                                            "end": {
                                                "character": 26,
                                                "line": 409
                                            },
                                            "start": {
                                                "character": 0,
                                                "line": 379
                                            }
                                        }
                                    },
                                    "range": {
                                        "end": {
                                            "character": 26,
                                            "line": 409
                                        },
                                        "start": {
                                            "character": 2,
                                            "line": 380
                                        }
                                    }
                                },
...
            "range": {
                "end": {
                    "character": 26,
                    "line": 409
                },
                "start": {
                    "character": 4,
                    "line": 409
                }
            }
        },
        "range": {
            "end": {
                "character": 26,
                "line": 409
            },
            "start": {
                "character": 20,
                "line": 409
            }
        }
    }
]
```


With that patch these are removed:
```
[Trace - 17:34:27] Received response 'textDocument/selectionRange - (149)' in 12ms.
Result: [
    {
        "parent": {
            "parent": {
                "parent": {
                    "parent": {
                        "parent": {
                            "parent": {
                                "parent": {
                                    "parent": {
                                        "parent": {
                                            "range": {
                                                "end": {
                                                    "character": 38,
                                                    "line": 968
                                                },
                                                "start": {
                                                    "character": 0,
                                                    "line": 0
                                                }
                                            }
                                        },
                                        "range": {
                                            "end": {
                                                "character": 26,
                                                "line": 409
                                            },
                                            "start": {
                                                "character": 0,
                                                "line": 379
                                            }
                                        }
                                    },
                                    "range": {
                                        "end": {
                                            "character": 26,
                                            "line": 409
                                        },
                                        "start": {
                                            "character": 2,
                                            "line": 380
                                        }
                                    }
                                },
...
            "range": {
                "end": {
                    "character": 26,
                    "line": 409
                },
                "start": {
                    "character": 4,
                    "line": 409
                }
            }
        },
        "range": {
            "end": {
                "character": 26,
                "line": 409
            },
            "start": {
                "character": 20,
                "line": 409
            }
        }
    }
]
```

Sadly vscode still feels the need to add extraneous steps, notably when there is some indentation:


https://github.com/user-attachments/assets/004d7466-ec50-4ed9-83d7-f56a09d51d60

That's quite unfortunate... but this PR at least improves the servers' answer and does remove a few no-op steps compared to the previous behaviour.