### PR TITLE
Add support for URI fragments

### DIFF
--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -150,10 +150,10 @@ let to_string { scheme; authority; path; query; fragment } =
      Buffer.add_char buff '?';
      Buffer.add_string buff (encode q));
   (match fragment with
-  | None -> ()
-  | Some f ->
-    Buffer.add_char buff '#';
-    Buffer.add_string buff (encode f));
+   | None -> ()
+   | Some f ->
+     Buffer.add_char buff '#';
+     Buffer.add_string buff (encode f));
   Buffer.contents buff
 ;;
 

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -14,9 +14,11 @@ type t = Uri_lexer.t =
   ; authority : string
   ; path : string
   ; query : string option
+  ; fragment : string option
   }
 
 let query t = t.query
+let fragment t = t.fragment
 
 let backslash_to_slash =
   String.map ~f:(function
@@ -35,7 +37,7 @@ let of_path path =
   Uri_lexer.of_path path
 ;;
 
-let to_path { path; authority; scheme; query } =
+let to_path { path; authority; scheme; query; _ } =
   let path =
     let len = String.length path in
     if len = 0
@@ -104,7 +106,7 @@ let encode ?(allow_slash = false) s =
   Buffer.contents buf
 ;;
 
-let to_string { scheme; authority; path; query } =
+let to_string { scheme; authority; path; query; fragment } =
   let buff = Buffer.create 64 in
   if not (String.is_empty scheme)
   then (
@@ -147,6 +149,11 @@ let to_string { scheme; authority; path; query } =
    | Some q ->
      Buffer.add_char buff '?';
      Buffer.add_string buff (encode q));
+  (match fragment with
+  | None -> ()
+  | Some f ->
+    Buffer.add_char buff '#';
+    Buffer.add_string buff (encode f));
   Buffer.contents buff
 ;;
 

--- a/lsp/src/uri0.mli
+++ b/lsp/src/uri0.mli
@@ -10,7 +10,9 @@ val hash : t -> int
 val to_path : t -> string
 val of_path : string -> t
 val to_string : t -> string
+val of_string : string -> t
 val query : t -> string option
+val fragment : t -> string option
 
 module Private : sig
   val win32 : bool ref

--- a/lsp/src/uri_lexer.mli
+++ b/lsp/src/uri_lexer.mli
@@ -3,6 +3,7 @@ type t =
   ; authority : string
   ; path : string
   ; query : string option
+  ; fragment : string option
   }
 
 val of_string : string -> t

--- a/lsp/src/uri_lexer.mll
+++ b/lsp/src/uri_lexer.mll
@@ -7,6 +7,7 @@ type t =
   ; authority : string
   ; path : string
   ; query: string option
+  ; fragment: string option
   }
 
 let int_of_hex_char c =
@@ -84,7 +85,8 @@ and uri = parse
 ([^':' '/' '?' '#']+ as scheme ':') ?
 ("//" ([^ '/' '?' '#']* as authority)) ?
 ([^ '?' '#']* as path)
-(('?' ([^ '#']* as raw_query) '#'?)) ?
+('?' ([^ '#']* as raw_query)) ?
+('#' (_ * as fragment)) ?
 {
   let scheme = scheme |> Option.value ~default:"file" in
   let authority =
@@ -102,15 +104,15 @@ and uri = parse
     | None -> None
     | Some c -> Some (query (Buffer.create (String.length c)) (Lexing.from_string c))
   in
-  { scheme; authority; path; query }
+  { scheme; authority; path; query; fragment }
 }
 
 and path = parse
-| "" { { scheme = "file"; authority = ""; path = "/"; query = None } }
-| "//" ([^ '/']* as authority) (['/']_* as path) { { scheme = "file"; authority; path ; query = None } }
-| "//" ([^ '/']* as authority) { { scheme = "file"; authority; path = "/" ; query = None } }
-| ("/" _* as path) { { scheme = "file"; authority = ""; path ; query = None } }
-| (_* as path) { { scheme = "file"; authority = ""; path = "/" ^ path ; query = None } }
+| "" { { scheme = "file"; authority = ""; path = "/"; query = None; fragment = None } }
+| "//" ([^ '/']* as authority) (['/']_* as path) { { scheme = "file"; authority; path ; query = None ; fragment = None } }
+| "//" ([^ '/']* as authority) { { scheme = "file"; authority; path = "/" ; query = None ; fragment = None } }
+| ("/" _* as path) { { scheme = "file"; authority = ""; path ; query = None ; fragment = None } }
+| (_* as path) { { scheme = "file"; authority = ""; path = "/" ^ path ; query = None ; fragment = None } }
 
 {
   let of_string s =

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -255,7 +255,7 @@ let%expect_test "of_string -> to_string" =
   [%expect
     {|
     Unix:
-    file://shares/pröjects/c%23/#l12 -> file://shares/pr%C3%B6jects/c%23/
+    file://shares/pröjects/c%23/#l12 -> file://shares/pr%C3%B6jects/c%23/#l12
     file://sh%c3%a4res/path -> file://sh%C3%A4res/path
     untitled:c:/Users/jrieken/Code/abc.txt -> untitled:c%3A/Users/jrieken/Code/abc.txt
     untitled:C:/Users/jrieken/Code/abc.txt -> untitled:c%3A/Users/jrieken/Code/abc.txt
@@ -267,7 +267,7 @@ let%expect_test "of_string -> to_string" =
     file:///pro%2Fjects/ -> file:///pro/jects/
     vscode://mount/test.ml -> vscode://mount/test.ml
     Windows:
-    file://shares/pröjects/c%23/#l12 -> file://shares/pr%C3%B6jects/c%23/
+    file://shares/pröjects/c%23/#l12 -> file://shares/pr%C3%B6jects/c%23/#l12
     file://sh%c3%a4res/path -> file://sh%C3%A4res/path
     untitled:c:/Users/jrieken/Code/abc.txt -> untitled:c%3A/Users/jrieken/Code/abc.txt
     untitled:C:/Users/jrieken/Code/abc.txt -> untitled:c%3A/Users/jrieken/Code/abc.txt


### PR DESCRIPTION
This is useful because in VSCode, file system URIs can contain line numbers in the fragment: `file:///path#N`.