### PR TITLE
Use DocumentUri converter directly in Merlin Call Compatible params

### DIFF
--- a/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.mli
@@ -3,13 +3,7 @@ open Import
 module Request_params : sig
   type t
 
-  val create
-    :  text_document:TextDocumentIdentifier.t
-    -> result_as_sexp:bool
-    -> command:string
-    -> args:string list
-    -> t
-
+  val create : uri:Uri.t -> result_as_sexp:bool -> command:string -> args:string list -> t
   val yojson_of_t : t -> Json.t
 end
 

--- a/ocaml-lsp-server/test/e2e-new/merlin_call_compatible.ml
+++ b/ocaml-lsp-server/test/e2e-new/merlin_call_compatible.ml
@@ -3,9 +3,8 @@ module Req = Ocaml_lsp_server.Custom_request.Merlin_call_compatible
 
 let call_merlin_compatible client command args result_as_sexp =
   let uri = DocumentUri.of_path "test.ml" in
-  let text_document = TextDocumentIdentifier.create ~uri in
   let params =
-    Req.Request_params.create ~text_document ~result_as_sexp ~command ~args
+    Req.Request_params.create ~uri ~result_as_sexp ~command ~args
     |> Req.Request_params.yojson_of_t
     |> Jsonrpc.Structured.t_of_yojson
     |> Option.some


### PR DESCRIPTION
It makes the intent clearer than relying on "unwrapping" a `TextDocumentIdentifier.t` (which is an object with a unique `uri : DocumentUri.t` field).

Ideally, we could change the spec of the request to better fit into the protocol to have a `textDocument : TextDocumentIdentifier.t` instead of a `uri : DocumentUri.t`. The same information is conveyed, but the former version is the one used across the protocol and most other custom queries.

We could transition by recognizing both fields until the clients are all updated ?

This is a follow-up to #1428. 

cc @awilliambauer 