### PR TITLE
Remove formatting in code action destruct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Support for `class`, `class type`, `method` and `property` for `DocumentSymbol` query (#1487 fixes #1449)
 - Fix `inlay-hint` for function parameters (#1515)
 - More precise diagnostics in the event of a failed identifier search (`Definition_query`) (#1518)
+- Remove `ocamlformat` application after `destruct` (that remove some useful parenthesis) (#1519)
 
 # 1.22.0
 

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -535,7 +535,7 @@ let f (x : t) = x
           {
             "edits": [
               {
-                "newText": "match x with Foo _ -> _ | Bar _ -> _\n",
+                "newText": "match x with | Foo _ -> _ | Bar _ -> _",
                 "range": {
                   "end": { "character": 17, "line": 2 },
                   "start": { "character": 16, "line": 2 }
@@ -951,7 +951,7 @@ let _ = defered_peek job_reader
           {
             "edits": [
               {
-                "newText": "match defered_peek job_reader with None -> _ | Some _ -> _\n",
+                "newText": "match defered_peek job_reader with | None -> _ | Some _ -> _",
                 "range": {
                   "end": { "character": 31, "line": 4 },
                   "start": { "character": 8, "line": 4 }
@@ -993,7 +993,7 @@ let _ = defered_peek job_reader
           {
             "edits": [
               {
-                "newText": "match job_reader with 0 -> _ | _ -> _\n",
+                "newText": "(match job_reader with | 0 -> _ | _ -> _)",
                 "range": {
                   "end": { "character": 31, "line": 4 },
                   "start": { "character": 21, "line": 4 }

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -927,6 +927,90 @@ let f (x: q) =
       |}]
 ;;
 
+let%expect_test "can destruct on sub-expression" =
+  let source =
+    {ocaml|
+let defered_peek x = if x >= 0 then Some (`Foo x) else None
+let job_reader = 10
+
+let _ = defered_peek job_reader
+|ocaml}
+  in
+  let range =
+    let start = Position.create ~line:4 ~character:8 in
+    let end_ = Position.create ~line:4 ~character:31 in
+    Range.create ~start ~end_
+  in
+  print_code_actions source range ~filter:(find_action "destruct (enumerate cases)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "match defered_peek job_reader with None -> _ | Some _ -> _\n",
+                "range": {
+                  "end": { "character": 31, "line": 4 },
+                  "start": { "character": 8, "line": 4 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct (enumerate cases)",
+      "title": "Destruct (enumerate cases)"
+    }
+    |}]
+;;
+
+let%expect_test "can destruct on sub-expression that need parenthesis" =
+  let source =
+    {ocaml|
+let defered_peek x = if x >= 0 then Some (`Foo x) else None
+let job_reader = 10
+
+let _ = defered_peek job_reader
+|ocaml}
+  in
+  let range =
+    let start = Position.create ~line:4 ~character:21 in
+    let end_ = Position.create ~line:4 ~character:31 in
+    Range.create ~start ~end_
+  in
+  print_code_actions source range ~filter:(find_action "destruct (enumerate cases)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "match job_reader with 0 -> _ | _ -> _\n",
+                "range": {
+                  "end": { "character": 31, "line": 4 },
+                  "start": { "character": 21, "line": 4 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct (enumerate cases)",
+      "title": "Destruct (enumerate cases)"
+    }
+    |}]
+;;
+
 let%expect_test "can infer module interfaces" =
   let impl_source =
     {ocaml|


### PR DESCRIPTION
Formatting on `destruct` is rarely useful: 
- when it generate cases, it fails (and it relay on the non-formatted case)
- when merlin return a result with parenthesis, since ocamlformat is not aware about the context, it remove parenthesis (making a lot of `destruct results` not insertable, which is very sad).