### PR TITLE
Correct nullable_option serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add custom `ocamllsp/jumpToTypedHole` to navigate through typed holes (#1516)
 - Add a code-action for combining pattern cases (just relaying on regex) (#1514)
 - Allow (by configuration) shortening of diagnostics (just highlighting the first line) (#1513)
+- Fix `yojson_of_t` for `Nullable_option`: serialize `None` as `Null` instead of asserting false (#1525 fixes #1524)
 
 ## Fixes
 

--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -216,7 +216,7 @@ module Json = struct
     ;;
 
     let yojson_of_t f = function
-      | None -> assert false
+      | None -> `Null
       | Some s -> f s
     ;;
   end


### PR DESCRIPTION
Changed `Nullable_option.yojson_of_t` to serialize `None` as `Null` instead of asserting false.

Fixes #1524