### PR TITLE
test(lsp): reproduce URI query path handling

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -55,6 +55,20 @@ let%expect_test "test uri parsing" =
     query: ab=1# |}]
 ;;
 
+let%expect_test "a URI query is not part of its filesystem path" =
+  Lsp.Uri.Private.win32 := false;
+  let uri = Uri.of_string "file:///foo.ml?revision=1" in
+  Printf.printf
+    "path: %s\nquery: %s\n"
+    (Uri.to_path uri)
+    (Option.value ~default:"<none>" (Uri.query uri));
+  [%expect
+    {|
+    path: /foo.ml?revision=1
+    query: revision=1
+    |}]
+;;
+
 let uri_of_path =
   let test path =
     let uri = Uri.of_path path in


### PR DESCRIPTION
## Summary

- add an expect test for a file URI carrying revision metadata
- record that the query is currently included in the filesystem path

The expect output is promoted to the current faulty behavior so this test-only change passes CI. The production fix and changelog entry will follow separately.

## Testing

- `make test`