### PR TITLE
refactor(custom-requests): reuse common request helpers

### DIFF
--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -77,18 +77,6 @@ let yojson_of_t { position; result } =
     ]
 ;;
 
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin ->
-    (match Document.Merlin.kind merlin with
-     | Document.Kind.Intf ->
-       (* Construct makes no sense if its called from an interface. *)
-       Fiber.return `Null
-     | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
-;;
-
 let make_construct_command position with_values depth =
   Query_protocol.Construct (position, with_values, depth)
 ;;
@@ -107,5 +95,6 @@ let on_request ~params state =
       Request_params.t_of_yojson params
     in
     let uri = text_document.uri in
-    with_pipeline state uri @@ dispatch_construct position with_values depth)
+    Util.with_impl_pipeline state uri ~default:`Null
+    @@ dispatch_construct position with_values depth)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_destruct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_destruct.ml
@@ -41,18 +41,6 @@ let yojson_of_t { range; content } =
   `Assoc [ "range", Range.yojson_of_t range; "content", `String content ]
 ;;
 
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin ->
-    (match Document.Merlin.kind merlin with
-     | Document.Kind.Intf ->
-       (* Destruct makes no sense if it's called from an interface. *)
-       Fiber.return `Null
-     | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
-;;
-
 let make_destruct_command start stop = Query_protocol.Case_analysis (start, stop)
 
 let dispatch_destruct range pipeline =
@@ -68,5 +56,5 @@ let on_request ~params state =
     let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
     let Request_params.{ text_document; range } = Request_params.t_of_yojson params in
     let uri = text_document.uri in
-    with_pipeline state uri @@ dispatch_destruct range)
+    Util.with_impl_pipeline state uri ~default:`Null @@ dispatch_destruct range)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_get_documentation.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_get_documentation.ml
@@ -65,17 +65,7 @@ module GetDoc = struct
     { doc }
   ;;
 
-  let create ~kind ~value =
-    let v =
-      match kind with
-      | MarkupKind.Markdown ->
-        (match Doc_to_md.translate value with
-         | Raw d -> d
-         | Markdown d -> d)
-      | MarkupKind.PlainText -> value
-    in
-    MarkupContent.create ~kind ~value:v
-  ;;
+  let create = Util.markup_content
 end
 
 type t = GetDoc.t
@@ -115,8 +105,6 @@ let on_request ~params state =
       GetDocParams.t_of_yojson params
     in
     let uri = text_document.uri in
-    let doc = Document_store.get state.State.store uri in
-    match Document.kind doc with
-    | `Other -> Fiber.return `Null
-    | `Merlin merlin -> dispatch ~merlin ~position ~identifier ~contentFormat)
+    Util.with_merlin state uri ~default:`Null (fun merlin ->
+      dispatch ~merlin ~position ~identifier ~contentFormat))
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
@@ -186,13 +186,6 @@ let rec map_tree_result result =
   { data; children }
 ;;
 
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin -> Document.Merlin.with_pipeline_exn merlin f
-;;
-
 let make_locate_types_command position = Query_protocol.Locate_types position
 
 let dispatch_locate_types position pipeline =
@@ -212,5 +205,5 @@ let on_request ~params state =
     let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
     let Request_params.{ text_document; position } = Request_params.t_of_yojson params in
     let uri = text_document.uri in
-    with_pipeline state uri @@ dispatch_locate_types position)
+    Util.with_pipeline state uri ~default:`Null @@ dispatch_locate_types position)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_call_compatible.ml
@@ -102,10 +102,7 @@ let t_of_yojson json =
 ;;
 
 let with_pipeline state uri specs raw_args cmd_args f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin ->
+  Util.with_merlin state uri ~default:`Null (fun merlin ->
     let open Fiber.O in
     let* config = Document.Merlin.mconfig merlin in
     let specs = List.map ~f:snd specs in
@@ -118,12 +115,7 @@ let with_pipeline state uri specs raw_args cmd_args f =
         config
         cmd_args
     in
-    Document.Merlin.with_configurable_pipeline_exn ~config merlin (f args)
-;;
-
-let raise_invalid_params ?data ~message () =
-  let open Jsonrpc.Response.Error in
-  raise @@ make ?data ~code:Code.InvalidParams ~message ()
+    Document.Merlin.with_configurable_pipeline_exn ~config merlin (f args))
 ;;
 
 let perform_query action params pipeline =
@@ -159,5 +151,5 @@ let on_request ~params state =
       yojson_of_t result
     | exception Not_found ->
       let data = `Assoc [ "command", `String command ] in
-      raise_invalid_params ~data ~message:"Unexpected command name" ())
+      Util.raise_invalid_params ~data ~message:"Unexpected command name" ())
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
@@ -81,10 +81,7 @@ let on_request ~params state =
     let params = JumpParams.t_of_yojson params in
     let uri = params.textDocument.uri in
     let position = params.position in
-    let doc = Document_store.get state.State.store uri in
-    match Document.kind doc with
-    | `Other -> Fiber.return `Null
-    | `Merlin merlin ->
+    Util.with_merlin state uri ~default:`Null (fun merlin ->
       let targets =
         match params.target with
         | None -> JumpParams.targets
@@ -100,5 +97,5 @@ let on_request ~params state =
                | None -> None
                | Some position -> Some (target, position))))
       in
-      Jump.yojson_of_t (List.filter_map results ~f:Fun.id))
+      Jump.yojson_of_t (List.filter_map results ~f:Fun.id)))
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_phrase.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_phrase.ml
@@ -51,14 +51,6 @@ end
 type t = Position.t
 
 let t_of_yojson x = Position.t_of_yojson x
-
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin -> Document.Merlin.with_pipeline_exn merlin f
-;;
-
 let make_phrase_command position target = Query_protocol.Phrase (target, position)
 
 let dispatch_phrase position target pipeline =
@@ -76,5 +68,5 @@ let on_request ~params state =
       (Option.value ~default:(`Assoc []) params :> Yojson.Safe.t)
       |> Request_params.t_of_yojson
     in
-    with_pipeline state uri @@ dispatch_phrase position target)
+    Util.with_pipeline state uri ~default:`Null @@ dispatch_phrase position target)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
@@ -48,18 +48,6 @@ let yojson_of_t { position; content; selection_range } =
     ]
 ;;
 
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin ->
-    (match Document.Merlin.kind merlin with
-     | Document.Kind.Intf ->
-       (* Extraction makes no sense if its called from an interface. *)
-       Fiber.return `Null
-     | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
-;;
-
 let dispatch ~range ~extract_name pipeline =
   let start = Position.logical range.Range.start in
   let end_ = Position.logical range.Range.end_ in
@@ -81,5 +69,5 @@ let on_request ~params state =
       Request_params.t_of_yojson params
     in
     let uri = text_document.uri in
-    with_pipeline state uri @@ dispatch ~range ~extract_name)
+    Util.with_impl_pipeline state uri ~default:`Null @@ dispatch ~range ~extract_name)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -79,16 +79,13 @@ let config_with_given_verbosity config verbosity =
 ;;
 
 let with_pipeline state uri verbosity with_pipeline =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return `Null
-  | `Merlin merlin ->
+  Util.with_merlin state uri ~default:`Null (fun merlin ->
     let open Fiber.O in
     let* config = Document.Merlin.mconfig merlin in
     Document.Merlin.with_configurable_pipeline_exn
       ~config:(config_with_given_verbosity config verbosity)
       merlin
-      with_pipeline
+      with_pipeline)
 ;;
 
 let make_enclosing_command position index =

--- a/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
@@ -36,13 +36,6 @@ type t = string
 
 let t_of_yojson = Yojson.Safe.Util.to_string
 
-let with_pipeline state uri f =
-  let doc = Document_store.get state.State.store uri in
-  match Document.kind doc with
-  | `Other -> Fiber.return None
-  | `Merlin merlin -> Document.Merlin.with_pipeline_exn merlin f
-;;
-
 let make_type_expr_command position expression =
   Query_protocol.Type_expr (expression, position)
 ;;
@@ -61,7 +54,9 @@ let on_request ~params state =
       (Option.value ~default:(`Assoc []) params :> Yojson.Safe.t)
       |> Request_params.t_of_yojson
     in
-    let* typ = with_pipeline state uri (dispatch_type_expr position expression) in
+    let* typ =
+      Util.with_pipeline state uri ~default:None (dispatch_type_expr position expression)
+    in
     match typ with
     | Some typ ->
       let* result = Ocamlformat_rpc.format_type ~typ state.ocamlformat_rpc in

--- a/ocaml-lsp-server/src/custom_requests/req_type_search.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_search.ml
@@ -49,18 +49,6 @@ end
 module TypeSearch = struct
   type t = string Query_protocol.type_search_result list
 
-  let doc_to_markupContent ~kind ~value =
-    let v =
-      match kind with
-      | MarkupKind.Markdown ->
-        (match Doc_to_md.translate value with
-         | Raw d -> d
-         | Markdown d -> d)
-      | MarkupKind.PlainText -> value
-    in
-    MarkupContent.create ~kind ~value:v
-  ;;
-
   let yojson_of_t (t : t) doc_format =
     let format =
       match doc_format with
@@ -75,7 +63,7 @@ module TypeSearch = struct
         ; ( "doc"
           , match res.doc with
             | Some value ->
-              doc_to_markupContent ~kind:format ~value |> MarkupContent.yojson_of_t
+              Util.markup_content ~kind:format ~value |> MarkupContent.yojson_of_t
             | None -> `Null )
         ; "cost", `Int res.cost
         ; "constructible", `String res.constructible
@@ -112,8 +100,6 @@ let on_request ~params state =
       TypeSearchParams.t_of_yojson params
     in
     let uri = text_document.uri in
-    let doc = Document_store.get state.State.store uri in
-    match Document.kind doc with
-    | `Other -> Fiber.return `Null
-    | `Merlin merlin -> dispatch merlin position limit query with_doc doc_format)
+    Util.with_merlin state uri ~default:`Null (fun merlin ->
+      dispatch merlin position limit query with_doc doc_format))
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_typed_holes.ml
@@ -20,25 +20,10 @@ module Request_params = struct
   ;;
 
   let parse_exn (params : Jsonrpc.Structured.t option) : t =
-    let raise_invalid_params ?data ~message () =
-      Jsonrpc.Response.Error.raise
-      @@ Jsonrpc.Response.Error.make
-           ?data
-           ~code:Jsonrpc.Response.Error.Code.InvalidParams
-           ~message
-           ()
+    let spec =
+      Util.{ params_schema = expected_params; of_jsonrpc_params = t_of_structured_json }
     in
-    match params with
-    | None -> raise_invalid_params ~message:"Expected params but received none" ()
-    | Some params ->
-      (match t_of_structured_json params with
-       | Some uri -> uri
-       | None ->
-         let error_json =
-           `Assoc
-             [ "params_expected", expected_params; "params_received", (params :> Json.t) ]
-         in
-         raise_invalid_params ~message:"Unxpected parameter format" ~data:error_json ())
+    Util.of_jsonrpc_params_exn spec params
   ;;
 
   let yojson_of_t = Uri.yojson_of_t

--- a/ocaml-lsp-server/src/custom_requests/util.ml
+++ b/ocaml-lsp-server/src/custom_requests/util.ml
@@ -5,15 +5,46 @@ type 't req_params_spec =
   ; of_jsonrpc_params : Jsonrpc.Structured.t -> 't option
   }
 
-let of_jsonrpc_params_exn spec params =
-  let raise_invalid_params ?data ~message () =
-    Jsonrpc.Response.Error.raise
-    @@ Jsonrpc.Response.Error.make
-         ?data
-         ~code:Jsonrpc.Response.Error.Code.InvalidParams
-         ~message
-         ()
+let with_merlin state uri ~default f =
+  let doc = Document_store.get state.State.store uri in
+  match Document.kind doc with
+  | `Other -> Fiber.return default
+  | `Merlin merlin -> f merlin
+;;
+
+let with_pipeline state uri ~default f =
+  with_merlin state uri ~default (fun merlin ->
+    Document.Merlin.with_pipeline_exn merlin f)
+;;
+
+let with_impl_pipeline state uri ~default f =
+  with_merlin state uri ~default (fun merlin ->
+    match Document.Merlin.kind merlin with
+    | Document.Kind.Intf -> Fiber.return default
+    | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
+;;
+
+let raise_invalid_params ?data ~message () =
+  Jsonrpc.Response.Error.raise
+  @@ Jsonrpc.Response.Error.make
+       ?data
+       ~code:Jsonrpc.Response.Error.Code.InvalidParams
+       ~message
+       ()
+;;
+
+let markup_content ~kind ~value =
+  let value =
+    match kind with
+    | MarkupKind.Markdown ->
+      (match Doc_to_md.translate value with
+       | Raw value | Markdown value -> value)
+    | MarkupKind.PlainText -> value
   in
+  MarkupContent.create ~kind ~value
+;;
+
+let of_jsonrpc_params_exn spec params =
   match params with
   | None -> raise_invalid_params ~message:"Expected params but received none" ()
   | Some params ->

--- a/ocaml-lsp-server/src/custom_requests/util.mli
+++ b/ocaml-lsp-server/src/custom_requests/util.mli
@@ -1,3 +1,24 @@
+open Import
+
+val with_merlin
+  :  State.t
+  -> Uri.t
+  -> default:'a
+  -> (Document.Merlin.t -> 'a Fiber.t)
+  -> 'a Fiber.t
+
+val with_pipeline : State.t -> Uri.t -> default:'a -> (Mpipeline.t -> 'a) -> 'a Fiber.t
+
+val with_impl_pipeline
+  :  State.t
+  -> Uri.t
+  -> default:'a
+  -> (Mpipeline.t -> 'a)
+  -> 'a Fiber.t
+
+val raise_invalid_params : ?data:Json.t -> message:string -> unit -> 'a
+val markup_content : kind:MarkupKind.t -> value:string -> MarkupContent.t
+
 type 't req_params_spec =
   { params_schema : Jsonrpc.Structured.t
     (** used to document the structure of the params; example:


### PR DESCRIPTION
Move repeated custom-request plumbing into Util. Shared helpers now select
Merlin documents and implementation pipelines, construct InvalidParams errors,
and convert documentation to the requested markup kind.

Use those helpers across the construct, destruct, documentation, locate, jump,
phrase, extraction, type-enclosing, type-expression, and type-search requests.
The typed-holes request also reuses the common parameter parser instead of
maintaining a second copy.