### PR TITLE
refactor(code-actions): share edit construction

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_add_rec.ml
+++ b/ocaml-lsp-server/src/code_actions/action_add_rec.ml
@@ -35,14 +35,9 @@ let has_missing_rec pipeline pos_start =
     | _ -> None)
 ;;
 
-let code_action_add_rec uri diagnostics doc loc =
-  let edit =
-    let textedit : TextEdit.t = { range = Range.of_loc loc; newText = "rec " } in
-    let version = Document.version doc in
-    let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-    let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ] in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-  in
+let code_action_add_rec diagnostics doc loc =
+  let textedit : TextEdit.t = { range = Range.of_loc loc; newText = "rec " } in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   CodeAction.create
     ~diagnostics
     ~title:action_title
@@ -70,7 +65,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
       in_range () && is_unbound ())
   in
   has_missing_rec pipeline pos_start
-  |> Option.map ~f:(code_action_add_rec params.textDocument.uri [ diagnostic ] doc)
+  |> Option.map ~f:(code_action_add_rec [ diagnostic ] doc)
 ;;
 
 let t = Code_action.batchable QuickFix code_action

--- a/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
+++ b/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
@@ -41,12 +41,9 @@ let pick_rhs rhs_expressions =
   | _ -> "_"
 ;;
 
-let make_text_edit ~range ~newText ~doc ~uri =
+let make_text_edit ~range ~newText ~doc =
   let text_edit = TextEdit.create ~range ~newText in
-  let version = Document.version doc in
-  let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-  let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit text_edit ] in
-  WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+  Code_action.workspace_edit doc [ text_edit ]
 ;;
 
 let code_action doc params =
@@ -67,7 +64,7 @@ let code_action doc params =
          let lhs = String.concat ~sep:" | " lhs_patterns in
          let rhs = pick_rhs rhs_expressions in
          let newText = indent ^ "| " ^ lhs ^ " -> " ^ rhs ^ "\n" in
-         let edit = make_text_edit ~range ~newText ~doc ~uri:params.textDocument.uri in
+         let edit = make_text_edit ~range ~newText ~doc in
          CodeAction.create
            ~title:(String.capitalize action_kind)
            ~kind

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -4,15 +4,10 @@ open Fiber.O
 let action_kind = "destruct (enumerate cases)"
 let kind = CodeActionKind.Other action_kind
 
-let code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText) =
+let code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText) =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
-  let edit : WorkspaceEdit.t =
-    let version = Document.version doc in
-    let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-    let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ] in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-  in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   let command =
     if supportsJumpToNextHole
@@ -34,7 +29,6 @@ let code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText) 
 ;;
 
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
-  let uri = params.textDocument.uri in
   match Document.kind doc with
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
@@ -52,8 +46,7 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
          |> Client.Experimental_capabilities.supportsJumpToNextHole
        in
        let opt =
-         Some
-           (code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText))
+         Some (code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText))
        in
        Fiber.return opt
      | Error

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -243,15 +243,10 @@ let format_merlin_reply ~(statement : destructable_statement) (new_code : string
        String.concat ~sep:" -> _\n" (String.strip first_line :: other_lines))
 ;;
 
-let code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText) =
+let code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText) =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
-  let edit : WorkspaceEdit.t =
-    let version = Document.version doc in
-    let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-    let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ] in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-  in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   let title = String.capitalize action_kind in
   let command =
     if supportsJumpToNextHole
@@ -282,7 +277,6 @@ let dispatch_destruct (merlin : Document.Merlin.t) (range : Range.t) =
 ;;
 
 let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.t) =
-  let uri = params.textDocument.uri in
   match Document.kind doc with
   | `Other -> Fiber.return None
   | `Merlin merlin ->
@@ -298,8 +292,7 @@ let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.
             State.experimental_client_capabilities state
             |> Client.Experimental_capabilities.supportsJumpToNextHole
           in
-          Some
-            (code_action_of_case_analysis ~supportsJumpToNextHole doc uri (loc, newText))
+          Some (code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText))
         | Error
             { exn =
                 ( Merlin_analysis.Destruct.Wrong_parent _

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -4,18 +4,8 @@ open Fiber.O
 let action_kind = "inferred_intf"
 
 let code_action_of_intf doc intf range =
-  let edit : WorkspaceEdit.t =
-    let edit =
-      let textedit : TextEdit.t = { range; newText = intf } in
-      let textDocument =
-        let uri = Document.uri doc in
-        let version = Document.version doc in
-        OptionalVersionedTextDocumentIdentifier.create ~uri ~version ()
-      in
-      TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ]
-    in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-  in
+  let textedit : TextEdit.t = { range; newText = intf } in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   let title = String.capitalize_ascii "Insert inferred interface" in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -370,21 +370,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
     in
     Some action
   | _ :: _, (Some _ | None) ->
-    let edit =
-      let version = Document.version doc in
-      let textDocument =
-        OptionalVersionedTextDocumentIdentifier.create
-          ~uri:params.textDocument.uri
-          ~version
-          ()
-      in
-      let edit =
-        TextDocumentEdit.create
-          ~textDocument
-          ~edits:(List.map edits ~f:(fun e -> `TextEdit e))
-      in
-      WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-    in
+    let edit = Code_action.workspace_edit doc edits in
     let action =
       CodeAction.create
         ~title:action_title

--- a/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
+++ b/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
@@ -34,28 +34,13 @@ let check_typeable_context pipeline pos_start =
   | _ :: _ | [] -> `Invalid
 ;;
 
-let get_source_text doc (loc : Loc.t) =
+let code_action_of_type_enclosing doc (loc, constr_loc) =
   let open Option.O in
-  let source = Document.source doc in
-  let* start = Position.of_lexical_position loc.loc_start in
-  let+ end_ = Position.of_lexical_position loc.loc_end in
-  let (`Offset start) = Msource.get_offset source (Position.logical start) in
-  let (`Offset end_) = Msource.get_offset source (Position.logical end_) in
-  String.sub (Msource.text source) ~pos:start ~len:(end_ - start)
-;;
-
-let code_action_of_type_enclosing uri doc (loc, constr_loc) =
-  let open Option.O in
-  let+ src_text = get_source_text doc loc in
-  let edit : WorkspaceEdit.t =
-    let textedit : TextEdit.t =
-      { range = Range.of_loc (Loc.union loc constr_loc); newText = src_text }
-    in
-    let version = Document.version doc in
-    let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-    let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ] in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+  let+ src_text = Code_action.source_text doc loc in
+  let textedit : TextEdit.t =
+    { range = Range.of_loc (Loc.union loc constr_loc); newText = src_text }
   in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   CodeAction.create
     ~title
@@ -70,8 +55,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
   let context = check_typeable_context pipeline pos_start in
   match context with
   | `Invalid -> None
-  | `Valid (loc1, loc2) ->
-    code_action_of_type_enclosing params.textDocument.uri doc (loc1, loc2)
+  | `Valid (loc1, loc2) -> code_action_of_type_enclosing doc (loc1, loc2)
 ;;
 
 let kind = CodeActionKind.Other action_kind

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -28,27 +28,12 @@ let check_typeable_context pipeline pos_start =
   | _ :: _ | [] -> `Invalid
 ;;
 
-let get_source_text doc (loc : Loc.t) =
+let code_action_of_type_enclosing doc (loc, typ) =
   let open Option.O in
-  let source = Document.source doc in
-  let* start = Position.of_lexical_position loc.loc_start in
-  let+ end_ = Position.of_lexical_position loc.loc_end in
-  let (`Offset start) = Msource.get_offset source (Position.logical start) in
-  let (`Offset end_) = Msource.get_offset source (Position.logical end_) in
-  String.sub (Msource.text source) ~pos:start ~len:(end_ - start)
-;;
-
-let code_action_of_type_enclosing uri doc (loc, typ) =
-  let open Option.O in
-  let+ original_text = get_source_text doc loc in
+  let+ original_text = Code_action.source_text doc loc in
   let newText = Printf.sprintf "(%s : %s)" original_text typ in
-  let edit : WorkspaceEdit.t =
-    let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
-    let version = Document.version doc in
-    let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-    let edit = TextDocumentEdit.create ~textDocument ~edits:[ `TextEdit textedit ] in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-  in
+  let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
+  let edit = Code_action.workspace_edit doc [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   CodeAction.create
     ~title
@@ -74,7 +59,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
   match res with
   | None | Some [] | Some ((_, `Index _, _) :: _) -> None
   | Some ((location, `String value, _) :: _) ->
-    code_action_of_type_enclosing params.textDocument.uri doc (location, value)
+    code_action_of_type_enclosing doc (location, value)
 ;;
 
 let kind = CodeActionKind.Other action_kind

--- a/ocaml-lsp-server/src/code_actions/action_update_signature.ml
+++ b/ocaml-lsp-server/src/code_actions/action_update_signature.ml
@@ -4,18 +4,7 @@ open Fiber.O
 let action_kind = "update_intf"
 
 let code_action_of_intf doc text_edits =
-  let edit : WorkspaceEdit.t =
-    let doc_edit =
-      let edits = List.map text_edits ~f:(fun e -> `TextEdit e) in
-      let textDocument =
-        let uri = Document.uri doc in
-        let version = Document.version doc in
-        OptionalVersionedTextDocumentIdentifier.create ~uri ~version ()
-      in
-      TextDocumentEdit.create ~textDocument ~edits
-    in
-    WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit doc_edit ] ()
-  in
+  let edit = Code_action.workspace_edit doc text_edits in
   let title = String.capitalize_ascii "update signature(s) to match implementation" in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/code_action.ml
+++ b/ocaml-lsp-server/src/code_actions/code_action.ml
@@ -16,3 +16,22 @@ type t =
 
 let batchable kind run = { kind; run = `Batchable run }
 let non_batchable kind run = { kind; run = `Non_batchable run }
+
+let source_text doc (loc : Loc.t) =
+  let open Option.O in
+  let source = Document.source doc in
+  let* start = Position.of_lexical_position loc.loc_start in
+  let+ end_ = Position.of_lexical_position loc.loc_end in
+  let (`Offset start) = Msource.get_offset source (Position.logical start) in
+  let (`Offset end_) = Msource.get_offset source (Position.logical end_) in
+  String.sub (Msource.text source) ~pos:start ~len:(end_ - start)
+;;
+
+let workspace_edit doc text_edits =
+  let uri = Document.uri doc in
+  let version = Document.version doc in
+  let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
+  let edits = List.map text_edits ~f:(fun edit -> `TextEdit edit) in
+  let edit = TextDocumentEdit.create ~textDocument ~edits in
+  WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+;;

--- a/ocaml-lsp-server/src/code_actions/code_action.mli
+++ b/ocaml-lsp-server/src/code_actions/code_action.mli
@@ -22,3 +22,6 @@ val non_batchable
   :  CodeActionKind.t
   -> (Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t)
   -> t
+
+val source_text : Document.t -> Loc.t -> string option
+val workspace_edit : Document.t -> TextEdit.t list -> WorkspaceEdit.t


### PR DESCRIPTION
Centralize source extraction and versioned workspace-edit construction in
Code_action. The action implementations now describe only their text edits,
while the shared helpers consistently derive the document URI and version and
construct the corresponding TextDocumentEdit and WorkspaceEdit.

This removes identical source-offset conversion from the type annotation
actions and repeated edit plumbing from nine code actions.