### PR TITLE
Disable jump code action by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Fixes
+
+- Deactivate the `jump` code actions by default. Clients can enable them with
+  the `merlinJumpCodeActions` configuration option. Alternatively a custom
+  request is provided for ad hoc use of the feature. (#1411)
+
 # 1.20.0
 
 ## Features

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -118,8 +118,8 @@ let compute server (params : CodeActionParams.t) =
     let open_related = Action_open_related.for_uri capabilities doc in
     let* merlin_jumps =
       match state.configuration.data.merlin_jump_code_actions with
-      | Some { enable = true } | None -> Action_jump.code_actions doc params capabilities
-      | Some { enable = false } -> Fiber.return []
+      | Some { enable = true } -> Action_jump.code_actions doc params capabilities
+      | Some { enable = false } | None -> Fiber.return []
     in
     (match Document.syntax doc with
      | Ocamllex | Menhir | Cram | Dune ->


### PR DESCRIPTION
In some cases these can make the `codeAction` request slow (>2s).