### PR TITLE
fix(workspaces): accept the first workspace-folder update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)
 - Point workspace symbols for generated sources to their files in the build
   directory. (#1742, @tatchi)

--- a/ocaml-lsp-server/src/workspaces.ml
+++ b/ocaml-lsp-server/src/workspaces.ml
@@ -26,7 +26,6 @@ let create (ip : InitializeParams.t) =
 ;;
 
 let on_change t { DidChangeWorkspaceFoldersParams.event = { added; removed } } =
-  assert (t.workspace_folders <> None);
   let workspace_folders =
     let init = Option.value t.workspace_folders ~default:Uri_map.empty in
     let init =

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -37,7 +37,7 @@ let%expect_test "can add the first workspace folder after initialization" =
   Stdlib.Sys.remove stderr_path;
   let failed = Base.String.is_substring stderr ~substring:"Assertion failed" in
   Printf.printf "workspace update error: %b\n" failed;
-  [%expect {| workspace update error: true |}]
+  [%expect {| workspace update error: false |}]
 ;;
 
 let%expect_test "disable codelens" =


### PR DESCRIPTION
Clients may initialize with `workspaceFolders` set to null and add a workspace folder later. Treat the absent folder map as empty instead of asserting, allowing the first dynamic workspace-folder update to succeed.

Updates the regression test introduced in #1729.