### PR TITLE
refactor(ocaml-lsp-server): reuse imported collection helpers

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_add_rec.ml
+++ b/ocaml-lsp-server/src/code_actions/action_add_rec.ml
@@ -28,7 +28,7 @@ let has_missing_rec pipeline pos_start =
       then
         (* Return the location of the first pattern in the let binding (the
            rec goes right before it) *)
-        let+ first_pat = List.hd_opt bound in
+        let+ first_pat = List.hd bound in
         let first_pat_loc = first_pat.vb_pat.pat_loc in
         { first_pat_loc with loc_end = first_pat_loc.loc_start }
       else None

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -7,11 +7,7 @@ let targets =
   [ "fun"; "match"; "let"; "module"; "module-type"; "match-next-case"; "match-prev-case" ]
 ;;
 
-let rename_target target =
-  if String.starts_with ~prefix:"match-" target
-  then String.sub target ~pos:6 ~len:(String.length target - 6)
-  else target
-;;
+let rename_target target = String.chop_prefix_if_exists target ~prefix:"match-"
 
 let available (capabilities : ShowDocumentClientCapabilities.t option) =
   match capabilities with

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -67,7 +67,7 @@ let suffix_of_position source position =
           | _ -> false
         in
         let until =
-          String.findi ~from text ~f:(fun c -> not (ident_char c))
+          String.lfindi ~pos:from text ~f:(fun _ c -> not (ident_char c))
           |> Option.value ~default:len
         in
         until - from
@@ -231,7 +231,10 @@ module Complete_with_construct = struct
           (not (String.equal expr "()"))
           && String.is_prefix expr ~prefix:"("
           && String.is_suffix expr ~suffix:")"
-        then String.sub expr ~pos:1 ~len:(String.length expr - 2)
+        then
+          expr
+          |> String.chop_prefix_if_exists ~prefix:"("
+          |> String.chop_suffix_if_exists ~suffix:")"
         else expr
       in
       let completionItem_of_constructed_expr idx expr =

--- a/ocaml-lsp-server/src/configuration.ml
+++ b/ocaml-lsp-server/src/configuration.ml
@@ -26,7 +26,7 @@ let update t { DidChangeConfigurationParams.settings } =
     match
       match settings with
       | `Assoc xs ->
-        (match List.assoc xs "diagnostics_delay" with
+        (match List.Assoc.find xs "diagnostics_delay" ~equal:String.equal with
          | Some (`Float f) -> Some f
          | Some (`Int i) -> Some (float_of_int i)
          | None -> None

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -42,7 +42,7 @@ module Request_params = struct
     |> member "withValues"
     |> to_string_option
     |> Option.bind ~f:(fun value ->
-      match String.(lowercase_ascii @@ trim value) with
+      match String.lowercase (String.trim value) with
       | "none" -> Some `None
       | "local" -> Some `Local
       | _ -> None)

--- a/ocaml-lsp-server/src/custom_requests/req_jump_to_typed_hole.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_jump_to_typed_hole.ml
@@ -38,7 +38,7 @@ module Request_params = struct
   let direction_of_yojson json =
     let open Yojson.Safe.Util in
     let dir = json |> member "direction" |> to_string in
-    match String.lowercase_ascii dir with
+    match String.lowercase dir with
     | "prev" -> `Prev
     | _ -> `Next
   ;;

--- a/ocaml-lsp-server/src/custom_requests/req_locate.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_locate.ml
@@ -41,7 +41,7 @@ module Request_params = struct
     json
     |> member "kind"
     |> to_string_option
-    |> Option.map ~f:String.lowercase_ascii
+    |> Option.map ~f:String.lowercase
     |> function
     | Some "type-definition" -> `Type_definition
     | Some "declaration" -> `Declaration

--- a/ocaml-lsp-server/src/custom_requests/req_phrase.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_phrase.ml
@@ -32,7 +32,7 @@ module Request_params = struct
     json
     |> member "target"
     |> to_string_option
-    |> Option.map ~f:String.lowercase_ascii
+    |> Option.map ~f:String.lowercase
     |> function
     | Some "next" -> `Next
     | Some "prev" -> `Prev

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -190,9 +190,7 @@ let send =
           | `All -> Base.Set.empty (module Uri)
           | `One uri -> Base.Set.remove t.dirty_uris uri);
       Table.fold pending ~init:[] ~f:(fun ~key:uri ~data:diagnostics acc ->
-        let diagnostics =
-          Range_map.to_list diagnostics |> List.map ~f:snd |> List.flatten
-        in
+        let diagnostics = Range_map.to_list diagnostics |> List.concat_map ~f:snd in
         (* we don't include a version because some of the diagnostics might
            come from dune which reads from the file system and not from the
            editor's view *)

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -94,7 +94,7 @@ module Syntax = struct
   ;;
 
   let of_text_document (td : Text_document.t) =
-    match List.assoc all (Text_document.languageId td) with
+    match List.Assoc.find all (Text_document.languageId td) ~equal:String.equal with
     | Some s -> s
     | None -> Text_document.documentUri td |> Uri.to_path |> of_fname
   ;;

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -345,7 +345,7 @@ end = struct
                         d ));
               promotions, requests :: add, remove)
       in
-      promotions, List.flatten add, List.flatten remove
+      promotions, List.concat add, List.concat remove
     in
     match res with
     | Error v -> raise (Drpc.Version_error.E v)
@@ -581,7 +581,7 @@ let uri_dune_overlap =
         | "." :: xs -> xs
         | xs -> xs)
   in
-  let normalize = if Sys.win32 then String.lowercase_ascii else fun x -> x in
+  let normalize = if Sys.win32 then String.lowercase else fun x -> x in
   fun (uri : Uri.t) (dune : Registry.Dune.t) ->
     let dune_root = Registry.Dune.root dune in
     let path =
@@ -777,7 +777,7 @@ let create
       &&
       match client_capabilities.experimental with
       | Some (`Assoc xs) ->
-        (match List.assoc xs (fst view_promotion_capability) with
+        (match List.Assoc.find xs (fst view_promotion_capability) ~equal:String.equal with
          | Some (`Bool b) -> b
          | _ -> false)
       | _ -> false

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -30,11 +30,7 @@ module Table = struct
   include Base.Hashtbl
 
   module Multi = struct
-    let find t key =
-      match find t key with
-      | None -> []
-      | Some x -> x
-    ;;
+    let find = find_multi
   end
 end
 
@@ -65,16 +61,12 @@ module List = struct
 
   let sort xs ~compare = sort xs ~compare:(fun x y -> Ordering.to_int (compare x y))
   let fold_left2 xs ys ~init ~f = Stdlib.List.fold_left2 f init xs ys
-  let assoc xs key = Assoc.find ~equal:Poly.equal xs key
-  let assoc_opt xs key = assoc xs key
   let mem t x ~equal = mem t x ~equal
   let map t ~f = map t ~f
   let concat_map t ~f = concat_map t ~f
-  let flatten t = Stdlib.List.flatten t
   let filter_map t ~f = filter_map t ~f
   let fold_left t ~init ~f = fold_left t ~init ~f
   let findi xs ~f = findi xs ~f
-  let find_opt xs ~f = find xs ~f
 
   let sort_uniq xs ~compare =
     Stdlib.List.sort_uniq (fun x y -> Ordering.to_int (compare x y)) xs
@@ -84,7 +76,6 @@ module List = struct
   let find_mapi xs ~f = find_mapi xs ~f
   let sub xs ~pos ~len = sub xs ~pos ~len
   let hd_exn t = hd_exn t
-  let hd_opt t = hd t
   let nth_exn t n = nth_exn t n
   let hd t = hd t
   let filter t ~f = filter t ~f
@@ -146,8 +137,6 @@ end
 
 module String = struct
   type t = string
-
-  let starts_with = Stdlib.String.starts_with
 
   module Map = struct
     include MoreLabels.Map.Make (Stdlib.String)
@@ -213,7 +202,7 @@ module String = struct
     let drop_prefix = chop_prefix
     let is_prefix = is_prefix
     let map = map
-    let lowercase_ascii = lowercase
+    let lowercase = lowercase
     let capitalize_ascii = capitalize
     let capitalize = capitalize
     let split_on_char t ~sep = split t ~on:sep
@@ -230,42 +219,6 @@ module String = struct
     let filter = filter
     let is_suffix = is_suffix
   end
-
-  let findi =
-    let rec loop s len ~f i =
-      if i >= len
-      then None
-      else if f (String.unsafe_get s i)
-      then Some i
-      else loop s len ~f (i + 1)
-    in
-    fun ?from s ~f ->
-      let len = String.length s in
-      let from =
-        match from with
-        | None -> 0
-        | Some i -> if i > len - 1 then Code_error.raise "findi: invalid from" [] else i
-      in
-      loop s len ~f from
-  ;;
-
-  let rfindi =
-    let rec loop s ~f i =
-      if i < 0
-      then None
-      else if f (String.unsafe_get s i)
-      then Some i
-      else loop s ~f (i - 1)
-    in
-    fun ?from s ~f ->
-      let from =
-        let len = String.length s in
-        match from with
-        | None -> len - 1
-        | Some i -> if i > len - 1 then Code_error.raise "rfindi: invalid from" [] else i
-      in
-      loop s ~f from
-  ;;
 end
 
 (* All modules from [Lsp] should be in the struct below. The modules are listed

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -558,7 +558,7 @@ let on_request
   match req with
   | Client_request.UnknownRequest { meth; params } ->
     (match
-       List.assoc
+       List.Assoc.find
          [ ( Req_switch_impl_intf.meth
            , fun ~params state ->
                Fiber.of_thunk (fun () ->
@@ -585,6 +585,7 @@ let on_request
          ; Req_refactor_extract.meth, Req_refactor_extract.on_request
          ]
          meth
+         ~equal:String.equal
      with
      | None ->
        Jsonrpc.Response.Error.raise

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -231,7 +231,7 @@ let format_snippet ~start ~stop ~padding formatter binary cancel contents =
   let prefix, to_format, suffix =
     ( String.sub contents ~pos:0 ~len:start
     , String.sub contents ~pos:start ~len:(stop - start)
-    , String.sub contents ~pos:stop ~len:(String.length contents - stop) )
+    , String.drop contents stop )
   in
   let args = args formatter in
   let args =

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -5,27 +5,12 @@ module Import = struct
     module List = struct
       include List
 
-      let find_mapi ~f l =
-        let rec k i = function
-          | [] -> None
-          | x :: xs ->
-            (match f i x with
-             | Some x' -> Some x'
-             | None -> (k [@tailcall]) (i + 1) xs)
-        in
-        k 0 l
-      ;;
-
       let take n l =
-        let rec take acc n l =
-          if n = 0
-          then acc
-          else (
-            match l with
-            | [] -> failwith "list shorter than n"
-            | x :: xs -> (take [@tailcall]) (x :: acc) (n - 1) xs)
-        in
-        List.rev (take [] n l)
+        if n < 0 || n > List.length l
+        then failwith "list shorter than n"
+        else
+          let open Base in
+          List.take l n
       ;;
     end
 


### PR DESCRIPTION
Remove local implementations and compatibility aliases where the imported
collection modules already provide the required operation. Expose lowercase
through Import.String so call sites continue to use the project-local String
module rather than qualifying Base directly.

This replaces manual list flattening, association lookup, prefix/suffix
slicing, lowercasing, and hashtable multi-value lookup while preserving the
existing test helper bounds checks.