### PR TITLE
Pin merlin in ocaml-lsp-server.opam.template

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           ocaml-compiler: "5.4"
 
-      # Remove this pin once a compatible version of Merlin has been released
-      - name: Pin dev Merlin
-        run: opam --cli=2.1 pin --with-version=5.7-504 https://github.com/ocaml/merlin.git#main
-
       - name: Build and install dependencies
         run: opam install .
 
@@ -88,10 +84,6 @@ jobs:
         run: |
           git config --global user.name github-actions[bot]
           git config --global user.email github-actions[bot]@users.noreply.github.com
-
-      # Remove this pin once a compatible version of Merlin has been released
-      - name: Pin dev Merlin
-        run: opam --cli=2.1 pin --with-version=5.6-504 https://github.com/ocaml/merlin.git#main
 
       - name: Install dependencies
         run: |

--- a/dune
+++ b/dune
@@ -5,9 +5,6 @@
 (rule
  (copy lsp.opam.template jsonrpc.opam.template))
 
-(rule
- (copy lsp.opam.template ocaml-lsp-server.opam.template))
-
 (env
  (_
   (flags :standard -alert -unstable -w -58)))

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -64,4 +64,9 @@ build: [
   ]
 ]
 
+pin-depends: [
+  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+]
+
 x-maintenance-intent: [ "(latest)" ]

--- a/ocaml-lsp-server.opam.template
+++ b/ocaml-lsp-server.opam.template
@@ -1,0 +1,20 @@
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+pin-depends: [
+  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+]
+
+x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
Github issue: #1602

So, basically, it moves the CI merlin pin to `ocaml-lsp-server.opam.template`, and removes the dune command, which was copying `lsp.opam.template`, instead doing it manually.

But I guess it's not enough, since both CI and local switch creation fail ^^'

UPD: ok, I just needed to run dune promote and update `ocaml-lsp-server.opam` file, I guess, not just the template ^^'

Does this need a changelog too?