### PR TITLE
ci: remove obsolete Merlin development pin

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,15 +39,10 @@ jobs:
         with:
           ocaml-compiler: "5.5"
 
-      # Remove this pin once a compatible version of Merlin has been released
-      - name: Pin dev Merlin
-        run: opam --cli=2.1 pin --with-version=5.8-505 https://github.com/ocaml/merlin.git
       - name: Build and install dependencies
         run: opam install .
 
-      # the makefile explains why we don't use --with-test
-      # ppx expect is not yet compatible with 5.1 and test output vary from one
-      # compiler to another. We only test on 4.14.
+      # The Makefile explains why we don't use --with-test.
       - name: Install test dependencies
         run: opam exec -- make install-test-deps
 


### PR DESCRIPTION
## Summary

- remove the temporary Merlin development pin from the main build job
- replace the stale OCaml 4.14 test comment with the current explanation

## Testing

- parsed `.github/workflows/build-and-test.yml` with PyYAML