### PR TITLE
chore: update OCaml development tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+compile_commands.json
 _opam/
 .idea/
 .log/

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.28.1
+version=0.29.0
 profile=janestreet
 ocaml-version=4.14.0

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ esy add @opam/ocaml-lsp-server
 
 If you are using [Dune for package
 management](https://dune.readthedocs.io/en/stable/explanation/package-management.html)
-on the [latest nightly build](https://preview.dune.build/) or version 3.21 or
+on the [latest nightly build](https://preview.dune.build/) or version 3.24 or
 later, you can install `ocamllsp` locally within the current project by
 running:
 ```sh

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.0)
+(lang dune 3.24)
 (using cinaps 1.0)
 (name lsp)
 
@@ -66,7 +66,7 @@ possible and does not make any assumptions about IO.
   astring
   camlp-streams
   (ppx_expect (and (>= v0.17.0) :with-test))
-  (ocamlformat (and :with-test (= 0.28.1)))
+  (ocamlformat (and :with-test (= 0.29.0)))
   (ocamlc-loc (>= 3.7.0))
   (pp (>= 1.1.2))
   (csexp (>= 1.5))

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "merlin": {
       "flake": false,
       "locked": {
-        "lastModified": 1783622752,
-        "narHash": "sha256-MocuwUOxabl9ccu6qeSyOCdkFkCur36ZDpMdISpUYxk=",
+        "lastModified": 1784181734,
+        "narHash": "sha256-SoA+QnidkbyD5ds7CUuO36dFoTUY6Rm+9YYF5TaIyq0=",
         "owner": "ocaml",
         "repo": "merlin",
-        "rev": "ee61a0deebab00230bd1a23cd72aae79bc9633ba",
+        "rev": "69de75beae7ddd0ab52e95e2d9e3b5365f8427ae",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773758448,
-        "narHash": "sha256-Sk8ZyjKMe1sM4xGYdxtqn6ojcXiB93BmYllEZbkCSkI=",
+        "lastModified": 1784348664,
+        "narHash": "sha256-lgWd0mAv2GL/xx7rmKC/qTgG4nxo8fWeMdtYpO3djsc=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "bca4e1e4d5221bec6e6ef881bc029f88d395dbf7",
+        "rev": "7ee4a7a0913924d90bd45d5900fe05fbdca7614f",
         "type": "github"
       },
       "original": {
@@ -54,17 +54,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1773738184,
-        "narHash": "sha256-zWRjT5oPabNCiC1A3QkFXpfnsgUjyg6fUZWC+IiiZH0=",
+        "lastModified": 1784326432,
+        "narHash": "sha256-y7F34IRgqcs9RKtNp8GfEI97YqhVEqfNgosxFDkH+Xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41a2715cc472025a19bc0eb9dc4ee8b7406bfa6f",
+        "rev": "1f622082bee30eee91f6ad47512fd13e176d29ee",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41a2715cc472025a19bc0eb9dc4ee8b7406bfa6f",
+        "rev": "1f622082bee30eee91f6ad47512fd13e176d29ee",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   outputs = { self, flake-utils, nixpkgs, ... }@inputs:
     let
       package = "ocaml-lsp-server";
-      ocamlformat = pkgs: pkgs.ocamlformat_0_28_1;
+      ocamlformat = pkgs: pkgs.ocamlformat_0_29_0;
       basePackage = {
         duneVersion = "3";
         version = "n/a";
@@ -158,7 +158,7 @@
               # present
               pkgsWithoutOverlays.ocaml
               (ocamlformat pkgsWithoutOverlays)
-              pkgsWithoutOverlays.dune_3
+              pkgsWithoutOverlays.ocamlPackages.dune
             ];
           };
 

--- a/jsonrpc.opam
+++ b/jsonrpc.opam
@@ -19,7 +19,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.24"}
   "yojson" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}

--- a/lsp.opam
+++ b/lsp.opam
@@ -23,7 +23,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.24"}
   "jsonrpc" {= version}
   "yojson"
   "ppx_yojson_conv_lib" {>= "v0.14"}

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -19,7 +19,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.24"}
   "yojson"
   "base" {>= "v0.16.0"}
   "lsp" {= version}
@@ -40,7 +40,7 @@ depends: [
   "astring"
   "camlp-streams"
   "ppx_expect" {>= "v0.17.0" & with-test}
-  "ocamlformat" {with-test & = "0.28.1"}
+  "ocamlformat" {with-test & = "0.29.0"}
   "ocamlc-loc" {>= "3.7.0"}
   "pp" {>= "1.1.2"}
   "csexp" {>= "1.5"}

--- a/ocaml-lsp-server/dune
+++ b/ocaml-lsp-server/dune
@@ -6,7 +6,7 @@
   lev-fiber-csexp
   (library
    (name lev_fiber_csexp)
-   (libraries fiber csexp stdune dyn lev_fiber))
+   (libraries fiber csexp stdune dyn lev_fiber unix))
   (copy_files# %{project_root}/submodules/lev/lev-fiber-csexp/src/*.{ml,mli}))
  (subdir
   lev-fiber

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -112,8 +112,7 @@ let create
 ;;
 
 let send =
-  let module Range_map =
-    Map.Make (struct
+  let module Range_map = Map.Make (struct
       include Range
 
       let compare x y = Ordering.to_int (compare x y)

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -882,8 +882,7 @@ let compute_tokens doc =
     Document.Merlin.with_pipeline_exn ~name:"semantic highlighting" doc (fun p ->
       Mpipeline.reader_parsetree p, Mpipeline.input_source p)
   in
-  let module Fold =
-    Parsetree_fold (struct
+  let module Fold = Parsetree_fold (struct
       let source = Msource.text source
     end)
   in

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -162,8 +162,8 @@ let read_file path =
   contents
 ;;
 
-let temp_dir prefix =
-  let dir = Stdlib.Filename.temp_file prefix "" in
+let temp_dir ?temp_dir prefix =
+  let dir = Stdlib.Filename.temp_file ?temp_dir prefix "" in
   Stdlib.Sys.remove dir;
   Unix.mkdir dir 0o700;
   dir

--- a/ocaml-lsp-server/test/e2e-new/with_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_pp.ml
@@ -1,9 +1,24 @@
 open! Test.Import
 
-let path = Filename.concat (Sys.getcwd ()) "for_pp.ml"
-let uri = DocumentUri.of_path path
+let project_root = Sys.getenv "DUNE_PROJECT_ROOT"
+let fixture = Filename.concat project_root "ocaml-lsp-server/test/e2e-new/for_pp.ml"
 
 let%expect_test "with-pp" =
+  let dir = Test.temp_dir ~temp_dir:project_root "ocamllsp-with-pp-" in
+  let path = Filename.concat dir "for_pp.ml" in
+  let uri = DocumentUri.of_path path in
+  Test.write_file path (Io.String_path.read_file fixture);
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.24)\n";
+  Test.write_file
+    (Filename.concat dir "dune")
+    {|(library
+ (name for_pp)
+ (modules for_pp)
+ (preprocess
+  (action
+   (run sed "s/world/universe/g" %{input-file}))))
+|};
+  Test.run_command ~cwd:dir "dune build";
   let position = Position.create ~line:0 ~character:9 in
   let handler =
     Client.Handler.make

--- a/ocaml-lsp-server/test/e2e-new/with_ppx.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_ppx.ml
@@ -1,9 +1,24 @@
 open! Test.Import
 
-let path = Filename.concat (Sys.getcwd ()) "for_ppx.ml"
-let uri = DocumentUri.of_path path
+let project_root = Sys.getenv "DUNE_PROJECT_ROOT"
+let fixture = Filename.concat project_root "ocaml-lsp-server/test/e2e-new/for_ppx.ml"
 
 let%expect_test "with-ppx" =
+  let dir = Test.temp_dir ~temp_dir:project_root "ocamllsp-with-ppx-" in
+  let path = Filename.concat dir "for_ppx.ml" in
+  let uri = DocumentUri.of_path path in
+  Test.write_file path (Io.String_path.read_file fixture);
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.24)\n";
+  Test.write_file
+    (Filename.concat dir "dune")
+    {|(library
+ (name for_ppx)
+ (modules for_ppx)
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect)))
+|};
+  Test.run_command ~cwd:dir "dune build";
   (* We will call 'hover' on the last line of this very file *)
   let position = Position.create ~line:2 ~character:5 in
   (* We need to wait for the first diagnostics *)

--- a/submodules/lev/lev-fiber-csexp/src/dune
+++ b/submodules/lev/lev-fiber-csexp/src/dune
@@ -1,4 +1,4 @@
 (library
  (name lev_fiber_csexp)
  (public_name lev-fiber-csexp)
- (libraries fiber csexp stdune dyn lev_fiber))
+ (libraries fiber csexp stdune dyn lev_fiber unix))


### PR DESCRIPTION
## Summary

- refresh the Nix flake inputs
- update the Dune language to 3.24 and OCamlFormat to 0.29.0
- regenerate package metadata and apply the new formatting rules
- make preprocessing tests self-contained inside Dune 3.24 sandboxes, using `DUNE_PROJECT_ROOT`
- declare the Unix dependency required by the refreshed toolchain
- ignore Dune’s generated compilation database

## Testing

- `nix develop --ignore-env --keep HOME path:.#fmt --command dune build --root . @fmt`
- `nix develop --ignore-env --keep HOME path:. --command dune build --root . @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest`
- `nix develop path:. --command dune build --root . @all @check @install`
- `nix flake check path:. --no-build`
- `nix build path:.#default --no-link`