### PR TITLE
test(lsp): model-check string zipper operations

### DIFF
--- a/lsp/test/string_zipper_quickcheck_tests.ml
+++ b/lsp/test/string_zipper_quickcheck_tests.ml
@@ -1,0 +1,305 @@
+open Base
+open Stdune
+open Base_quickcheck
+module Position = Lsp.Types.Position
+module Range = Lsp.Types.Range
+module String_zipper = Lsp.Private.String_zipper
+module Substring = Lsp.Private.Substring
+
+type atom =
+  | A
+  | Space
+  | Tab
+  | Nul
+  | Newline
+  | Two_byte
+  | Three_byte
+  | Four_byte
+[@@deriving quickcheck, sexp_of]
+
+type encoding =
+  | UTF8
+  | UTF16
+[@@deriving quickcheck, sexp_of]
+
+(* Integer selectors are mapped to valid positions in the current model. This lets
+   Quickcheck generate operation lists without knowing each intermediate state. *)
+type operation =
+  | Insert of atom list
+  | Goto_line of int
+  | Goto_position of encoding * int
+  | Apply_change of encoding * int * int * atom list
+  | Drop_until of encoding * int * int
+  | Add_buffer_between of encoding * int * int
+  | Goto_end
+  | Squash
+[@@deriving quickcheck, sexp_of]
+
+module Case = struct
+  type t =
+    { initial : atom list
+    ; operations : operation list
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let string_of_atom = function
+  | A -> "a"
+  | Space -> " "
+  | Tab -> "\t"
+  | Nul -> "\000"
+  | Newline -> "\n"
+  | Two_byte -> "é"
+  | Three_byte -> "€"
+  | Four_byte -> "😀"
+;;
+
+let string_of_atoms atoms = List.map atoms ~f:string_of_atom |> String.concat ~sep:""
+
+let lsp_encoding = function
+  | UTF8 -> `UTF8
+  | UTF16 -> `UTF16
+;;
+
+type cursor =
+  { byte_offset : int
+  ; line : int
+  ; character : int
+  }
+
+let position { line; character; byte_offset = _ } = Position.create ~line ~character
+
+let cursors text encoding =
+  let text_length = String.length text in
+  let rec loop byte_offset line character acc =
+    let acc = { byte_offset; line; character } :: acc in
+    if byte_offset = text_length
+    then List.rev acc
+    else (
+      let decoded = Stdlib.String.get_utf_8_uchar text byte_offset in
+      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
+      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
+      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
+      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
+      then loop (byte_offset + byte_length) (line + 1) 0 acc
+      else (
+        let code_units =
+          match encoding with
+          | UTF8 -> byte_length
+          | UTF16 -> Stdlib.Uchar.utf_16_byte_length uchar / 2
+        in
+        loop (byte_offset + byte_length) line (character + code_units) acc))
+  in
+  loop 0 0 0 []
+;;
+
+let index selector ~length = Stdlib.Int.rem (selector land Stdlib.max_int) length
+
+let select_cursor text encoding selector =
+  let cursors = cursors text encoding |> Array.of_list in
+  cursors.(index selector ~length:(Array.length cursors))
+;;
+
+let ordered_cursors text encoding first second =
+  let first = select_cursor text encoding first in
+  let second = select_cursor text encoding second in
+  if first.byte_offset <= second.byte_offset then first, second else second, first
+;;
+
+let replace text ~start ~stop replacement =
+  let length = String.length text in
+  Stdlib.String.sub text 0 start
+  ^ replacement
+  ^ Stdlib.String.sub text stop (length - stop)
+;;
+
+let line_starts text =
+  let rec loop offset acc =
+    if offset = String.length text
+    then List.rev acc
+    else if Char.equal text.[offset] '\n'
+    then loop (offset + 1) ((offset + 1) :: acc)
+    else loop (offset + 1) acc
+  in
+  loop 0 [ 0 ]
+;;
+
+let count_newlines_before text stop =
+  let rec loop offset count =
+    if offset = stop
+    then count
+    else loop (offset + 1) (if Char.equal text.[offset] '\n' then count + 1 else count)
+  in
+  loop 0 0
+;;
+
+type model =
+  { text : string
+  ; offset : int
+  }
+
+type state =
+  { model : model
+  ; zipper : String_zipper.t
+  }
+
+let fail state message =
+  let { model = { text; offset }; zipper } = state in
+  failwith
+    (Printf.sprintf
+       "%s\nmodel: text=%S offset=%d\nzipper: text=%S offset=%d debug=%S"
+       message
+       text
+       offset
+       (String_zipper.to_string zipper)
+       (String_zipper.offset zipper)
+       (String_zipper.to_string_debug zipper))
+;;
+
+(* Check the observable result and the representation invariants after every operation. *)
+let check state =
+  let { model = { text; offset }; zipper } = state in
+  let actual_text = String_zipper.to_string zipper in
+  if not (String.equal text actual_text) then fail state "text differs";
+  if String_zipper.offset zipper <> offset then fail state "offset differs";
+  let expected_debug =
+    Stdlib.String.sub text 0 offset
+    ^ "|"
+    ^ Stdlib.String.sub text offset (String.length text - offset)
+  in
+  if not (String.equal expected_debug (String_zipper.to_string_debug zipper))
+  then fail state "debug rendering differs";
+  let { String_zipper.Private.left; rel_pos; abs_pos; current; right; line } =
+    String_zipper.Private.reflect zipper
+  in
+  let current_length = Substring.length current in
+  if rel_pos < 0 || rel_pos > current_length
+  then fail state "relative position is invalid";
+  let expected_abs_pos =
+    List.fold_left left ~init:0 ~f:(fun total substring ->
+      total + Substring.length substring)
+  in
+  if abs_pos <> expected_abs_pos
+  then fail state "absolute position differs from left chunks";
+  if abs_pos + rel_pos <> offset then fail state "internal positions differ from offset";
+  if rel_pos = current_length && not (List.is_empty right)
+  then fail state "cursor is at the end of a non-final chunk";
+  let expected_line = count_newlines_before text offset in
+  if line <> expected_line then fail state "line differs"
+;;
+
+let state_at_position state encoding cursor =
+  let zipper =
+    String_zipper.goto_position state.zipper (position cursor) (lsp_encoding encoding)
+  in
+  let state = { model = { state.model with offset = cursor.byte_offset }; zipper } in
+  check state;
+  state
+;;
+
+let apply_operation state = function
+  | Insert atoms ->
+    let replacement = string_of_atoms atoms in
+    let model =
+      { state.model with
+        text =
+          replace
+            state.model.text
+            ~start:state.model.offset
+            ~stop:state.model.offset
+            replacement
+      }
+    in
+    { model; zipper = String_zipper.insert state.zipper replacement }
+  | Goto_line selector ->
+    let starts = line_starts state.model.text |> Array.of_list in
+    let line = index selector ~length:(Array.length starts + 2) in
+    let offset =
+      if line < Array.length starts then starts.(line) else String.length state.model.text
+    in
+    let model = { state.model with offset } in
+    { model; zipper = String_zipper.goto_line state.zipper line }
+  | Goto_position (encoding, selector) ->
+    let cursor = select_cursor state.model.text encoding selector in
+    state_at_position state encoding cursor
+  | Apply_change (encoding, first, second, atoms) ->
+    let first, second = ordered_cursors state.model.text encoding first second in
+    let replacement = string_of_atoms atoms in
+    let range = Range.create ~start:(position first) ~end_:(position second) in
+    let zipper =
+      String_zipper.apply_change state.zipper range (lsp_encoding encoding) ~replacement
+    in
+    let model =
+      { text =
+          replace
+            state.model.text
+            ~start:first.byte_offset
+            ~stop:second.byte_offset
+            replacement
+      ; offset = first.byte_offset
+      }
+    in
+    { model; zipper }
+  | Drop_until (encoding, first, second) ->
+    let first, second = ordered_cursors state.model.text encoding first second in
+    let from = state_at_position state encoding first in
+    let until = state_at_position state encoding second in
+    let zipper = String_zipper.drop_until from.zipper until.zipper in
+    let model =
+      { text =
+          replace state.model.text ~start:first.byte_offset ~stop:second.byte_offset ""
+      ; offset = first.byte_offset
+      }
+    in
+    { model; zipper }
+  | Add_buffer_between (encoding, first, second) ->
+    let first, second = ordered_cursors state.model.text encoding first second in
+    let start = state_at_position state encoding first in
+    let stop = state_at_position state encoding second in
+    let buffer = Buffer.create 0 in
+    String_zipper.add_buffer_between buffer start.zipper stop.zipper;
+    let expected =
+      Stdlib.String.sub
+        state.model.text
+        first.byte_offset
+        (second.byte_offset - first.byte_offset)
+    in
+    if not (String.equal expected (Buffer.contents buffer))
+    then fail state "buffer contents differ";
+    state
+  | Goto_end ->
+    let model = { state.model with offset = String.length state.model.text } in
+    { model; zipper = String_zipper.goto_end state.zipper }
+  | Squash ->
+    let zipper, text = String_zipper.squash state.zipper in
+    if not (String.equal text state.model.text) then fail state "squashed text differs";
+    { state with zipper }
+;;
+
+let run_case { Case.initial; operations } =
+  let text = string_of_atoms initial in
+  let initial = { model = { text; offset = 0 }; zipper = String_zipper.of_string text } in
+  check initial;
+  List.fold_left operations ~init:initial ~f:(fun state operation ->
+    let state = apply_operation state operation in
+    check state;
+    state)
+  |> ignore
+;;
+
+(* These paths previously corrupted [abs_pos]. Keep them even if the generated
+   distribution changes. *)
+let regression_cases : Case.t list =
+  [ { initial = [ A ]; operations = [ Goto_end; Insert [ A ] ] }
+  ; { initial = [ A; Newline; A ]
+    ; operations = [ Goto_line 1; Insert [ A ]; Goto_end; Goto_line 0 ]
+    }
+  ; { initial = [ A ]; operations = [ Drop_until (UTF8, 0, 0) ] }
+  ; { initial = [ A; A; A ]; operations = [ Drop_until (UTF16, 1, 2) ] }
+  ]
+;;
+
+let%expect_test "random operation sequences agree with a string model" =
+  Base_quickcheck.Test.run_exn (module Case) ~examples:regression_cases ~f:run_case;
+  [%expect {| |}]
+;;

--- a/lsp/test/string_zipper_tests.ml
+++ b/lsp/test/string_zipper_tests.ml
@@ -16,18 +16,55 @@ let to_dyn { String_zipper.Private.left; rel_pos; current; right; line; abs_pos 
     ]
 ;;
 
+let check_invariants zipper =
+  let state = String_zipper.Private.reflect zipper in
+  let fail invariant =
+    failwith (Printf.sprintf "%s: %s" invariant (state |> to_dyn |> Dyn.to_string))
+  in
+  let check invariant condition = if not condition then fail invariant in
+  let substring_length total substring = total + Substring.length substring in
+  let left_length = List.fold_left state.left ~init:0 ~f:substring_length in
+  let current_length = Substring.length state.current in
+  check "abs_pos differs from the left chunks" (state.abs_pos = left_length);
+  check
+    "rel_pos is outside the current chunk"
+    (state.rel_pos >= 0 && state.rel_pos <= current_length);
+  check
+    "cursor is at the end of a non-final chunk"
+    (state.rel_pos <> current_length || List.is_empty state.right);
+  let offset = left_length + state.rel_pos in
+  check "offset differs from the cursor" (String_zipper.offset zipper = offset);
+  let text = String_zipper.to_string zipper in
+  check "offset is outside the text" (offset >= 0 && offset <= String.length text);
+  let rec count_newlines position count =
+    if position = offset
+    then count
+    else
+      count_newlines
+        (position + 1)
+        (if Char.equal text.[position] '\n' then count + 1 else count)
+  in
+  check "line differs from the text prefix" (state.line = count_newlines 0 0)
+;;
+
+let checked zipper =
+  check_invariants zipper;
+  zipper
+;;
+
 type op =
   [ `Goto_line of int
   | `Insert of string
   ]
 
 let test ?(which = `All) mode start operations =
+  check_invariants start;
   let results =
     List.fold_left
       operations
       ~init:[ `Hide, start ]
       ~f:(fun acc (op : [ op | `Hide of op ]) ->
-        let final =
+        let display, result =
           let _, last = List.hd acc in
           let commit_op op =
             match op with
@@ -38,7 +75,8 @@ let test ?(which = `All) mode start operations =
           | `Hide op -> `Hide, commit_op op
           | #op as x -> `Show, commit_op x
         in
-        final :: acc)
+        check_invariants result;
+        (display, result) :: acc)
     |> List.rev
     |> List.tl
   in
@@ -129,33 +167,34 @@ let%expect_test "mixed insert goto" =
 ;;
 
 let%expect_test "drop_until" =
-  let t = String_zipper.of_string "foo\nbar\nxxx" in
-  let t = String_zipper.goto_line t 1 in
-  let t' = String_zipper.goto_line t 2 in
-  let t = String_zipper.drop_until t t' in
+  let t = String_zipper.of_string "foo\nbar\nxxx" |> checked in
+  let t = String_zipper.goto_line t 1 |> checked in
+  let t' = String_zipper.goto_line t 2 |> checked in
+  let t = String_zipper.drop_until t t' |> checked in
   printfn "%S" (String_zipper.to_string_debug t);
   [%expect
     {|
     "foo\n|xxx" |}];
-  let t = String_zipper.of_string "foo\nbar\n" in
-  let t = String_zipper.goto_line t 2 in
-  let t = String_zipper.drop_until t t in
+  let t = String_zipper.of_string "foo\nbar\n" |> checked in
+  let t = String_zipper.goto_line t 2 |> checked in
+  let t = String_zipper.drop_until t t |> checked in
   printfn "%S" (String_zipper.to_string_debug t);
   [%expect
     {|
     "foo\nbar\n|" |}];
-  let t = String_zipper.of_string "123\n" in
-  let t = String_zipper.goto_line t 1 in
-  let t = String_zipper.drop_until t t in
+  let t = String_zipper.of_string "123\n" |> checked in
+  let t = String_zipper.goto_line t 1 |> checked in
+  let t = String_zipper.drop_until t t |> checked in
   printfn "%S" (String_zipper.to_string_debug t);
   [%expect {| "123\n|" |}]
 ;;
 
 let%expect_test "squashing" =
   let str = "foo\nbar" in
-  let t = String_zipper.of_string str in
-  let t = String_zipper.goto_line t 1 in
+  let t = String_zipper.of_string str |> checked in
+  let t = String_zipper.goto_line t 1 |> checked in
   let t, str' = String_zipper.squash t in
+  check_invariants t;
   assert (String.equal str str');
   printfn "squashing: %S" (String_zipper.to_string_debug t);
   [%expect
@@ -165,8 +204,8 @@ let%expect_test "squashing" =
 
 let%expect_test "add buffer between" =
   let str = "foo\nbar" in
-  let t = String_zipper.of_string str in
-  let t' = String_zipper.goto_line t 1 in
+  let t = String_zipper.of_string str |> checked in
+  let t' = String_zipper.goto_line t 1 |> checked in
   let b = Buffer.create 0 in
   String_zipper.add_buffer_between b t t';
   printfn "result: %S" (Buffer.contents b);
@@ -176,10 +215,10 @@ let%expect_test "add buffer between" =
 ;;
 
 let%expect_test "drop_until bug" =
-  let t = String_zipper.of_string "foo\nbar\nxxx" in
-  let t' = String_zipper.goto_line t 10 in
-  let t = String_zipper.goto_line t 2 in
-  let t = String_zipper.drop_until t t' in
+  let t = String_zipper.of_string "foo\nbar\nxxx" |> checked in
+  let t' = String_zipper.goto_line t 10 |> checked in
+  let t = String_zipper.goto_line t 2 |> checked in
+  let t = String_zipper.drop_until t t' |> checked in
   printfn "%S" (String_zipper.to_string_debug t);
   [%expect
     {|


### PR DESCRIPTION
## Summary

- add a Base_quickcheck state-machine test that compares `String_zipper` with a simple string-and-offset model
- generate UTF-8/UTF-16 positions and sequences of insertion, navigation, replacement, deletion, buffer extraction, end, and squash operations
- check the public result and internal chunk/position invariants after every operation
- fix three `abs_pos` bookkeeping errors exposed by the model in insert-at-end, backward navigation across chunks, and `drop_until`
