### PR TITLE
Bump merlin-lib version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -69,7 +69,7 @@ possible and does not make any assumptions about IO.
   (csexp (>= 1.5))
   (ocamlformat-rpc-lib (>= 0.21.0))
   (odoc :with-doc)
-  (merlin-lib (and (>= 5.0) (< 6.0)))))
+  (merlin-lib (and (>= 5.2) (< 6.0)))))
 
 (package
  (name jsonrpc)


### PR DESCRIPTION
Merlin lib version was bumped in the opam file but not in the dune-project.