### PR TITLE
refactor(ocaml-lsp-server): share show-document helper

### DIFF
--- a/ocaml-lsp-server/src/client.ml
+++ b/ocaml-lsp-server/src/client.ml
@@ -1,4 +1,19 @@
 open Import
+open Fiber.O
+
+let show_document_contents server ~prefix ~suffix contents =
+  let path, chan =
+    Filename.open_temp_file (sprintf "%s.%d" prefix (Unix.getpid ())) suffix
+  in
+  output_string chan contents;
+  close_out_noerr chan;
+  let uri = Uri.of_path path in
+  let request =
+    Server_request.ShowDocumentRequest (ShowDocumentParams.create ~uri ~takeFocus:true ())
+  in
+  let+ { ShowDocumentResult.success = _ } = Server.request server request in
+  ()
+;;
 
 module Experimental_capabilities = struct
   type t = bool

--- a/ocaml-lsp-server/src/client.mli
+++ b/ocaml-lsp-server/src/client.mli
@@ -3,6 +3,13 @@ open Import
 (** This module is a collection of client-specific functionality (client =
     editor) *)
 
+val show_document_contents
+  :  _ Server.t
+  -> prefix:string
+  -> suffix:string
+  -> string
+  -> unit Fiber.t
+
 module Experimental_capabilities : sig
   (** Module to store experimental client capabilities *)
 

--- a/ocaml-lsp-server/src/document_text_command.ml
+++ b/ocaml-lsp-server/src/document_text_command.ml
@@ -1,5 +1,4 @@
 open Import
-open Fiber.O
 
 let command_name = "ocamllsp/show-document-text"
 
@@ -10,17 +9,9 @@ let command_run server store args =
     | _ -> assert false
   in
   let doc = Document_store.get store (Uri.t_of_yojson (`String uri)) |> Document.text in
-  let uri, chan =
-    Filename.open_temp_file
-      (sprintf "ocamllsp-document.%d" (Unix.getpid ()))
-      (Filename.extension uri)
-  in
-  output_string chan doc;
-  close_out_noerr chan;
-  let req =
-    let uri = Uri.of_path uri in
-    Server_request.ShowDocumentRequest (ShowDocumentParams.create ~uri ~takeFocus:true ())
-  in
-  let+ { ShowDocumentResult.success = _ } = Server.request server req in
-  ()
+  Client.show_document_contents
+    server
+    ~prefix:"ocamllsp-document"
+    ~suffix:(Filename.extension uri)
+    doc
 ;;

--- a/ocaml-lsp-server/src/merlin_config_command.ml
+++ b/ocaml-lsp-server/src/merlin_config_command.ml
@@ -19,15 +19,5 @@ let command_run server store =
     let json = `Assoc docs in
     Format.asprintf "%a@.%!" Json.pp json
   in
-  let uri, chan =
-    Filename.open_temp_file (sprintf "merlin-config.%d" (Unix.getpid ())) ".json"
-  in
-  output_string chan json;
-  close_out_noerr chan;
-  let req =
-    let uri = Uri.of_path uri in
-    Server_request.ShowDocumentRequest (ShowDocumentParams.create ~uri ~takeFocus:true ())
-  in
-  let+ { ShowDocumentResult.success = _ } = Server.request server req in
-  ()
+  Client.show_document_contents server ~prefix:"merlin-config" ~suffix:".json" json
 ;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -18,16 +18,9 @@ let view_metrics_command_name = "ocamllsp/view-metrics"
 
 let view_metrics server =
   let* json = Metrics.dump () in
-  let uri, chan =
-    Filename.open_temp_file (sprintf "lsp-metrics.%d" (Unix.getpid ())) ".json"
+  let+ () =
+    Client.show_document_contents server ~prefix:"lsp-metrics" ~suffix:".json" json
   in
-  output_string chan json;
-  close_out_noerr chan;
-  let req =
-    let uri = Uri.of_path uri in
-    Server_request.ShowDocumentRequest (ShowDocumentParams.create ~uri ~takeFocus:true ())
-  in
-  let+ { ShowDocumentResult.success = _ } = Server.request server req in
   `Null
 ;;
 


### PR DESCRIPTION
Add a client helper that writes contents to a temporary file and asks the
editor to display it. Reuse it for metrics, Merlin configuration, and document
text commands so temporary-file naming, URI conversion, and showDocument
request construction live in one place.