### PR TITLE
Avoid NeoVim error when opening .mll files

### DIFF
--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -8,7 +8,7 @@ module Kind = struct
 
   let of_fname_opt p =
     match Filename.extension p with
-    | ".ml" | ".eliom" | ".re" -> Some Impl
+    | ".ml" | ".eliom" | ".re" | ".mll" | ".mly" -> Some Impl
     | ".mli" | ".eliomi" | ".rei" -> Some Intf
     | _ -> None
   ;;


### PR DESCRIPTION
Opening a .mll file results in:
`ocamllsp: -32600: unsuppported file extension`

There is still an error because NeoVim sends the wrong language ID (`ocaml` instead of `ocaml.ocamllex`) 
(which https://github.com/ocaml/vim-ocaml/pull/61 is trying to fix), but at least with this change there is one less error.