### PR TITLE
Pin merlin-lib and ocaml-index to 5.8-505

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.28.0
+
+## Fixes
+
+- Fix opam installation error due to `merlin-lib` version. (#1611)
+
 # 1.27.0
 
 ## Features

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -66,7 +66,7 @@ build: [
 
 pin-depends: [
   [ "merlin-lib.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
-  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "ocaml-index.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
 ]
 
 x-maintenance-intent: [ "(latest)" ]

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -65,7 +65,7 @@ build: [
 ]
 
 pin-depends: [
-  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "merlin-lib.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
   [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
 ]
 

--- a/ocaml-lsp-server.opam.template
+++ b/ocaml-lsp-server.opam.template
@@ -14,7 +14,7 @@ build: [
 
 pin-depends: [
   [ "merlin-lib.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
-  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "ocaml-index.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
 ]
 
 x-maintenance-intent: [ "(latest)" ]

--- a/ocaml-lsp-server.opam.template
+++ b/ocaml-lsp-server.opam.template
@@ -13,7 +13,7 @@ build: [
 ]
 
 pin-depends: [
-  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "merlin-lib.5.8-505" "git+https://github.com/ocaml/merlin.git#main" ]
   [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
 ]
 

--- a/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-hoverExtended.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/ocamllsp-hoverExtended.ts
@@ -347,7 +347,7 @@ int
   "contents": {
     "kind": "markdown",
     "value": "\`\`\`ocaml
-type s = t
+type s = string
 \`\`\`",
   },
   "range": {

--- a/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
+++ b/ocaml-lsp-server/test/e2e/__tests__/textDocument-hover.test.ts
@@ -397,7 +397,7 @@ int
   "contents": {
     "kind": "markdown",
     "value": "\`\`\`ocaml
-type s = t
+type s = string
 \`\`\`",
   },
   "range": {


### PR DESCRIPTION
`opam switch create . -y`

```
The following additional pinnings are required by ocaml-lsp-server.1.27.0:
  - merlin-lib.5.7-504 at git+https://github.com/ocaml/merlin.git#main
  - ocaml-index.5.7-504 at git+https://github.com/ocaml/merlin.git#main
Pin and install them? [Y/n] y
[merlin-lib.5.7-504] synchronised (no changes)
merlin-lib is now pinned to git+https://github.com/ocaml/merlin.git#main (version 5.7-504)
[ocaml-index.5.7-504] synchronised (no changes)
ocaml-index is now pinned to git+https://github.com/ocaml/merlin.git#main (version 5.7-504)
ocaml-lsp-server is now pinned to git+file:///home/pedro/Desktop/projects/ocaml-lsp#master (ver
sion 1.27.0)
lsp is now pinned to git+file:///home/pedro/Desktop/projects/ocaml-lsp#master (version 1.27.0)
jsonrpc is now pinned to git+file:///home/pedro/Desktop/projects/ocaml-lsp#master (version 1.27
.0)

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml" {>= "4.05.0"}]
[ERROR] Could not determine which packages to install for this switch:
  * Missing dependency:
    - ocaml-lsp-server >= 1.27.0 → merlin-lib >= 5.8
    not available because the package is pinned to version 5.7-504
```