### PR TITLE
ci: restore the Nix formatting workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,22 +1,13 @@
-name: "Nix"
+name: Nix
+
 on:
   pull_request:
   push:
     branches:
       - master
+  workflow_dispatch:
+
 jobs:
-  # tests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout tree
-  #       uses: actions/checkout@v7
-  #       with:
-  #         submodules: true
-  #     - name: nix
-  #       uses: cachix/install-nix-action@v31
-  #       with:
-  #         nix_path: nixpkgs=channel:nixos-unstable
-  #     - run: nix develop .#check -c make nix-tests
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -28,4 +19,4 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix develop .#fmt -c make nix-fmt
+      - run: nix develop .#fmt --command make nix-fmt


### PR DESCRIPTION
## Summary

- restore the Nix workflow in GitHub Actions
- add `workflow_dispatch` so the formatting check can be run manually
- remove the obsolete commented-out Nix test job
- use the explicit `nix develop --command` spelling

The workflow has also been re-enabled in the repository settings. The non-mutating `nix-fmt` fix landed separately in #1736.

## Testing

- exported the revision to a clean directory
- `nix develop --ignore-env --keep HOME path:.#fmt --command make nix-fmt`
- parsed `.github/workflows/nix.yml` with PyYAML