### PR TITLE
Update Jump functionality

### DIFF
--- a/ocaml-lsp-server/docs/ocamllsp/merlinJump-spec.md
+++ b/ocaml-lsp-server/docs/ocamllsp/merlinJump-spec.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This custom request allows Merlin-type code navigation in a source buffer.
+This custom request allows Merlin-type code navigation in a source buffer. It will fetch all the possible jump targets and return them.
 
 ## Server capability
 
@@ -12,20 +12,7 @@ This custom request allows Merlin-type code navigation in a source buffer.
 ## Request
 
 - method: `ocamllsp/jump`
-- params: `JumpParams`  extends [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentPositionParams) and is defined as follows:
-
-```js
-export interface JumpParams extends TextDocumentPositionParams
-{
-    /**
-     * The requested target of the jump, one of `fun`, `let`, `module`,
-     * `module-type`, `match`, `match-next-case`, `match-prev-case`.
-     *
-     * If omitted, all valid targets will be considered.
-     */
-    target?: string;
-}
-```
+- params: [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentPositionParams)
 
 ## Response
 

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -4,10 +4,6 @@ open Stdune
 
 let command_name = "ocamllsp/merlin-jump-to-target"
 
-let targets =
-  [ "fun"; "match"; "let"; "module"; "module-type"; "match-next-case"; "match-prev-case" ]
-;;
-
 let rename_target target =
   if String.starts_with ~prefix:"match-" target
   then String.sub target ~pos:6 ~len:(String.length target - 6)
@@ -49,16 +45,10 @@ let command_run server (params : ExecuteCommandParams.t) =
 ;;
 
 (* Dispatch the jump request to Merlin and get the result *)
-let process_jump_request ~merlin ~position ~target =
-  let+ results =
-    Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-      let pposition = Position.logical position in
-      let query = Query_protocol.Jump (target, pposition) in
-      Query_commands.dispatch pipeline query)
-  in
-  match results with
-  | `Error _ -> None
-  | `Found pos -> Some pos
+let get_all_possible_jump_targets ~merlin ~position =
+  Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
+    let typedtree = Mpipeline.typer_result pipeline |> Mtyper.get_typedtree in
+    Merlin_analysis.Jump.get_all typedtree position)
 ;;
 
 let code_actions
@@ -68,26 +58,30 @@ let code_actions
   =
   match Document.kind doc with
   | `Merlin merlin when available capabilities ->
-    let+ actions =
-      (* TODO: Merlin Jump command that returns all available jump locations for a source code buffer. *)
-      Fiber.parallel_map targets ~f:(fun target ->
-        let+ res = process_jump_request ~merlin ~position:params.range.start ~target in
-        let open Option.O in
-        let* lexing_pos = res in
-        let+ position = Position.of_lexical_position lexing_pos in
-        let uri = Document.uri doc in
-        let range = { Range.start = position; end_ = position } in
-        let title = sprintf "%s jump" (String.capitalize_ascii (rename_target target)) in
-        let command =
-          let arguments = [ DocumentUri.yojson_of_t uri; Range.yojson_of_t range ] in
-          Command.create ~title ~command:command_name ~arguments ()
-        in
-        CodeAction.create
-          ~title
-          ~kind:(CodeActionKind.Other (sprintf "merlin-jump-%s" (rename_target target)))
-          ~command
-          ())
+    let uri = Document.uri doc in
+    let { Position.line; character } = params.range.start in
+    let position =
+      { Lexing.pos_fname = DocumentUri.to_string uri
+      ; pos_lnum = line
+      ; pos_cnum = character
+      ; pos_bol = 0
+      }
     in
-    List.filter_opt actions
+    let+ res = get_all_possible_jump_targets ~merlin ~position in
+    List.filter_map res ~f:(fun (target, lexing_pos) ->
+      let open Option.O in
+      let+ position = Position.of_lexical_position lexing_pos in
+      let uri = Document.uri doc in
+      let range = { Range.start = position; end_ = position } in
+      let title = sprintf "%s jump" (String.capitalize_ascii (rename_target target)) in
+      let command =
+        let arguments = [ DocumentUri.yojson_of_t uri; Range.yojson_of_t range ] in
+        Command.create ~title ~command:command_name ~arguments ()
+      in
+      CodeAction.create
+        ~title
+        ~kind:(CodeActionKind.Other (sprintf "merlin-jump-%s" (rename_target target)))
+        ~command
+        ())
   | _ -> Fiber.return []
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
@@ -5,39 +5,23 @@ let meth = "ocamllsp/jump"
 let capability = "handleJump", `Bool true
 
 module JumpParams = struct
-  let targets =
-    [ "fun"
-    ; "match"
-    ; "let"
-    ; "module"
-    ; "module-type"
-    ; "match-next-case"
-    ; "match-prev-case"
-    ]
-  ;;
-
   type t =
     { textDocument : TextDocumentIdentifier.t
     ; position : Position.t
-    ; target : string option
     }
 
   let t_of_yojson json =
     let open Yojson.Safe.Util in
     { textDocument = json |> member "textDocument" |> TextDocumentIdentifier.t_of_yojson
     ; position = json |> member "position" |> Position.t_of_yojson
-    ; target = json |> member "target" |> to_string_option
     }
   ;;
 
-  let yojson_of_t { textDocument; position; target } =
-    let target =
-      Option.value_map target ~default:[] ~f:(fun v -> [ "target", `String v ])
-    in
+  let yojson_of_t { textDocument; position } =
     `Assoc
-      (("textDocument", TextDocumentIdentifier.yojson_of_t textDocument)
-       :: ("position", Position.yojson_of_t position)
-       :: target)
+      [ "textDocument", TextDocumentIdentifier.yojson_of_t textDocument
+      ; "position", Position.yojson_of_t position
+      ]
   ;;
 end
 
@@ -62,16 +46,16 @@ module Request_params = struct
 
   let yojson_of_t t = JumpParams.yojson_of_t t
 
-  let create ~uri ~position ~target =
-    { JumpParams.textDocument = TextDocumentIdentifier.create ~uri; position; target }
+  let create ~uri ~position =
+    { JumpParams.textDocument = TextDocumentIdentifier.create ~uri; position }
   ;;
 end
 
-let dispatch ~merlin ~position ~target =
+let dispatch ~merlin ~position =
   Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-    let pposition = Position.logical position in
-    let query = Query_protocol.Jump (target, pposition) in
-    Query_commands.dispatch pipeline query)
+    let position = Mpipeline.get_lexing_pos pipeline position in
+    let typedtree = Mpipeline.typer_result pipeline |> Mtyper.get_typedtree in
+    Merlin_analysis.Jump.get_all typedtree position)
 ;;
 
 let on_request ~params state =
@@ -80,25 +64,15 @@ let on_request ~params state =
     let params = (Option.value ~default:(`Assoc []) params :> Yojson.Safe.t) in
     let params = JumpParams.t_of_yojson params in
     let uri = params.textDocument.uri in
-    let position = params.position in
+    let position = Position.logical params.position in
     let doc = Document_store.get state.State.store uri in
     match Document.kind doc with
     | `Other -> Fiber.return `Null
     | `Merlin merlin ->
-      let targets =
-        match params.target with
-        | None -> JumpParams.targets
-        | Some target -> [ target ]
-      in
-      let+ results =
-        Fiber.parallel_map targets ~f:(fun target ->
-          dispatch ~merlin ~position ~target
-          |> Fiber.map ~f:(function
-            | `Error _ -> None
-            | `Found pos ->
-              (match Position.of_lexical_position pos with
-               | None -> None
-               | Some position -> Some (target, position))))
-      in
-      Jump.yojson_of_t (List.filter_map results ~f:Fun.id))
+      let+ res = dispatch ~merlin ~position in
+      Jump.yojson_of_t
+        (List.filter_map res ~f:(fun (target, position) ->
+           match Position.of_lexical_position position with
+           | Some pos -> Some (target, pos)
+           | None -> None)))
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_jump.mli
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_jump.mli
@@ -4,7 +4,7 @@ module Request_params : sig
   type t
 
   val yojson_of_t : t -> Json.t
-  val create : uri:DocumentUri.t -> position:Position.t -> target:string option -> t
+  val create : uri:DocumentUri.t -> position:Position.t -> t
 end
 
 type t


### PR DESCRIPTION
This PR enhances jump functionality used in : 
- Jump Code Actions
- The Jump Custom request

Instead of recursively checking if each target is possible, we now send a single query and get all the possible jump targets.

The trace on computing code actions is: 

- Getting each target separately
`[Trace - 5:07:56 AM] Received response 'textDocument/codeAction - (2)' in 523ms.`
`[Trace - 5:08:35 AM] Received response 'textDocument/codeAction - (17)' in 18ms.`

- Getting all targets at once
`[Trace - 5:15:50 AM] Received response 'textDocument/codeAction - (2)' in 244ms`.
`Trace - 5:15:59 AM] Received response 'textDocument/codeAction - (11)' in 7ms.`

which indicates some performance improvement.

This Pr is dependent on the corresponding Merlin implementation  https://github.com/ocaml/merlin/pull/1891


cc @voodoos 