### PR TITLE
use correct -short-paths config for merlin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 ## Fixes
 
 - Enable "hover" on more locations, notably class and object related (#1599)
+- do not force `-short-paths` (#1579)
 
 # 1.25.0
 

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -314,8 +314,7 @@ let create db path =
     let filename = Filename.basename path in
     let init = Mconfig.initial in
     { init with
-      ocaml = { init.ocaml with real_paths = false }
-    ; query = { init.query with filename; directory; verbosity = Mconfig.Verbosity.Smart }
+      query = { init.query with filename; directory; verbosity = Mconfig.Verbosity.Smart }
     }
   in
   { path; directory; initial; db; entry = None }


### PR DESCRIPTION
Fix #1395

The default needs to be `real_paths = true` (from `Mconfig.initial`), because `get_external_config` (called in `config`) will modify the config from the ocaml flags which will not contain a negated `-short-paths` when short paths are not wanted.

Should backport cleanly to 414-LTS (or rather I tested on 414-LTS then moved the commit on top of master ;))