### PR TITLE
refactor(lsp_gen): use top-closure

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,6 +35,7 @@ possible and does not make any assumptions about IO.
   (ppx_yojson_conv_lib (>= "v0.14"))
   (cinaps :with-test)
   (ppx_expect (and (>= v0.17.0) :with-test))
+  (top-closure (or :with-test :with-dev-setup))
   (uutf (>= 1.0.2))
   (odoc :with-doc)
   (ocaml (>= 4.14))

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
               p.cinaps
               p.ppx_expect
               p.ppx_yojson_conv
+              p.top-closure
               (ocamlformat pkgs)
             ];
           });

--- a/lsp.opam
+++ b/lsp.opam
@@ -29,6 +29,7 @@ depends: [
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "cinaps" {with-test}
   "ppx_expect" {>= "v0.17.0" & with-test}
+  "top-closure" {with-test | with-dev-setup}
   "uutf" {>= "1.0.2"}
   "odoc" {with-doc}
   "ocaml" {>= "4.14"}

--- a/lsp/bin/dune
+++ b/lsp/bin/dune
@@ -13,4 +13,4 @@
  (instrumentation
   (backend bisect_ppx))
  (modules :standard \ test_metamodel)
- (libraries dyn pp yojson))
+ (libraries dyn pp top-closure yojson))

--- a/lsp/bin/typescript/ts_types.ml
+++ b/lsp/bin/typescript/ts_types.ml
@@ -297,41 +297,24 @@ module Ident = struct
   module Keys = struct
     include MoreLabels.Set.Make (T)
 
-    let add x y = add y x
-    let mem x y = mem y x
+    let add t x = add x t
+    let mem t x = mem x t
   end
 
-  let top_closure ~key ~deps elements =
-    let rec loop res visited elt ~temporarily_marked =
-      let key = key elt in
-      if Keys.mem temporarily_marked key
-      then Error [ elt ]
-      else if not (Keys.mem visited key)
-      then (
-        let visited = Keys.add visited key in
-        let temporarily_marked = Keys.add temporarily_marked key in
-        deps elt
-        |> iter_elts res visited ~temporarily_marked
-        |> function
-        | Error l -> Error (elt :: l)
-        | Ok (res, visited) ->
-          let res = elt :: res in
-          Ok (res, visited))
-      else Ok (res, visited)
-    and iter_elts res visited elts ~temporarily_marked =
-      match elts with
-      | [] -> Ok (res, visited)
-      | elt :: elts ->
-        loop res visited elt ~temporarily_marked
-        |> (function
-         | Error _ as result -> result
-         | Ok (res, visited) -> iter_elts res visited elts ~temporarily_marked)
-    in
-    iter_elts [] Keys.empty elements ~temporarily_marked:Keys.empty
-    |> function
-    | Ok (res, _visited) -> Ok (List.rev res)
-    | Error elts -> Error elts
-  ;;
+  module Identity = struct
+    type 'a t = 'a
+
+    let return x = x
+
+    module O = struct
+      let ( >>| ) x f = f x
+      let ( >>= ) x f = f x
+    end
+  end
+
+  module Closure = Top_closure.Make (Keys) (Identity)
+
+  let top_closure = Closure.top_closure
 end
 
 module Prim = struct


### PR DESCRIPTION
Replace the hand-written topological closure implementation in the LSP metamodel generator with the top-closure package, and wire the dependency into the generator/test setup.