### PR TITLE
test(workspace-symbol): reproduce generated source location

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -417,3 +417,58 @@ let%expect_test "shows a notification message if no build directory found" =
     }
     |}]
 ;;
+
+let setup_generated_workspace () =
+  let path = Test.temp_dir "ocamllsp-generated-workspace-symbol-" in
+  let lib = Stdlib.Filename.concat path "lib" in
+  mkdir lib;
+  Test.write_file (Stdlib.Filename.concat path "dune-project") "(lang dune 2.5)\n";
+  Test.write_file
+    (Stdlib.Filename.concat lib "dune")
+    {dune|
+(library
+ (name generated_source))
+
+(rule
+ (target gen.ml)
+ (action
+  (with-stdout-to
+   %{target}
+   (echo "let generated_workspace_symbol = 42"))))
+|dune};
+  Test.run_command ~cwd:path "dune build";
+  let name = "generated-source" in
+  let uri = DocumentUri.of_path path in
+  { name; path; folder = WorkspaceFolder.create ~name ~uri }
+;;
+
+let relative_path ~root path =
+  let prefix = root ^ Stdlib.Filename.dir_sep in
+  if Stdlib.String.starts_with ~prefix path
+  then String.drop path (String.length prefix)
+  else path
+;;
+
+let%expect_test "generated source has an existing workspace-symbol location" =
+  let workspace = setup_generated_workspace () in
+  run [ workspace ] (fun client ->
+    let* symbols = workspace_symbol client "generated_workspace_symbol" in
+    let symbols = Option.value symbols ~default:[] in
+    (match
+       List.find_map symbols ~f:(fun (symbol : SymbolInformation.t) ->
+         if String.equal symbol.name "generated_workspace_symbol"
+         then Some symbol
+         else None)
+     with
+     | None -> print_endline "generated_workspace_symbol: not found"
+     | Some symbol ->
+       let path = DocumentUri.to_path symbol.location.uri in
+       Printf.printf "path: %s\n" (relative_path ~root:workspace.path path);
+       Printf.printf "exists: %b\n" (Stdlib.Sys.file_exists path));
+    Fiber.return ());
+  [%expect
+    {|
+    path: lib/gen.ml
+    exists: false
+    |}]
+;;


### PR DESCRIPTION
## Summary

- Port the Dune-generated source reproduction from #1097 to the OCaml end-to-end test suite.
- Record that the generated workspace symbol currently points to a nonexistent source-tree path.
