### PR TITLE
[codex] Use string for diagnostic messages

### DIFF
--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -16865,34 +16865,13 @@ module CodeDescription = struct
 end
 
 module Diagnostic = struct
-  type message_pvar =
-    [ `String of string
-    | `MarkupContent of MarkupContent.t
-    ]
-
-  let message_pvar_of_yojson (json : Json.t) : message_pvar =
-    match json with
-    | `String j -> `String j
-    | _ ->
-      Json.Of.untagged_union
-        "message_pvar"
-        [ (fun json -> `MarkupContent (MarkupContent.t_of_yojson json)) ]
-        json
-  ;;
-
-  let yojson_of_message_pvar (message_pvar : message_pvar) : Json.t =
-    match message_pvar with
-    | `String j -> `String j
-    | `MarkupContent s -> MarkupContent.yojson_of_t s
-  ;;
-
   type t =
     { code : Jsonrpc.Id.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; codeDescription : CodeDescription.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; data : Json.t option [@yojson.option]
-    ; message : message_pvar
+    ; message : string
     ; range : Range.t
     ; relatedInformation : DiagnosticRelatedInformation.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -16954,7 +16933,7 @@ module Diagnostic = struct
             | "message" ->
               (match Ppx_yojson_conv_lib.( ! ) message_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = message_pvar_of_yojson _field_yojson in
+                 let fvalue = string_of_yojson _field_yojson in
                  message_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -17153,7 +17132,7 @@ module Diagnostic = struct
          ("range", arg) :: bnds
        in
        let bnds =
-         let arg = yojson_of_message_pvar v_message in
+         let arg = yojson_of_string v_message in
          ("message", arg) :: bnds
        in
        let bnds =
@@ -17195,7 +17174,7 @@ module Diagnostic = struct
         ?(code : Jsonrpc.Id.t option)
         ?(codeDescription : CodeDescription.t option)
         ?(data : Json.t option)
-        ~(message : message_pvar)
+        ~(message : string)
         ~(range : Range.t)
         ?(relatedInformation : DiagnosticRelatedInformation.t list option)
         ?(severity : DiagnosticSeverity.t option)

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -1853,7 +1853,7 @@ module Diagnostic : sig
     { code : Jsonrpc.Id.t option
     ; codeDescription : CodeDescription.t option
     ; data : Json.t option
-    ; message : [ `String of string | `MarkupContent of MarkupContent.t ]
+    ; message : string
     ; range : Range.t
     ; relatedInformation : DiagnosticRelatedInformation.t list option
     ; severity : DiagnosticSeverity.t option
@@ -1865,7 +1865,7 @@ module Diagnostic : sig
     :  ?code:Jsonrpc.Id.t
     -> ?codeDescription:CodeDescription.t
     -> ?data:Json.t
-    -> message:[ `String of string | `MarkupContent of MarkupContent.t ]
+    -> message:string
     -> range:Range.t
     -> ?relatedInformation:DiagnosticRelatedInformation.t list
     -> ?severity:DiagnosticSeverity.t

--- a/ocaml-lsp-server/src/code_actions/action_add_rec.ml
+++ b/ocaml-lsp-server/src/code_actions/action_add_rec.ml
@@ -56,12 +56,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
   let pos_start = Position.logical params.range.start in
   let* diagnostic =
     List.find params.context.diagnostics ~f:(fun (d : Diagnostic.t) ->
-      let is_unbound () =
-        String.is_prefix
-          ~prefix:"Unbound value"
-          (match d.message with
-           | `String m -> m
-           | `MarkupContent { value; _ } -> value)
+      let is_unbound () = String.is_prefix ~prefix:"Unbound value" d.message
       and in_range () =
         match Position.compare_inclusion params.range.start d.range with
         | `Outside _ -> false

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -36,16 +36,7 @@ let find_unused_diagnostic pos ds =
     | `Outside _ -> false
     | `Inside -> true)
   |> List.find_map ~f:(fun (d : Diagnostic.t) ->
-    let* group =
-      let message =
-        match d.message with
-        | `String m -> m
-        | `MarkupContent { value = m; _ } ->
-          (* TODO: this is wrong *)
-          m
-      in
-      Re.exec_opt diagnostic_regex message
-    in
+    let* group = Re.exec_opt diagnostic_regex d.message in
     let+ kind =
       List.find_map diagnostic_regex_marks ~f:(fun (m, k) ->
         if Re.Mark.test group m then Some k else None)

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -134,12 +134,7 @@ let send =
                    | None -> assert false
                    | Some source ->
                      String.equal ocamllsp_source source
-                     &&
-                       (match d.message, diagnostic.message with
-                       | `String m1, `String m2 -> equal_message m1 m2
-                       | `MarkupContent { kind; value }, `MarkupContent mc ->
-                         Poly.equal kind mc.kind && equal_message value mc.value
-                       | _, _ -> false))
+                     && equal_message d.message diagnostic.message)
                then diagnostics
                else diagnostic :: diagnostics))
     in
@@ -348,13 +343,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
     Option.merge maybe_extra_range_information related_information ~f:( @ )
   in
   let tags = tags_of_message diagnostics ~src:`Merlin message in
-  create_diagnostic
-    ?tags
-    ?relatedInformation
-    ~range
-    ~message:(`String message)
-    ~severity
-    ()
+  create_diagnostic ?tags ?relatedInformation ~range ~message ~severity ()
 ;;
 
 let merlin_diagnostics diagnostics merlin =
@@ -370,10 +359,7 @@ let merlin_diagnostics diagnostics merlin =
       match Query_commands.dispatch pipeline command with
       | exception Merlin_extend.Extend_main.Handshake.Error error ->
         let message =
-          `String
-            (sprintf
-               "%s.\nHint: install the following packages: merlin-extend, reason"
-               error)
+          sprintf "%s.\nHint: install the following packages: merlin-extend, reason" error
         in
         [ create_diagnostic ~range:Range.first_line ~message () ]
       | errors ->
@@ -390,12 +376,7 @@ let merlin_diagnostics diagnostics merlin =
             in
             (* we set specific diagnostic code = "hole" to be able to
                filter through diagnostics easily *)
-            create_diagnostic
-              ~code:(`String "hole")
-              ~range
-              ~message:(`String message)
-              ~severity
-              ())
+            create_diagnostic ~code:(`String "hole") ~range ~message ~severity ())
         in
         (* Can we use [List.merge] instead? *)
         List.rev_append holes_as_err_diags merlin_diagnostics

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -237,7 +237,7 @@ end = struct
       ~range
       ?severity
       ~source:Diagnostics.dune_source
-      ~message:(`String message)
+      ~message
       ?tags
       ?data
       ()

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -199,8 +199,7 @@ let set_diagnostics detached diagnostics doc =
      | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
        let no_reason_merlin =
          let message =
-           `String
-             (sprintf "Could not detect %s. Please install reason" ocamlmerlin_reason)
+           sprintf "Could not detect %s. Please install reason" ocamlmerlin_reason
          in
          Diagnostic.create
            ~source:Diagnostics.ocamllsp_source

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -648,10 +648,8 @@ end = struct
       | Pexp_setinstvar (_, _)
       | Pexp_override _ | Pexp_assert _ | Pexp_lazy _
       | Pexp_poly (_, _)
-      | Pexp_object _
-      | Pexp_pack _
-      | Pexp_struct_item _
-      | Pexp_extension _ -> `Default_iterator
+      | Pexp_object _ | Pexp_pack _ | Pexp_struct_item _ | Pexp_extension _ ->
+        `Default_iterator
     with
     | `Default_iterator -> Ast_iterator.default_iterator.expr self exp
     | `Custom_iterator -> self.attributes self pexp_attributes

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -4,7 +4,7 @@ let run_test ~title ~message source =
   let src, range = Code_actions.parse_selection source in
   Option.iter
     (Code_actions.apply_code_action
-       ~diagnostics:[ Diagnostic.create ~message:(`String message) ~range () ]
+       ~diagnostics:[ Diagnostic.create ~message ~range () ]
        title
        src
        range)

--- a/ocaml-lsp-server/test/e2e-new/with_ppx.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_ppx.ml
@@ -30,10 +30,7 @@ let%expect_test "with-ppx" =
       match n with
       | PublishDiagnostics diag ->
         printfn "Received %i diagnostics" (List.length diag.diagnostics);
-        List.iter diag.diagnostics ~f:(fun (d : Diagnostic.t) ->
-          match d.message with
-          | `String m -> print_endline m
-          | `MarkupContent _ -> assert false);
+        List.iter diag.diagnostics ~f:(fun (d : Diagnostic.t) -> print_endline d.message);
         Fiber.Ivar.fill diagnostics ()
       | _ -> Fiber.return ()
     in


### PR DESCRIPTION
## Summary

This changes LSP diagnostics so `Diagnostic.message` is represented as a plain string again instead of accepting either a string or markup content.

Callers that inspected diagnostic messages now use the string directly, and diagnostic construction sites no longer wrap messages in `` `String``.

See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic

## Impact

This aligns the typed API with the expected diagnostic message shape and removes unnecessary markup handling in diagnostic consumers and tests.

## Validation

- `make check`
