### PR TITLE
fix(dune): initialize promotion reference counts correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)
 - Point workspace symbols for generated sources to their files in the build
   directory. (#1742, @tatchi)
 - Prevent whole-document formatting requests for OCamllex, Menhir, and Cram

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -174,7 +174,7 @@ let register_promotions t uris =
   List.filter uris ~f:(fun uri ->
     match Table.find t.db uri with
     | None ->
-      let doc = ref { document = None; promotions = 0; semantic_tokens_cache = None } in
+      let doc = ref { document = None; promotions = 1; semantic_tokens_cache = None } in
       Table.set t.db ~key:uri ~data:doc;
       true
     | Some doc ->


### PR DESCRIPTION
Initialize new Dune promotion document-store entries with a reference count of one. This keeps promotion command registration and unregistration balanced after diagnostics are cleared.