### PR TITLE
Avoid Stdune.Pid for process ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 ## Fixes
 
 - Enable "hover" on more locations, notably class and object related (#1599)
+- Fix compatibility with upcoming Dune versions by avoiding the `Stdune.Pid`
+  module. (#1608)
 
 # 1.25.0
 

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -24,7 +24,7 @@ module Dune = struct
 
   module T = struct
     type t =
-      { pid : Pid.t
+      { pid : int
       ; id : Id.t
       }
 
@@ -165,7 +165,7 @@ let send =
         if annotate_dune_pid
         then
           fun pid (d : Diagnostic.t) ->
-            let source = Some (sprintf "dune (pid=%d)" (Pid.to_int pid)) in
+            let source = Some (sprintf "dune (pid=%d)" pid) in
             { d with source }
         else fun _pid x -> x
       in

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -17,7 +17,7 @@ val send : t -> [ `All | `One of Uri.t ] -> unit Fiber.t
 module Dune : sig
   type t
 
-  val gen : Pid.t -> t
+  val gen : int -> t
 end
 
 val set

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -459,7 +459,7 @@ end = struct
       ; finish
       ; promotions = String.Map.empty
       ; client = None
-      ; diagnostics_id = Diagnostics.Dune.gen (Pid.of_int (Registry.Dune.pid source))
+      ; diagnostics_id = Diagnostics.Dune.gen (Registry.Dune.pid source)
       ; id = Id.gen ()
       }
     in

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -11,7 +11,6 @@ include struct
   module Unix_env = Env
   module Map = Map
   module Monoid = Monoid
-  module Pid = Pid
   module Poly = Poly
 
   let sprintf = sprintf

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -34,7 +34,7 @@ let empty = Mconfig_dot.empty_config
 
 module Process = struct
   type nonrec t =
-    { pid : Pid.t
+    { pid : int
     ; prog : string
     ; initial_cwd : string
     ; stdin : Lev_fiber.Io.output Lev_fiber.Io.t
@@ -44,11 +44,11 @@ module Process = struct
 
   let to_dyn { pid; initial_cwd; _ } =
     let open Dyn in
-    record [ "pid", Pid.to_dyn pid; "initial_cwd", string initial_cwd ]
+    record [ "pid", int pid; "initial_cwd", string initial_cwd ]
   ;;
 
   let waitpid t =
-    let+ status = Lev_fiber.waitpid ~pid:(Pid.to_int t.pid) in
+    let+ status = Lev_fiber.waitpid ~pid:t.pid in
     (match status with
      | Unix.WEXITED n ->
        (match n with
@@ -81,14 +81,13 @@ module Process = struct
       let stdout_r, stdout_w = Unix.pipe () in
       Unix.set_close_on_exec stdin_w;
       let pid =
-        Pid.of_int
-          (Spawn.spawn
-             ~cwd:(Path dir)
-             ~prog
-             ~argv:(prog :: args)
-             ~stdin:stdin_r
-             ~stdout:stdout_w
-             ())
+        Spawn.spawn
+          ~cwd:(Path dir)
+          ~prog
+          ~argv:(prog :: args)
+          ~stdin:stdin_r
+          ~stdout:stdout_w
+          ()
       in
       Unix.close stdin_r;
       Unix.close stdout_w;
@@ -369,7 +368,7 @@ module DB = struct
   let stop t =
     let* () = Fiber.return () in
     Table.iter t.running ~f:(fun running ->
-      let pid = Pid.to_int running.process.pid in
+      let pid = running.process.pid in
       Unix.kill pid (if Sys.win32 then Sys.sigkill else Sys.sigterm));
     Fiber.Pool.stop t.pool
   ;;

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -15,7 +15,6 @@ let run_command ?(cwd = Spawn.Working_dir.Inherit) cancel prog stdin_value args 
     let pid =
       let argv = prog :: args in
       Spawn.spawn ~cwd ~prog ~argv ~stdin:stdin_i ~stdout:stdout_o ~stderr:stderr_o ()
-      |> Stdune.Pid.of_int
     in
     Unix.close stdin_i;
     Unix.close stdout_o;
@@ -28,7 +27,7 @@ let run_command ?(cwd = Spawn.Working_dir.Inherit) cancel prog stdin_value args 
           res, Fiber.Cancel.Not_cancelled
       | Some token ->
         let on_cancel () =
-          Unix.kill (Pid.to_int pid) Sys.sigterm;
+          Unix.kill pid Sys.sigterm;
           Fiber.return ()
         in
         fun f -> Fiber.Cancel.with_handler token ~on_cancel f
@@ -69,7 +68,7 @@ let run_command ?(cwd = Spawn.Working_dir.Inherit) cancel prog stdin_value args 
     in
     let+ status, (stdout, stderr) =
       Fiber.fork_and_join
-        (fun () -> Lev_fiber.waitpid ~pid:(Pid.to_int pid))
+        (fun () -> Lev_fiber.waitpid ~pid)
         (fun () ->
            Fiber.fork_and_join_unit stdin (fun () ->
              Fiber.fork_and_join (read stdout_i) (read stderr_i)))

--- a/ocaml-lsp-server/src/ocamlformat_rpc.ml
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.ml
@@ -19,7 +19,7 @@ module Ocamlformat_rpc = Ocamlformat_rpc_lib.Make (struct
 module Process : sig
   type t
 
-  val pid : t -> Pid.t
+  val pid : t -> int
   val client : t -> Ocamlformat_rpc.client
 
   val create
@@ -31,7 +31,7 @@ module Process : sig
   val run : t -> unit Fiber.t
 end = struct
   type t =
-    { pid : Pid.t
+    { pid : int
     ; session : Lev_fiber_csexp.Session.t
     ; client : Ocamlformat_rpc.client
     }
@@ -101,7 +101,7 @@ end = struct
       in
       Fiber.return @@ Error `No_process
     | Ok client ->
-      let process = { pid = Pid.of_int pid; session; client } in
+      let process = { pid; session; client } in
       let* () = configure ~logger process in
       let+ () =
         let message = Printf.sprintf "Ocamlformat-RPC server started with PID %i" pid in
@@ -111,7 +111,7 @@ end = struct
   ;;
 
   let run { pid; session; _ } =
-    let+ (_ : Unix.process_status) = Lev_fiber.waitpid ~pid:(Pid.to_int pid) in
+    let+ (_ : Unix.process_status) = Lev_fiber.waitpid ~pid in
     Lev_fiber_csexp.Session.close session
   ;;
 end
@@ -199,7 +199,7 @@ let stop t =
     t := Stopped;
     Fiber.fork_and_join_unit (maybe_fill wait_init) (maybe_fill ask_init)
   | Running process ->
-    let pid = Pid.to_int (Process.pid process) in
+    let pid = Process.pid process in
     t := Stopped;
     Unix.kill pid Sys.sigkill;
     Fiber.return ()

--- a/submodules/lev/lev-fiber/src/lev_fiber.ml
+++ b/submodules/lev/lev-fiber/src/lev_fiber.ml
@@ -59,10 +59,10 @@ end
 
 module Process_watcher = struct
   module Process_table = struct
-    type process = { pid : Pid.t; ivar : Unix.process_status Fiber.Ivar.t }
-    type t = { loop : Lev.Loop.t; active : (Pid.t, process) Table.t }
+    type process = { pid : int; ivar : Unix.process_status Fiber.Ivar.t }
+    type t = { loop : Lev.Loop.t; active : (int, process) Table.t }
 
-    let create loop = { loop; active = Table.create (module Pid) 16 }
+    let create loop = { loop; active = Table.create (module Int) 16 }
 
     let spawn t pid =
       Lev.Loop.ref t.loop;
@@ -75,7 +75,7 @@ module Process_watcher = struct
 
     let reap t queue =
       Table.filteri_inplace t.active ~f:(fun ~key:pid ~data:process ->
-          let pid, status = Unix.waitpid [ WNOHANG ] (Pid.to_int pid) in
+          let pid, status = Unix.waitpid [ WNOHANG ] pid in
           match pid with
           | 0 -> true
           | _ ->
@@ -429,7 +429,6 @@ module Timer = struct
 end
 
 let waitpid ~pid =
-  let pid = Pid.of_int pid in
   let* t = Fiber.Var.get_exn t in
   let ivar = Process_watcher.waitpid t.process_watcher ~pid in
   Fiber.Ivar.read ivar


### PR DESCRIPTION
Avoid using `Stdune.Pid` for process ids, matching the Dune API change in ocaml/dune@39d8a28027768119a3ced17aa8d28a187891124f.