### PR TITLE
Deleted ocaml-language-server as the link is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,3 @@ date. Also, both servers seem deprecated.
   use merlin which means that it supports fewer versions of OCaml and offers less
   "smart" functionality - especially in the face of sources that do not yet
   compile.
-
-- [ocaml-language-server](https://github.com/ocaml-lsp/ocaml-language-server)
-  This project is extremely similar in the functionality it provides because it
-  also reuses merlin on the backend. The essential difference is that this
-  project is written in typescript, while our server is in OCaml. We feel that
-  it's best to use OCaml to maximize the contributor pool.


### PR DESCRIPTION
The link https://github.com/ocaml-lsp/ocaml-language-server is dead, so I removed its entry.