### PR TITLE
ci: re-enable Nix formatting checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ nix-tests:
 
 .PHONY: nix-fmt
 nix-fmt:
-	dune build @fmt --auto-promote
+	dune build @fmt
 
 .PHONY: coverage-deps
 coverage-deps:


### PR DESCRIPTION
## Summary

- re-enable the Nix workflow in GitHub Actions
- make the formatting check non-mutating by removing `--auto-promote`
- add `workflow_dispatch` for manual verification
- remove the obsolete commented-out Nix test job
- use the explicit `nix develop --command` spelling

## Testing

- exported the PR revision to a clean directory
- `nix develop --ignore-env --keep HOME path:.#fmt --command make nix-fmt`
- parsed `.github/workflows/nix.yml` with PyYAML