### PR TITLE
Rely on upstream Merlin analyses

### DIFF
--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -45,7 +45,7 @@ depends: [
   "csexp" {>= "1.5"}
   "ocamlformat-rpc-lib" {>= "0.21.0"}
   "odoc" {with-doc}
-  "merlin-lib" {>= "5.0" & < "6.0"}
+  "merlin-lib" {>= "5.2" & < "6.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -126,23 +126,10 @@ let infer_intf (state : State.t) intf_doc =
 (** Extracts an [Ident.t] from all variants that have one at the top level. For
     many of the other variants, it would be possible to extract a list of IDs,
     but that's not needed for the update-signatures code action. *)
-let top_level_id (item : Typedtree.signature_item) =
-  match item.sig_desc with
-  | Typedtree.Tsig_value { val_id; _ } -> Some val_id
-  | Typedtree.Tsig_module { md_id; _ } -> md_id
-  | Typedtree.Tsig_modsubst { ms_id; _ } -> Some ms_id
-  | Typedtree.Tsig_modtype { mtd_id; _ } -> Some mtd_id
-  | Typedtree.Tsig_modtypesubst { mtd_id; _ } -> Some mtd_id
-  | Typedtree.Tsig_type _
-  | Typedtree.Tsig_typesubst _
-  | Typedtree.Tsig_typext _
-  | Typedtree.Tsig_exception _
-  | Typedtree.Tsig_recmodule _
-  | Typedtree.Tsig_open _
-  | Typedtree.Tsig_include _
-  | Typedtree.Tsig_class _
-  | Typedtree.Tsig_class_type _
-  | Typedtree.Tsig_attribute _ -> None
+let top_level_id item =
+  match Merlin_analysis.Typedtree_utils.extract_toplevel_identifier item with
+  | [ ident ] -> Some ident
+  | _ -> None
 ;;
 
 (** Represents an item that's present in the existing interface and has a

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -1,107 +1,13 @@
 open Import
 open Fiber.O
 
-let range_overlaps_loc range loc =
-  match Range.of_loc_opt loc with
-  | Some range' -> Range.overlaps range range'
-  | None -> false
-;;
-
-let outline_type ~env typ =
-  Ocaml_typing.Printtyp.wrap_printing_env env (fun () ->
-    Format.asprintf "@[<h>: %a@]" Ocaml_typing.Printtyp.type_scheme typ)
+let outline_type typ =
+  typ
+  |> Format.asprintf "@[<h>: %s@]"
   |> String.extract_words ~is_word_char:(function
     | ' ' | '\t' | '\n' -> false
     | _ -> true)
   |> String.concat ~sep:" "
-;;
-
-let hint_binding_iter
-  ?(hint_let_bindings = false)
-  ?(hint_pattern_variables = false)
-  typedtree
-  range
-  k
-  =
-  let module I = Ocaml_typing.Tast_iterator in
-  (* to be used for pattern variables in match cases, but not for function
-     arguments *)
-  let case hint_lhs (iter : I.iterator) (case : _ Typedtree.case) =
-    if hint_lhs then iter.pat iter case.c_lhs;
-    Option.iter case.c_guard ~f:(iter.expr iter);
-    iter.expr iter case.c_rhs
-  in
-  let value_binding hint_lhs (iter : I.iterator) (vb : Typedtree.value_binding) =
-    if range_overlaps_loc range vb.vb_loc
-    then
-      if not hint_lhs
-      then iter.expr iter vb.vb_expr
-      else (
-        match vb.vb_expr.exp_desc with
-        | Texp_function _ -> iter.expr iter vb.vb_expr
-        | _ -> I.default_iterator.value_binding iter vb)
-  in
-  let expr (iter : I.iterator) (e : Typedtree.expression) =
-    if range_overlaps_loc range e.exp_loc
-    then (
-      match e.exp_desc with
-      | Texp_function
-          ( _
-          , Tfunction_cases
-              { cases =
-                  [ { c_rhs = { exp_desc = Texp_let (_, [ { vb_pat; _ } ], body); _ }; _ }
-                  ]
-              ; _
-              } ) ->
-        iter.pat iter vb_pat;
-        iter.expr iter body
-      | Texp_let (_, vbs, body) ->
-        List.iter vbs ~f:(value_binding hint_let_bindings iter);
-        iter.expr iter body
-      | Texp_letop { body; _ } -> case hint_let_bindings iter body
-      | Texp_match (expr, cases, _) ->
-        iter.expr iter expr;
-        List.iter cases ~f:(case hint_pattern_variables iter)
-      (* Stop iterating when we see a ghost location to avoid annotating generated code *)
-      | _ when e.exp_loc.loc_ghost && not inside_test -> ()
-      | _ -> I.default_iterator.expr iter e)
-  in
-  let structure_item (iter : I.iterator) (item : Typedtree.structure_item) =
-    if range_overlaps_loc range item.str_loc
-    then (
-      match item.str_desc with
-      | Typedtree.Tstr_value (_, vbs) ->
-        List.iter vbs ~f:(fun (vb : Typedtree.value_binding) -> expr iter vb.vb_expr)
-      (* Stop iterating when we see a ghost location to avoid annotating generated code *)
-      | _ when item.str_loc.loc_ghost && not inside_test -> ()
-      | _ -> I.default_iterator.structure_item iter item)
-  in
-  let pat (type k) iter (pat : k Typedtree.general_pattern) =
-    if range_overlaps_loc range pat.pat_loc
-    then (
-      let has_constraint =
-        List.exists pat.pat_extra ~f:(fun (extra, _, _) ->
-          match extra with
-          | Typedtree.Tpat_constraint _ -> true
-          | _ -> false)
-      in
-      if not has_constraint
-      then (
-        I.default_iterator.pat iter pat;
-        match pat.pat_desc with
-        | Tpat_var _ when not pat.pat_loc.loc_ghost ->
-          k pat.pat_env pat.pat_type pat.pat_loc
-        | _ -> ()))
-  in
-  let iterator =
-    { I.default_iterator with
-      expr
-    ; structure_item
-    ; pat
-    ; value_binding = value_binding true
-    }
-  in
-  iterator.structure iterator typedtree
 ;;
 
 let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _ } =
@@ -116,36 +22,34 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
     let+ hints =
       let hint_let_bindings =
         Option.map state.configuration.data.inlay_hints ~f:(fun c -> c.hint_let_bindings)
+        |> Option.value ~default:false
       in
       let hint_pattern_variables =
         Option.map state.configuration.data.inlay_hints ~f:(fun c ->
           c.hint_pattern_variables)
+        |> Option.value ~default:false
       in
       Document.Merlin.with_pipeline_exn ~name:"inlay-hints" doc (fun pipeline ->
-        let hints = ref [] in
-        (match Mtyper.get_typedtree (Mpipeline.typer_result pipeline) with
-         | `Interface _ -> ()
-         | `Implementation typedtree ->
-           hint_binding_iter
-             ?hint_let_bindings
-             ?hint_pattern_variables
-             typedtree
-             range
-             (fun env type_ loc ->
-                let hint =
-                  let label = outline_type ~env type_ in
-                  let open Option.O in
-                  let+ position = Position.of_lexical_position loc.loc_end in
-                  InlayHint.create
-                    ~kind:Type
-                    ~position
-                    ~label:(`String label)
-                    ~paddingLeft:false
-                    ~paddingRight:false
-                    ()
-                in
-                Option.iter hint ~f:(fun hint -> hints := hint :: !hints)));
-        !hints)
+        let start = range.start |> Position.logical
+        and stop = range.end_ |> Position.logical in
+        let command =
+          Query_protocol.Inlay_hints
+            (start, stop, hint_let_bindings, hint_pattern_variables, not inside_test)
+        in
+        let hints = Query_commands.dispatch pipeline command in
+        List.filter_map
+          ~f:(fun (pos, label) ->
+            let open Option.O in
+            let+ position = Position.of_lexical_position pos in
+            let label = `String (outline_type label) in
+            InlayHint.create
+              ~kind:Type
+              ~position
+              ~label
+              ~paddingLeft:false
+              ~paddingRight:false
+              ())
+          hints)
     in
     Some hints
 ;;

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -10,172 +10,6 @@ open struct
   module Btype = Btype
 end
 
-type parameter_info =
-  { label : Asttypes.arg_label
-  ; param_start : int
-  ; param_end : int
-  ; argument : Typedtree.expression option
-  }
-
-type application_signature =
-  { function_name : string option
-  ; function_position : Msource.position
-  ; signature : string
-  ; parameters : parameter_info list
-  ; active_param : int option
-  }
-
-(* extract a properly parenthesized identifier from (expression_desc (Texp_ident
-   (Longident))) *)
-let extract_ident (exp_desc : Typedtree.expression_desc) =
-  let rec longident ppf : Longident.t -> unit = function
-    | Lident s -> Format.fprintf ppf "%s" (Misc_utils.parenthesize_name s)
-    | Ldot (p, s) ->
-      Format.fprintf ppf "%a.%s" longident p (Misc_utils.parenthesize_name s)
-    | Lapply (p1, p2) -> Format.fprintf ppf "%a(%a)" longident p1 longident p2
-  in
-  match exp_desc with
-  | Texp_ident (_, { txt = li; _ }, _) ->
-    let ppf, to_string = Format.to_string () in
-    longident ppf li;
-    Some (to_string ())
-  | _ -> None
-;;
-
-(* Type variables shared across arguments should all be printed with the same
-   name. [Printtyp.type_scheme] ensure that a name is unique within a given
-   type, but not across different invocations. [reset] followed by calls to
-   [mark_loops] and [type_sch] provide that *)
-let pp_type env ppf ty =
-  let module Printtyp = Type_utils.Printtyp in
-  Printtyp.wrap_printing_env env ~verbosity:(Lvl 0) (fun () ->
-    Printtyp.shared_type_scheme ppf ty)
-;;
-
-let rec type_is_arrow ty =
-  match Types.get_desc ty with
-  | Tarrow _ -> true
-  | Tlink ty -> type_is_arrow ty
-  | Tpoly (ty, _) -> type_is_arrow ty
-  | _ -> false
-;;
-
-(* surround function types in parentheses *)
-let pp_parameter_type env ppf ty =
-  if type_is_arrow ty
-  then Format.fprintf ppf "(%a)" (pp_type env) ty
-  else pp_type env ppf ty
-;;
-
-(* print parameter labels and types *)
-let pp_parameter env label ppf ty =
-  match (label : Asttypes.arg_label) with
-  | Nolabel -> pp_parameter_type env ppf ty
-  | Labelled l -> Format.fprintf ppf "%s:%a" l (pp_parameter_type env) ty
-  | Optional l ->
-    (* unwrap option for optional labels the same way as
-       [Raw_compat.labels_of_application] *)
-    let unwrap_option ty =
-      match Types.get_desc ty with
-      | Types.Tconstr (path, [ ty ], _) when Path.same path Predef.path_option -> ty
-      | _ -> ty
-    in
-    Format.fprintf ppf "?%s:%a" l (pp_parameter_type env) (unwrap_option ty)
-;;
-
-(* record buffer offsets to be able to underline parameter types *)
-let print_parameter_offset ?arg:argument ppf buffer env label ty =
-  let param_start = Buffer.length buffer in
-  Format.fprintf ppf "%a%!" (pp_parameter env label) ty;
-  let param_end = Buffer.length buffer in
-  Format.pp_print_string ppf " -> ";
-  Format.pp_print_flush ppf ();
-  { label; param_start; param_end; argument }
-;;
-
-let separate_function_signature ~args (e : Typedtree.expression) =
-  Type_utils.Printtyp.reset ();
-  let buffer = Buffer.create 16 in
-  let ppf = Format.formatter_of_buffer buffer in
-  let rec separate ?(i = 0) ?(parameters = []) args ty =
-    match args, Types.get_desc ty with
-    | (_l, arg) :: args, Tarrow (label, ty1, ty2, _) ->
-      let parameter = print_parameter_offset ppf buffer e.exp_env label ty1 ?arg in
-      separate args ty2 ~i:(succ i) ~parameters:(parameter :: parameters)
-    | [], Tarrow (label, ty1, ty2, _) ->
-      let parameter = print_parameter_offset ppf buffer e.exp_env label ty1 in
-      separate args ty2 ~i:(succ i) ~parameters:(parameter :: parameters)
-    (* end of function type, print remaining type without recording offsets *)
-    | _ ->
-      Format.fprintf ppf "%a%!" (pp_type e.exp_env) ty;
-      { function_name = extract_ident e.exp_desc
-      ; function_position = `Offset e.exp_loc.loc_end.pos_cnum
-      ; signature = Buffer.contents buffer
-      ; parameters = List.rev parameters
-      ; active_param = None
-      }
-  in
-  separate args e.exp_type
-;;
-
-let active_parameter_by_arg ~arg params =
-  let find_by_arg = function
-    | { argument = Some a; _ } when a == arg -> true
-    | _ -> false
-  in
-  try Some (List.index params ~f:find_by_arg) with
-  | Not_found -> None
-;;
-
-let active_parameter_by_prefix ~prefix params =
-  let common = function
-    | Asttypes.Nolabel -> Some 0
-    | l when String.is_prefixed ~by:"~" prefix || String.is_prefixed ~by:"?" prefix ->
-      Some (String.common_prefix_len (Btype.prefixed_label_name l) prefix)
-    | _ -> None
-  in
-  let rec find_by_prefix ?(i = 0) ?longest_len ?longest_i = function
-    | [] -> longest_i
-    | p :: ps ->
-      (match common p.label, longest_len with
-       | Some common_len, Some longest_len when common_len > longest_len ->
-         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
-       | Some common_len, None ->
-         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
-       | _ -> find_by_prefix ps ~i:(succ i) ?longest_len ?longest_i)
-  in
-  find_by_prefix params
-;;
-
-let is_arrow t =
-  match Types.get_desc t with
-  | Tarrow _ -> true
-  | _ -> false
-;;
-
-let application_signature ~prefix = function
-  (* provide signature information for applied functions *)
-  | (_, Browse_raw.Expression arg)
-    :: (_, Expression { exp_desc = Texp_apply (({ exp_type; _ } as e), args); _ })
-    :: _
-    when is_arrow exp_type ->
-    let result = separate_function_signature e ~args in
-    let active_param = active_parameter_by_arg ~arg result.parameters in
-    let active_param =
-      match active_param with
-      | Some _ as ap -> ap
-      | None -> active_parameter_by_prefix ~prefix result.parameters
-    in
-    Some { result with active_param }
-  (* provide signature information directly after an unapplied function-type
-     value *)
-  | (_, Expression ({ exp_type; _ } as e)) :: _ when is_arrow exp_type ->
-    let result = separate_function_signature e ~args:[] in
-    let active_param = active_parameter_by_prefix ~prefix result.parameters in
-    Some { result with active_param }
-  | _ -> None
-;;
-
 let format_doc ~markdown ~doc =
   `MarkupContent
     (if markdown
@@ -217,7 +51,7 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
           let typer = Mpipeline.typer_result pipeline in
           let pos = Mpipeline.get_lexing_pos pipeline pos in
           let node = Mtyper.node_at typer pos in
-          application_signature node ~prefix)
+          Merlin_analysis.Signature_help.application_signature node ~prefix ~cursor:pos)
     in
     (match application_signature with
      | None ->
@@ -237,9 +71,11 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
        in
        let info =
          let parameters =
-           List.map application_signature.parameters ~f:(fun (p : parameter_info) ->
-             let label = `Offset (offset + p.param_start, offset + p.param_end) in
-             ParameterInformation.create ~label ())
+           List.map
+             application_signature.parameters
+             ~f:(fun (p : Merlin_analysis.Signature_help.parameter_info) ->
+               let label = `Offset (offset + p.param_start, offset + p.param_end) in
+               ParameterInformation.create ~label ())
          in
          let documentation =
            let open Option.O in


### PR DESCRIPTION
This brings together changes from [#1366](https://github.com/ocaml/ocaml-lsp/pull/1366), https://github.com/ocaml/ocaml-lsp/pull/1367 and https://github.com/ocaml/ocaml-lsp/pull/1375.

We now rely on `merlin-lib` implementations for inlay-hint and signature help.