### PR TITLE
Avoid workspace symbol warnings for missing build directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Point workspace symbols for generated sources to their files in the build
   directory. (#1742, @tatchi)
+- Stop workspace symbol searches from repeatedly warning when a workspace has
+  not been built yet.
 - Prevent whole-document formatting requests for OCamllex, Menhir, and Cram
   files from being routed through Dune's S-expression formatter.
 - Refactor ppx hover to use merlin directly (#1606, fixes #1614)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -602,8 +602,7 @@ let on_request
      | Some doc -> now (Some (Msource.text (Document.source doc))))
   | DebugEcho params -> now params
   | Shutdown -> Fiber.return (Reply.now (), state)
-  | WorkspaceSymbol req ->
-    later (fun state () -> Workspace_symbol.run server state req) ()
+  | WorkspaceSymbol req -> later (fun state () -> Workspace_symbol.run state req) ()
   | CodeActionResolve ca -> now ca
   | ExecuteCommand command ->
     if String.equal command.command Merlin_config_command.command_name

--- a/ocaml-lsp-server/src/workspace_symbol.ml
+++ b/ocaml-lsp-server/src/workspace_symbol.ml
@@ -39,11 +39,9 @@ let is_directory dir =
   | Sys_error _ -> false
 ;;
 
-type error = Build_dir_not_found of string
-
-let find_build_dir ({ name; uri } : WorkspaceFolder.t) =
-  let build_dir = Filename.concat (Uri.to_path uri) "_build/default" in
-  if is_directory build_dir then Ok build_dir else Error (Build_dir_not_found name)
+let find_build_dir root =
+  let build_dir = Filename.concat root "_build/default" in
+  Option.some_if (is_directory build_dir) build_dir
 ;;
 
 type cm_file =
@@ -342,73 +340,50 @@ let run
   in
   try
     Ok
-      (List.map workspace_folders ~f:(fun (workspace_folder : WorkspaceFolder.t) ->
-         let open Result.O in
-         let+ build_dir = find_build_dir workspace_folder in
-         let cm_files = find_cm_files build_dir in
+      (List.concat_map workspace_folders ~f:(fun (workspace_folder : WorkspaceFolder.t) ->
          let root_dir = Uri.to_path workspace_folder.uri in
-         let resolve_uri = Base.Staged.unstage (make_uri_resolver ~root_dir ~build_dir) in
-         List.concat_map ~f:(symbols_from_cm_file ~filter ~resolve_uri cancel) cm_files))
+         match find_build_dir root_dir with
+         | None -> []
+         | Some build_dir ->
+           let cm_files = find_cm_files build_dir in
+           let resolve_uri =
+             Base.Staged.unstage (make_uri_resolver ~root_dir ~build_dir)
+           in
+           List.concat_map ~f:(symbols_from_cm_file ~filter ~resolve_uri cancel) cm_files))
   with
   | Cancelled -> Error `Cancelled
 ;;
 
-let run server (state : State.t) (params : WorkspaceSymbolParams.t) =
+let run (state : State.t) (params : WorkspaceSymbolParams.t) =
   let open Fiber.O in
-  let* symbols, errors =
-    let workspaces = Workspaces.workspace_folders (State.workspaces state) in
-    let* thread = Lazy_fiber.force state.symbols_thread in
-    let+ symbols_results =
-      let* cancel = Server.cancel_token () in
-      let task =
-        Lev_fiber.Thread.task thread ~f:(fun () -> run params workspaces cancel)
+  let workspaces = Workspaces.workspace_folders (State.workspaces state) in
+  let* thread = Lazy_fiber.force state.symbols_thread in
+  let* cancel = Server.cancel_token () in
+  let task = Lev_fiber.Thread.task thread ~f:(fun () -> run params workspaces cancel) in
+  let* res, cancel =
+    match task with
+    | Error `Stopped -> Fiber.never
+    | Ok task ->
+      let maybe_cancel =
+        match cancel with
+        | None ->
+          fun f ->
+            let+ res = f () in
+            res, Fiber.Cancel.Not_cancelled
+        | Some token ->
+          let on_cancel () = Lev_fiber.Thread.cancel task in
+          fun f -> Fiber.Cancel.with_handler token ~on_cancel f
       in
-      let* res, cancel =
-        match task with
-        | Error `Stopped -> Fiber.never
-        | Ok task ->
-          let maybe_cancel =
-            match cancel with
-            | None ->
-              fun f ->
-                let+ res = f () in
-                res, Fiber.Cancel.Not_cancelled
-            | Some token ->
-              let on_cancel () = Lev_fiber.Thread.cancel task in
-              fun f -> Fiber.Cancel.with_handler token ~on_cancel f
-          in
-          maybe_cancel @@ fun () -> Lev_fiber.Thread.await task
-      in
-      match cancel with
-      | Cancelled () ->
-        let e =
-          Jsonrpc.Response.Error.make ~code:RequestCancelled ~message:"cancelled" ()
-        in
-        raise (Jsonrpc.Response.Error.E e)
-      | Fiber.Cancel.Not_cancelled ->
-        (match res with
-         | Ok (Ok s) -> Fiber.return s
-         | Ok (Error `Cancelled) -> assert false
-         | Error `Cancelled -> assert false
-         | Error (`Exn exn) -> Exn_with_backtrace.reraise exn)
-    in
-    List.partition_result symbols_results
+      maybe_cancel @@ fun () -> Lev_fiber.Thread.await task
   in
-  let+ () =
-    match errors with
-    | [] -> Fiber.return ()
-    | _ :: _ ->
-      let msg =
-        let message =
-          List.map errors ~f:(function Build_dir_not_found workspace_name ->
-              workspace_name)
-          |> String.concat ~sep:", "
-          |> sprintf "No build directory found in workspace(s): %s"
-        in
-        ShowMessageParams.create ~message ~type_:Warning
-      in
-      task_if_running state.detached ~f:(fun () ->
-        Server.notification server (ShowMessage msg))
-  in
-  Some (List.concat symbols)
+  match cancel with
+  | Cancelled () ->
+    let e = Jsonrpc.Response.Error.make ~code:RequestCancelled ~message:"cancelled" () in
+    raise (Jsonrpc.Response.Error.E e)
+  | Fiber.Cancel.Not_cancelled ->
+    (match res with
+     | Ok (Ok symbols) -> Fiber.return (Some symbols)
+     | Ok (Error `Cancelled) -> assert false
+     | Error `Cancelled -> assert false
+     | Error (`Exn exn) -> Exn_with_backtrace.reraise exn)
 ;;

--- a/ocaml-lsp-server/src/workspace_symbol.mli
+++ b/ocaml-lsp-server/src/workspace_symbol.mli
@@ -1,7 +1,3 @@
 open Import
 
-val run
-  :  _ Server.t
-  -> State.t
-  -> WorkspaceSymbolParams.t
-  -> SymbolInformation.t list option Fiber.t
+val run : State.t -> WorkspaceSymbolParams.t -> SymbolInformation.t list option Fiber.t

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -390,31 +390,58 @@ let%expect_test "handles multiple workspaces" =
     |}]
 ;;
 
-let%expect_test "shows a notification message if no build directory found" =
+let%expect_test "missing build directories return empty results without notifications" =
   let workspace_a, workspace_b = setup_workspaces () in
   clean_project workspace_a;
   clean_project workspace_b;
-  let notification = Fiber.Ivar.create () in
+  let show_messages = Queue.create () in
   let on_notification _ = function
-    | Lsp.Server_notification.ShowMessage params ->
-      let* filled = Fiber.Ivar.peek notification in
-      (match filled with
-       | Some _ -> Fiber.return ()
-       | None -> Fiber.Ivar.fill notification params)
+    | Lsp.Server_notification.ShowMessage message ->
+      Queue.push show_messages message;
+      Fiber.return ()
     | _ -> Fiber.return ()
   in
   let workspaces = [ workspace_a; workspace_b ] in
   run ~on_notification workspaces (fun client ->
-    let* (_ : SymbolInformation.t list option) = workspace_symbol client "" in
-    let* params = Fiber.Ivar.read notification in
-    ShowMessageParams.yojson_of_t params |> Test.print_result;
+    let* first = workspace_symbol client "" in
+    let* second = workspace_symbol client "changed query" in
+    Printf.printf
+      "first result: %d symbols\n"
+      (Option.value first ~default:[] |> List.length);
+    Printf.printf
+      "second result: %d symbols\n"
+      (Option.value second ~default:[] |> List.length);
     Fiber.return ());
+  Printf.printf "show messages: %d\n" (Queue.length show_messages);
   [%expect
     {|
-    {
-      "message": "No build directory found in workspace(s): workspace_symbol_A, workspace_symbol_B",
-      "type": 2
-    }
+    first result: 0 symbols
+    second result: 0 symbols
+    show messages: 0
+    |}]
+;;
+
+let%expect_test "mixed workspaces return symbols only from built workspaces" =
+  let workspace_a, workspace_b = setup_workspaces () in
+  build_project workspace_a;
+  clean_project workspace_b;
+  let show_messages = Queue.create () in
+  let on_notification _ = function
+    | Lsp.Server_notification.ShowMessage message ->
+      Queue.push show_messages message;
+      Fiber.return ()
+    | _ -> Fiber.return ()
+  in
+  let workspaces = [ workspace_b; workspace_a ] in
+  run ~on_notification workspaces (fun client ->
+    let* symbols = workspace_symbol client "a_x" in
+    print_symbols workspaces symbols;
+    Fiber.return ());
+  Printf.printf "show messages: %d\n" (Queue.length show_messages);
+  [%expect
+    {|
+    a_x 12 /workspace_symbol_A/bin/a.ml 0:0 0:11
+    show messages: 0
     |}]
 ;;
 


### PR DESCRIPTION
## Summary

- Treat a missing `<workspace>/_build/default` directory as an empty workspace-symbol source.
- Continue returning symbols from built folders in multi-root workspaces.
- Remove repeated `window/showMessage` warnings and add regression coverage in the OCaml end-to-end tests.

## Background

Editor features such as VS Code Quick Open may send a `workspace/symbol` request whenever the search query changes. The server previously converted a missing build directory into an error and emitted `No build directory found in workspace(s)` for every request, even when the workspace had simply not been built or was not a Dune project.

This addresses the behaviour reported in [ocamllabs/vscode-ocaml-platform#917](https://github.com/ocamllabs/vscode-ocaml-platform/issues/917).

The existing `<workspace>/_build/default` lookup is deliberately retained. Broader Dune root and build-directory discovery remains separate from this fix.

## Testing

- `opam exec -- dune build @fmt`
- `opam exec -- dune build @ocaml-lsp-server/runtest`
- `opam exec -- make check`
- `opam exec -- yarn --cwd ocaml-lsp-server/test/e2e test workspace-symbol.test.ts --runInBand`
