### PR TITLE
fix: correct spelling in ocamlformat errors

### DIFF
--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -364,15 +364,17 @@ let type_enclosing_hover
       let* result = Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ in
       match result with
       | Ok v ->
-        (* OCamlformat adds an unnecessay newline at the end of the type *)
+        (* OCamlformat adds an unnecessary newline at the end of the type *)
         Fiber.return (String.trim v)
       | Error `No_process -> Fiber.return typ
       | Error (`Msg message) ->
-        (* We log OCamlformat errors and display the unformated type *)
+        (* We log OCamlformat errors and display the unformatted type *)
         let+ () =
           let message =
             sprintf
-              "An error occured while querying ocamlformat:\nInput type: %s\n\nAnswer: %s"
+              "An error occurred while querying ocamlformat:\n\
+               Input type: %s\n\n\
+               Answer: %s"
               typ
               message
           in

--- a/ocaml-lsp-server/src/ocamlformat_rpc.ml
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.ml
@@ -56,7 +56,7 @@ end = struct
        | Ok () -> Fiber.return ()
        | Error (`Msg msg) ->
          let message =
-           Printf.sprintf "An error occured while configuring ocamlformat: %s" msg
+           Printf.sprintf "An error occurred while configuring ocamlformat: %s" msg
          in
          logger ~type_:MessageType.Warning ~message)
   ;;


### PR DESCRIPTION
## Summary

Correct spelling in OCamlFormat warning messages and nearby comments.

## Testing

- `nix develop path:.#fmt --command dune build --root . @fmt`
- `nix develop path:. --command dune build --root . @all @check`