### PR TITLE
Restrict Dune formatting to Dune documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 # Unreleased
 
 ## Fixes
- - Refactor ppx hover to use merlin directly (#1606, fixes #1614)
+
+- Prevent whole-document formatting requests for OCamllex, Menhir, and Cram
+  files from being routed through Dune's S-expression formatter.
+- Refactor ppx hover to use merlin directly (#1606, fixes #1614)
 
 # 1.27.0
 

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -205,10 +205,15 @@ type merlin =
   ; kind : Kind.t option
   }
 
-type dune = Text_document.t
+module Dune = struct
+  type t = Text_document.t
+
+  let uri = Text_document.documentUri
+  let text = Text_document.text
+end
 
 type t =
-  | Dune of dune
+  | Dune of Dune.t
   | Other of
       { tdoc : Text_document.t
       ; syntax : Syntax.t
@@ -288,13 +293,6 @@ let update_text ?version t changes =
      | Other o -> Other { o with tdoc }
      | Merlin t -> Merlin { t with tdoc })
 ;;
-
-module Dune = struct
-  type t = dune
-
-  let uri = Text_document.documentUri
-  let text = Text_document.text
-end
 
 let dune = function
   | Dune d -> Some d

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -205,7 +205,10 @@ type merlin =
   ; kind : Kind.t option
   }
 
+type dune = Text_document.t
+
 type t =
+  | Dune of dune
   | Other of
       { tdoc : Text_document.t
       ; syntax : Syntax.t
@@ -213,6 +216,7 @@ type t =
   | Merlin of merlin
 
 let text_document = function
+  | Dune d -> d
   | Other d -> d.tdoc
   | Merlin m -> m.tdoc
 ;;
@@ -220,6 +224,7 @@ let text_document = function
 let uri t = Text_document.documentUri (text_document t)
 
 let syntax = function
+  | Dune _ -> Syntax.Dune
   | Merlin m -> m.syntax
   | Other t -> t.syntax
 ;;
@@ -257,7 +262,8 @@ let make wheel config pipeline (doc : DidOpenTextDocumentParams.t) ~position_enc
     let syntax = Syntax.of_text_document tdoc in
     match syntax with
     | Ocaml | Reason | Mlx -> make_merlin wheel config pipeline tdoc syntax
-    | Ocamllex | Menhir | Cram | Dune -> Fiber.return (Other { tdoc; syntax }))
+    | Dune -> Fiber.return (Dune tdoc)
+    | Ocamllex | Menhir | Cram -> Fiber.return (Other { tdoc; syntax }))
 ;;
 
 let update_text ?version t changes =
@@ -278,8 +284,21 @@ let update_text ?version t changes =
     t
   | tdoc ->
     (match t with
+     | Dune _ -> Dune tdoc
      | Other o -> Other { o with tdoc }
      | Merlin t -> Merlin { t with tdoc })
+;;
+
+module Dune = struct
+  type t = dune
+
+  let uri = Text_document.documentUri
+  let text = Text_document.text
+end
+
+let dune = function
+  | Dune d -> Some d
+  | Other _ | Merlin _ -> None
 ;;
 
 module Merlin = struct
@@ -401,7 +420,7 @@ let edit t text_edits =
 
 let kind = function
   | Merlin merlin -> `Merlin merlin
-  | Other _ -> `Other
+  | Dune _ | Other _ -> `Other
 ;;
 
 let merlin_exn t =
@@ -415,7 +434,7 @@ let merlin_exn t =
 
 let close t =
   match t with
-  | Other _ -> Fiber.return ()
+  | Dune _ | Other _ -> Fiber.return ()
   | Merlin t ->
     Fiber.fork_and_join_unit
       (fun () -> Merlin_config.destroy t.merlin_config)

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -42,6 +42,17 @@ val uri : t -> Uri.t
 val text : t -> string
 val source : t -> Msource.t
 
+module Dune : sig
+  type t
+
+  val uri : t -> Uri.t
+  val text : t -> string
+end
+
+(** [dune t] returns the Dune view of [t], if any. {!val:kind} deliberately
+    classifies Dune documents as [`Other]. *)
+val dune : t -> Dune.t option
+
 module Merlin : sig
   type doc := t
   type t

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -132,7 +132,7 @@ type config =
 module Instance : sig
   type t
 
-  val format_dune_file : t -> Document.t -> string Fiber.t
+  val format_dune_file : t -> Document.Dune.t -> string Fiber.t
   val stop : t -> unit Fiber.t
   val run : t -> unit Fiber.t
   val connect : t -> (unit, unit) result Fiber.t
@@ -521,8 +521,8 @@ end = struct
         | Ok req -> req
       in
       let+ res =
-        let path = Document.uri doc |> Uri.to_path |> Drpc.Path.absolute in
-        Client.request client req (path, `Contents (Document.text doc))
+        let path = Document.Dune.uri doc |> Uri.to_path |> Drpc.Path.absolute in
+        Client.request client req (path, `Contents (Document.Dune.text doc))
       in
       (match res with
        | Ok res -> res
@@ -940,7 +940,7 @@ let for_doc t doc =
   match !t with
   | Closed -> []
   | Active t ->
-    let uri = Document.uri doc in
+    let uri = Document.Dune.uri doc in
     String.Map.fold ~init:[] t.instances ~f:(fun instance acc ->
       if uri_dune_overlap uri (Instance.source instance) then instance :: acc else acc)
 ;;

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -3,7 +3,7 @@ open! Import
 module Instance : sig
   type t
 
-  val format_dune_file : t -> Document.t -> string Fiber.t
+  val format_dune_file : t -> Document.Dune.t -> string Fiber.t
 end
 
 type t
@@ -25,4 +25,4 @@ val stop : t -> unit Fiber.t
 val commands : string list
 val on_command : t -> ExecuteCommandParams.t -> Json.t Fiber.t
 val code_actions : t -> Uri.t -> CodeAction.t list
-val for_doc : t -> Document.t -> Instance.t list
+val for_doc : t -> Document.Dune.t -> Instance.t list

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -323,56 +323,10 @@ module Formatter = struct
     make_error ~code ~message ()
   ;;
 
-  let run rpc doc =
-    let state : State.t = Server.state rpc in
-    match Document.kind doc with
-    | `Merlin _ ->
-      let* res =
-        let* cancel = Server.cancel_token () in
-        Ocamlformat.run doc cancel
-      in
-      (match res with
-       | Ok result -> Fiber.return (Some result)
-       | Error e ->
-         let+ () =
-           let state : State.t = Server.state rpc in
-           let msg =
-             let message = Ocamlformat.message e in
-             ShowMessageParams.create ~message ~type_:Warning
-           in
-           task_if_running state.detached ~f:(fun () ->
-             Server.notification rpc (ShowMessage msg))
-         in
-         Jsonrpc.Response.Error.raise (jsonrpc_error e))
-    | `Other ->
-      (match Dune.for_doc (State.dune state) doc with
-       | [] ->
-         let message =
-           sprintf
-             "No dune instance found. Please run dune in watch mode for %s"
-             (Uri.to_path (Document.uri doc))
-         in
-         Jsonrpc.Response.Error.raise (make_error ~code:InvalidRequest ~message ())
-       | dune :: rest ->
-         let* () =
-           match rest with
-           | [] -> Fiber.return ()
-           | _ :: _ ->
-             let message =
-               sprintf
-                 "More than one dune instance detected for %s. Selecting one at random"
-                 (Uri.to_path (Document.uri doc))
-             in
-             State.log_msg rpc ~type_:MessageType.Warning ~message
-         in
-         let+ to_ = Dune.Instance.format_dune_file dune doc in
-         Some (Diff.edit ~from:(Document.text doc) ~to_))
-  ;;
-
-  let run_on_range rpc doc range =
+  let run_ocamlformat rpc format =
     let* res =
       let* cancel = Server.cancel_token () in
-      Ocamlformat.run_on_range doc range cancel
+      format cancel
     in
     match res with
     | Ok result -> Fiber.return (Some result)
@@ -387,6 +341,48 @@ module Formatter = struct
           Server.notification rpc (ShowMessage msg))
       in
       Jsonrpc.Response.Error.raise (jsonrpc_error e)
+  ;;
+
+  let run_dune rpc doc =
+    let state : State.t = Server.state rpc in
+    match Dune.for_doc (State.dune state) doc with
+    | [] ->
+      let message =
+        sprintf
+          "No dune instance found. Please run dune in watch mode for %s"
+          (Uri.to_path (Document.Dune.uri doc))
+      in
+      Jsonrpc.Response.Error.raise (make_error ~code:InvalidRequest ~message ())
+    | dune :: rest ->
+      let* () =
+        match rest with
+        | [] -> Fiber.return ()
+        | _ :: _ ->
+          let message =
+            sprintf
+              "More than one dune instance detected for %s. Selecting one at random"
+              (Uri.to_path (Document.Dune.uri doc))
+          in
+          State.log_msg rpc ~type_:MessageType.Warning ~message
+      in
+      let+ to_ = Dune.Instance.format_dune_file dune doc in
+      Some (Diff.edit ~from:(Document.Dune.text doc) ~to_)
+  ;;
+
+  let run rpc doc =
+    match Document.kind doc with
+    | `Merlin merlin -> run_ocamlformat rpc (Ocamlformat.run merlin)
+    | `Other ->
+      (match Document.dune doc with
+       | Some dune -> run_dune rpc dune
+       | None -> Fiber.return None)
+  ;;
+
+  let run_on_range rpc doc range =
+    match Document.syntax doc with
+    | Dune | Cram -> Fiber.return None
+    | Ocaml | Reason | Mlx | Ocamllex | Menhir ->
+      run_ocamlformat rpc (Ocamlformat.run_on_range doc range)
   ;;
 end
 

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -158,7 +158,8 @@ let exec ?cwd cancel refmt args stdin =
      | _ -> Result.Error (Unexpected_result { message = res.stderr }))
 ;;
 
-let run doc cancel : (TextEdit.t list, error) result Fiber.t =
+let run merlin cancel : (TextEdit.t list, error) result Fiber.t =
+  let doc = Document.Merlin.to_doc merlin in
   let res =
     let open Result.O in
     let* formatter = formatter doc in

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -12,7 +12,11 @@ type error =
   | Unknown_extension of Uri.t
 
 val message : error -> string
-val run : Document.t -> Fiber.Cancel.t option -> (TextEdit.t list, error) result Fiber.t
+
+val run
+  :  Document.Merlin.t
+  -> Fiber.Cancel.t option
+  -> (TextEdit.t list, error) result Fiber.t
 
 val run_on_range
   :  Document.t

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -648,10 +648,8 @@ end = struct
       | Pexp_setinstvar (_, _)
       | Pexp_override _ | Pexp_assert _ | Pexp_lazy _
       | Pexp_poly (_, _)
-      | Pexp_object _
-      | Pexp_pack _
-      | Pexp_struct_item _
-      | Pexp_extension _ -> `Default_iterator
+      | Pexp_object _ | Pexp_pack _ | Pexp_struct_item _ | Pexp_extension _ ->
+        `Default_iterator
     with
     | `Default_iterator -> Ast_iterator.default_iterator.expr self exp
     | `Custom_iterator -> self.attributes self pexp_attributes

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -7,7 +7,7 @@ let iter_code_actions ?prep ?path ?(diagnostics = []) ~source range =
     Lsp.Client_request.CodeAction
       (CodeActionParams.create ~textDocument ~range ~context ())
   in
-  iter_lsp_response ?prep ?path ~makeRequest ~source
+  iter_lsp_response ?prep ?path ~language_id:"ocaml" ~makeRequest ~source
 ;;
 
 let print_code_actions

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -12,7 +12,7 @@ let iter_completions
     Lsp.Client_request.TextDocumentCompletion
       (CompletionParams.create ~textDocument ~position ~context ())
   in
-  Lsp_helpers.iter_lsp_response ?prep ?path ~makeRequest
+  Lsp_helpers.iter_lsp_response ?prep ?path ~language_id:"ocaml" ~makeRequest
 ;;
 
 let print_completions

--- a/ocaml-lsp-server/test/e2e-new/formatting.ml
+++ b/ocaml-lsp-server/test/e2e-new/formatting.ml
@@ -35,13 +35,18 @@ let setup_ocamlformat content =
   tmpdir
 ;;
 
-let iter_formatting source path =
-  let makeRequest textDocument =
-    let options = FormattingOptions.create ~tabSize:2 ~insertSpaces:true () in
-    Lsp.Client_request.TextDocumentFormatting
-      (DocumentFormattingParams.create ~textDocument ~options ())
-  in
-  Lsp_helpers.iter_lsp_response ~path ~makeRequest ~source
+let make_request textDocument =
+  let options = FormattingOptions.create ~tabSize:2 ~insertSpaces:true () in
+  Lsp.Client_request.TextDocumentFormatting
+    (DocumentFormattingParams.create ~textDocument ~options ())
+;;
+
+let iter_formatting ?language_id source path =
+  Lsp_helpers.iter_lsp_response
+    ~language_id:(Option.value language_id ~default:"ocaml")
+    ~path
+    ~makeRequest:make_request
+    ~source
 ;;
 
 let print_formatting_textedits = function
@@ -54,7 +59,20 @@ let print_formatting_textedits = function
     |> print_endline
 ;;
 
-let print_formatting source path = iter_formatting source path print_formatting_textedits
+let print_formatting ?language_id source path =
+  iter_formatting ?language_id source path print_formatting_textedits
+;;
+
+let print_formatting_error ?language_id source path =
+  Lsp_helpers.iter_lsp_response_result
+    ~language_id:(Option.value language_id ~default:"ocaml")
+    ~path
+    ~makeRequest:make_request
+    ~source
+    (function
+    | Error error -> Jsonrpc.Response.Error.yojson_of_t error |> Test.print_result
+    | Ok _ -> print_endline "Expected formatting to fail")
+;;
 
 let%expect_test "can format an ocaml impl file" =
   let source =
@@ -144,4 +162,51 @@ let%expect_test "does not format ignored files" =
   let path = Stdlib.Filename.concat tmpdir name in
   print_formatting source path;
   [%expect {| No formatting needed |}]
+;;
+
+let%expect_test "does not format unsupported documents" =
+  let test language_id path source =
+    print_endline language_id;
+    print_formatting ~language_id source path
+  in
+  test
+    "ocaml.ocamllex"
+    "lexer.mll"
+    {|rule token = parse
+  | eof { EOF }
+|};
+  test
+    "ocaml.menhir"
+    "parser.mly"
+    {|%token EOF
+%%
+main:
+  | EOF { () }
+|};
+  test
+    "cram"
+    "test.t"
+    {|  $ echo hello
+  hello
+|};
+  [%expect
+    {|
+    ocaml.ocamllex
+    No formatting result
+    ocaml.menhir
+    No formatting result
+    cram
+    No formatting result
+    |}]
+;;
+
+let%expect_test "routes dune documents through dune" =
+  print_formatting_error ~language_id:"dune" "(library)" "dune";
+  [%expect
+    {|
+    {
+      "code": -32600,
+      "message": "No dune instance found. Please run dune in watch mode for /dune"
+    }
+    |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
@@ -2,9 +2,9 @@ open Test.Import
 
 let change_config ~client params = Client.notification client (ChangeConfiguration params)
 
-let open_document ~client ~uri ~source =
+let open_document ~language_id ~client ~uri ~source =
   let textDocument =
-    TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:source
+    TextDocumentItem.create ~uri ~languageId:language_id ~version:0 ~text:source
   in
   Client.notification
     client
@@ -44,28 +44,18 @@ let open_document_with_client ~prep ~path ~source client =
   in
   let uri = DocumentUri.of_path path in
   let* () = prep client in
-  open_document ~client ~uri ~source
+  open_document ~language_id:"ocaml" ~client ~uri ~source
 ;;
 
-let iter_lsp_response
+let iter_lsp_response_internal
       ?(prep = fun _ -> Fiber.return ())
       ?(path = "foo.ml")
+      ~language_id
       ~makeRequest
       ~source
       k
   =
-  let got_diagnostics = Fiber.Ivar.create () in
-  let handler =
-    Client.Handler.make
-      ~on_notification:(fun _ -> function
-         | PublishDiagnostics _ ->
-           let* diag = Fiber.Ivar.peek got_diagnostics in
-           (match diag with
-            | Some _ -> Fiber.return ()
-            | None -> Fiber.Ivar.fill got_diagnostics ())
-         | _ -> Fiber.return ())
-      ()
-  in
+  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
   Test.run ~handler
   @@ fun client ->
   let run_client () =
@@ -78,22 +68,46 @@ let iter_lsp_response
     in
     Client.start client (InitializeParams.create ~capabilities ())
   in
-  let run =
+  let request () =
     let* (_ : InitializeResult.t) = Client.initialized client in
     let uri = DocumentUri.of_path path in
     let* () = prep client in
-    let* () = open_document ~client ~uri ~source in
-    let+ resp =
-      let request =
-        let textDocument = TextDocumentIdentifier.create ~uri in
-        makeRequest textDocument
-      in
-      Client.request client request
+    let* () = open_document ~language_id ~client ~uri ~source in
+    let* response =
+      Fiber.collect_errors (fun () ->
+        let request =
+          let textDocument = TextDocumentIdentifier.create ~uri in
+          makeRequest textDocument
+        in
+        Client.request client request)
     in
-    k resp
+    k response
   in
-  Fiber.fork_and_join_unit run_client (fun () ->
-    run >>> Fiber.Ivar.read got_diagnostics >>> Client.stop client)
+  let shutdown () =
+    let* () = Client.request client Shutdown in
+    Client.notification client Exit
+  in
+  Fiber.fork_and_join_unit run_client (fun () -> Fiber.finalize request ~finally:shutdown)
+;;
+
+let iter_lsp_response ?prep ?path ~language_id ~makeRequest ~source k =
+  iter_lsp_response_internal ?prep ?path ~language_id ~makeRequest ~source (function
+    | Ok response ->
+      k response;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors)
+;;
+
+let iter_lsp_response_result ?prep ?path ~language_id ~makeRequest ~source k =
+  iter_lsp_response_internal ?prep ?path ~language_id ~makeRequest ~source (function
+    | Ok response ->
+      k (Ok response);
+      Fiber.return ()
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
+      k (Error error);
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors)
 ;;
 
 let open_document_with_diagnostics_callback

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
@@ -6,7 +6,8 @@ val change_config : client:'a Client.t -> DidChangeConfigurationParams.t -> unit
 (** Opens a document with the language server. This must be done before trying
     to access it *)
 val open_document
-  :  client:'a Client.t
+  :  language_id:string
+  -> client:'a Client.t
   -> uri:DocumentUri.t
   -> source:string
   -> unit Fiber.t
@@ -16,9 +17,20 @@ val open_document
 val iter_lsp_response
   :  ?prep:(unit Client.t -> unit Fiber.t)
   -> ?path:string
+  -> language_id:string
   -> makeRequest:(TextDocumentIdentifier.t -> 'a Client.out_request)
   -> source:string
   -> ('a -> unit)
+  -> unit
+
+(** Like [iter_lsp_response], but exposes request errors to the handler. *)
+val iter_lsp_response_result
+  :  ?prep:(unit Client.t -> unit Fiber.t)
+  -> ?path:string
+  -> language_id:string
+  -> makeRequest:(TextDocumentIdentifier.t -> 'a Client.out_request)
+  -> source:string
+  -> (('a, Jsonrpc.Response.Error.t) result -> unit)
   -> unit
 
 (** Opens the file in the specified path with source code as specified in src.

--- a/ocaml-lsp-server/test/e2e-new/range_formatting.ml
+++ b/ocaml-lsp-server/test/e2e-new/range_formatting.ml
@@ -22,17 +22,21 @@ wrap-comments=true
 |}
 ;;
 
-let iter_range_formatting source path range =
+let iter_range_formatting ?language_id source path range =
   let makeRequest textDocument =
     let options = FormattingOptions.create ~tabSize:2 ~insertSpaces:true () in
     Lsp.Client_request.TextDocumentRangeFormatting
       (DocumentRangeFormattingParams.create ~textDocument ~range ~options ())
   in
-  Lsp_helpers.iter_lsp_response ~path ~makeRequest ~source
+  Lsp_helpers.iter_lsp_response
+    ~language_id:(Option.value language_id ~default:"ocaml")
+    ~path
+    ~makeRequest
+    ~source
 ;;
 
-let print_formatting source path range =
-  iter_range_formatting source path range print_formatting_textedits
+let print_formatting ?language_id source path range =
+  iter_range_formatting ?language_id source path range print_formatting_textedits
 ;;
 
 let%expect_test "can format part of an ocaml impl file" =
@@ -114,7 +118,7 @@ rule censor = parse
       ~end_:(Position.create ~line:5 ~character:82)
   in
   let path = Filename.concat (setup_ocamlformat ocamlformat_config) "lexer.mll" in
-  print_formatting source path range;
+  print_formatting ~language_id:"ocaml.ocamllex" source path range;
   (* this also implicitly tests that `margin` is correctly read;
     if the value of 60 is not retrieved and 80 is used, the
     string would not be split across two lines *)
@@ -129,6 +133,55 @@ rule censor = parse
         }
       }
     ]
+    |}]
+;;
+
+let%expect_test "formats semantic actions in menhir files" =
+  let source =
+    {menhir|%token <int> INT
+%start <int> main
+%%
+main:
+  | value = INT { value+1 }
+|menhir}
+  in
+  let range =
+    Range.create
+      ~start:(Position.create ~line:4 ~character:18)
+      ~end_:(Position.create ~line:4 ~character:25)
+  in
+  let path = Filename.concat (setup_ocamlformat ocamlformat_config) "parser.mly" in
+  print_formatting ~language_id:"ocaml.menhir" source path range;
+  [%expect
+    {|
+    [
+      {
+        "newText": "  | value = INT { value + 1 }\n",
+        "range": {
+          "end": { "character": 0, "line": 5 },
+          "start": { "character": 0, "line": 4 }
+        }
+      }
+    ]
+    |}]
+;;
+
+let%expect_test "does not range format unsupported documents" =
+  let range =
+    Range.create
+      ~start:(Position.create ~line:0 ~character:0)
+      ~end_:(Position.create ~line:0 ~character:1)
+  in
+  print_endline "cram";
+  print_formatting ~language_id:"cram" "x" "test.t" range;
+  print_endline "dune";
+  print_formatting ~language_id:"dune" "(library)" "dune" range;
+  [%expect
+    {|
+    cram
+    No formatting result
+    dune
+    No formatting result
     |}]
 ;;
 


### PR DESCRIPTION
## Summary

- distinguish Dune documents from other non-Merlin documents in `Document.t`
- expose an abstract `Document.Dune.t` and require it throughout the Dune formatting path
- restrict whole-document OCaml formatting to `Document.Merlin.t`
- preserve OCamllex and Menhir semantic-action range formatting while returning no edits for unsupported requests
- add regression coverage for OCamllex, Menhir, Cram and Dune documents

## Motivation

`Document.kind` intentionally presents every non-Merlin document as `Other`. The formatting handler treated that compatibility view as a formatting classification and sent every `Other` document to Dune's S-expression formatter. As a result, OCamllex, Menhir and Cram documents could be misrouted through Dune RPC.

This change makes the Dune formatter's contract explicit in the type system, so non-Dune documents cannot be passed to it accidentally. Unsupported formatting requests now return no edits without a warning. Dune documents retain the existing `InvalidRequest` behaviour when no Dune RPC instance is available.

Related:

- https://github.com/ocamllabs/vscode-ocaml-platform/issues/1159
- https://github.com/ocamllabs/vscode-ocaml-platform/issues/1487

## Validation

- `make fmt`
- `make check`
- `make test`
