### PR TITLE
Introduce project-wide renaming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Enable experimental project-wide renaming of identifiers (#1431)
+
 # 1.21.0
 
 ## Features

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -130,6 +130,8 @@ include struct
     include Uri
 
     let to_dyn t = Dyn.string (to_string t)
+
+    module Map = Stdlib.Map.Make (Uri)
   end
 end
 

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-rename.test.ts
@@ -111,12 +111,12 @@ describe("textDocument/rename", () => {
         "newText": "new_num",
         "range": {
           "end": {
-            "character": 7,
-            "line": 0,
+            "character": 13,
+            "line": 1,
           },
           "start": {
-            "character": 4,
-            "line": 0,
+            "character": 10,
+            "line": 1,
           },
         },
       },
@@ -124,12 +124,12 @@ describe("textDocument/rename", () => {
         "newText": "new_num",
         "range": {
           "end": {
-            "character": 13,
-            "line": 1,
+            "character": 7,
+            "line": 0,
           },
           "start": {
-            "character": 10,
-            "line": 1,
+            "character": 4,
+            "line": 0,
           },
         },
       },
@@ -163,12 +163,12 @@ describe("textDocument/rename", () => {
           "newText": "new_num",
           "range": {
             "end": {
-              "character": 7,
-              "line": 0,
+              "character": 13,
+              "line": 1,
             },
             "start": {
-              "character": 4,
-              "line": 0,
+              "character": 10,
+              "line": 1,
             },
           },
         },
@@ -176,12 +176,12 @@ describe("textDocument/rename", () => {
           "newText": "new_num",
           "range": {
             "end": {
-              "character": 13,
-              "line": 1,
+              "character": 7,
+              "line": 0,
             },
             "start": {
-              "character": 10,
-              "line": 1,
+              "character": 4,
+              "line": 0,
             },
           },
         },
@@ -218,19 +218,6 @@ let () = bar ~foo
   "changes": {
     "file:///test.ml": [
       {
-        "newText": "ident",
-        "range": {
-          "end": {
-            "character": 7,
-            "line": 0,
-          },
-          "start": {
-            "character": 4,
-            "line": 0,
-          },
-        },
-      },
-      {
         "newText": ":ident",
         "range": {
           "end": {
@@ -240,6 +227,19 @@ let () = bar ~foo
           "start": {
             "character": 17,
             "line": 4,
+          },
+        },
+      },
+      {
+        "newText": "ident",
+        "range": {
+          "end": {
+            "character": 7,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
           },
         },
       },
@@ -272,19 +272,6 @@ ignore (bar ?foo ())
   "changes": {
     "file:///test.ml": [
       {
-        "newText": "sunit",
-        "range": {
-          "end": {
-            "character": 7,
-            "line": 0,
-          },
-          "start": {
-            "character": 4,
-            "line": 0,
-          },
-        },
-      },
-      {
         "newText": ":sunit",
         "range": {
           "end": {
@@ -294,6 +281,19 @@ ignore (bar ?foo ())
           "start": {
             "character": 16,
             "line": 5,
+          },
+        },
+      },
+      {
+        "newText": "sunit",
+        "range": {
+          "end": {
+            "character": 7,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
           },
         },
       },


### PR DESCRIPTION
This introduces a first functional version of project-wide renaming in ocaml-lsp based on [preview work](https://github.com/ocaml/merlin/pull/1877) on Merlin.

It re-employs the existing mechanism to handle function labelled arguments correctly. There is no guarantees related to possible shadowing. Here is an example of the feature in action, renaming a value of a functor included from its parameter. The name is changes in all the files, both in signatures and implementations, and the project rebuilds immediately:


https://github.com/user-attachments/assets/8608b5f9-6102-4a39-a808-c9d7b642c8ee

This PR is based on #1386 and only the last 2 commits are relevant.
