### PR TITLE
fix(server): make shutdown deterministic

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -70,12 +70,13 @@ struct
     ; on_request : ('state, Request.t) context -> (Reply.t * 'state) Fiber.t
     ; on_notification : ('state, Notification.t) context -> (Notify.t * 'state) Fiber.t
     ; pending : (Response.t, [ `Stopped | `Cancelled ]) result Fiber.Ivar.t Id.Table.t
-    ; stopped : unit Fiber.Ivar.t
     ; name : string
     ; mutable running : bool
     ; mutable tick : int
     ; mutable state : 'state
     ; mutable pending_requests_stopped : bool
+    ; mutable closing : bool
+    ; close_result : (unit, Exn_with_backtrace.t list) result Fiber.Ivar.t
     }
 
   and ('a, 'message) context = 'a t * 'message
@@ -148,16 +149,22 @@ struct
     ; on_request
     ; on_notification
     ; pending
-    ; stopped = Fiber.Ivar.create ()
     ; name
     ; running = false
     ; tick = 0
     ; state
     ; pending_requests_stopped = false
+    ; closing = false
+    ; close_result = Fiber.Ivar.create ()
     }
   ;;
 
-  let stopped t = Fiber.Ivar.read t.stopped
+  let stopped t =
+    let+ (_ : (unit, Exn_with_backtrace.t list) result) =
+      Fiber.Ivar.read t.close_result
+    in
+    ()
+  ;;
 
   let stop t =
     Fiber.fork_and_join_unit
@@ -165,16 +172,32 @@ struct
       (fun () -> stop_pending_requests t)
   ;;
 
-  let close t =
-    Fiber.all_concurrently_unit
-      [ Chan.close t.chan `Read
-      ; Chan.close t.chan `Write
-      ; Fiber.Ivar.fill t.stopped ()
-      ; stop_pending_requests t
-      ]
+  let await_close t =
+    Fiber.Ivar.read t.close_result
+    >>= function
+    | Ok () -> Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
   ;;
 
-  let run t =
+  let close t =
+    Fiber.of_thunk (fun () ->
+      if t.closing
+      then await_close t
+      else (
+        t.closing <- true;
+        let* () =
+          let* result =
+            Fiber.collect_errors (fun () ->
+              Fiber.fork_and_join_unit
+                (fun () -> stop t)
+                (fun () -> Chan.close t.chan `Write))
+          in
+          Fiber.Ivar.fill t.close_result result
+        in
+        await_close t))
+  ;;
+
+  let run_until_stopped t =
     let send_response resp =
       log t (fun () ->
         Log.msg "sending response" [ "response", Response.yojson_of_t resp ]);
@@ -278,8 +301,10 @@ struct
              Fiber.Pool.stop later)
           (fun () -> Fiber.Pool.run later)
       in
-      close t)
+      stop t)
   ;;
+
+  let run t = Fiber.finalize (fun () -> run_until_stopped t) ~finally:(fun () -> close t)
 
   let check_running t =
     if not t.running then Code_error.raise "jsonrpc must be running" []

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -46,7 +46,20 @@ module Make (Chan : sig
   val state : 'a t -> 'a
   val stop : _ t -> unit Fiber.t
   val stopped : _ t -> unit Fiber.t
+
+  (** Close the session's input and output channels. This operation is
+      idempotent: concurrent and subsequent callers observe the same success or
+      failure. *)
+  val close : _ t -> unit Fiber.t
+
+  (** Process messages until the session stops. The output channel remains open
+      until [close] is called, allowing callers to finish work that may send
+      messages before closing the session. *)
+  val run_until_stopped : _ t -> unit Fiber.t
+
+  (** Process messages until the session stops, then close it. *)
   val run : _ t -> unit Fiber.t
+
   val notification : _ t -> Jsonrpc.Notification.t -> unit Fiber.t
   val request : _ t -> Jsonrpc.Request.t -> Jsonrpc.Response.t Fiber.t
 

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -46,6 +46,66 @@ let%expect_test "start and stop server" =
     <opaque> |}]
 ;;
 
+let%expect_test "cleanup precedes explicit output close" =
+  let output =
+    Out.create (function
+      | None ->
+        print_endline "output closed";
+        Fiber.return ()
+      | Some _ ->
+        print_endline "notification sent";
+        Fiber.return ())
+  in
+  let jrpc = Jrpc.create ~name:"test" (In.of_list [], output) () in
+  let cleanup () =
+    print_endline "stopping";
+    let notification = Jsonrpc.Notification.create ~method_:"cleanup" () in
+    Jrpc.notification jrpc notification
+  in
+  Fiber_test.test Dyn.opaque (fun () ->
+    Fiber.finalize
+      (fun () ->
+         let* () = Jrpc.run_until_stopped jrpc in
+         cleanup ())
+      ~finally:(fun () -> Jrpc.close jrpc));
+  [%expect
+    {|
+    stopping
+    notification sent
+    output closed
+    <opaque> |}]
+;;
+
+let%expect_test "close shares failures between callers" =
+  let close_attempts = ref 0 in
+  let output =
+    Out.create (function
+      | None ->
+        incr close_attempts;
+        failwith "close failed"
+      | Some _ -> Fiber.return ())
+  in
+  let jrpc = Jrpc.create ~name:"test" (In.of_list [], output) () in
+  let close () =
+    let+ result = Fiber.collect_errors (fun () -> Jrpc.close jrpc) in
+    print_endline
+      (match result with
+       | Ok () -> "close succeeded"
+       | Error _ -> "close failed")
+  in
+  Fiber_test.test Dyn.opaque (fun () ->
+    let* () = Fiber.fork_and_join_unit close close in
+    let+ () = close () in
+    Printf.printf "close attempts: %d\n" !close_attempts);
+  [%expect
+    {|
+    close failed
+    close failed
+    close failed
+    close attempts: 1
+    <opaque> |}]
+;;
+
 let%expect_test "server accepts notifications" =
   let notif =
     { Jsonrpc.Notification.method_ = "method"; params = Some (`List [ `String "bar" ]) }

--- a/lsp-fiber/src/rpc.ml
+++ b/lsp-fiber/src/rpc.ml
@@ -48,6 +48,7 @@ module type S = sig
   val state : 'a t -> 'a
   val make : 'state Handler.t -> Fiber_io.t -> 'state -> 'state t
   val stop : _ t -> unit Fiber.t
+  val close : _ t -> unit Fiber.t
   val request : _ t -> 'resp out_request -> 'resp Fiber.t
   val notification : _ t -> out_notification -> unit Fiber.t
   val cancel_token : unit -> Fiber.Cancel.t option Fiber.t
@@ -328,10 +329,15 @@ struct
     t.state <- Closed
   ;;
 
+  let close t =
+    let+ () = Session.close (Fdecl.get t.session) in
+    t.state <- Closed
+  ;;
+
   let start_loop t =
     Fiber.fork_and_join_unit
       (fun () ->
-         let* () = Session.run (Fdecl.get t.session) in
+         let* () = Session.run_until_stopped (Fdecl.get t.session) in
          Fiber.Pool.stop t.detached)
       (fun () -> Fiber.Pool.run t.detached)
   ;;
@@ -385,7 +391,9 @@ module Client = struct
         t.state <- Running;
         Fiber.Ivar.fill t.initialized resp
       in
-      Fiber.fork_and_join_unit loop init)
+      Fiber.finalize
+        ~finally:(fun () -> close t)
+        (fun () -> Fiber.fork_and_join_unit loop init))
   ;;
 end
 

--- a/lsp-fiber/src/rpc.mli
+++ b/lsp-fiber/src/rpc.mli
@@ -35,6 +35,7 @@ module type S = sig
   val state : 'a t -> 'a
   val make : 'state Handler.t -> Fiber_io.t -> 'state -> 'state t
   val stop : 'state t -> unit Fiber.t
+  val close : 'state t -> unit Fiber.t
   val request : _ t -> 'resp out_request -> 'resp Fiber.t
   val notification : _ t -> out_notification -> unit Fiber.t
 
@@ -87,5 +88,8 @@ module Server : sig
      and type in_notification = Client_notification.t
 
   val initialized : _ t -> InitializeParams.t Fiber.t
+
+  (** Process messages until the server stops and drain detached RPC jobs. The
+      output channel remains open until [close] is called. *)
   val start : _ t -> unit Fiber.t
 end

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -29,7 +29,12 @@ module Test = struct
         let handler = Server.Handler.make ?on_request ?on_notification () in
         Server.make handler stream_io state
       in
-      server, Server.start server
+      let running =
+        Fiber.finalize
+          ~finally:(fun () -> Server.close server)
+          (fun () -> Server.start server)
+      in
+      server, running
     ;;
   end
 end

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -938,28 +938,38 @@ let start stream =
         Server.notification server (Server_notification.ShowMessage log))
   in
   let run () =
+    let run_detached () =
+      with_log_errors "detached" (fun () -> Fiber.Pool.run detached)
+    in
+    let cleanup () =
+      let finalize =
+        [ Document_store.close_all store
+        ; Fiber.Pool.stop detached
+        ; Ocamlformat_rpc.stop ocamlformat_rpc
+        ; Lev_fiber.Timer.Wheel.stop wheel
+        ; Merlin_config.DB.stop state.merlin_config
+        ; Fiber.of_thunk (fun () ->
+            Lev_fiber.Thread.close merlin;
+            Fiber.return ())
+        ]
+      in
+      let finalize =
+        match (Server.state server).init with
+        | Uninitialized -> finalize
+        | Initialized init -> Dune.stop init.dune :: finalize
+      in
+      Fiber.all_concurrently_unit finalize
+    in
+    let serve () = Fiber.finalize (fun () -> Server.start server) ~finally:cleanup in
+    let run_server () =
+      Fiber.finalize
+        (fun () -> Fiber.fork_and_join_unit run_detached serve)
+        ~finally:(fun () -> Server.close server)
+    in
     Fiber.all_concurrently_unit
-      [ with_log_errors "detached" (fun () -> Fiber.Pool.run detached)
-      ; Lev_fiber.Timer.Wheel.run wheel
+      [ Lev_fiber.Timer.Wheel.run wheel
       ; with_log_errors "merlin" (fun () -> Merlin_config.DB.run state.merlin_config)
-      ; (let* () = Server.start server in
-         let finalize =
-           [ Document_store.close_all store
-           ; Fiber.Pool.stop detached
-           ; Ocamlformat_rpc.stop ocamlformat_rpc
-           ; Lev_fiber.Timer.Wheel.stop wheel
-           ; Merlin_config.DB.stop state.merlin_config
-           ; Fiber.of_thunk (fun () ->
-               Lev_fiber.Thread.close merlin;
-               Fiber.return ())
-           ]
-         in
-         let finalize =
-           match (Server.state server).init with
-           | Uninitialized -> finalize
-           | Initialized init -> Dune.stop init.dune :: finalize
-         in
-         Fiber.all_concurrently_unit finalize)
+      ; run_server ()
       ; with_log_errors "ocamlformat-rpc" run_ocamlformat_rpc
       ]
   in


### PR DESCRIPTION
Keep the JSON-RPC output open while the server stops and drains background tasks so pending diagnostics cannot race transport shutdown.

Separate processing-until-stop from transport closure in `jsonrpc-fiber`, while retaining `run` as the automatically closing convenience API. Explicit `close` is idempotent, with concurrent and subsequent callers observing the same success or failure.

The LSP server uses the two-phase lifecycle to drain RPC jobs, stop documents, Dune, Merlin, timers, and detached jobs, and finally close the session in a `finally` block. Focused JSON-RPC tests cover notification delivery before explicit closure and shared close failures.
