### PR TITLE
Handle error cases in `definition_query`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Support for `class`, `class type`, `method` and `property` for `DocumentSymbol` query (#1487 fixes #1449)
 - Fix `inlay-hint` for function parameters (#1515)
+- More precise diagnostics in the event of a failed identifier search (`Definition_query`) (#1518)
 
 # 1.22.0
 

--- a/ocaml-lsp-server/src/definition_query.ml
+++ b/ocaml-lsp-server/src/definition_query.ml
@@ -4,10 +4,7 @@ open Fiber.O
 let location_of_merlin_loc uri : _ -> (_, string) result = function
   | `At_origin -> Error "Already at definition point"
   | `Builtin s ->
-    Error
-      (sprintf
-         "%S is a builtin, and it is therefore impossible to jump to its definition"
-         s)
+    Error (sprintf "%S is a builtin, it is not possible to jump to its definition" s)
   | `File_not_found s -> Error (sprintf "File_not_found: %s" s)
   | `Invalid_context -> Error "Not a valid identifier"
   | `Not_found (ident, where) ->


### PR DESCRIPTION
In order to have best diagnostics at the editor level.