### PR TITLE
test(lsp): reproduce incremental edit offset drift

### DIFF
--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -312,5 +312,6 @@ let%expect_test "get position after change" =
   [%expect
     {|
     \nfochangeo\nbar\nbaz\n
-    pos: 22 |}]
+    pos: 22
+    |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -2296,3 +2296,82 @@ let f (x:bool) =
     }
     |}]
 ;;
+
+let%expect_test "combine-cases survives an incremental edit" =
+  let source =
+    {ocaml|type t = A | B
+let f = function
+  | A -> 1
+  | B -> 1
+|ocaml}
+  in
+  let first_diagnostics = Fiber.Ivar.create () in
+  let handler =
+    Client.Handler.make
+      ~on_notification:(fun _ -> function
+         | PublishDiagnostics _ ->
+           let* filled = Fiber.Ivar.peek first_diagnostics in
+           (match filled with
+            | Some _ -> Fiber.return ()
+            | None -> Fiber.Ivar.fill first_diagnostics ())
+         | _ -> Fiber.return ())
+      ()
+  in
+  Test.run ~handler (fun client ->
+    let run_client () =
+      Client.start
+        client
+        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+    in
+    let run () =
+      let* (_ : InitializeResult.t) = Client.initialized client in
+      let textDocument =
+        TextDocumentItem.create
+          ~uri:Helpers.uri
+          ~languageId:"ocaml"
+          ~version:0
+          ~text:source
+      in
+      let* () =
+        Client.notification
+          client
+          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+      in
+      let* () = Fiber.Ivar.read first_diagnostics in
+      let settings = `Assoc [ "diagnostics_delay", `Float 10.0 ] in
+      let* () = Client.notification client (ChangeConfiguration { settings }) in
+      let edit_range =
+        range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
+      in
+      let contentChanges =
+        [ TextDocumentContentChangeEvent.create ~range:edit_range ~text:" " () ]
+      in
+      let textDocument =
+        VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
+      in
+      let change = DidChangeTextDocumentParams.create ~textDocument ~contentChanges in
+      let* () = Client.notification client (TextDocumentDidChange change) in
+      let query_range =
+        range ~start_line:2 ~start_character:0 ~end_line:4 ~end_character:0
+      in
+      let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+      let context =
+        CodeActionContext.create
+          ~diagnostics:[]
+          ~only:[ CodeActionKind.Other "combine-cases" ]
+          ()
+      in
+      let params = CodeActionParams.create ~textDocument ~range:query_range ~context () in
+      let* response = Client.request client (CodeAction params) in
+      let available =
+        response
+        |> Option.value ~default:[]
+        |> List.exists ~f:(find_action "combine-cases")
+      in
+      Printf.printf "combine-cases available: %b\n" available;
+      let* () = Client.request client Shutdown in
+      Client.notification client Exit
+    in
+    Fiber.fork_and_join_unit run_client run);
+  [%expect {| combine-cases available: false |}]
+;;


### PR DESCRIPTION
## Summary

- exercise text-document offsets after incremental edits
- verify the user-visible effect through combine-cases availability
- record the current faulty offsets and missing action