### PR TITLE
fix(code-actions): compute multiline post-edit ranges correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)
 - Point workspace symbols for generated sources to their files in the build

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -52,7 +52,7 @@ let resize_for_edit { TextEdit.range; newText } =
         let last_line_len =
           List.last several_lines |> Option.value_exn |> String.length
         in
-        start.character + last_line_len
+        if line = start.line then start.character + last_line_len else last_line_len
       in
       { Position.line; character }
     in

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -2348,7 +2348,7 @@ let f (x:bool) =
   [%expect
     {|
     {
-      "end": { "character": 15, "line": 4 },
+      "end": { "character": 13, "line": 4 },
       "start": { "character": 2, "line": 2 }
     }
     |}]


### PR DESCRIPTION
LSP character offsets are relative to their line. When inserted text spans multiple lines, the resulting end character is therefore the length of the final inserted line; the original start column applies only when the insertion remains on its starting line.

This corrects the jump-to-next-hole range covered by the regression test introduced in #1728.

Specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position