### PR TITLE
feature(lsp): update spec to 3.18

### DIFF
--- a/lsp/bin/cinaps.ml
+++ b/lsp/bin/cinaps.ml
@@ -8,75 +8,27 @@ let preprocess_metamodel =
       match
         List.filter_map types ~f:(function
           | Metamodel.Literal (Record []) -> None
-          | _ as t -> Some (self#type_ path t))
+          | type_ -> Some (self#type_ path type_))
       with
       | [] -> assert false
-      | [ t ] -> t
-      | [ Metamodel.Literal (Record f1); Literal (Record f2) ] as ts ->
-        (match path with
-         | Top (Alias s) when s.name = "TextDocumentContentChangeEvent" ->
-           let t =
-             let union_fields l1 l2 ~f =
-               let of_map xs =
-                 List.map xs ~f:(fun (x : Metamodel.property) -> x.name, x)
-                 |> String.Map.of_list
-               in
-               String.Map.merge (of_map l1) (of_map l2) ~f
-               |> String.Map.bindings
-               |> List.map ~f:snd
-             in
-             union_fields f1 f2 ~f:(fun k t1 t2 ->
-               if k = "text"
-               then t1
-               else if k = "range"
-               then (
-                 match t1, t2 with
-                 | None, Some s | Some s, None ->
-                   assert (not s.optional);
-                   Some { s with optional = true }
-                 | None, None | Some _, Some _ -> assert false)
-               else (
-                 match t1, t2 with
-                 | None, None -> assert false
-                 | Some s, None | None, Some s -> Some s
-                 | Some _, Some _ -> assert false))
-           in
-           self#type_ path (Metamodel.Literal (Record t))
-         | _ -> super#or_ path ts)
-      | ts -> super#or_ path ts
-
-    method! property path (p : Metamodel.property) =
-      let update_type type_ =
-        let type_ = self#type_ path type_ in
-        super#property path { p with type_ }
-      in
-      let open Metamodel.Path in
-      match path with
-      | Top (Structure s)
-        when p.name = "trace"
-             && (s.name = "_InitializeParams" || s.name = "InitializeParams") ->
-        update_type (Reference "TraceValues")
-      | Top (Structure s) when p.name = "location" && s.name = "WorkspaceSymbol" ->
-        (match p.type_ with
-         | Or [ type_; _ ] -> update_type type_
-         | _ -> assert false)
-      | _ -> super#property path p
+      | [ type_ ] -> type_
+      | types -> super#or_ path types
 
     method! enumeration m =
-      match m.name = "TraceValues" with
-      | false -> super#enumeration m
-      | true ->
-        super#enumeration
-          (let values =
-             let compact : Metamodel.enumerationEntry =
-               { name = "Compact"
-               ; value = `String "compact"
-               ; doc = { since = None; documentation = None }
-               }
-             in
-             compact :: m.values
-           in
-           { m with values })
+      if m.name <> "TraceValue"
+      then super#enumeration m
+      else (
+        (* ["compact"] is not part of the LSP specification. It leaked into an older
+           upstream meta-model from VS Code's implementation-specific trace mode, and
+           previous OCaml-LSP releases consequently accepted it. Keep accepting it for
+           backwards compatibility. *)
+        let compact : Metamodel.enumerationEntry =
+          { name = "Compact"
+          ; value = `String "compact"
+          ; doc = { since = None; documentation = None }
+          }
+        in
+        super#enumeration { m with values = compact :: m.values })
   end
 ;;
 

--- a/lsp/bin/metamodel/metaModel.json
+++ b/lsp/bin/metamodel/metaModel.json
@@ -1,10 +1,11 @@
 {
 	"metaData": {
-		"version": "3.17.0"
+		"version": "3.18.0"
 	},
 	"requests": [
 		{
 			"method": "textDocument/implementation",
+			"typeName": "ImplementationRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -26,6 +27,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.implementation",
+			"serverCapability": "implementationProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ImplementationParams"
@@ -57,6 +60,7 @@
 		},
 		{
 			"method": "textDocument/typeDefinition",
+			"typeName": "TypeDefinitionRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -78,6 +82,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.typeDefinition",
+			"serverCapability": "typeDefinitionProvider",
 			"params": {
 				"kind": "reference",
 				"name": "TypeDefinitionParams"
@@ -109,6 +115,7 @@
 		},
 		{
 			"method": "workspace/workspaceFolders",
+			"typeName": "WorkspaceFoldersRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -126,10 +133,13 @@
 				]
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.workspaceFolders",
+			"serverCapability": "workspace.workspaceFolders",
 			"documentation": "The `workspace/workspaceFolders` is sent from the server to the client to fetch the open workspace folders."
 		},
 		{
 			"method": "workspace/configuration",
+			"typeName": "ConfigurationRequest",
 			"result": {
 				"kind": "array",
 				"element": {
@@ -138,14 +148,16 @@
 				}
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.configuration",
 			"params": {
 				"kind": "reference",
 				"name": "ConfigurationParams"
 			},
-			"documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model where the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
+			"documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
 		},
 		{
 			"method": "textDocument/documentColor",
+			"typeName": "DocumentColorRequest",
 			"result": {
 				"kind": "array",
 				"element": {
@@ -154,6 +166,8 @@
 				}
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.colorProvider",
+			"serverCapability": "colorProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentColorParams"
@@ -173,6 +187,7 @@
 		},
 		{
 			"method": "textDocument/colorPresentation",
+			"typeName": "ColorPresentationRequest",
 			"result": {
 				"kind": "array",
 				"element": {
@@ -181,6 +196,8 @@
 				}
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.colorProvider",
+			"serverCapability": "colorProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ColorPresentationParams"
@@ -193,22 +210,14 @@
 				}
 			},
 			"registrationOptions": {
-				"kind": "and",
-				"items": [
-					{
-						"kind": "reference",
-						"name": "WorkDoneProgressOptions"
-					},
-					{
-						"kind": "reference",
-						"name": "TextDocumentRegistrationOptions"
-					}
-				]
+				"kind": "reference",
+				"name": "DocumentColorRegistrationOptions"
 			},
-			"documentation": "A request to list all presentation for a color. The request's\nparameter is of type {@link ColorPresentationParams} the\nresponse is of type {@link ColorInformation ColorInformation[]} or a Thenable\nthat resolves to such."
+			"documentation": "A request to list all presentation for a color. The request's\nparameter is of type {@link ColorPresentationParams} the\nresponse is of type {@link ColorPresentation ColorPresentation[]} or a Thenable\nthat resolves to such."
 		},
 		{
 			"method": "textDocument/foldingRange",
+			"typeName": "FoldingRangeRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -226,6 +235,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.foldingRange",
+			"serverCapability": "foldingRangeProvider",
 			"params": {
 				"kind": "reference",
 				"name": "FoldingRangeParams"
@@ -245,17 +256,19 @@
 		},
 		{
 			"method": "workspace/foldingRange/refresh",
+			"typeName": "FoldingRangeRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
-			"documentation": "@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"clientCapability": "workspace.foldingRange.refreshSupport",
+			"documentation": "A request to refresh the folding ranges in a document.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"method": "textDocument/declaration",
+			"typeName": "DeclarationRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -277,6 +290,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.declaration",
+			"serverCapability": "declarationProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DeclarationParams"
@@ -308,6 +323,7 @@
 		},
 		{
 			"method": "textDocument/selectionRange",
+			"typeName": "SelectionRangeRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -325,6 +341,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.selectionRange",
+			"serverCapability": "selectionRangeProvider",
 			"params": {
 				"kind": "reference",
 				"name": "SelectionRangeParams"
@@ -344,11 +362,13 @@
 		},
 		{
 			"method": "window/workDoneProgress/create",
+			"typeName": "WorkDoneProgressCreateRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "window.workDoneProgress",
 			"params": {
 				"kind": "reference",
 				"name": "WorkDoneProgressCreateParams"
@@ -357,6 +377,7 @@
 		},
 		{
 			"method": "textDocument/prepareCallHierarchy",
+			"typeName": "CallHierarchyPrepareRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -374,6 +395,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyPrepareParams"
@@ -387,6 +410,7 @@
 		},
 		{
 			"method": "callHierarchy/incomingCalls",
+			"typeName": "CallHierarchyIncomingCallsRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -404,6 +428,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyIncomingCallsParams"
@@ -420,6 +446,7 @@
 		},
 		{
 			"method": "callHierarchy/outgoingCalls",
+			"typeName": "CallHierarchyOutgoingCallsRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -437,6 +464,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyOutgoingCallsParams"
@@ -453,6 +482,7 @@
 		},
 		{
 			"method": "textDocument/semanticTokens/full",
+			"typeName": "SemanticTokensRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -467,6 +497,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.semanticTokens",
+			"serverCapability": "semanticTokensProvider",
 			"params": {
 				"kind": "reference",
 				"name": "SemanticTokensParams"
@@ -485,6 +517,7 @@
 		},
 		{
 			"method": "textDocument/semanticTokens/full/delta",
+			"typeName": "SemanticTokensDeltaRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -503,6 +536,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.semanticTokens.requests.full.delta",
+			"serverCapability": "semanticTokensProvider.full.delta",
 			"params": {
 				"kind": "reference",
 				"name": "SemanticTokensDeltaParams"
@@ -530,6 +565,7 @@
 		},
 		{
 			"method": "textDocument/semanticTokens/range",
+			"typeName": "SemanticTokensRangeRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -544,6 +580,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.semanticTokens.requests.range",
+			"serverCapability": "semanticTokensProvider.range",
 			"params": {
 				"kind": "reference",
 				"name": "SemanticTokensRangeParams"
@@ -558,21 +596,25 @@
 		},
 		{
 			"method": "workspace/semanticTokens/refresh",
+			"typeName": "SemanticTokensRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.semanticTokens.refreshSupport",
 			"documentation": "@since 3.16.0",
 			"since": "3.16.0"
 		},
 		{
 			"method": "window/showDocument",
+			"typeName": "ShowDocumentRequest",
 			"result": {
 				"kind": "reference",
 				"name": "ShowDocumentResult"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "window.showDocument.support",
 			"params": {
 				"kind": "reference",
 				"name": "ShowDocumentParams"
@@ -582,6 +624,7 @@
 		},
 		{
 			"method": "textDocument/linkedEditingRange",
+			"typeName": "LinkedEditingRangeRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -596,6 +639,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.linkedEditingRange",
+			"serverCapability": "linkedEditingRangeProvider",
 			"params": {
 				"kind": "reference",
 				"name": "LinkedEditingRangeParams"
@@ -609,6 +654,7 @@
 		},
 		{
 			"method": "workspace/willCreateFiles",
+			"typeName": "WillCreateFilesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -623,6 +669,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.willCreate",
+			"serverCapability": "workspace.fileOperations.willCreate",
 			"params": {
 				"kind": "reference",
 				"name": "CreateFilesParams"
@@ -636,6 +684,7 @@
 		},
 		{
 			"method": "workspace/willRenameFiles",
+			"typeName": "WillRenameFilesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -650,6 +699,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.willRename",
+			"serverCapability": "workspace.fileOperations.willRename",
 			"params": {
 				"kind": "reference",
 				"name": "RenameFilesParams"
@@ -663,6 +714,7 @@
 		},
 		{
 			"method": "workspace/willDeleteFiles",
+			"typeName": "WillDeleteFilesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -677,6 +729,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.willDelete",
+			"serverCapability": "workspace.fileOperations.willDelete",
 			"params": {
 				"kind": "reference",
 				"name": "DeleteFilesParams"
@@ -690,6 +744,7 @@
 		},
 		{
 			"method": "textDocument/moniker",
+			"typeName": "MonikerRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -707,6 +762,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.moniker",
+			"serverCapability": "monikerProvider",
 			"params": {
 				"kind": "reference",
 				"name": "MonikerParams"
@@ -726,6 +783,7 @@
 		},
 		{
 			"method": "textDocument/prepareTypeHierarchy",
+			"typeName": "TypeHierarchyPrepareRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -743,6 +801,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.typeHierarchy",
+			"serverCapability": "typeHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "TypeHierarchyPrepareParams"
@@ -756,6 +816,7 @@
 		},
 		{
 			"method": "typeHierarchy/supertypes",
+			"typeName": "TypeHierarchySupertypesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -789,6 +850,7 @@
 		},
 		{
 			"method": "typeHierarchy/subtypes",
+			"typeName": "TypeHierarchySubtypesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -822,6 +884,7 @@
 		},
 		{
 			"method": "textDocument/inlineValue",
+			"typeName": "InlineValueRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -839,6 +902,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.inlineValue",
+			"serverCapability": "inlineValueProvider",
 			"params": {
 				"kind": "reference",
 				"name": "InlineValueParams"
@@ -859,16 +924,19 @@
 		},
 		{
 			"method": "workspace/inlineValue/refresh",
+			"typeName": "InlineValueRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.inlineValue.refreshSupport",
 			"documentation": "@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "textDocument/inlayHint",
+			"typeName": "InlayHintRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -886,6 +954,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.inlayHint",
+			"serverCapability": "inlayHintProvider",
 			"params": {
 				"kind": "reference",
 				"name": "InlayHintParams"
@@ -906,11 +976,14 @@
 		},
 		{
 			"method": "inlayHint/resolve",
+			"typeName": "InlayHintResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "InlayHint"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.inlayHint.resolveSupport",
+			"serverCapability": "inlayHintProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "InlayHint"
@@ -920,28 +993,33 @@
 		},
 		{
 			"method": "workspace/inlayHint/refresh",
+			"typeName": "InlayHintRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.inlayHint.refreshSupport",
 			"documentation": "@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "textDocument/diagnostic",
+			"typeName": "DocumentDiagnosticRequest",
 			"result": {
 				"kind": "reference",
 				"name": "DocumentDiagnosticReport"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.diagnostic",
+			"serverCapability": "diagnosticProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentDiagnosticParams"
 			},
 			"partialResult": {
 				"kind": "reference",
-				"name": "DocumentDiagnosticReportPartialResult"
+				"name": "DocumentDiagnosticReportProgress"
 			},
 			"errorData": {
 				"kind": "reference",
@@ -951,16 +1029,19 @@
 				"kind": "reference",
 				"name": "DiagnosticRegistrationOptions"
 			},
-			"documentation": "The document diagnostic request definition.\n\n@since 3.17.0",
+			"documentation": "The document diagnostic request definition.\n\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "workspace/diagnostic",
+			"typeName": "WorkspaceDiagnosticRequest",
 			"result": {
 				"kind": "reference",
 				"name": "WorkspaceDiagnosticReport"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.diagnostics",
+			"serverCapability": "diagnosticProvider.workspaceDiagnostics",
 			"params": {
 				"kind": "reference",
 				"name": "WorkspaceDiagnosticParams"
@@ -978,16 +1059,19 @@
 		},
 		{
 			"method": "workspace/diagnostic/refresh",
+			"typeName": "DiagnosticRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.diagnostics.refreshSupport",
 			"documentation": "The diagnostic refresh request definition.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "textDocument/inlineCompletion",
+			"typeName": "InlineCompletionRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1009,6 +1093,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.inlineCompletion",
+			"serverCapability": "inlineCompletionProvider",
 			"params": {
 				"kind": "reference",
 				"name": "InlineCompletionParams"
@@ -1024,12 +1110,48 @@
 				"kind": "reference",
 				"name": "InlineCompletionRegistrationOptions"
 			},
-			"documentation": "A request to provide inline completions in a document. The request's parameter is of\ntype {@link InlineCompletionParams}, the response is of type\n{@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "A request to provide inline completions in a document. The request's parameter is of\ntype {@link InlineCompletionParams}, the response is of type\n{@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"method": "workspace/textDocumentContent",
+			"typeName": "TextDocumentContentRequest",
+			"result": {
+				"kind": "reference",
+				"name": "TextDocumentContentResult"
+			},
+			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.textDocumentContent",
+			"serverCapability": "workspace.textDocumentContent",
+			"params": {
+				"kind": "reference",
+				"name": "TextDocumentContentParams"
+			},
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "TextDocumentContentRegistrationOptions"
+			},
+			"documentation": "The `workspace/textDocumentContent` request is sent from the client to the\nserver to request the content of a text document.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"method": "workspace/textDocumentContent/refresh",
+			"typeName": "TextDocumentContentRefreshRequest",
+			"result": {
+				"kind": "base",
+				"name": "null"
+			},
+			"messageDirection": "serverToClient",
+			"params": {
+				"kind": "reference",
+				"name": "TextDocumentContentRefreshParams"
+			},
+			"documentation": "The `workspace/textDocumentContent` request is sent from the server to the client to refresh\nthe content of a specific text document.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"method": "client/registerCapability",
+			"typeName": "RegistrationRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
@@ -1043,6 +1165,7 @@
 		},
 		{
 			"method": "client/unregisterCapability",
+			"typeName": "UnregistrationRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
@@ -1056,6 +1179,7 @@
 		},
 		{
 			"method": "initialize",
+			"typeName": "InitializeRequest",
 			"result": {
 				"kind": "reference",
 				"name": "InitializeResult"
@@ -1073,6 +1197,7 @@
 		},
 		{
 			"method": "shutdown",
+			"typeName": "ShutdownRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
@@ -1082,6 +1207,7 @@
 		},
 		{
 			"method": "window/showMessageRequest",
+			"typeName": "ShowMessageRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1096,6 +1222,7 @@
 				]
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "window.showMessage",
 			"params": {
 				"kind": "reference",
 				"name": "ShowMessageRequestParams"
@@ -1104,6 +1231,7 @@
 		},
 		{
 			"method": "textDocument/willSaveWaitUntil",
+			"typeName": "WillSaveTextDocumentWaitUntilRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1121,6 +1249,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization.willSaveWaitUntil",
+			"serverCapability": "textDocumentSync.willSaveWaitUntil",
 			"params": {
 				"kind": "reference",
 				"name": "WillSaveTextDocumentParams"
@@ -1133,6 +1263,7 @@
 		},
 		{
 			"method": "textDocument/completion",
+			"typeName": "CompletionRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1154,6 +1285,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.completion",
+			"serverCapability": "completionProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CompletionParams"
@@ -1173,11 +1306,14 @@
 		},
 		{
 			"method": "completionItem/resolve",
+			"typeName": "CompletionResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "CompletionItem"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.completion.completionItem.resolveSupport",
+			"serverCapability": "completionProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CompletionItem"
@@ -1186,6 +1322,7 @@
 		},
 		{
 			"method": "textDocument/hover",
+			"typeName": "HoverRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1200,6 +1337,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.hover",
+			"serverCapability": "hoverProvider",
 			"params": {
 				"kind": "reference",
 				"name": "HoverParams"
@@ -1212,6 +1351,7 @@
 		},
 		{
 			"method": "textDocument/signatureHelp",
+			"typeName": "SignatureHelpRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1226,6 +1366,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.signatureHelp",
+			"serverCapability": "signatureHelpProvider",
 			"params": {
 				"kind": "reference",
 				"name": "SignatureHelpParams"
@@ -1237,6 +1379,7 @@
 		},
 		{
 			"method": "textDocument/definition",
+			"typeName": "DefinitionRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1258,6 +1401,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.definition",
+			"serverCapability": "definitionProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DefinitionParams"
@@ -1289,6 +1434,7 @@
 		},
 		{
 			"method": "textDocument/references",
+			"typeName": "ReferencesRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1306,6 +1452,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.references",
+			"serverCapability": "referencesProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ReferenceParams"
@@ -1325,6 +1473,7 @@
 		},
 		{
 			"method": "textDocument/documentHighlight",
+			"typeName": "DocumentHighlightRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1342,6 +1491,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.documentHighlight",
+			"serverCapability": "documentHighlightProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentHighlightParams"
@@ -1361,6 +1512,7 @@
 		},
 		{
 			"method": "textDocument/documentSymbol",
+			"typeName": "DocumentSymbolRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1385,6 +1537,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.documentSymbol",
+			"serverCapability": "documentSymbolProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentSymbolParams"
@@ -1416,6 +1570,7 @@
 		},
 		{
 			"method": "textDocument/codeAction",
+			"typeName": "CodeActionRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1442,6 +1597,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.codeAction",
+			"serverCapability": "codeActionProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CodeActionParams"
@@ -1470,11 +1627,14 @@
 		},
 		{
 			"method": "codeAction/resolve",
+			"typeName": "CodeActionResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "CodeAction"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.codeAction.resolveSupport",
+			"serverCapability": "codeActionProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CodeAction"
@@ -1483,6 +1643,7 @@
 		},
 		{
 			"method": "workspace/symbol",
+			"typeName": "WorkspaceSymbolRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1507,6 +1668,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.symbol",
+			"serverCapability": "workspaceSymbolProvider",
 			"params": {
 				"kind": "reference",
 				"name": "WorkspaceSymbolParams"
@@ -1539,11 +1702,14 @@
 		},
 		{
 			"method": "workspaceSymbol/resolve",
+			"typeName": "WorkspaceSymbolResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "WorkspaceSymbol"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.symbol.resolveSupport",
+			"serverCapability": "workspaceSymbolProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "WorkspaceSymbol"
@@ -1553,6 +1719,7 @@
 		},
 		{
 			"method": "textDocument/codeLens",
+			"typeName": "CodeLensRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1570,6 +1737,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.codeLens",
+			"serverCapability": "codeLensProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CodeLensParams"
@@ -1589,11 +1758,14 @@
 		},
 		{
 			"method": "codeLens/resolve",
+			"typeName": "CodeLensResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "CodeLens"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.codeLens.resolveSupport",
+			"serverCapability": "codeLensProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CodeLens"
@@ -1602,16 +1774,19 @@
 		},
 		{
 			"method": "workspace/codeLens/refresh",
+			"typeName": "CodeLensRefreshRequest",
 			"result": {
 				"kind": "base",
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.codeLens",
 			"documentation": "A request to refresh all code actions\n\n@since 3.16.0",
 			"since": "3.16.0"
 		},
 		{
 			"method": "textDocument/documentLink",
+			"typeName": "DocumentLinkRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1629,6 +1804,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.documentLink",
+			"serverCapability": "documentLinkProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentLinkParams"
@@ -1648,11 +1825,14 @@
 		},
 		{
 			"method": "documentLink/resolve",
+			"typeName": "DocumentLinkResolveRequest",
 			"result": {
 				"kind": "reference",
 				"name": "DocumentLink"
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.documentLink",
+			"serverCapability": "documentLinkProvider.resolveProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentLink"
@@ -1661,6 +1841,7 @@
 		},
 		{
 			"method": "textDocument/formatting",
+			"typeName": "DocumentFormattingRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1678,6 +1859,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.formatting",
+			"serverCapability": "documentFormattingProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentFormattingParams"
@@ -1690,6 +1873,7 @@
 		},
 		{
 			"method": "textDocument/rangeFormatting",
+			"typeName": "DocumentRangeFormattingRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1707,6 +1891,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.rangeFormatting",
+			"serverCapability": "documentRangeFormattingProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentRangeFormattingParams"
@@ -1719,6 +1905,7 @@
 		},
 		{
 			"method": "textDocument/rangesFormatting",
+			"typeName": "DocumentRangesFormattingRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1736,6 +1923,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.rangeFormatting.rangesSupport",
+			"serverCapability": "documentRangeFormattingProvider.rangesSupport",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentRangesFormattingParams"
@@ -1744,12 +1933,12 @@
 				"kind": "reference",
 				"name": "DocumentRangeFormattingRegistrationOptions"
 			},
-			"documentation": "A request to format ranges in a document.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "A request to format ranges in a document.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"method": "textDocument/onTypeFormatting",
+			"typeName": "DocumentOnTypeFormattingRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1767,6 +1956,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.onTypeFormatting",
+			"serverCapability": "documentOnTypeFormattingProvider",
 			"params": {
 				"kind": "reference",
 				"name": "DocumentOnTypeFormattingParams"
@@ -1779,6 +1970,7 @@
 		},
 		{
 			"method": "textDocument/rename",
+			"typeName": "RenameRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1793,6 +1985,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.rename",
+			"serverCapability": "renameProvider",
 			"params": {
 				"kind": "reference",
 				"name": "RenameParams"
@@ -1805,6 +1999,7 @@
 		},
 		{
 			"method": "textDocument/prepareRename",
+			"typeName": "PrepareRenameRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1819,6 +2014,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.rename.prepareSupport",
+			"serverCapability": "renameProvider.prepareProvider",
 			"params": {
 				"kind": "reference",
 				"name": "PrepareRenameParams"
@@ -1828,6 +2025,7 @@
 		},
 		{
 			"method": "workspace/executeCommand",
+			"typeName": "ExecuteCommandRequest",
 			"result": {
 				"kind": "or",
 				"items": [
@@ -1842,6 +2040,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.executeCommand",
+			"serverCapability": "executeCommandProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ExecuteCommandParams"
@@ -1850,26 +2050,30 @@
 				"kind": "reference",
 				"name": "ExecuteCommandRegistrationOptions"
 			},
-			"documentation": "A request sent from the client to the server to execute a command. The request might return\na workspace edit which the client will apply to the workspace."
+			"documentation": "A request send from the client to the server to execute a command. The request might return\na workspace edit which the client will apply to the workspace."
 		},
 		{
 			"method": "workspace/applyEdit",
+			"typeName": "ApplyWorkspaceEditRequest",
 			"result": {
 				"kind": "reference",
 				"name": "ApplyWorkspaceEditResult"
 			},
 			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.applyEdit",
 			"params": {
 				"kind": "reference",
 				"name": "ApplyWorkspaceEditParams"
 			},
-			"documentation": "A request sent from the server to the client to modify certain resources."
+			"documentation": "A request sent from the server to the client to modified certain resources."
 		}
 	],
 	"notifications": [
 		{
 			"method": "workspace/didChangeWorkspaceFolders",
+			"typeName": "DidChangeWorkspaceFoldersNotification",
 			"messageDirection": "clientToServer",
+			"serverCapability": "workspace.workspaceFolders.changeNotifications",
 			"params": {
 				"kind": "reference",
 				"name": "DidChangeWorkspaceFoldersParams"
@@ -1878,6 +2082,7 @@
 		},
 		{
 			"method": "window/workDoneProgress/cancel",
+			"typeName": "WorkDoneProgressCancelNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
@@ -1887,7 +2092,10 @@
 		},
 		{
 			"method": "workspace/didCreateFiles",
+			"typeName": "DidCreateFilesNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.didCreate",
+			"serverCapability": "workspace.fileOperations.didCreate",
 			"params": {
 				"kind": "reference",
 				"name": "CreateFilesParams"
@@ -1901,7 +2109,10 @@
 		},
 		{
 			"method": "workspace/didRenameFiles",
+			"typeName": "DidRenameFilesNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.didRename",
+			"serverCapability": "workspace.fileOperations.didRename",
 			"params": {
 				"kind": "reference",
 				"name": "RenameFilesParams"
@@ -1915,7 +2126,10 @@
 		},
 		{
 			"method": "workspace/didDeleteFiles",
+			"typeName": "DidDeleteFilesNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.fileOperations.didDelete",
+			"serverCapability": "workspace.fileOperations.didDelete",
 			"params": {
 				"kind": "reference",
 				"name": "DeleteFilesParams"
@@ -1929,48 +2143,69 @@
 		},
 		{
 			"method": "notebookDocument/didOpen",
+			"typeName": "DidOpenNotebookDocumentNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
 				"name": "DidOpenNotebookDocumentParams"
 			},
 			"registrationMethod": "notebookDocument/sync",
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "NotebookDocumentSyncRegistrationOptions"
+			},
 			"documentation": "A notification sent when a notebook opens.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "notebookDocument/didChange",
+			"typeName": "DidChangeNotebookDocumentNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
 				"name": "DidChangeNotebookDocumentParams"
 			},
-			"registrationMethod": "notebookDocument/sync"
+			"registrationMethod": "notebookDocument/sync",
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "NotebookDocumentSyncRegistrationOptions"
+			}
 		},
 		{
 			"method": "notebookDocument/didSave",
+			"typeName": "DidSaveNotebookDocumentNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
 				"name": "DidSaveNotebookDocumentParams"
 			},
 			"registrationMethod": "notebookDocument/sync",
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "NotebookDocumentSyncRegistrationOptions"
+			},
 			"documentation": "A notification sent when a notebook document is saved.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "notebookDocument/didClose",
+			"typeName": "DidCloseNotebookDocumentNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
 				"name": "DidCloseNotebookDocumentParams"
 			},
 			"registrationMethod": "notebookDocument/sync",
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "NotebookDocumentSyncRegistrationOptions"
+			},
 			"documentation": "A notification sent when a notebook closes.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
 			"method": "initialized",
+			"typeName": "InitializedNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
@@ -1980,12 +2215,15 @@
 		},
 		{
 			"method": "exit",
+			"typeName": "ExitNotification",
 			"messageDirection": "clientToServer",
 			"documentation": "The exit event is sent from the client to the server to\nask the server to exit its process."
 		},
 		{
 			"method": "workspace/didChangeConfiguration",
+			"typeName": "DidChangeConfigurationNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.didChangeConfiguration",
 			"params": {
 				"kind": "reference",
 				"name": "DidChangeConfigurationParams"
@@ -1998,7 +2236,9 @@
 		},
 		{
 			"method": "window/showMessage",
+			"typeName": "ShowMessageNotification",
 			"messageDirection": "serverToClient",
+			"clientCapability": "window.showMessage",
 			"params": {
 				"kind": "reference",
 				"name": "ShowMessageParams"
@@ -2007,6 +2247,7 @@
 		},
 		{
 			"method": "window/logMessage",
+			"typeName": "LogMessageNotification",
 			"messageDirection": "serverToClient",
 			"params": {
 				"kind": "reference",
@@ -2016,6 +2257,7 @@
 		},
 		{
 			"method": "telemetry/event",
+			"typeName": "TelemetryEventNotification",
 			"messageDirection": "serverToClient",
 			"params": {
 				"kind": "reference",
@@ -2025,7 +2267,10 @@
 		},
 		{
 			"method": "textDocument/didOpen",
+			"typeName": "DidOpenTextDocumentNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization",
+			"serverCapability": "textDocumentSync.openClose",
 			"params": {
 				"kind": "reference",
 				"name": "DidOpenTextDocumentParams"
@@ -2038,7 +2283,10 @@
 		},
 		{
 			"method": "textDocument/didChange",
+			"typeName": "DidChangeTextDocumentNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization",
+			"serverCapability": "textDocumentSync",
 			"params": {
 				"kind": "reference",
 				"name": "DidChangeTextDocumentParams"
@@ -2051,7 +2299,10 @@
 		},
 		{
 			"method": "textDocument/didClose",
+			"typeName": "DidCloseTextDocumentNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization",
+			"serverCapability": "textDocumentSync.openClose",
 			"params": {
 				"kind": "reference",
 				"name": "DidCloseTextDocumentParams"
@@ -2064,7 +2315,10 @@
 		},
 		{
 			"method": "textDocument/didSave",
+			"typeName": "DidSaveTextDocumentNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization.didSave",
+			"serverCapability": "textDocumentSync.save",
 			"params": {
 				"kind": "reference",
 				"name": "DidSaveTextDocumentParams"
@@ -2077,7 +2331,10 @@
 		},
 		{
 			"method": "textDocument/willSave",
+			"typeName": "WillSaveTextDocumentNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.synchronization.willSave",
+			"serverCapability": "textDocumentSync.willSave",
 			"params": {
 				"kind": "reference",
 				"name": "WillSaveTextDocumentParams"
@@ -2090,7 +2347,9 @@
 		},
 		{
 			"method": "workspace/didChangeWatchedFiles",
+			"typeName": "DidChangeWatchedFilesNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.didChangeWatchedFiles",
 			"params": {
 				"kind": "reference",
 				"name": "DidChangeWatchedFilesParams"
@@ -2103,7 +2362,9 @@
 		},
 		{
 			"method": "textDocument/publishDiagnostics",
+			"typeName": "PublishDiagnosticsNotification",
 			"messageDirection": "serverToClient",
+			"clientCapability": "textDocument.publishDiagnostics",
 			"params": {
 				"kind": "reference",
 				"name": "PublishDiagnosticsParams"
@@ -2112,6 +2373,7 @@
 		},
 		{
 			"method": "$/setTrace",
+			"typeName": "SetTraceNotification",
 			"messageDirection": "clientToServer",
 			"params": {
 				"kind": "reference",
@@ -2120,6 +2382,7 @@
 		},
 		{
 			"method": "$/logTrace",
+			"typeName": "LogTraceNotification",
 			"messageDirection": "serverToClient",
 			"params": {
 				"kind": "reference",
@@ -2128,6 +2391,7 @@
 		},
 		{
 			"method": "$/cancelRequest",
+			"typeName": "CancelNotification",
 			"messageDirection": "both",
 			"params": {
 				"kind": "reference",
@@ -2136,6 +2400,7 @@
 		},
 		{
 			"method": "$/progress",
+			"typeName": "ProgressNotification",
 			"messageDirection": "both",
 			"params": {
 				"kind": "reference",
@@ -2437,42 +2702,6 @@
 			]
 		},
 		{
-			"name": "WorkDoneProgressOptions",
-			"properties": [
-				{
-					"name": "workDoneProgress",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true
-				}
-			]
-		},
-		{
-			"name": "TextDocumentRegistrationOptions",
-			"properties": [
-				{
-					"name": "documentSelector",
-					"type": {
-						"kind": "or",
-						"items": [
-							{
-								"kind": "reference",
-								"name": "DocumentSelector"
-							},
-							{
-								"kind": "base",
-								"name": "null"
-							}
-						]
-					},
-					"documentation": "A document selector to identify the scope of the registration. If set to null\nthe document selector provided on the client side will be used."
-				}
-			],
-			"documentation": "General text document registration options."
-		},
-		{
 			"name": "FoldingRangeParams",
 			"properties": [
 				{
@@ -2540,7 +2769,7 @@
 						"name": "FoldingRangeKind"
 					},
 					"optional": true,
-					"documentation": "Describes the kind of the folding range such as `comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee {@link FoldingRangeKind} for an enumeration of standardized kinds."
+					"documentation": "Describes the kind of the folding range such as 'comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee {@link FoldingRangeKind} for an enumeration of standardized kinds."
 				},
 				{
 					"name": "collapsedText",
@@ -3655,7 +3884,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The document range for which inline values should be computed."
+					"documentation": "The document range for which inline values information will be returned."
 				},
 				{
 					"name": "context",
@@ -3663,7 +3892,7 @@
 						"kind": "reference",
 						"name": "InlineValueContext"
 					},
-					"documentation": "Additional information about the context in which inline values were\nrequested."
+					"documentation": "Additional information about the context in which inline values information was\nrequested."
 				}
 			],
 			"mixins": [
@@ -3893,36 +4122,6 @@
 			"since": "3.17.0"
 		},
 		{
-			"name": "DocumentDiagnosticReportPartialResult",
-			"properties": [
-				{
-					"name": "relatedDocuments",
-					"type": {
-						"kind": "map",
-						"key": {
-							"kind": "base",
-							"name": "DocumentUri"
-						},
-						"value": {
-							"kind": "or",
-							"items": [
-								{
-									"kind": "reference",
-									"name": "FullDocumentDiagnosticReport"
-								},
-								{
-									"kind": "reference",
-									"name": "UnchangedDocumentDiagnosticReport"
-								}
-							]
-						}
-					}
-				}
-			],
-			"documentation": "A partial result for a document diagnostic report.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
 			"name": "DiagnosticServerCancellationData",
 			"properties": [
 				{
@@ -4056,6 +4255,24 @@
 			"since": "3.17.0"
 		},
 		{
+			"name": "NotebookDocumentSyncRegistrationOptions",
+			"properties": [],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "NotebookDocumentSyncOptions"
+				}
+			],
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "StaticRegistrationOptions"
+				}
+			],
+			"documentation": "Registration options specific to a notebook.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
 			"name": "DidChangeNotebookDocumentParams",
 			"properties": [
 				{
@@ -4143,9 +4360,8 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "A parameter literal used in inline completion requests.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "A parameter literal used in inline completion requests.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "InlineCompletionList",
@@ -4162,9 +4378,8 @@
 					"documentation": "The inline completion items"
 				}
 			],
-			"documentation": "Represents a collection of {@link InlineCompletionItem inline completion items} to be presented in the editor.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Represents a collection of {@link InlineCompletionItem inline completion items} to be presented in the editor.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "InlineCompletionItem",
@@ -4214,9 +4429,8 @@
 					"documentation": "An optional {@link Command} that is executed *after* inserting this completion."
 				}
 			],
-			"documentation": "An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "InlineCompletionRegistrationOptions",
@@ -4237,9 +4451,71 @@
 					"name": "StaticRegistrationOptions"
 				}
 			],
-			"documentation": "Inline completion options used during static or dynamic registration.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Inline completion options used during static or dynamic registration.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "The uri of the text document."
+				}
+			],
+			"documentation": "Parameters for the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentResult",
+			"properties": [
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The text content of the text document. Please note, that the content of\nany subsequent open notifications for the text document might differ\nfrom the returned content due to whitespace and line ending\nnormalizations done on the client"
+				}
+			],
+			"documentation": "Result of the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentRegistrationOptions",
+			"properties": [],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "TextDocumentContentOptions"
+				}
+			],
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "StaticRegistrationOptions"
+				}
+			],
+			"documentation": "Text document content provider registration options.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentRefreshParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "The uri of the text document to refresh."
+				}
+			],
+			"documentation": "Parameters for the `workspace/textDocumentContent/refresh` request.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "RegistrationParams",
@@ -4299,28 +4575,8 @@
 				{
 					"name": "serverInfo",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "name",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "The name of the server as defined by the server."
-								},
-								{
-									"name": "version",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "The server's version as defined by the server."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ServerInfo"
 					},
 					"optional": true,
 					"documentation": "Information about the server.\n\n@since 3.15.0",
@@ -4489,6 +4745,29 @@
 				}
 			],
 			"documentation": "The parameters sent in an open text document notification"
+		},
+		{
+			"name": "TextDocumentRegistrationOptions",
+			"properties": [
+				{
+					"name": "documentSelector",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "reference",
+								"name": "DocumentSelector"
+							},
+							{
+								"kind": "base",
+								"name": "null"
+							}
+						]
+					},
+					"documentation": "A document selector to identify the scope of the registration. If set to null\nthe document selector provided on the client side will be used."
+				}
+			],
+			"documentation": "General text document registration options."
 		},
 		{
 			"name": "DidChangeTextDocumentParams",
@@ -4954,94 +5233,22 @@
 				{
 					"name": "itemDefaults",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "commitCharacters",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"optional": true,
-									"documentation": "A default commit character set.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								},
-								{
-									"name": "editRange",
-									"type": {
-										"kind": "or",
-										"items": [
-											{
-												"kind": "reference",
-												"name": "Range"
-											},
-											{
-												"kind": "literal",
-												"value": {
-													"properties": [
-														{
-															"name": "insert",
-															"type": {
-																"kind": "reference",
-																"name": "Range"
-															}
-														},
-														{
-															"name": "replace",
-															"type": {
-																"kind": "reference",
-																"name": "Range"
-															}
-														}
-													]
-												}
-											}
-										]
-									},
-									"optional": true,
-									"documentation": "A default edit range.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								},
-								{
-									"name": "insertTextFormat",
-									"type": {
-										"kind": "reference",
-										"name": "InsertTextFormat"
-									},
-									"optional": true,
-									"documentation": "A default insert text format.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								},
-								{
-									"name": "insertTextMode",
-									"type": {
-										"kind": "reference",
-										"name": "InsertTextMode"
-									},
-									"optional": true,
-									"documentation": "A default insert text mode.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								},
-								{
-									"name": "data",
-									"type": {
-										"kind": "reference",
-										"name": "LSPAny"
-									},
-									"optional": true,
-									"documentation": "A default data value.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "CompletionItemDefaults"
 					},
 					"optional": true,
-					"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value the one from the item is used.\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
+					"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value, the rules for combining these are\ndefined by `applyKinds` (if the client supports it), defaulting to\nApplyKind.Replace.\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "applyKind",
+					"type": {
+						"kind": "reference",
+						"name": "CompletionItemApplyKinds"
+					},
+					"optional": true,
+					"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIf unspecified, all fields will be treated as ApplyKind.Replace.\n\nIf a field's value is ApplyKind.Replace, the value from a completion item\n(if provided and not `null`) will always be used instead of the value\nfrom `completionItem.itemDefaults`.\n\nIf a field's value is ApplyKind.Merge, the values will be merged using\nthe rules defined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				},
 				{
 					"name": "items",
@@ -5210,7 +5417,7 @@
 						]
 					},
 					"optional": true,
-					"documentation": "The active parameter of the active signature.\n\nIf `null`, no parameter of the signature is active (for example a named\nargument that does not match any declared parameters). This is only valid\nsince 3.18.0 and if the client specifies the client capability\n`textDocument.signatureHelp.noActiveParameterSupport === true`\n\nIf omitted or the value lies outside the range of\n`signatures[activeSignature].parameters` defaults to 0 if the active\nsignature has parameters.\n\nIf the active signature has no parameters it is ignored.\n\nIn future version of the protocol this property might become\nmandatory (but still nullable) to better express the active parameter if\nthe active signature does have any."
+					"documentation": "The active parameter of the active signature.\n\nIf `null`, no parameter of the signature is active (for example a named\nargument that does not match any declared parameters). This is only valid\nif the client specifies the client capability\n`textDocument.signatureHelp.noActiveParameterSupport === true`\n\nIf omitted or the value lies outside the range of\n`signatures[activeSignature].parameters` defaults to 0 if the active\nsignature has parameters.\n\nIf the active signature has no parameters it is ignored.\n\nIn future version of the protocol this property might become\nmandatory (but still nullable) to better express the active parameter if\nthe active signature does have any.\n\nSince version 3.16.0 the `SignatureInformation` itself provides a\n`activeParameter` property and it should be used instead of this one."
 				}
 			],
 			"documentation": "Signature help represents the signature of something\ncallable. There can be multiple signature but only one\nactive and only one active parameter."
@@ -5572,6 +5779,16 @@
 					"documentation": "Title of the command, like `save`."
 				},
 				{
+					"name": "tooltip",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "An optional tooltip.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
 					"name": "command",
 					"type": {
 						"kind": "base",
@@ -5639,19 +5856,8 @@
 				{
 					"name": "disabled",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "reason",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "Human readable description of why the code action is currently disabled.\n\nThis is displayed in the code actions UI."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "CodeActionDisabled"
 					},
 					"optional": true,
 					"documentation": "Marks that the code action cannot currently be applied.\n\nClients should follow the following guidelines regarding disabled code actions:\n\n  - Disabled code actions are not shown in automatic [lightbulbs](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)\n    code action menus.\n\n  - Disabled actions are shown as faded out in the code action menu when the user requests a more specific type\n    of code action, such as refactorings.\n\n  - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)\n    that auto applies a code action and only disabled code actions are returned, the client should show the user an\n    error message with `reason` in the editor.\n\n@since 3.16.0",
@@ -5684,6 +5890,19 @@
 					"optional": true,
 					"documentation": "A data entry field that is preserved on a code action between\na `textDocument/codeAction` and a `codeAction/resolve` request.\n\n@since 3.16.0",
 					"since": "3.16.0"
+				},
+				{
+					"name": "tags",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CodeActionTag"
+						}
+					},
+					"optional": true,
+					"documentation": "Tags for this code action.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "A code action represents a change that can be performed in code, e.g. to fix a problem or\nto refactor code.\n\nA CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed."
@@ -5712,7 +5931,7 @@
 						"kind": "base",
 						"name": "string"
 					},
-					"documentation": "A query string to filter symbols by. Clients may send an empty\nstring here to request all symbols."
+					"documentation": "A query string to filter symbols by. Clients may send an empty\nstring here to request all symbols.\n\nThe `query`-parameter should be interpreted in a *relaxed way* as editors\nwill apply their own highlighting and scoring on the results. A good rule\nof thumb is to match case-insensitive and to simply check that the\ncharacters of *query* appear in their order in a candidate symbol.\nServers shouldn't use prefix, substring, or similar strict matching."
 				}
 			],
 			"mixins": [
@@ -5740,18 +5959,8 @@
 								"name": "Location"
 							},
 							{
-								"kind": "literal",
-								"value": {
-									"properties": [
-										{
-											"name": "uri",
-											"type": {
-												"kind": "base",
-												"name": "DocumentUri"
-											}
-										}
-									]
-								}
+								"kind": "reference",
+								"name": "LocationUriOnly"
 							}
 						]
 					},
@@ -6070,9 +6279,8 @@
 					"name": "WorkDoneProgressParams"
 				}
 			],
-			"documentation": "The parameters of a {@link DocumentRangesFormattingRequest}.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "The parameters of a {@link DocumentRangesFormattingRequest}.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "DocumentOnTypeFormattingParams",
@@ -6131,28 +6339,18 @@
 			"name": "RenameParams",
 			"properties": [
 				{
-					"name": "textDocument",
-					"type": {
-						"kind": "reference",
-						"name": "TextDocumentIdentifier"
-					},
-					"documentation": "The document to rename."
-				},
-				{
-					"name": "position",
-					"type": {
-						"kind": "reference",
-						"name": "Position"
-					},
-					"documentation": "The position at which this request was sent."
-				},
-				{
 					"name": "newName",
 					"type": {
 						"kind": "base",
 						"name": "string"
 					},
 					"documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a {@link ResponseError} with an\nappropriate message set."
+				}
+			],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "TextDocumentPositionParams"
 				}
 			],
 			"mixins": [
@@ -6256,6 +6454,16 @@
 						"name": "WorkspaceEdit"
 					},
 					"documentation": "The edits to apply."
+				},
+				{
+					"name": "metadata",
+					"type": {
+						"kind": "reference",
+						"name": "WorkspaceEditMetadata"
+					},
+					"optional": true,
+					"documentation": "Additional data about the edit.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The parameters passed via an apply workspace edit request."
@@ -6407,7 +6615,7 @@
 					"name": "value",
 					"type": {
 						"kind": "reference",
-						"name": "TraceValues"
+						"name": "TraceValue"
 					}
 				}
 			]
@@ -6763,7 +6971,7 @@
 						"kind": "base",
 						"name": "uinteger"
 					},
-					"documentation": "Line position in a document (zero-based).\n\nIf a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.\nIf a line number is negative, it defaults to 0."
+					"documentation": "Line position in a document (zero-based)."
 				},
 				{
 					"name": "character",
@@ -6771,7 +6979,7 @@
 						"kind": "base",
 						"name": "uinteger"
 					},
-					"documentation": "Character offset on a line in a document (zero-based).\n\nThe meaning of this offset is determined by the negotiated\n`PositionEncodingKind`.\n\nIf the character value is greater than the line length it defaults back to the\nline length."
+					"documentation": "Character offset on a line in a document (zero-based).\n\nThe meaning of this offset is determined by the negotiated\n`PositionEncodingKind`."
 				}
 			],
 			"documentation": "Position in a text document expressed as zero-based line and character\noffset. Prior to 3.17 the offsets were always based on a UTF-16 string\nrepresentation. So a string of the form `a𐐀b` the character offset of the\ncharacter `a` is 0, the character offset of `𐐀` is 1 and the character\noffset of b is 3 since `𐐀` is represented using two code units in UTF-16.\nSince 3.17 clients and servers can agree on a different string encoding\nrepresentation (e.g. UTF-8). The client announces it's supported encoding\nvia the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).\nThe value is an array of position encodings the client supports, with\ndecreasing preference (e.g. the encoding at index `0` is the most preferred\none). To stay backwards compatible the only mandatory encoding is UTF-16\nrepresented via the string `utf-16`. The server can pick one of the\nencodings offered by the client and signals that encoding back to the\nclient via the initialize result's property\n[`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value\n`utf-16` is missing from the client's capability `general.positionEncodings`\nservers can safely assume that the client supports UTF-16. If the server\nomits the position encoding in its initialize result the encoding defaults\nto the string value `utf-16`. Implementation considerations: since the\nconversion from one encoding into another requires the content of the\nfile / line the conversion is best done where the file is read which is\nusually on the server side.\n\nPositions are line end character agnostic. So you can not specify a position\nthat denotes `\\r|\\n` or `\\n|` where `|` represents the character offset.\n\n@since 3.17.0 - support for negotiated position encoding.",
@@ -6840,20 +7048,8 @@
 								"name": "boolean"
 							},
 							{
-								"kind": "literal",
-								"value": {
-									"properties": [
-										{
-											"name": "delta",
-											"type": {
-												"kind": "base",
-												"name": "boolean"
-											},
-											"optional": true,
-											"documentation": "The server supports deltas for full documents."
-										}
-									]
-								}
+								"kind": "reference",
+								"name": "SemanticTokensFullDelta"
 							}
 						]
 					},
@@ -6922,9 +7118,9 @@
 					"name": "uri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the location of the file/folder being created."
+					"documentation": "A URI for the location of the file/folder being created."
 				}
 			],
 			"documentation": "Represents information on a file/folder create.\n\n@since 3.16.0",
@@ -6955,12 +7151,20 @@
 								{
 									"kind": "reference",
 									"name": "AnnotatedTextEdit"
+								},
+								{
+									"kind": "reference",
+									"name": "SnippetTextEdit"
 								}
 							]
 						}
 					},
-					"documentation": "The edits to be applied.\n\n@since 3.16.0 - support for AnnotatedTextEdit. This is guarded using a\nclient capability.",
-					"since": "3.16.0 - support for AnnotatedTextEdit. This is guarded using a\nclient capability."
+					"documentation": "The edits to be applied.\n\n@since 3.16.0 - support for AnnotatedTextEdit. This is guarded using a\nclient capability.\n\n@since 3.18.0 - support for SnippetTextEdit. This is guarded using a\nclient capability.",
+					"since": "3.18.0 - support for SnippetTextEdit. This is guarded using a\nclient capability.",
+					"sinceTags": [
+						"3.16.0 - support for AnnotatedTextEdit. This is guarded using a\nclient capability.",
+						"3.18.0 - support for SnippetTextEdit. This is guarded using a\nclient capability."
+					]
 				}
 			],
 			"documentation": "Describes textual changes on a text document. A TextDocumentEdit describes all changes\non a document version Si and after they are applied move the document to version Si+1.\nSo the creator of a TextDocumentEdit doesn't need to sort the array of edits or do any\nkind of ordering. However the edits must be non overlapping."
@@ -7148,17 +7352,17 @@
 					"name": "oldUri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the original location of the file/folder being renamed."
+					"documentation": "A URI for the original location of the file/folder being renamed."
 				},
 				{
 					"name": "newUri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the new location of the file/folder being renamed."
+					"documentation": "A URI for the new location of the file/folder being renamed."
 				}
 			],
 			"documentation": "Represents information on a file/folder rename.\n\n@since 3.16.0",
@@ -7171,9 +7375,9 @@
 					"name": "uri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the location of the file/folder being deleted."
+					"documentation": "A URI for the location of the file/folder being deleted."
 				}
 			],
 			"documentation": "Represents information on a file/folder delete.\n\n@since 3.16.0",
@@ -7244,7 +7448,7 @@
 					"documentation": "The text of the inline value."
 				}
 			],
-			"documentation": "Provide inline value as text.\n\n@since 3.17.0",
+			"documentation": "Returns inline value information as the complete text to be shown.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -7256,7 +7460,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The document range for which the inline value applies.\nThe range is used to extract the variable name from the underlying document."
+					"documentation": "The document range for which the inline value applies.\n\nThe range could be used to extract the variable name\nfrom the underlying document."
 				},
 				{
 					"name": "variableName",
@@ -7276,7 +7480,7 @@
 					"documentation": "How to perform the lookup."
 				}
 			],
-			"documentation": "Provide inline value through a variable lookup.\nIf only a range is specified, the variable name will be extracted from the underlying document.\nAn optional variable name can be used to override the extracted name.\n\n@since 3.17.0",
+			"documentation": "To compute inline value through a variable lookup.\n\nIf only a range is specified, the variable name should\nbe extracted from the underlying document.\n\nAn optional variable name could be used to lookup instead\nof the extracted name.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -7288,7 +7492,7 @@
 						"kind": "reference",
 						"name": "Range"
 					},
-					"documentation": "The document range for which the inline value applies.\nThe range is used to extract the evaluatable expression from the underlying document."
+					"documentation": "The document range for which the inline value applies.\n\nThe range could be used to extract the evaluatable expression\nfrom the underlying document."
 				},
 				{
 					"name": "expression",
@@ -7297,10 +7501,10 @@
 						"name": "string"
 					},
 					"optional": true,
-					"documentation": "If specified the expression overrides the extracted expression."
+					"documentation": "If specified the expression could be evaluated instead."
 				}
 			],
-			"documentation": "Provide an inline value through an expression evaluation.\nIf only a range is specified, the expression will be extracted from the underlying document.\nAn optional expression can be used to override the extracted expression.\n\n@since 3.17.0",
+			"documentation": "To compute an inline value through an expression evaluation.\n\nIf only a range is specified, the expression should be\nextracted from the underlying document.\n\nAn optional expression could be evaluated instead of\nthe extracted expression.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -7489,61 +7693,33 @@
 			"since": "3.17.0"
 		},
 		{
-			"name": "FullDocumentDiagnosticReport",
+			"name": "DocumentDiagnosticReportPartialResult",
 			"properties": [
 				{
-					"name": "kind",
+					"name": "relatedDocuments",
 					"type": {
-						"kind": "stringLiteral",
-						"value": "full"
-					},
-					"documentation": "A full document diagnostic report."
-				},
-				{
-					"name": "resultId",
-					"type": {
-						"kind": "base",
-						"name": "string"
-					},
-					"optional": true,
-					"documentation": "An optional result id. If provided it will\nbe sent on the next diagnostic request for the\nsame document."
-				},
-				{
-					"name": "items",
-					"type": {
-						"kind": "array",
-						"element": {
-							"kind": "reference",
-							"name": "Diagnostic"
+						"kind": "map",
+						"key": {
+							"kind": "base",
+							"name": "DocumentUri"
+						},
+						"value": {
+							"kind": "or",
+							"items": [
+								{
+									"kind": "reference",
+									"name": "FullDocumentDiagnosticReport"
+								},
+								{
+									"kind": "reference",
+									"name": "UnchangedDocumentDiagnosticReport"
+								}
+							]
 						}
-					},
-					"documentation": "The actual items."
+					}
 				}
 			],
-			"documentation": "A diagnostic report with a full set of problems.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "UnchangedDocumentDiagnosticReport",
-			"properties": [
-				{
-					"name": "kind",
-					"type": {
-						"kind": "stringLiteral",
-						"value": "unchanged"
-					},
-					"documentation": "A document diagnostic report indicating\nno changes to the last result. A server can\nonly return `unchanged` if result ids are\nprovided."
-				},
-				{
-					"name": "resultId",
-					"type": {
-						"kind": "base",
-						"name": "string"
-					},
-					"documentation": "A result id which will be sent on the next\ndiagnostic request for the same document."
-				}
-			],
-			"documentation": "A diagnostic report indicating that the last returned\nreport is still accurate.\n\n@since 3.17.0",
+			"documentation": "A partial result for a document diagnostic report.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -7672,8 +7848,8 @@
 				{
 					"name": "languageId",
 					"type": {
-						"kind": "base",
-						"name": "string"
+						"kind": "reference",
+						"name": "LanguageKind"
 					},
 					"documentation": "The text document's language identifier."
 				},
@@ -7695,6 +7871,42 @@
 				}
 			],
 			"documentation": "An item to transfer a text document from the client to the\nserver."
+		},
+		{
+			"name": "NotebookDocumentSyncOptions",
+			"properties": [
+				{
+					"name": "notebookSelector",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "or",
+							"items": [
+								{
+									"kind": "reference",
+									"name": "NotebookDocumentFilterWithNotebook"
+								},
+								{
+									"kind": "reference",
+									"name": "NotebookDocumentFilterWithCells"
+								}
+							]
+						}
+					},
+					"documentation": "The notebooks to be synced"
+				},
+				{
+					"name": "save",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether save notification should be forwarded to\nthe server. Will only be honored if mode === `notebook`."
+				}
+			],
+			"documentation": "Options specific to a notebook plus its cells\nto be synced to the server.\n\nIf a selector provides a notebook document\nfilter but no cell selector all cells of a\nmatching notebook document will be synced.\n\nIf a selector provides no notebook document\nfilter but only a cell selector all notebook\ndocument that contain at least one matching\ncell will be synced.\n\n@since 3.17.0",
+			"since": "3.17.0"
 		},
 		{
 			"name": "VersionedNotebookDocumentIdentifier",
@@ -7734,99 +7946,8 @@
 				{
 					"name": "cells",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "structure",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "array",
-													"type": {
-														"kind": "reference",
-														"name": "NotebookCellArrayChange"
-													},
-													"documentation": "The change to the cell array."
-												},
-												{
-													"name": "didOpen",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "reference",
-															"name": "TextDocumentItem"
-														}
-													},
-													"optional": true,
-													"documentation": "Additional opened cell text documents."
-												},
-												{
-													"name": "didClose",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "reference",
-															"name": "TextDocumentIdentifier"
-														}
-													},
-													"optional": true,
-													"documentation": "Additional closed cell text documents."
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "Changes to the cell structure to add or\nremove cells."
-								},
-								{
-									"name": "data",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "NotebookCell"
-										}
-									},
-									"optional": true,
-									"documentation": "Changes to notebook cells properties like its\nkind, execution summary or metadata."
-								},
-								{
-									"name": "textContent",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "literal",
-											"value": {
-												"properties": [
-													{
-														"name": "document",
-														"type": {
-															"kind": "reference",
-															"name": "VersionedTextDocumentIdentifier"
-														}
-													},
-													{
-														"name": "changes",
-														"type": {
-															"kind": "array",
-															"element": {
-																"kind": "reference",
-																"name": "TextDocumentContentChangeEvent"
-															}
-														}
-													}
-												]
-											}
-										}
-									},
-									"optional": true,
-									"documentation": "Changes to the text content of notebook cells."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "NotebookDocumentCellChanges"
 					},
 					"optional": true,
 					"documentation": "Changes to cells"
@@ -7871,9 +7992,8 @@
 					"documentation": "Provides information about the currently selected item in the autocomplete widget if it is visible."
 				}
 			],
-			"documentation": "Provides information about the context in which an inline completion was requested.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Provides information about the context in which an inline completion was requested.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "StringValue",
@@ -7895,9 +8015,8 @@
 					"documentation": "The snippet string."
 				}
 			],
-			"documentation": "A string value used as a snippet is a template which allows to insert text\nand to control the editor cursor when insertion happens.\n\nA snippet can define tab stops and placeholders with `$1`, `$2`\nand `${3:foo}`. `$0` defines the final tab stop, it defaults to\nthe end of the snippet. Variables are defined with `$name` and\n`${name:default value}`.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "A string value used as a snippet is a template which allows to insert text\nand to control the editor cursor when insertion happens.\n\nA snippet can define tab stops and placeholders with `$1`, `$2`\nand `${3:foo}`. `$0` defines the final tab stop, it defaults to\nthe end of the snippet. Variables are defined with `$name` and\n`${name:default value}`.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "InlineCompletionOptions",
@@ -7908,9 +8027,26 @@
 				}
 			],
 			"properties": [],
-			"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentOptions",
+			"properties": [
+				{
+					"name": "schemes",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The schemes for which the server provides content."
+				}
+			],
+			"documentation": "Text document content provider options.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "Registration",
@@ -7988,28 +8124,8 @@
 				{
 					"name": "clientInfo",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "name",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "The name of the client as defined by the client."
-								},
-								{
-									"name": "version",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "The client's version as defined by the client."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientInfo"
 					},
 					"optional": true,
 					"documentation": "Information about the client\n\n@since 3.15.0",
@@ -8083,7 +8199,7 @@
 					"name": "trace",
 					"type": {
 						"kind": "reference",
-						"name": "TraceValues"
+						"name": "TraceValue"
 					},
 					"optional": true,
 					"documentation": "The initial trace setting. If omitted trace is disabled ('off')."
@@ -8732,75 +8848,14 @@
 						]
 					},
 					"optional": true,
-					"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
-				},
-				{
-					"name": "textDocument",
-					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "diagnostic",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "markupMessageSupport",
-													"type": {
-														"kind": "base",
-														"name": "boolean"
-													},
-													"optional": true,
-													"documentation": "Whether the server supports `MarkupContent` in diagnostic messages.",
-													"since": "3.18.0",
-													"proposed": true
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "Capabilities specific to the diagnostic pull model.\n\n@since 3.18.0",
-									"since": "3.18.0"
-								}
-							]
-						}
-					},
-					"optional": true,
-					"documentation": "Text document specific server capabilities.\n\n@since 3.18.0\n@proposed",
+					"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0",
 					"since": "3.18.0"
 				},
 				{
 					"name": "workspace",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "workspaceFolders",
-									"type": {
-										"kind": "reference",
-										"name": "WorkspaceFoldersServerCapabilities"
-									},
-									"optional": true,
-									"documentation": "The server supports workspace folder.\n\n@since 3.6.0",
-									"since": "3.6.0"
-								},
-								{
-									"name": "fileOperations",
-									"type": {
-										"kind": "reference",
-										"name": "FileOperationOptions"
-									},
-									"optional": true,
-									"documentation": "The server is interested in notifications/requests for operations on files.\n\n@since 3.16.0",
-									"since": "3.16.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "WorkspaceOptions"
 					},
 					"optional": true,
 					"documentation": "Workspace specific server capabilities."
@@ -8816,6 +8871,34 @@
 				}
 			],
 			"documentation": "Defines the capabilities provided by a language\nserver."
+		},
+		{
+			"name": "ServerInfo",
+			"properties": [
+				{
+					"name": "name",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The name of the server as defined by the server."
+				},
+				{
+					"name": "version",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The server's version as defined by the server."
+				}
+			],
+			"documentation": "Information about the server\n\n@since 3.15.0\n@since 3.18.0 ServerInfo type name added.",
+			"since": "3.18.0 ServerInfo type name added.",
+			"sinceTags": [
+				"3.15.0",
+				"3.18.0 ServerInfo type name added."
+			]
 		},
 		{
 			"name": "VersionedTextDocumentIdentifier",
@@ -8915,7 +8998,7 @@
 						"name": "DiagnosticSeverity"
 					},
 					"optional": true,
-					"documentation": "The diagnostic's severity. Can be omitted. If omitted it is up to the\nclient to interpret diagnostics as error, warning, info or hint."
+					"documentation": "The diagnostic's severity. To avoid interpretation mismatches when a\nserver is used with different clients it is highly recommended that servers\nalways provide a severity value."
 				},
 				{
 					"name": "code",
@@ -8969,7 +9052,8 @@
 							}
 						]
 					},
-					"documentation": "The diagnostic's message. It usually appears in the user interface.\n\n@since 3.18.0 - support for `MarkupContent`. This is guarded by the client capability `textDocument.diagnostic.markupMessageSupport`."
+					"documentation": "The diagnostic's message. It usually appears in the user interface.\n\n@since 3.18.0 - support for MarkupContent. This is guarded by the client\ncapability `textDocument.diagnostic.markupMessageSupport`.",
+					"since": "3.18.0 - support for MarkupContent. This is guarded by the client\ncapability `textDocument.diagnostic.markupMessageSupport`."
 				},
 				{
 					"name": "tags",
@@ -9089,6 +9173,102 @@
 			"since": "3.16.0"
 		},
 		{
+			"name": "CompletionItemDefaults",
+			"properties": [
+				{
+					"name": "commitCharacters",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"optional": true,
+					"documentation": "A default commit character set.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				},
+				{
+					"name": "editRange",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "reference",
+								"name": "Range"
+							},
+							{
+								"kind": "reference",
+								"name": "EditRangeWithInsertReplace"
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "A default edit range.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				},
+				{
+					"name": "insertTextFormat",
+					"type": {
+						"kind": "reference",
+						"name": "InsertTextFormat"
+					},
+					"optional": true,
+					"documentation": "A default insert text format.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				},
+				{
+					"name": "insertTextMode",
+					"type": {
+						"kind": "reference",
+						"name": "InsertTextMode"
+					},
+					"optional": true,
+					"documentation": "A default insert text mode.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				},
+				{
+					"name": "data",
+					"type": {
+						"kind": "reference",
+						"name": "LSPAny"
+					},
+					"optional": true,
+					"documentation": "A default data value.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				}
+			],
+			"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value, the rules for combining these are\ndefined by `applyKinds` (if the client supports it), defaulting to\nApplyKind.Replace.\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "CompletionItemApplyKinds",
+			"properties": [
+				{
+					"name": "commitCharacters",
+					"type": {
+						"kind": "reference",
+						"name": "ApplyKind"
+					},
+					"optional": true,
+					"documentation": "Specifies whether commitCharacters on a completion will replace or be\nmerged with those in `completionList.itemDefaults.commitCharacters`.\n\nIf ApplyKind.Replace, the commit characters from the completion item will\nalways be used unless not provided, in which case those from\n`completionList.itemDefaults.commitCharacters` will be used. An\nempty list can be used if a completion item does not have any commit\ncharacters and also should not use those from\n`completionList.itemDefaults.commitCharacters`.\n\nIf ApplyKind.Merge the commitCharacters for the completion will be the\nunion of all values in both `completionList.itemDefaults.commitCharacters`\nand the completion's own `commitCharacters`.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "data",
+					"type": {
+						"kind": "reference",
+						"name": "ApplyKind"
+					},
+					"optional": true,
+					"documentation": "Specifies whether the `data` field on a completion will replace or\nbe merged with data from `completionList.itemDefaults.data`.\n\nIf ApplyKind.Replace, the data from the completion item will be used if\nprovided (and not `null`), otherwise\n`completionList.itemDefaults.data` will be used. An empty object can\nbe used if a completion item does not have any data but also should\nnot use the value from `completionList.itemDefaults.data`.\n\nIf ApplyKind.Merge, a shallow merge will be performed between\n`completionList.itemDefaults.data` and the completion's own data\nusing the following rules:\n\n- If a completion's `data` field is not provided (or `null`), the\n  entire `data` field from `completionList.itemDefaults.data` will be\n  used as-is.\n- If a completion's `data` field is provided, each field will\n  overwrite the field of the same name in\n  `completionList.itemDefaults.data` but no merging of nested fields\n  within that value will occur.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			],
+			"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIf unspecified, all fields will be treated as ApplyKind.Replace.\n\nIf a field's value is ApplyKind.Replace, the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is ApplyKind.Merge, the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"name": "CompletionOptions",
 			"properties": [
 				{
@@ -9128,21 +9308,8 @@
 				{
 					"name": "completionItem",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "labelDetailsSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "The server has support for completion item label\ndetails (see also `CompletionItemLabelDetails`) when\nreceiving a completion item in a resolve call.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ServerCompletionItemOptions"
 					},
 					"optional": true,
 					"documentation": "The server supports the following `CompletionItem` specific\ncapabilities.\n\n@since 3.17.0",
@@ -9266,7 +9433,7 @@
 						]
 					},
 					"optional": true,
-					"documentation": "The index of the active parameter.\n\nIf `null`, no parameter of the signature is active (for example a named\nargument that does not match any declared parameters). This is only valid\nsince 3.18.0 and if the client specifies the client capability\n`textDocument.signatureHelp.noActiveParameterSupport === true`\n\nIf provided (or `null`), this is used in place of\n`SignatureHelp.activeParameter`.\n\n@since 3.16.0",
+					"documentation": "The index of the active parameter.\n\nIf `null`, no parameter of the signature is active (for example a named\nargument that does not match any declared parameters). This is only valid\nif the client specifies the client capability\n`textDocument.signatureHelp.noActiveParameterSupport === true`\n\nIf provided (or `null`), this is used in place of\n`SignatureHelp.activeParameter`.\n\n@since 3.16.0",
 					"since": "3.16.0"
 				}
 			],
@@ -9434,7 +9601,7 @@
 							"name": "Diagnostic"
 						}
 					},
-					"documentation": "An array of diagnostics known on the client side overlapping the range provided to the\n`textDocument/codeAction` request. They are provided so that the server knows which\nerrors are currently presented to the user for the given range. There is no guarantee\nthat these accurately reflect the error state of the resource. The primary parameter\nto compute code actions is the provided range.\n\nNote that the client should check the `textDocument.diagnostic.markupMessageSupport` server capability before sending diagnostics with markup messages to a server."
+					"documentation": "An array of diagnostics known on the client side overlapping the range provided to the\n`textDocument/codeAction` request. They are provided so that the server knows which\nerrors are currently presented to the user for the given range. There is no guarantee\nthat these accurately reflect the error state of the resource. The primary parameter\nto compute code actions is the provided range."
 				},
 				{
 					"name": "only",
@@ -9462,6 +9629,21 @@
 			"documentation": "Contains additional diagnostic information about the context in which\na {@link CodeActionProvider.provideCodeActions code action} is run."
 		},
 		{
+			"name": "CodeActionDisabled",
+			"properties": [
+				{
+					"name": "reason",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "Human readable description of why the code action is currently disabled.\n\nThis is displayed in the code actions UI."
+				}
+			],
+			"documentation": "Captures why the code action is currently disabled.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"name": "CodeActionOptions",
 			"properties": [
 				{
@@ -9475,6 +9657,19 @@
 					},
 					"optional": true,
 					"documentation": "CodeActionKinds that this server may return.\n\nThe list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server\nmay list out every specific kind they provide."
+				},
+				{
+					"name": "documentation",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CodeActionKindDocumentation"
+						}
+					},
+					"optional": true,
+					"documentation": "Static documentation for a class of code actions.\n\nDocumentation from the provider should be shown in the code actions menu if either:\n\n- Code actions of `kind` are requested by the editor. In this case, the editor will show the documentation that\n  most closely matches the requested code action kind. For example, if a provider has documentation for\n  both `Refactor` and `RefactorExtract`, when the user requests code actions for `RefactorExtract`,\n  the editor will use the documentation for `RefactorExtract` instead of the documentation for `Refactor`.\n\n- Any code actions of `kind` are returned by the provider.\n\nAt most one documentation entry should be shown per provider.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				},
 				{
 					"name": "resolveProvider",
@@ -9494,6 +9689,20 @@
 				}
 			],
 			"documentation": "Provider options for a {@link CodeActionRequest}."
+		},
+		{
+			"name": "LocationUriOnly",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					}
+				}
+			],
+			"documentation": "Location with only uri and does not include range.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "WorkspaceSymbolOptions",
@@ -9632,9 +9841,8 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether the server supports formatting multiple ranges at once.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Whether the server supports formatting multiple ranges at once.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"mixins": [
@@ -9694,6 +9902,41 @@
 			"documentation": "Provider options for a {@link RenameRequest}."
 		},
 		{
+			"name": "PrepareRenamePlaceholder",
+			"properties": [
+				{
+					"name": "range",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					}
+				},
+				{
+					"name": "placeholder",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					}
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "PrepareRenameDefaultBehavior",
+			"properties": [
+				{
+					"name": "defaultBehavior",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					}
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"name": "ExecuteCommandOptions",
 			"properties": [
 				{
@@ -9715,6 +9958,35 @@
 				}
 			],
 			"documentation": "The server capabilities of a {@link ExecuteCommandRequest}."
+		},
+		{
+			"name": "WorkspaceEditMetadata",
+			"properties": [
+				{
+					"name": "isRefactoring",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Signal to the editor that this edit is a refactoring."
+				}
+			],
+			"documentation": "Additional data about a workspace edit.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "WorkDoneProgressOptions",
+			"properties": [
+				{
+					"name": "workDoneProgress",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true
+				}
+			]
 		},
 		{
 			"name": "SemanticTokensLegend",
@@ -9744,6 +10016,22 @@
 			],
 			"documentation": "@since 3.16.0",
 			"since": "3.16.0"
+		},
+		{
+			"name": "SemanticTokensFullDelta",
+			"properties": [
+				{
+					"name": "delta",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The server supports deltas for full documents."
+				}
+			],
+			"documentation": "Semantic tokens options to support deltas for full documents\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "OptionalVersionedTextDocumentIdentifier",
@@ -9794,6 +10082,38 @@
 			],
 			"documentation": "A special text edit with an additional change annotation.\n\n@since 3.16.0.",
 			"since": "3.16.0."
+		},
+		{
+			"name": "SnippetTextEdit",
+			"properties": [
+				{
+					"name": "range",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					},
+					"documentation": "The range of the text document to be manipulated."
+				},
+				{
+					"name": "snippet",
+					"type": {
+						"kind": "reference",
+						"name": "StringValue"
+					},
+					"documentation": "The snippet to be inserted."
+				},
+				{
+					"name": "annotationId",
+					"type": {
+						"kind": "reference",
+						"name": "ChangeAnnotationIdentifier"
+					},
+					"optional": true,
+					"documentation": "The actual identifier of the snippet edit."
+				}
+			],
+			"documentation": "An interactive text edit.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "ResourceOperation",
@@ -9900,7 +10220,7 @@
 						"kind": "base",
 						"name": "string"
 					},
-					"documentation": "The glob pattern to match. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
+					"documentation": "The glob pattern to match. Glob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
 				},
 				{
 					"name": "matches",
@@ -9923,6 +10243,64 @@
 			],
 			"documentation": "A pattern to describe in which file operation requests or notifications\nthe server is interested in receiving.\n\n@since 3.16.0",
 			"since": "3.16.0"
+		},
+		{
+			"name": "FullDocumentDiagnosticReport",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "full"
+					},
+					"documentation": "A full document diagnostic report."
+				},
+				{
+					"name": "resultId",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "An optional result id. If provided it will\nbe sent on the next diagnostic request for the\nsame document."
+				},
+				{
+					"name": "items",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "Diagnostic"
+						}
+					},
+					"documentation": "The actual items."
+				}
+			],
+			"documentation": "A diagnostic report with a full set of problems.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "UnchangedDocumentDiagnosticReport",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "unchanged"
+					},
+					"documentation": "A document diagnostic report indicating\nno changes to the last result. A server can\nonly return `unchanged` if result ids are\nprovided."
+				},
+				{
+					"name": "resultId",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "A result id which will be sent on the next\ndiagnostic request for the same document."
+				}
+			],
+			"documentation": "A diagnostic report indicating that the last returned\nreport is still accurate.\n\n@since 3.17.0",
+			"since": "3.17.0"
 		},
 		{
 			"name": "WorkspaceFullDocumentDiagnosticReport",
@@ -10042,26 +10420,91 @@
 			"since": "3.17.0"
 		},
 		{
-			"name": "NotebookCellArrayChange",
+			"name": "NotebookDocumentFilterWithNotebook",
 			"properties": [
 				{
-					"name": "start",
+					"name": "notebook",
 					"type": {
-						"kind": "base",
-						"name": "uinteger"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "NotebookDocumentFilter"
+							}
+						]
 					},
-					"documentation": "The start oftest of the cell that changed."
-				},
-				{
-					"name": "deleteCount",
-					"type": {
-						"kind": "base",
-						"name": "uinteger"
-					},
-					"documentation": "The deleted cells"
+					"documentation": "The notebook to be synced If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
 				},
 				{
 					"name": "cells",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "NotebookCellLanguage"
+						}
+					},
+					"optional": true,
+					"documentation": "The cells of the matching notebook to be synced."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentFilterWithCells",
+			"properties": [
+				{
+					"name": "notebook",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "NotebookDocumentFilter"
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "The notebook to be synced If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
+				},
+				{
+					"name": "cells",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "NotebookCellLanguage"
+						}
+					},
+					"documentation": "The cells of the matching notebook to be synced."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentCellChanges",
+			"properties": [
+				{
+					"name": "structure",
+					"type": {
+						"kind": "reference",
+						"name": "NotebookDocumentCellChangeStructure"
+					},
+					"optional": true,
+					"documentation": "Changes to the cell structure to add or\nremove cells."
+				},
+				{
+					"name": "data",
 					"type": {
 						"kind": "array",
 						"element": {
@@ -10070,11 +10513,23 @@
 						}
 					},
 					"optional": true,
-					"documentation": "The new cells, if any"
+					"documentation": "Changes to notebook cells properties like its\nkind, execution summary or metadata."
+				},
+				{
+					"name": "textContent",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "NotebookDocumentCellContentChanges"
+						}
+					},
+					"optional": true,
+					"documentation": "Changes to the text content of notebook cells."
 				}
 			],
-			"documentation": "A change describing how to move a `NotebookCell`\narray from state S to S'.\n\n@since 3.17.0",
-			"since": "3.17.0"
+			"documentation": "Cell changes to a notebook document.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "SelectedCompletionInfo",
@@ -10096,9 +10551,36 @@
 					"documentation": "The text the range will be replaced with if this completion is accepted."
 				}
 			],
-			"documentation": "Describes the currently selected completion item.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Describes the currently selected completion item.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientInfo",
+			"properties": [
+				{
+					"name": "name",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The name of the client as defined by the client."
+				},
+				{
+					"name": "version",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The client's version as defined by the client."
+				}
+			],
+			"documentation": "Information about the client\n\n@since 3.15.0\n@since 3.18.0 ClientInfo type name added.",
+			"since": "3.18.0 ClientInfo type name added.",
+			"sinceTags": [
+				"3.15.0",
+				"3.18.0 ClientInfo type name added."
+			]
 		},
 		{
 			"name": "ClientCapabilities",
@@ -10222,235 +10704,98 @@
 			]
 		},
 		{
-			"name": "NotebookDocumentSyncOptions",
+			"name": "WorkspaceOptions",
 			"properties": [
 				{
-					"name": "notebookSelector",
+					"name": "workspaceFolders",
 					"type": {
-						"kind": "array",
-						"element": {
-							"kind": "or",
-							"items": [
-								{
-									"kind": "literal",
-									"value": {
-										"properties": [
-											{
-												"name": "notebook",
-												"type": {
-													"kind": "or",
-													"items": [
-														{
-															"kind": "base",
-															"name": "string"
-														},
-														{
-															"kind": "reference",
-															"name": "NotebookDocumentFilter"
-														}
-													]
-												},
-												"documentation": "The notebook to be synced If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
-											},
-											{
-												"name": "cells",
-												"type": {
-													"kind": "array",
-													"element": {
-														"kind": "literal",
-														"value": {
-															"properties": [
-																{
-																	"name": "language",
-																	"type": {
-																		"kind": "base",
-																		"name": "string"
-																	}
-																}
-															]
-														}
-													}
-												},
-												"optional": true,
-												"documentation": "The cells of the matching notebook to be synced."
-											}
-										]
-									}
-								},
-								{
-									"kind": "literal",
-									"value": {
-										"properties": [
-											{
-												"name": "notebook",
-												"type": {
-													"kind": "or",
-													"items": [
-														{
-															"kind": "base",
-															"name": "string"
-														},
-														{
-															"kind": "reference",
-															"name": "NotebookDocumentFilter"
-														}
-													]
-												},
-												"optional": true,
-												"documentation": "The notebook to be synced If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
-											},
-											{
-												"name": "cells",
-												"type": {
-													"kind": "array",
-													"element": {
-														"kind": "literal",
-														"value": {
-															"properties": [
-																{
-																	"name": "language",
-																	"type": {
-																		"kind": "base",
-																		"name": "string"
-																	}
-																}
-															]
-														}
-													}
-												},
-												"documentation": "The cells of the matching notebook to be synced."
-											}
-										]
-									}
-								}
-							]
-						}
-					},
-					"documentation": "The notebooks to be synced"
-				},
-				{
-					"name": "save",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
+						"kind": "reference",
+						"name": "WorkspaceFoldersServerCapabilities"
 					},
 					"optional": true,
-					"documentation": "Whether save notification should be forwarded to\nthe server. Will only be honored if mode === `notebook`."
-				}
-			],
-			"documentation": "Options specific to a notebook plus its cells\nto be synced to the server.\n\nIf a selector provides a notebook document\nfilter but no cell selector all cells of a\nmatching notebook document will be synced.\n\nIf a selector provides no notebook document\nfilter but only a cell selector all notebook\ndocument that contain at least one matching\ncell will be synced.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "NotebookDocumentSyncRegistrationOptions",
-			"properties": [],
-			"extends": [
-				{
-					"kind": "reference",
-					"name": "NotebookDocumentSyncOptions"
-				}
-			],
-			"mixins": [
-				{
-					"kind": "reference",
-					"name": "StaticRegistrationOptions"
-				}
-			],
-			"documentation": "Registration options specific to a notebook.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "WorkspaceFoldersServerCapabilities",
-			"properties": [
-				{
-					"name": "supported",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true,
-					"documentation": "The server has support for workspace folders"
+					"documentation": "The server supports workspace folder.\n\n@since 3.6.0",
+					"since": "3.6.0"
 				},
 				{
-					"name": "changeNotifications",
+					"name": "fileOperations",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in notifications/requests for operations on files.\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "textDocumentContent",
 					"type": {
 						"kind": "or",
 						"items": [
 							{
-								"kind": "base",
-								"name": "string"
+								"kind": "reference",
+								"name": "TextDocumentContentOptions"
 							},
 							{
-								"kind": "base",
-								"name": "boolean"
+								"kind": "reference",
+								"name": "TextDocumentContentRegistrationOptions"
 							}
 						]
 					},
 					"optional": true,
-					"documentation": "Whether the server wants to receive workspace folder\nchange notifications.\n\nIf a string is provided the string is treated as an ID\nunder which the notification is registered on the client\nside. The ID can be used to unregister for these events\nusing the `client/unregisterCapability` request."
-				}
-			]
-		},
-		{
-			"name": "FileOperationOptions",
-			"properties": [
-				{
-					"name": "didCreate",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving didCreateFiles notifications."
-				},
-				{
-					"name": "willCreate",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving willCreateFiles requests."
-				},
-				{
-					"name": "didRename",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving didRenameFiles notifications."
-				},
-				{
-					"name": "willRename",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving willRenameFiles requests."
-				},
-				{
-					"name": "didDelete",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving didDeleteFiles file notifications."
-				},
-				{
-					"name": "willDelete",
-					"type": {
-						"kind": "reference",
-						"name": "FileOperationRegistrationOptions"
-					},
-					"optional": true,
-					"documentation": "The server is interested in receiving willDeleteFiles file requests."
+					"documentation": "The server supports the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
-			"documentation": "Options for notifications/requests for user operations on files.\n\n@since 3.16.0",
-			"since": "3.16.0"
+			"documentation": "Defines workspace specific capabilities of the server.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentChangePartial",
+			"properties": [
+				{
+					"name": "range",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					},
+					"documentation": "The range of the document that changed."
+				},
+				{
+					"name": "rangeLength",
+					"type": {
+						"kind": "base",
+						"name": "uinteger"
+					},
+					"optional": true,
+					"documentation": "The optional length of the range that got replaced.\n\n@deprecated use range instead.",
+					"deprecated": "use range instead."
+				},
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The new text for the provided range."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentChangeWholeDocument",
+			"properties": [
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The new text of the whole document."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "CodeDescription",
@@ -10490,6 +10835,66 @@
 			"documentation": "Represents a related message and source code location for a diagnostic. This should be\nused to point to code locations that cause or related to a diagnostics, e.g when duplicating\na symbol in a scope."
 		},
 		{
+			"name": "EditRangeWithInsertReplace",
+			"properties": [
+				{
+					"name": "insert",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					}
+				},
+				{
+					"name": "replace",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					}
+				}
+			],
+			"documentation": "Edit range variant that includes ranges for insert and replace operations.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ServerCompletionItemOptions",
+			"properties": [
+				{
+					"name": "labelDetailsSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The server has support for completion item label\ndetails (see also `CompletionItemLabelDetails`) when\nreceiving a completion item in a resolve call.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "MarkedStringWithLanguage",
+			"properties": [
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					}
+				},
+				{
+					"name": "value",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					}
+				}
+			],
+			"documentation": "@since 3.18.0\n@deprecated use MarkupContent instead.",
+			"since": "3.18.0",
+			"deprecated": "use MarkupContent instead."
+		},
+		{
 			"name": "ParameterInformation",
 			"properties": [
 				{
@@ -10516,7 +10921,7 @@
 							}
 						]
 					},
-					"documentation": "The label of this parameter information.\n\nEither a string or an inclusive start and exclusive end offsets within its containing\nsignature label. (see SignatureInformation.label). The offsets are based on a UTF-16\nstring representation as `Position` and `Range` does.\n\n*Note*: a label of type string should be a substring of its containing signature label.\nIts intended use case is to highlight the parameter label part in the `SignatureInformation.label`."
+					"documentation": "The label of this parameter information.\n\nEither a string or an inclusive start and exclusive end offsets within its containing\nsignature label. (see SignatureInformation.label). The offsets are based on a UTF-16\nstring representation as `Position` and `Range` does.\n\nTo avoid ambiguities a server should use the [start, end] offset value instead of using\na substring. Whether a client support this is controlled via `labelOffsetSupport` client\ncapability.\n\n*Note*: a label of type string should be a substring of its containing signature label.\nIts intended use case is to highlight the parameter label part in the `SignatureInformation.label`."
 				},
 				{
 					"name": "documentation",
@@ -10540,37 +10945,27 @@
 			"documentation": "Represents a parameter of a callable-signature. A parameter can\nhave a label and a doc-comment."
 		},
 		{
-			"name": "NotebookCellTextDocumentFilter",
+			"name": "CodeActionKindDocumentation",
 			"properties": [
 				{
-					"name": "notebook",
+					"name": "kind",
 					"type": {
-						"kind": "or",
-						"items": [
-							{
-								"kind": "base",
-								"name": "string"
-							},
-							{
-								"kind": "reference",
-								"name": "NotebookDocumentFilter"
-							}
-						]
+						"kind": "reference",
+						"name": "CodeActionKind"
 					},
-					"documentation": "A filter that matches against the notebook\ncontaining the notebook cell. If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
+					"documentation": "The kind of the code action being documented.\n\nIf the kind is generic, such as `CodeActionKind.Refactor`, the documentation will be shown whenever any\nrefactorings are returned. If the kind if more specific, such as `CodeActionKind.RefactorExtract`, the\ndocumentation will only be shown when extract refactoring code actions are returned."
 				},
 				{
-					"name": "language",
+					"name": "command",
 					"type": {
-						"kind": "base",
-						"name": "string"
+						"kind": "reference",
+						"name": "Command"
 					},
-					"optional": true,
-					"documentation": "A language id like `python`.\n\nWill be matched against the language id of the\nnotebook cell document. '*' matches every language."
+					"documentation": "Command that is ued to display the documentation to the user.\n\nThe title of this documentation code action is taken from {@linkcode Command.title}"
 				}
 			],
-			"documentation": "A notebook cell text document filter denotes a cell text\ndocument by different properties.\n\n@since 3.17.0",
-			"since": "3.17.0"
+			"documentation": "Documentation for a class of code actions.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "FileOperationPatternOptions",
@@ -10609,6 +11004,83 @@
 					"documentation": "Whether the execution was successful or\nnot if known by the client."
 				}
 			]
+		},
+		{
+			"name": "NotebookCellLanguage",
+			"properties": [
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					}
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentCellChangeStructure",
+			"properties": [
+				{
+					"name": "array",
+					"type": {
+						"kind": "reference",
+						"name": "NotebookCellArrayChange"
+					},
+					"documentation": "The change to the cell array."
+				},
+				{
+					"name": "didOpen",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "TextDocumentItem"
+						}
+					},
+					"optional": true,
+					"documentation": "Additional opened cell text documents."
+				},
+				{
+					"name": "didClose",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "TextDocumentIdentifier"
+						}
+					},
+					"optional": true,
+					"documentation": "Additional closed cell text documents."
+				}
+			],
+			"documentation": "Structural changes to cells in a notebook document.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentCellContentChanges",
+			"properties": [
+				{
+					"name": "document",
+					"type": {
+						"kind": "reference",
+						"name": "VersionedTextDocumentIdentifier"
+					}
+				},
+				{
+					"name": "changes",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "TextDocumentContentChangeEvent"
+						}
+					}
+				}
+			],
+			"documentation": "Content changes to a cell in a notebook document.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "WorkspaceClientCapabilities",
@@ -10753,9 +11225,18 @@
 						"name": "FoldingRangeWorkspaceClientCapabilities"
 					},
 					"optional": true,
-					"documentation": "Capabilities specific to the folding range requests scoped to the workspace.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Capabilities specific to the folding range requests scoped to the workspace.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "textDocumentContent",
+					"type": {
+						"kind": "reference",
+						"name": "TextDocumentContentClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Capabilities specific to the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -10771,6 +11252,16 @@
 					},
 					"optional": true,
 					"documentation": "Defines which synchronization capabilities the client supports."
+				},
+				{
+					"name": "filters",
+					"type": {
+						"kind": "reference",
+						"name": "TextDocumentFilterClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Defines which filters the client supports.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				},
 				{
 					"name": "completion",
@@ -11054,9 +11545,8 @@
 						"name": "InlineCompletionClientCapabilities"
 					},
 					"optional": true,
-					"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "Text document specific client capabilities."
@@ -11118,30 +11608,8 @@
 				{
 					"name": "staleRequestSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "cancel",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"documentation": "The client will actively cancel the request."
-								},
-								{
-									"name": "retryOnContentModified",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"documentation": "The list of requests for which the client\nwill retry the request if it receives a\nresponse with error code `ContentModified`"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "StaleRequestSupportOptions"
 					},
 					"optional": true,
 					"documentation": "Client capability that signals how the client\nhandles stale requests (e.g. a request\nfor which the client will not process the response\nanymore since the information is outdated).\n\n@since 3.17.0",
@@ -11185,6 +11653,132 @@
 			"since": "3.16.0"
 		},
 		{
+			"name": "WorkspaceFoldersServerCapabilities",
+			"properties": [
+				{
+					"name": "supported",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The server has support for workspace folders"
+				},
+				{
+					"name": "changeNotifications",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "base",
+								"name": "boolean"
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "Whether the server wants to receive workspace folder\nchange notifications.\n\nIf a string is provided the string is treated as an ID\nunder which the notification is registered on the client\nside. The ID can be used to unregister for these events\nusing the `client/unregisterCapability` request."
+				}
+			]
+		},
+		{
+			"name": "FileOperationOptions",
+			"properties": [
+				{
+					"name": "didCreate",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving didCreateFiles notifications."
+				},
+				{
+					"name": "willCreate",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving willCreateFiles requests."
+				},
+				{
+					"name": "didRename",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving didRenameFiles notifications."
+				},
+				{
+					"name": "willRename",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving willRenameFiles requests."
+				},
+				{
+					"name": "didDelete",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving didDeleteFiles file notifications."
+				},
+				{
+					"name": "willDelete",
+					"type": {
+						"kind": "reference",
+						"name": "FileOperationRegistrationOptions"
+					},
+					"optional": true,
+					"documentation": "The server is interested in receiving willDeleteFiles file requests."
+				}
+			],
+			"documentation": "Options for notifications/requests for user operations on files.\n\n@since 3.16.0",
+			"since": "3.16.0"
+		},
+		{
+			"name": "NotebookCellTextDocumentFilter",
+			"properties": [
+				{
+					"name": "notebook",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "NotebookDocumentFilter"
+							}
+						]
+					},
+					"documentation": "A filter that matches against the notebook\ncontaining the notebook cell. If a string\nvalue is provided it matches against the\nnotebook type. '*' matches every notebook."
+				},
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A language id like `python`.\n\nWill be matched against the language id of the\nnotebook cell document. '*' matches every language."
+				}
+			],
+			"documentation": "A notebook cell text document filter denotes a cell text\ndocument by different properties.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
 			"name": "RelativePattern",
 			"properties": [
 				{
@@ -11214,6 +11808,140 @@
 				}
 			],
 			"documentation": "A relative pattern is a helper to construct glob patterns that are matched\nrelatively to a base URI. The common value for a `baseUri` is a workspace\nfolder root, but it can be another absolute URI as well.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "NotebookDocumentFilterNotebookType",
+			"properties": [
+				{
+					"name": "notebookType",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The type of the enclosing notebook."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"optional": true,
+					"documentation": "A glob pattern."
+				}
+			],
+			"documentation": "A notebook document filter where `notebookType` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentFilterScheme",
+			"properties": [
+				{
+					"name": "notebookType",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The type of the enclosing notebook."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"optional": true,
+					"documentation": "A glob pattern."
+				}
+			],
+			"documentation": "A notebook document filter where `scheme` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookDocumentFilterPattern",
+			"properties": [
+				{
+					"name": "notebookType",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The type of the enclosing notebook."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"documentation": "A glob pattern."
+				}
+			],
+			"documentation": "A notebook document filter where `pattern` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "NotebookCellArrayChange",
+			"properties": [
+				{
+					"name": "start",
+					"type": {
+						"kind": "base",
+						"name": "uinteger"
+					},
+					"documentation": "The start oftest of the cell that changed."
+				},
+				{
+					"name": "deleteCount",
+					"type": {
+						"kind": "base",
+						"name": "uinteger"
+					},
+					"documentation": "The deleted cells"
+				},
+				{
+					"name": "cells",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "NotebookCell"
+						}
+					},
+					"optional": true,
+					"documentation": "The new cells, if any"
+				}
+			],
+			"documentation": "A change describing how to move a `NotebookCell`\narray from state S to S'.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -11264,24 +11992,32 @@
 				{
 					"name": "changeAnnotationSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "groupsOnLabel",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Whether the client groups edits with equal labels into tree nodes,\nfor instance all edits labelled with \"Changes in Strings\" would\nbe a tree node."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ChangeAnnotationsSupportOptions"
 					},
 					"optional": true,
 					"documentation": "Whether the client in general supports change annotations on text edits,\ncreate file, rename file and delete file changes.\n\n@since 3.16.0",
 					"since": "3.16.0"
+				},
+				{
+					"name": "metadataSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports `WorkspaceEditMetadata` in `WorkspaceEdit`s.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "snippetEditSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports snippets as text edits.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			]
 		},
@@ -11338,23 +12074,8 @@
 				{
 					"name": "symbolKind",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "SymbolKind"
-										}
-									},
-									"optional": true,
-									"documentation": "The symbol kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown.\n\nIf this property is not present the client only supports\nthe symbol kinds from `File` to `Array` as defined in\nthe initial version of the protocol."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSymbolKindOptions"
 					},
 					"optional": true,
 					"documentation": "Specific capabilities for the `SymbolKind` in the `workspace/symbol` request."
@@ -11362,22 +12083,8 @@
 				{
 					"name": "tagSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "SymbolTag"
-										}
-									},
-									"documentation": "The tags supported by the client."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSymbolTagOptions"
 					},
 					"optional": true,
 					"documentation": "The client supports tags on `SymbolInformation`.\nClients supporting tags have to handle unknown tags gracefully.\n\n@since 3.16.0",
@@ -11386,22 +12093,8 @@
 				{
 					"name": "resolveSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "properties",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"documentation": "The properties that a client can resolve lazily. Usually\n`location.range`"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSymbolResolveOptions"
 					},
 					"optional": true,
 					"documentation": "The client support partial workspace symbols. The client will send the\nrequest `workspaceSymbol/resolve` to the server to resolve additional\nproperties.\n\n@since 3.17.0",
@@ -11585,14 +12278,28 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
-			"documentation": "Client workspace capabilities specific to folding ranges\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Client workspace capabilities specific to folding ranges\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentContentClientCapabilities",
+			"properties": [
+				{
+					"name": "dynamicRegistration",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Text document content provider supports dynamic registration."
+				}
+			],
+			"documentation": "Client capabilities for a text document content provider.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -11636,6 +12343,21 @@
 			]
 		},
 		{
+			"name": "TextDocumentFilterClientCapabilities",
+			"properties": [
+				{
+					"name": "relativePatternSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client supports Relative Patterns.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			]
+		},
+		{
 			"name": "CompletionClientCapabilities",
 			"properties": [
 				{
@@ -11650,150 +12372,8 @@
 				{
 					"name": "completionItem",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "snippetSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Client supports snippets as insert text.\n\nA snippet can define tab stops and placeholders with `$1`, `$2`\nand `${3:foo}`. `$0` defines the final tab stop, it defaults to\nthe end of the snippet. Placeholders with equal identifiers are linked,\nthat is typing in one will update others too."
-								},
-								{
-									"name": "commitCharactersSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Client supports commit characters on a completion item."
-								},
-								{
-									"name": "documentationFormat",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "MarkupKind"
-										}
-									},
-									"optional": true,
-									"documentation": "Client supports the following content formats for the documentation\nproperty. The order describes the preferred format of the client."
-								},
-								{
-									"name": "deprecatedSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Client supports the deprecated property on a completion item."
-								},
-								{
-									"name": "preselectSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Client supports the preselect property on a completion item."
-								},
-								{
-									"name": "tagSupport",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "valueSet",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "reference",
-															"name": "CompletionItemTag"
-														}
-													},
-													"documentation": "The tags supported by the client."
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "Client supports the tag property on a completion item. Clients supporting\ntags have to handle unknown tags gracefully. Clients especially need to\npreserve unknown tags when sending a completion item back to the server in\na resolve call.\n\n@since 3.15.0",
-									"since": "3.15.0"
-								},
-								{
-									"name": "insertReplaceSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Client support insert replace edit to control different behavior if a\ncompletion item is inserted in the text or should replace text.\n\n@since 3.16.0",
-									"since": "3.16.0"
-								},
-								{
-									"name": "resolveSupport",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "properties",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "base",
-															"name": "string"
-														}
-													},
-													"documentation": "The properties that a client can resolve lazily."
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "Indicates which properties a client can resolve lazily on a completion\nitem. Before version 3.16.0 only the predefined properties `documentation`\nand `details` could be resolved lazily.\n\n@since 3.16.0",
-									"since": "3.16.0"
-								},
-								{
-									"name": "insertTextModeSupport",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "valueSet",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "reference",
-															"name": "InsertTextMode"
-														}
-													}
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "The client supports the `insertTextMode` property on\na completion item to override the whitespace handling mode\nas defined by the client (see `insertTextMode`).\n\n@since 3.16.0",
-									"since": "3.16.0"
-								},
-								{
-									"name": "labelDetailsSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "The client has support for completion item label\ndetails (see also `CompletionItemLabelDetails`).\n\n@since 3.17.0",
-									"since": "3.17.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientCompletionItemOptions"
 					},
 					"optional": true,
 					"documentation": "The client supports the following `CompletionItem` specific\ncapabilities."
@@ -11801,25 +12381,11 @@
 				{
 					"name": "completionItemKind",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "CompletionItemKind"
-										}
-									},
-									"optional": true,
-									"documentation": "The completion item kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown.\n\nIf this property is not present the client only supports\nthe completion items kinds from `Text` to `Reference` as defined in\nthe initial version of the protocol."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientCompletionItemOptionsKind"
 					},
-					"optional": true
+					"optional": true,
+					"documentation": "The client supports the following completion item kinds."
 				},
 				{
 					"name": "insertTextMode",
@@ -11843,24 +12409,8 @@
 				{
 					"name": "completionList",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "itemDefaults",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"optional": true,
-									"documentation": "The client supports the following itemDefaults on\na completion list.\n\nThe value lists the supported property names of the\n`CompletionList.itemDefaults` object. If omitted\nno properties are supported.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "CompletionListCapabilities"
 					},
 					"optional": true,
 					"documentation": "The client supports the following `CompletionList` specific\ncapabilities.\n\n@since 3.17.0",
@@ -11910,65 +12460,8 @@
 				{
 					"name": "signatureInformation",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "documentationFormat",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "MarkupKind"
-										}
-									},
-									"optional": true,
-									"documentation": "Client supports the following content formats for the documentation\nproperty. The order describes the preferred format of the client."
-								},
-								{
-									"name": "parameterInformation",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "labelOffsetSupport",
-													"type": {
-														"kind": "base",
-														"name": "boolean"
-													},
-													"optional": true,
-													"documentation": "The client supports processing label offsets instead of a\nsimple label string.\n\n@since 3.14.0",
-													"since": "3.14.0"
-												}
-											]
-										}
-									},
-									"optional": true,
-									"documentation": "Client capabilities specific to parameter information."
-								},
-								{
-									"name": "activeParameterSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "The client supports the `activeParameter` property on `SignatureInformation`\nliteral.\n\n@since 3.16.0",
-									"since": "3.16.0"
-								},
-								{
-									"name": "noActiveParameterSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "The client supports the `activeParameter` property on\n`SignatureInformation` being set to `null` to indicate that no\nparameter should be active.\n\n@since 3.18.0",
-									"since": "3.18.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSignatureInformationOptions"
 					},
 					"optional": true,
 					"documentation": "The client supports the following `SignatureInformation`\nspecific properties."
@@ -12131,23 +12624,8 @@
 				{
 					"name": "symbolKind",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "SymbolKind"
-										}
-									},
-									"optional": true,
-									"documentation": "The symbol kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown.\n\nIf this property is not present the client only supports\nthe symbol kinds from `File` to `Array` as defined in\nthe initial version of the protocol."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSymbolKindOptions"
 					},
 					"optional": true,
 					"documentation": "Specific capabilities for the `SymbolKind` in the\n`textDocument/documentSymbol` request."
@@ -12164,22 +12642,8 @@
 				{
 					"name": "tagSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "SymbolTag"
-										}
-									},
-									"documentation": "The tags supported by the client."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSymbolTagOptions"
 					},
 					"optional": true,
 					"documentation": "The client supports tags on `SymbolInformation`. Tags are supported on\n`DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.\nClients supporting tags have to handle unknown tags gracefully.\n\n@since 3.16.0",
@@ -12213,33 +12677,8 @@
 				{
 					"name": "codeActionLiteralSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "codeActionKind",
-									"type": {
-										"kind": "literal",
-										"value": {
-											"properties": [
-												{
-													"name": "valueSet",
-													"type": {
-														"kind": "array",
-														"element": {
-															"kind": "reference",
-															"name": "CodeActionKind"
-														}
-													},
-													"documentation": "The code action kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown."
-												}
-											]
-										}
-									},
-									"documentation": "The code action kind is support with the following value\nset."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientCodeActionLiteralOptions"
 					},
 					"optional": true,
 					"documentation": "The client support code action literals of type `CodeAction` as a valid\nresponse of the `textDocument/codeAction` request. If the property is not\nset the request can only return `Command` literals.\n\n@since 3.8.0",
@@ -12278,22 +12717,8 @@
 				{
 					"name": "resolveSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "properties",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"documentation": "The properties that a client can resolve lazily."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientCodeActionResolveOptions"
 					},
 					"optional": true,
 					"documentation": "Whether the client supports resolving additional code action\nproperties via a separate `codeAction/resolve` request.\n\n@since 3.16.0",
@@ -12308,6 +12733,26 @@
 					"optional": true,
 					"documentation": "Whether the client honors the change annotations in\ntext edits and resource operations returned via the\n`CodeAction#edit` property by for example presenting\nthe workspace edit in the user interface and asking\nfor confirmation.\n\n@since 3.16.0",
 					"since": "3.16.0"
+				},
+				{
+					"name": "documentationSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports documentation for a class of\ncode actions.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "tagSupport",
+					"type": {
+						"kind": "reference",
+						"name": "CodeActionTagOptions"
+					},
+					"optional": true,
+					"documentation": "Client supports the tag property on a code action. Clients\nsupporting tags have to handle unknown tags gracefully.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The Client Capabilities of a {@link CodeActionRequest}."
@@ -12323,6 +12768,16 @@
 					},
 					"optional": true,
 					"documentation": "Whether code lens supports dynamic registration."
+				},
+				{
+					"name": "resolveSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientCodeLensResolveOptions"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports resolving additional code lens\nproperties via a separate `codeLens/resolve` request.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The client capabilities  of a {@link CodeLensRequest}."
@@ -12400,9 +12855,8 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether the client supports formatting multiple ranges at once.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Whether the client supports formatting multiple ranges at once.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "Client capabilities of a {@link DocumentRangeFormattingRequest}."
@@ -12499,23 +12953,8 @@
 				{
 					"name": "foldingRangeKind",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "FoldingRangeKind"
-										}
-									},
-									"optional": true,
-									"documentation": "The folding range kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientFoldingRangeKindOptions"
 					},
 					"optional": true,
 					"documentation": "Specific options for the folding range kind.\n\n@since 3.17.0",
@@ -12524,21 +12963,8 @@
 				{
 					"name": "foldingRange",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "collapsedText",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "If set, the client signals that it supports setting collapsedText on\nfolding ranges to display custom labels instead of the default text.\n\n@since 3.17.0",
-									"since": "3.17.0"
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientFoldingRangeOptions"
 					},
 					"optional": true,
 					"documentation": "Specific options for the folding range.\n\n@since 3.17.0",
@@ -12564,39 +12990,6 @@
 			"name": "PublishDiagnosticsClientCapabilities",
 			"properties": [
 				{
-					"name": "relatedInformation",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true,
-					"documentation": "Whether the clients accepts diagnostics with related information."
-				},
-				{
-					"name": "tagSupport",
-					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "valueSet",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "reference",
-											"name": "DiagnosticTag"
-										}
-									},
-									"documentation": "The tags supported by the client."
-								}
-							]
-						}
-					},
-					"optional": true,
-					"documentation": "Client supports the tag property to provide meta data about a diagnostic.\nClients supporting tags have to handle unknown tags gracefully.\n\n@since 3.15.0",
-					"since": "3.15.0"
-				},
-				{
 					"name": "versionSupport",
 					"type": {
 						"kind": "base",
@@ -12605,26 +12998,12 @@
 					"optional": true,
 					"documentation": "Whether the client interprets the version property of the\n`textDocument/publishDiagnostics` notification's parameter.\n\n@since 3.15.0",
 					"since": "3.15.0"
-				},
+				}
+			],
+			"extends": [
 				{
-					"name": "codeDescriptionSupport",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true,
-					"documentation": "Client supports a codeDescription property\n\n@since 3.16.0",
-					"since": "3.16.0"
-				},
-				{
-					"name": "dataSupport",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true,
-					"documentation": "Whether code action supports the `data` property which is\npreserved between a `textDocument/publishDiagnostics` and\n`textDocument/codeAction` request.\n\n@since 3.16.0",
-					"since": "3.16.0"
+					"kind": "reference",
+					"name": "DiagnosticsCapabilities"
 				}
 			],
 			"documentation": "The publish diagnostic client capabilities."
@@ -12660,61 +13039,8 @@
 				{
 					"name": "requests",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "range",
-									"type": {
-										"kind": "or",
-										"items": [
-											{
-												"kind": "base",
-												"name": "boolean"
-											},
-											{
-												"kind": "literal",
-												"value": {
-													"properties": []
-												}
-											}
-										]
-									},
-									"optional": true,
-									"documentation": "The client will send the `textDocument/semanticTokens/range` request if\nthe server provides a corresponding handler."
-								},
-								{
-									"name": "full",
-									"type": {
-										"kind": "or",
-										"items": [
-											{
-												"kind": "base",
-												"name": "boolean"
-											},
-											{
-												"kind": "literal",
-												"value": {
-													"properties": [
-														{
-															"name": "delta",
-															"type": {
-																"kind": "base",
-																"name": "boolean"
-															},
-															"optional": true,
-															"documentation": "The client will send the `textDocument/semanticTokens/full/delta` request if\nthe server provides a corresponding handler."
-														}
-													]
-												}
-											}
-										]
-									},
-									"optional": true,
-									"documentation": "The client will send the `textDocument/semanticTokens/full` request if\nthe server provides a corresponding handler."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientSemanticTokensRequestOptions"
 					},
 					"documentation": "Which requests the client supports and might send to the server\ndepending on the server's capability. Please note that clients might not\nshow semantic tokens or degrade some of the user experience if a range\nor full request is advertised by the client but not provided by the\nserver. If for example the client capability `requests.full` and\n`request.range` are both set to true but the server only provides a\nrange provider the client might not render a minimap correctly or might\neven decide to not show any semantic tokens at all."
 				},
@@ -12872,22 +13198,8 @@
 				{
 					"name": "resolveSupport",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "properties",
-									"type": {
-										"kind": "array",
-										"element": {
-											"kind": "base",
-											"name": "string"
-										}
-									},
-									"documentation": "The properties that a client can resolve lazily."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientInlayHintResolveOptions"
 					},
 					"optional": true,
 					"documentation": "Indicates which properties a client can resolve lazily on an inlay\nhint."
@@ -12924,9 +13236,14 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether the client supports `MarkupContent` in diagnostic messages.",
-					"since": "3.18.0",
-					"proposed": true
+					"documentation": "Whether the client supports `MarkupContent` in diagnostic messages.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "DiagnosticsCapabilities"
 				}
 			],
 			"documentation": "Client capabilities specific to diagnostic pull requests.\n\n@since 3.17.0",
@@ -12945,9 +13262,8 @@
 					"documentation": "Whether implementation supports dynamic registration for inline completion providers."
 				}
 			],
-			"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "NotebookDocumentSyncClientCapabilities",
@@ -12980,20 +13296,8 @@
 				{
 					"name": "messageActionItem",
 					"type": {
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "additionalPropertiesSupport",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									},
-									"optional": true,
-									"documentation": "Whether the client supports additional attributes which\nare preserved and send back to the server in the\nrequest's response."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "ClientShowMessageActionItemOptions"
 					},
 					"optional": true,
 					"documentation": "Capabilities specific to the `MessageActionItem` type."
@@ -13017,13 +13321,39 @@
 			"since": "3.16.0"
 		},
 		{
+			"name": "StaleRequestSupportOptions",
+			"properties": [
+				{
+					"name": "cancel",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"documentation": "The client will actively cancel the request."
+				},
+				{
+					"name": "retryOnContentModified",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The list of requests for which the client\nwill retry the request if it receives a\nresponse with error code `ContentModified`"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"name": "RegularExpressionsClientCapabilities",
 			"properties": [
 				{
 					"name": "engine",
 					"type": {
-						"kind": "base",
-						"name": "string"
+						"kind": "reference",
+						"name": "RegularExpressionEngineKind"
 					},
 					"documentation": "The engine's name."
 				},
@@ -13076,6 +13406,732 @@
 			],
 			"documentation": "Client capabilities specific to the used markdown parser.\n\n@since 3.16.0",
 			"since": "3.16.0"
+		},
+		{
+			"name": "TextDocumentFilterLanguage",
+			"properties": [
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "A language id, like `typescript`."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"optional": true,
+					"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.\n\n@since 3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`.",
+					"since": "3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`."
+				}
+			],
+			"documentation": "A document filter where `language` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentFilterScheme",
+			"properties": [
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A language id, like `typescript`."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"optional": true,
+					"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.\n\n@since 3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`.",
+					"since": "3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`."
+				}
+			],
+			"documentation": "A document filter where `scheme` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TextDocumentFilterPattern",
+			"properties": [
+				{
+					"name": "language",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A language id, like `typescript`."
+				},
+				{
+					"name": "scheme",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "reference",
+						"name": "GlobPattern"
+					},
+					"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.\n\n@since 3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`.",
+					"since": "3.18.0 - support for relative patterns. Whether clients support\nrelative patterns depends on the client capability\n`textDocuments.filters.relativePatternSupport`."
+				}
+			],
+			"documentation": "A document filter where `pattern` is required field.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ChangeAnnotationsSupportOptions",
+			"properties": [
+				{
+					"name": "groupsOnLabel",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client groups edits with equal labels into tree nodes,\nfor instance all edits labelled with \"Changes in Strings\" would\nbe a tree node."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientSymbolKindOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "SymbolKind"
+						}
+					},
+					"optional": true,
+					"documentation": "The symbol kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown.\n\nIf this property is not present the client only supports\nthe symbol kinds from `File` to `Array` as defined in\nthe initial version of the protocol."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientSymbolTagOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "SymbolTag"
+						}
+					},
+					"documentation": "The tags supported by the client."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientSymbolResolveOptions",
+			"properties": [
+				{
+					"name": "properties",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The properties that a client can resolve lazily. Usually\n`location.range`"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCompletionItemOptions",
+			"properties": [
+				{
+					"name": "snippetSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client supports snippets as insert text.\n\nA snippet can define tab stops and placeholders with `$1`, `$2`\nand `${3:foo}`. `$0` defines the final tab stop, it defaults to\nthe end of the snippet. Placeholders with equal identifiers are linked,\nthat is typing in one will update others too."
+				},
+				{
+					"name": "commitCharactersSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client supports commit characters on a completion item."
+				},
+				{
+					"name": "documentationFormat",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "MarkupKind"
+						}
+					},
+					"optional": true,
+					"documentation": "Client supports the following content formats for the documentation\nproperty. The order describes the preferred format of the client."
+				},
+				{
+					"name": "deprecatedSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client supports the deprecated property on a completion item."
+				},
+				{
+					"name": "preselectSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client supports the preselect property on a completion item."
+				},
+				{
+					"name": "tagSupport",
+					"type": {
+						"kind": "reference",
+						"name": "CompletionItemTagOptions"
+					},
+					"optional": true,
+					"documentation": "Client supports the tag property on a completion item. Clients supporting\ntags have to handle unknown tags gracefully. Clients especially need to\npreserve unknown tags when sending a completion item back to the server in\na resolve call.\n\n@since 3.15.0",
+					"since": "3.15.0"
+				},
+				{
+					"name": "insertReplaceSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client support insert replace edit to control different behavior if a\ncompletion item is inserted in the text or should replace text.\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "resolveSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientCompletionItemResolveOptions"
+					},
+					"optional": true,
+					"documentation": "Indicates which properties a client can resolve lazily on a completion\nitem. Before version 3.16.0 only the predefined properties `documentation`\nand `details` could be resolved lazily.\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "insertTextModeSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientCompletionItemInsertTextModeOptions"
+					},
+					"optional": true,
+					"documentation": "The client supports the `insertTextMode` property on\na completion item to override the whitespace handling mode\nas defined by the client (see `insertTextMode`).\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "labelDetailsSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client has support for completion item label\ndetails (see also `CompletionItemLabelDetails`).\n\n@since 3.17.0",
+					"since": "3.17.0"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCompletionItemOptionsKind",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CompletionItemKind"
+						}
+					},
+					"optional": true,
+					"documentation": "The completion item kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown.\n\nIf this property is not present the client only supports\nthe completion items kinds from `Text` to `Reference` as defined in\nthe initial version of the protocol."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "CompletionListCapabilities",
+			"properties": [
+				{
+					"name": "itemDefaults",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"optional": true,
+					"documentation": "The client supports the following itemDefaults on\na completion list.\n\nThe value lists the supported property names of the\n`CompletionList.itemDefaults` object. If omitted\nno properties are supported.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				},
+				{
+					"name": "applyKindSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Specifies whether the client supports `CompletionList.applyKind` to\nindicate how supported values from `completionList.itemDefaults`\nand `completion` will be combined.\n\nIf a client supports `applyKind` it must support it for all fields\nthat it supports that are listed in `CompletionList.applyKind`. This\nmeans when clients add support for new/future fields in completion\nitems the MUST also support merge for them if those fields are\ndefined in `CompletionList.applyKind`.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			],
+			"documentation": "The client supports the following `CompletionList` specific\ncapabilities.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "ClientSignatureInformationOptions",
+			"properties": [
+				{
+					"name": "documentationFormat",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "MarkupKind"
+						}
+					},
+					"optional": true,
+					"documentation": "Client supports the following content formats for the documentation\nproperty. The order describes the preferred format of the client."
+				},
+				{
+					"name": "parameterInformation",
+					"type": {
+						"kind": "reference",
+						"name": "ClientSignatureParameterInformationOptions"
+					},
+					"optional": true,
+					"documentation": "Client capabilities specific to parameter information."
+				},
+				{
+					"name": "activeParameterSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client supports the `activeParameter` property on `SignatureInformation`\nliteral.\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "noActiveParameterSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client supports the `activeParameter` property on\n`SignatureHelp`/`SignatureInformation` being set to `null` to\nindicate that no parameter should be active.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCodeActionLiteralOptions",
+			"properties": [
+				{
+					"name": "codeActionKind",
+					"type": {
+						"kind": "reference",
+						"name": "ClientCodeActionKindOptions"
+					},
+					"documentation": "The code action kind is support with the following value\nset."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCodeActionResolveOptions",
+			"properties": [
+				{
+					"name": "properties",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The properties that a client can resolve lazily."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "CodeActionTagOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CodeActionTag"
+						}
+					},
+					"documentation": "The tags supported by the client."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCodeLensResolveOptions",
+			"properties": [
+				{
+					"name": "properties",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The properties that a client can resolve lazily."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientFoldingRangeKindOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "FoldingRangeKind"
+						}
+					},
+					"optional": true,
+					"documentation": "The folding range kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientFoldingRangeOptions",
+			"properties": [
+				{
+					"name": "collapsedText",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "If set, the client signals that it supports setting collapsedText on\nfolding ranges to display custom labels instead of the default text.\n\n@since 3.17.0",
+					"since": "3.17.0"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "DiagnosticsCapabilities",
+			"properties": [
+				{
+					"name": "relatedInformation",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the clients accepts diagnostics with related information."
+				},
+				{
+					"name": "tagSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientDiagnosticsTagOptions"
+					},
+					"optional": true,
+					"documentation": "Client supports the tag property to provide meta data about a diagnostic.\nClients supporting tags have to handle unknown tags gracefully.\n\n@since 3.15.0",
+					"since": "3.15.0"
+				},
+				{
+					"name": "codeDescriptionSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Client supports a codeDescription property\n\n@since 3.16.0",
+					"since": "3.16.0"
+				},
+				{
+					"name": "dataSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether code action supports the `data` property which is\npreserved between a `textDocument/publishDiagnostics` and\n`textDocument/codeAction` request.\n\n@since 3.16.0",
+					"since": "3.16.0"
+				}
+			],
+			"documentation": "General diagnostics capabilities for pull and push model."
+		},
+		{
+			"name": "ClientSemanticTokensRequestOptions",
+			"properties": [
+				{
+					"name": "range",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "boolean"
+							},
+							{
+								"kind": "literal",
+								"value": {
+									"properties": []
+								}
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "The client will send the `textDocument/semanticTokens/range` request if\nthe server provides a corresponding handler."
+				},
+				{
+					"name": "full",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "boolean"
+							},
+							{
+								"kind": "reference",
+								"name": "ClientSemanticTokensRequestFullDelta"
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "The client will send the `textDocument/semanticTokens/full` request if\nthe server provides a corresponding handler."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientInlayHintResolveOptions",
+			"properties": [
+				{
+					"name": "properties",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The properties that a client can resolve lazily."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientShowMessageActionItemOptions",
+			"properties": [
+				{
+					"name": "additionalPropertiesSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports additional attributes which\nare preserved and send back to the server in the\nrequest's response."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "CompletionItemTagOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CompletionItemTag"
+						}
+					},
+					"documentation": "The tags supported by the client."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCompletionItemResolveOptions",
+			"properties": [
+				{
+					"name": "properties",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "base",
+							"name": "string"
+						}
+					},
+					"documentation": "The properties that a client can resolve lazily."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCompletionItemInsertTextModeOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "InsertTextMode"
+						}
+					}
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientSignatureParameterInformationOptions",
+			"properties": [
+				{
+					"name": "labelOffsetSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client supports processing label offsets instead of a\nsimple label string.\n\n@since 3.14.0",
+					"since": "3.14.0"
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientCodeActionKindOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "CodeActionKind"
+						}
+					},
+					"documentation": "The code action kind values the client supports. When this\nproperty exists the client also guarantees that it will\nhandle values outside its set gracefully and falls back\nto a default value when unknown."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientDiagnosticsTagOptions",
+			"properties": [
+				{
+					"name": "valueSet",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "DiagnosticTag"
+						}
+					},
+					"documentation": "The tags supported by the client."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "ClientSemanticTokensRequestFullDelta",
+			"properties": [
+				{
+					"name": "delta",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "The client will send the `textDocument/semanticTokens/full/delta` request if\nthe server provides a corresponding handler."
+				}
+			],
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
 		}
 	],
 	"enumerations": [
@@ -13180,6 +14236,12 @@
 					"value": "decorator",
 					"documentation": "@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "label",
+					"value": "label",
+					"documentation": "@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"supportsCustomValues": true,
@@ -13881,6 +14943,12 @@
 					"documentation": "Base kind for refactoring inline actions: 'refactor.inline'\n\nExample inline actions:\n\n- Inline function\n- Inline variable\n- Inline constant\n- ..."
 				},
 				{
+					"name": "RefactorMove",
+					"value": "refactor.move",
+					"documentation": "Base kind for refactoring move actions: `refactor.move`\n\nExample move actions:\n\n- Move a function to a new file\n- Move a property between classes\n- Move method to base class\n- ...\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
 					"name": "RefactorRewrite",
 					"value": "refactor.rewrite",
 					"documentation": "Base kind for refactoring rewrite actions: 'refactor.rewrite'\n\nExample rewrite actions:\n\n- Convert JavaScript function to class\n- Add or remove parameter\n- Encapsulate field\n- Make method static\n- Move method to base class\n- ..."
@@ -13900,13 +14968,35 @@
 					"value": "source.fixAll",
 					"documentation": "Base kind for auto-fix source actions: `source.fixAll`.\n\nFix all actions automatically fix errors that have a clear fix that do not require user input.\nThey should not suppress errors or perform unsafe fixes such as generating new types or classes.\n\n@since 3.15.0",
 					"since": "3.15.0"
+				},
+				{
+					"name": "Notebook",
+					"value": "notebook",
+					"documentation": "Base kind for all code actions applying to the entire notebook's scope. CodeActionKinds using\nthis should always begin with `notebook.`\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"supportsCustomValues": true,
 			"documentation": "A set of predefined code action kinds"
 		},
 		{
-			"name": "TraceValues",
+			"name": "CodeActionTag",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "LLMGenerated",
+					"value": 1,
+					"documentation": "Marks the code action as LLM-generated."
+				}
+			],
+			"documentation": "Code action tags are extra annotations that tweak the behavior of a code action.\n\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
+			"name": "TraceValue",
 			"type": {
 				"kind": "base",
 				"name": "string"
@@ -13950,6 +15040,272 @@
 			"documentation": "Describes the content type that a client supports in various\nresult literals like `Hover`, `ParameterInfo` or `CompletionItem`.\n\nPlease note that `MarkupKinds` must not start with a `$`. This kinds\nare reserved for internal usage."
 		},
 		{
+			"name": "LanguageKind",
+			"type": {
+				"kind": "base",
+				"name": "string"
+			},
+			"values": [
+				{
+					"name": "ABAP",
+					"value": "abap"
+				},
+				{
+					"name": "WindowsBat",
+					"value": "bat"
+				},
+				{
+					"name": "BibTeX",
+					"value": "bibtex"
+				},
+				{
+					"name": "Clojure",
+					"value": "clojure"
+				},
+				{
+					"name": "Coffeescript",
+					"value": "coffeescript"
+				},
+				{
+					"name": "C",
+					"value": "c"
+				},
+				{
+					"name": "CPP",
+					"value": "cpp"
+				},
+				{
+					"name": "CSharp",
+					"value": "csharp"
+				},
+				{
+					"name": "CSS",
+					"value": "css"
+				},
+				{
+					"name": "D",
+					"value": "d",
+					"documentation": "@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "Delphi",
+					"value": "pascal",
+					"documentation": "@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "Diff",
+					"value": "diff"
+				},
+				{
+					"name": "Dart",
+					"value": "dart"
+				},
+				{
+					"name": "Dockerfile",
+					"value": "dockerfile"
+				},
+				{
+					"name": "Elixir",
+					"value": "elixir"
+				},
+				{
+					"name": "Erlang",
+					"value": "erlang"
+				},
+				{
+					"name": "FSharp",
+					"value": "fsharp"
+				},
+				{
+					"name": "GitCommit",
+					"value": "git-commit"
+				},
+				{
+					"name": "GitRebase",
+					"value": "git-rebase"
+				},
+				{
+					"name": "Go",
+					"value": "go"
+				},
+				{
+					"name": "Groovy",
+					"value": "groovy"
+				},
+				{
+					"name": "Handlebars",
+					"value": "handlebars"
+				},
+				{
+					"name": "Haskell",
+					"value": "haskell"
+				},
+				{
+					"name": "HTML",
+					"value": "html"
+				},
+				{
+					"name": "Ini",
+					"value": "ini"
+				},
+				{
+					"name": "Java",
+					"value": "java"
+				},
+				{
+					"name": "JavaScript",
+					"value": "javascript"
+				},
+				{
+					"name": "JavaScriptReact",
+					"value": "javascriptreact"
+				},
+				{
+					"name": "JSON",
+					"value": "json"
+				},
+				{
+					"name": "LaTeX",
+					"value": "latex"
+				},
+				{
+					"name": "Less",
+					"value": "less"
+				},
+				{
+					"name": "Lua",
+					"value": "lua"
+				},
+				{
+					"name": "Makefile",
+					"value": "makefile"
+				},
+				{
+					"name": "Markdown",
+					"value": "markdown"
+				},
+				{
+					"name": "ObjectiveC",
+					"value": "objective-c"
+				},
+				{
+					"name": "ObjectiveCPP",
+					"value": "objective-cpp"
+				},
+				{
+					"name": "Pascal",
+					"value": "pascal",
+					"documentation": "@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "Perl",
+					"value": "perl"
+				},
+				{
+					"name": "Perl6",
+					"value": "perl6"
+				},
+				{
+					"name": "PHP",
+					"value": "php"
+				},
+				{
+					"name": "Plaintext",
+					"value": "plaintext"
+				},
+				{
+					"name": "Powershell",
+					"value": "powershell"
+				},
+				{
+					"name": "Pug",
+					"value": "jade"
+				},
+				{
+					"name": "Python",
+					"value": "python"
+				},
+				{
+					"name": "R",
+					"value": "r"
+				},
+				{
+					"name": "Razor",
+					"value": "razor"
+				},
+				{
+					"name": "Ruby",
+					"value": "ruby"
+				},
+				{
+					"name": "Rust",
+					"value": "rust"
+				},
+				{
+					"name": "SCSS",
+					"value": "scss"
+				},
+				{
+					"name": "SASS",
+					"value": "sass"
+				},
+				{
+					"name": "Scala",
+					"value": "scala"
+				},
+				{
+					"name": "ShaderLab",
+					"value": "shaderlab"
+				},
+				{
+					"name": "ShellScript",
+					"value": "shellscript"
+				},
+				{
+					"name": "SQL",
+					"value": "sql"
+				},
+				{
+					"name": "Swift",
+					"value": "swift"
+				},
+				{
+					"name": "TypeScript",
+					"value": "typescript"
+				},
+				{
+					"name": "TypeScriptReact",
+					"value": "typescriptreact"
+				},
+				{
+					"name": "TeX",
+					"value": "tex"
+				},
+				{
+					"name": "VisualBasic",
+					"value": "vb"
+				},
+				{
+					"name": "XML",
+					"value": "xml"
+				},
+				{
+					"name": "XSL",
+					"value": "xsl"
+				},
+				{
+					"name": "YAML",
+					"value": "yaml"
+				}
+			],
+			"supportsCustomValues": true,
+			"documentation": "Predefined Language kinds\n@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"name": "InlineCompletionTriggerKind",
 			"type": {
 				"kind": "base",
@@ -13958,18 +15314,17 @@
 			"values": [
 				{
 					"name": "Invoked",
-					"value": 0,
+					"value": 1,
 					"documentation": "Completion was triggered explicitly by a user gesture."
 				},
 				{
 					"name": "Automatic",
-					"value": 1,
+					"value": 2,
 					"documentation": "Completion was triggered automatically while editing."
 				}
 			],
-			"documentation": "Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.\n\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "PositionEncodingKind",
@@ -14123,6 +15478,27 @@
 				}
 			],
 			"documentation": "How a completion was triggered"
+		},
+		{
+			"name": "ApplyKind",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "Replace",
+					"value": 1,
+					"documentation": "The value from the individual item (if provided and not `null`) will be\nused instead of the default."
+				},
+				{
+					"name": "Merge",
+					"value": 2,
+					"documentation": "The value from the item will be merged with the default.\n\nThe specific rules for mergeing values are defined against each field\nthat supports merging."
+				}
+			],
+			"documentation": "Defines how values from a set of defaults and an individual item will be\nmerged.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "SignatureHelpTriggerKind",
@@ -14446,6 +15822,24 @@
 			"since": "3.17.0"
 		},
 		{
+			"name": "DocumentDiagnosticReportProgress",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReport"
+					},
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReportPartialResult"
+					}
+				]
+			},
+			"documentation": "The document diagnostic report used when reporting partial result.\n\nWhen using partial results, the first literal sent needs to be a\nDocumentDiagnosticReport providing the diagnostics on the document\nfollowed by n DocumentDiagnosticReportPartialResult literals providing\nthe diagnostics for related documents.\n\n```\nDocumentDiagnosticReport\nDocumentDiagnosticReportPartialResult\nDocumentDiagnosticReportPartialResult\n...\n```\n\n@since 3.18.1",
+			"since": "3.18.1"
+		},
+		{
 			"name": "PrepareRenameResult",
 			"type": {
 				"kind": "or",
@@ -14455,54 +15849,15 @@
 						"name": "Range"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "range",
-									"type": {
-										"kind": "reference",
-										"name": "Range"
-									}
-								},
-								{
-									"name": "placeholder",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									}
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "PrepareRenamePlaceholder"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "defaultBehavior",
-									"type": {
-										"kind": "base",
-										"name": "boolean"
-									}
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "PrepareRenameDefaultBehavior"
 					}
 				]
 			}
-		},
-		{
-			"name": "DocumentSelector",
-			"type": {
-				"kind": "array",
-				"element": {
-					"kind": "reference",
-					"name": "DocumentFilter"
-				}
-			},
-			"documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
-			"since": "3.16.0."
 		},
 		{
 			"name": "ProgressToken",
@@ -14547,56 +15902,29 @@
 			"since": "3.17.0"
 		},
 		{
+			"name": "DocumentSelector",
+			"type": {
+				"kind": "array",
+				"element": {
+					"kind": "reference",
+					"name": "DocumentFilter"
+				}
+			},
+			"documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
+			"since": "3.16.0."
+		},
+		{
 			"name": "TextDocumentContentChangeEvent",
 			"type": {
 				"kind": "or",
 				"items": [
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "range",
-									"type": {
-										"kind": "reference",
-										"name": "Range"
-									},
-									"documentation": "The range of the document that changed."
-								},
-								{
-									"name": "rangeLength",
-									"type": {
-										"kind": "base",
-										"name": "uinteger"
-									},
-									"optional": true,
-									"documentation": "The optional length of the range that got replaced.\n\n@deprecated use range instead."
-								},
-								{
-									"name": "text",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "The new text for the provided range."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "TextDocumentContentChangePartial"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "text",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "The new text of the whole document."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "TextDocumentContentChangeWholeDocument"
 					}
 				]
 			},
@@ -14612,48 +15940,13 @@
 						"name": "string"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "language",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									}
-								},
-								{
-									"name": "value",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									}
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "MarkedStringWithLanguage"
 					}
 				]
 			},
 			"documentation": "MarkedString can be used to render human readable text. It is either a markdown string\nor a code-block that provides a language and a code snippet. The language identifier\nis semantically equal to the optional language identifier in fenced code blocks in GitHub\nissues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting\n\nThe pair of a language and a value is an equivalent to markdown:\n```${language}\n${value}\n```\n\nNote that markdown strings will be sanitized - that means html will be escaped.\n@deprecated use MarkupContent instead.",
 			"deprecated": "use MarkupContent instead."
-		},
-		{
-			"name": "DocumentFilter",
-			"type": {
-				"kind": "or",
-				"items": [
-					{
-						"kind": "reference",
-						"name": "TextDocumentFilter"
-					},
-					{
-						"kind": "reference",
-						"name": "NotebookCellTextDocumentFilter"
-					}
-				]
-			},
-			"documentation": "A document filter describes a top level text document or\na notebook cell document.\n\n@since 3.17.0 - proposed support for NotebookCellTextDocumentFilter.",
-			"since": "3.17.0 - proposed support for NotebookCellTextDocumentFilter."
 		},
 		{
 			"name": "LSPObject",
@@ -14670,6 +15963,24 @@
 			},
 			"documentation": "LSP object definition.\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "DocumentFilter",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "TextDocumentFilter"
+					},
+					{
+						"kind": "reference",
+						"name": "NotebookCellTextDocumentFilter"
+					}
+				]
+			},
+			"documentation": "A document filter describes a top level text document or\na notebook cell document.\n\n@since 3.17.0 - support for NotebookCellTextDocumentFilter.",
+			"since": "3.17.0 - support for NotebookCellTextDocumentFilter."
 		},
 		{
 			"name": "GlobPattern",
@@ -14690,221 +16001,47 @@
 			"since": "3.17.0"
 		},
 		{
-			"name": "TextDocumentFilter",
-			"type": {
-				"kind": "or",
-				"items": [
-					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "language",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "A language id, like `typescript`."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
-								}
-							]
-						}
-					},
-					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "language",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A language id, like `typescript`."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
-								}
-							]
-						}
-					},
-					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "language",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A language id, like `typescript`."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
-								}
-							]
-						}
-					}
-				]
-			},
-			"documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
 			"name": "NotebookDocumentFilter",
 			"type": {
 				"kind": "or",
 				"items": [
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "notebookType",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "The type of the enclosing notebook."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A glob pattern."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "NotebookDocumentFilterNotebookType"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "notebookType",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "The type of the enclosing notebook."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A glob pattern."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "NotebookDocumentFilterScheme"
 					},
 					{
-						"kind": "literal",
-						"value": {
-							"properties": [
-								{
-									"name": "notebookType",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "The type of the enclosing notebook."
-								},
-								{
-									"name": "scheme",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"optional": true,
-									"documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
-								},
-								{
-									"name": "pattern",
-									"type": {
-										"kind": "base",
-										"name": "string"
-									},
-									"documentation": "A glob pattern."
-								}
-							]
-						}
+						"kind": "reference",
+						"name": "NotebookDocumentFilterPattern"
 					}
 				]
 			},
 			"documentation": "A notebook document filter denotes a notebook document by\ndifferent properties. The properties will be match\nagainst the notebook's URI (same as with documents)\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "TextDocumentFilter",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "TextDocumentFilterLanguage"
+					},
+					{
+						"kind": "reference",
+						"name": "TextDocumentFilterScheme"
+					},
+					{
+						"kind": "reference",
+						"name": "TextDocumentFilterPattern"
+					}
+				]
+			},
+			"documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -14913,8 +16050,15 @@
 				"kind": "base",
 				"name": "string"
 			},
-			"documentation": "The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@since 3.17.0",
+			"documentation": "The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "RegularExpressionEngineKind",
+			"type": {
+				"kind": "base",
+				"name": "string"
+			}
 		}
 	]
 }

--- a/lsp/bin/ocaml/json_gen.ml
+++ b/lsp/bin/ocaml/json_gen.ml
@@ -75,7 +75,16 @@ let add_json_conv_for_t (sig_ : Module.sig_ Module.t) =
 ;;
 
 module Enum = struct
+  let deduplicate_literals constrs =
+    List.fold_left constrs ~init:[] ~f:(fun unique ((_, literal) as entry) ->
+      if List.exists unique ~f:(fun (_, existing) -> Poly.equal literal existing)
+      then unique
+      else entry :: unique)
+    |> List.rev
+  ;;
+
   let of_json ~allow_other ~poly { Named.name; data = constrs } =
+    let constrs = deduplicate_literals constrs in
     let open Ml.Expr in
     let body =
       let clauses =

--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -33,7 +33,12 @@ let skipped_ts_decls =
 
 (* XXX this is temporary until we support the [supportsCustomValues] field *)
 let with_custom_values =
-  [ "FoldingRangeKind"; "CodeActionKind"; "PositionEncodingKind"; "WatchKind" ]
+  [ "FoldingRangeKind"
+  ; "CodeActionKind"
+  ; "LanguageKind"
+  ; "PositionEncodingKind"
+  ; "WatchKind"
+  ]
 ;;
 
 module Expanded = struct

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -4,9 +4,12 @@ include struct
   open Types
   module DidOpenTextDocumentParams = DidOpenTextDocumentParams
   module DocumentUri = DocumentUri
+  module LanguageKind = LanguageKind
   module Range = Range
   module TextDocumentItem = TextDocumentItem
   module TextDocumentContentChangeEvent = TextDocumentContentChangeEvent
+  module TextDocumentContentChangePartial = TextDocumentContentChangePartial
+  module TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument
   module TextEdit = TextEdit
 end
 
@@ -35,6 +38,11 @@ let make
       }
   =
   let zipper = String_zipper.of_string text in
+  let languageId =
+    match LanguageKind.yojson_of_t languageId with
+    | `String languageId -> languageId
+    | _ -> assert false
+  in
   { text = Some text; position_encoding; zipper; uri; version; languageId }
 ;;
 
@@ -43,9 +51,10 @@ let version (t : t) = t.version
 let languageId (t : t) = t.languageId
 
 let apply_change encoding sz (change : TextDocumentContentChangeEvent.t) =
-  match change.range with
-  | None -> String_zipper.of_string change.text
-  | Some range -> String_zipper.apply_change sz range encoding ~replacement:change.text
+  match change with
+  | `TextDocumentContentChangeWholeDocument { text } -> String_zipper.of_string text
+  | `TextDocumentContentChangePartial { range; rangeLength = _; text } ->
+    String_zipper.apply_change sz range encoding ~replacement:text
 ;;
 
 let apply_content_changes ?version t changes =

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -315,6 +315,25 @@ module TextDocumentFilter = struct
 end
 
 (*$ Lsp_gen.print_ml () *)
+module ApplyKind = struct
+  type t =
+    | Replace
+    | Merge
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | Replace -> `Int 1
+    | Merge -> `Int 2
+  ;;
+
+  let t_of_yojson (json : Json.t) : t =
+    match json with
+    | `Int 1 -> Replace
+    | `Int 2 -> Merge
+    | _ -> Json.error "Invalid\nvalue. Expected one of: 1, 2" json
+  ;;
+end
+
 module SymbolTag = struct
   type t = Deprecated
 
@@ -703,6 +722,21 @@ module CompletionItemTag = struct
   ;;
 end
 
+module CodeActionTag = struct
+  type t = LLMGenerated
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | LLMGenerated -> `Int 1
+  ;;
+
+  let t_of_yojson (json : Json.t) : t =
+    match json with
+    | `Int 1 -> LLMGenerated
+    | _ -> Json.error "Invalid value. Expected one\nof: 1" json
+  ;;
+end
+
 module CodeActionKind = struct
   type t =
     | Empty
@@ -710,10 +744,12 @@ module CodeActionKind = struct
     | Refactor
     | RefactorExtract
     | RefactorInline
+    | RefactorMove
     | RefactorRewrite
     | Source
     | SourceOrganizeImports
     | SourceFixAll
+    | Notebook
     | Other of string
 
   let yojson_of_t (t : t) : Json.t =
@@ -723,10 +759,12 @@ module CodeActionKind = struct
     | Refactor -> `String "refactor"
     | RefactorExtract -> `String "refactor.extract"
     | RefactorInline -> `String "refactor.inline"
+    | RefactorMove -> `String "refactor.move"
     | RefactorRewrite -> `String "refactor.rewrite"
     | Source -> `String "source"
     | SourceOrganizeImports -> `String "source.organizeImports"
     | SourceFixAll -> `String "source.fixAll"
+    | Notebook -> `String "notebook"
     | Other s -> `String s
   ;;
 
@@ -737,17 +775,19 @@ module CodeActionKind = struct
     | `String "refactor" -> Refactor
     | `String "refactor.extract" -> RefactorExtract
     | `String "refactor.inline" -> RefactorInline
+    | `String "refactor.move" -> RefactorMove
     | `String "refactor.rewrite" -> RefactorRewrite
     | `String "source" -> Source
     | `String "source.organizeImports" -> SourceOrganizeImports
     | `String "source.fixAll" -> SourceFixAll
+    | `String "notebook" -> Notebook
     | `String s -> Other s
     | _ ->
       Json.error
-        "Invalid value. Expected one of: \"\",\n\
-         \"quickfix\", \"refactor\", \"refactor.extract\", \"refactor.inline\",\n\
-         \"refactor.rewrite\", \"source\", \"source.organizeImports\",\n\
-         \"source.fixAll\""
+        "Invalid value.\n\
+         Expected one of: \"\", \"quickfix\", \"refactor\", \"refactor.extract\",\n\
+         \"refactor.inline\", \"refactor.move\", \"refactor.rewrite\", \"source\",\n\
+         \"source.organizeImports\", \"source.fixAll\", \"notebook\""
         json
   ;;
 end
@@ -860,6 +900,220 @@ module InsertTextFormat = struct
     | `Int 1 -> PlainText
     | `Int 2 -> Snippet
     | _ -> Json.error "Invalid\nvalue. Expected one of: 1, 2" json
+  ;;
+end
+
+module LanguageKind = struct
+  type t =
+    | ABAP
+    | WindowsBat
+    | BibTeX
+    | Clojure
+    | Coffeescript
+    | C
+    | CPP
+    | CSharp
+    | CSS
+    | D
+    | Delphi
+    | Diff
+    | Dart
+    | Dockerfile
+    | Elixir
+    | Erlang
+    | FSharp
+    | GitCommit
+    | GitRebase
+    | Go
+    | Groovy
+    | Handlebars
+    | Haskell
+    | HTML
+    | Ini
+    | Java
+    | JavaScript
+    | JavaScriptReact
+    | JSON
+    | LaTeX
+    | Less
+    | Lua
+    | Makefile
+    | Markdown
+    | ObjectiveC
+    | ObjectiveCPP
+    | Pascal
+    | Perl
+    | Perl6
+    | PHP
+    | Plaintext
+    | Powershell
+    | Pug
+    | Python
+    | R
+    | Razor
+    | Ruby
+    | Rust
+    | SCSS
+    | SASS
+    | Scala
+    | ShaderLab
+    | ShellScript
+    | SQL
+    | Swift
+    | TypeScript
+    | TypeScriptReact
+    | TeX
+    | VisualBasic
+    | XML
+    | XSL
+    | YAML
+    | Other of string
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | ABAP -> `String "abap"
+    | WindowsBat -> `String "bat"
+    | BibTeX -> `String "bibtex"
+    | Clojure -> `String "clojure"
+    | Coffeescript -> `String "coffeescript"
+    | C -> `String "c"
+    | CPP -> `String "cpp"
+    | CSharp -> `String "csharp"
+    | CSS -> `String "css"
+    | D -> `String "d"
+    | Delphi -> `String "pascal"
+    | Diff -> `String "diff"
+    | Dart -> `String "dart"
+    | Dockerfile -> `String "dockerfile"
+    | Elixir -> `String "elixir"
+    | Erlang -> `String "erlang"
+    | FSharp -> `String "fsharp"
+    | GitCommit -> `String "git-commit"
+    | GitRebase -> `String "git-rebase"
+    | Go -> `String "go"
+    | Groovy -> `String "groovy"
+    | Handlebars -> `String "handlebars"
+    | Haskell -> `String "haskell"
+    | HTML -> `String "html"
+    | Ini -> `String "ini"
+    | Java -> `String "java"
+    | JavaScript -> `String "javascript"
+    | JavaScriptReact -> `String "javascriptreact"
+    | JSON -> `String "json"
+    | LaTeX -> `String "latex"
+    | Less -> `String "less"
+    | Lua -> `String "lua"
+    | Makefile -> `String "makefile"
+    | Markdown -> `String "markdown"
+    | ObjectiveC -> `String "objective-c"
+    | ObjectiveCPP -> `String "objective-cpp"
+    | Pascal -> `String "pascal"
+    | Perl -> `String "perl"
+    | Perl6 -> `String "perl6"
+    | PHP -> `String "php"
+    | Plaintext -> `String "plaintext"
+    | Powershell -> `String "powershell"
+    | Pug -> `String "jade"
+    | Python -> `String "python"
+    | R -> `String "r"
+    | Razor -> `String "razor"
+    | Ruby -> `String "ruby"
+    | Rust -> `String "rust"
+    | SCSS -> `String "scss"
+    | SASS -> `String "sass"
+    | Scala -> `String "scala"
+    | ShaderLab -> `String "shaderlab"
+    | ShellScript -> `String "shellscript"
+    | SQL -> `String "sql"
+    | Swift -> `String "swift"
+    | TypeScript -> `String "typescript"
+    | TypeScriptReact -> `String "typescriptreact"
+    | TeX -> `String "tex"
+    | VisualBasic -> `String "vb"
+    | XML -> `String "xml"
+    | XSL -> `String "xsl"
+    | YAML -> `String "yaml"
+    | Other s -> `String s
+  ;;
+
+  let t_of_yojson (json : Json.t) : t =
+    match json with
+    | `String "abap" -> ABAP
+    | `String "bat" -> WindowsBat
+    | `String "bibtex" -> BibTeX
+    | `String "clojure" -> Clojure
+    | `String "coffeescript" -> Coffeescript
+    | `String "c" -> C
+    | `String "cpp" -> CPP
+    | `String "csharp" -> CSharp
+    | `String "css" -> CSS
+    | `String "d" -> D
+    | `String "pascal" -> Delphi
+    | `String "diff" -> Diff
+    | `String "dart" -> Dart
+    | `String "dockerfile" -> Dockerfile
+    | `String "elixir" -> Elixir
+    | `String "erlang" -> Erlang
+    | `String "fsharp" -> FSharp
+    | `String "git-commit" -> GitCommit
+    | `String "git-rebase" -> GitRebase
+    | `String "go" -> Go
+    | `String "groovy" -> Groovy
+    | `String "handlebars" -> Handlebars
+    | `String "haskell" -> Haskell
+    | `String "html" -> HTML
+    | `String "ini" -> Ini
+    | `String "java" -> Java
+    | `String "javascript" -> JavaScript
+    | `String "javascriptreact" -> JavaScriptReact
+    | `String "json" -> JSON
+    | `String "latex" -> LaTeX
+    | `String "less" -> Less
+    | `String "lua" -> Lua
+    | `String "makefile" -> Makefile
+    | `String "markdown" -> Markdown
+    | `String "objective-c" -> ObjectiveC
+    | `String "objective-cpp" -> ObjectiveCPP
+    | `String "perl" -> Perl
+    | `String "perl6" -> Perl6
+    | `String "php" -> PHP
+    | `String "plaintext" -> Plaintext
+    | `String "powershell" -> Powershell
+    | `String "jade" -> Pug
+    | `String "python" -> Python
+    | `String "r" -> R
+    | `String "razor" -> Razor
+    | `String "ruby" -> Ruby
+    | `String "rust" -> Rust
+    | `String "scss" -> SCSS
+    | `String "sass" -> SASS
+    | `String "scala" -> Scala
+    | `String "shaderlab" -> ShaderLab
+    | `String "shellscript" -> ShellScript
+    | `String "sql" -> SQL
+    | `String "swift" -> Swift
+    | `String "typescript" -> TypeScript
+    | `String "typescriptreact" -> TypeScriptReact
+    | `String "tex" -> TeX
+    | `String "vb" -> VisualBasic
+    | `String "xml" -> XML
+    | `String "xsl" -> XSL
+    | `String "yaml" -> YAML
+    | `String s -> Other s
+    | _ ->
+      Json.error
+        "Invalid value. Expected one of: \"abap\", \"bat\", \"bibtex\",\n\
+         \"clojure\", \"coffeescript\", \"c\", \"cpp\", \"csharp\", \"css\", \"d\",\n\
+         \"pascal\", \"diff\", \"dart\", \"dockerfile\", \"elixir\", \"erlang\",\n\
+         \"fsharp\", \"git-commit\", \"git-rebase\", \"go\", \"groovy\",\n\
+         \"handlebars\", \"haskell\", \"html\", \"ini\", \"java\", \"javascript\",\n\
+         \"javascriptreact\", \"json\", \"latex\", \"less\", \"lua\", \"makefile\",\n\
+         \"markdown\", \"objective-c\", \"objective-cpp\", \"perl\", \"perl6\",\n\
+         \"php\", \"plaintext\", \"powershell\", \"jade\", \"python\", \"r\",\n\
+         \"razor\", \"ruby\", \"rust\", \"scss\", \"sass\", \"scala\", \"shaderlab\",\n\
+         \"shellscript\", \"sql\", \"swift\", \"typescript\", \"typescriptreact\",\n\
+         \"tex\", \"vb\", \"xml\", \"xsl\", \"yaml\""
+        json
   ;;
 end
 
@@ -989,7 +1243,7 @@ module FileOperationPatternKind = struct
   ;;
 end
 
-module TraceValues = struct
+module TraceValue = struct
   type t =
     | Compact
     | Off
@@ -1065,15 +1319,15 @@ module InlineCompletionTriggerKind = struct
 
   let yojson_of_t (t : t) : Json.t =
     match t with
-    | Invoked -> `Int 0
-    | Automatic -> `Int 1
+    | Invoked -> `Int 1
+    | Automatic -> `Int 2
   ;;
 
   let t_of_yojson (json : Json.t) : t =
     match json with
-    | `Int 0 -> Invoked
-    | `Int 1 -> Automatic
-    | _ -> Json.error "Invalid\nvalue. Expected one of: 0, 1" json
+    | `Int 1 -> Invoked
+    | `Int 2 -> Automatic
+    | _ -> Json.error "Invalid\nvalue. Expected one of: 1, 2" json
   ;;
 end
 
@@ -1235,6 +1489,7 @@ module SemanticTokenTypes = struct
     | Regexp
     | Operator
     | Decorator
+    | Label
 
   let yojson_of_t (t : t) : Json.t =
     match t with
@@ -1261,6 +1516,7 @@ module SemanticTokenTypes = struct
     | Regexp -> `String "regexp"
     | Operator -> `String "operator"
     | Decorator -> `String "decorator"
+    | Label -> `String "label"
   ;;
 
   let t_of_yojson (json : Json.t) : t =
@@ -1288,13 +1544,15 @@ module SemanticTokenTypes = struct
     | `String "regexp" -> Regexp
     | `String "operator" -> Operator
     | `String "decorator" -> Decorator
+    | `String "label" -> Label
     | _ ->
       Json.error
-        "Invalid value. Expected one of: \"namespace\",\n\
-         \"type\", \"class\", \"enum\", \"interface\", \"struct\", \"typeParameter\",\n\
-         \"parameter\", \"variable\", \"property\", \"enumMember\", \"event\",\n\
-         \"function\", \"method\", \"macro\", \"keyword\", \"modifier\", \"comment\",\n\
-         \"string\", \"number\", \"regexp\", \"operator\", \"decorator\""
+        "Invalid value.\n\
+         Expected one of: \"namespace\", \"type\", \"class\", \"enum\", \"interface\",\n\
+         \"struct\", \"typeParameter\", \"parameter\", \"variable\", \"property\",\n\
+         \"enumMember\", \"event\", \"function\", \"method\", \"macro\", \"keyword\",\n\
+         \"modifier\", \"comment\", \"string\", \"number\", \"regexp\", \"operator\",\n\
+         \"decorator\", \"label\""
         json
   ;;
 end
@@ -1691,6 +1949,89 @@ module AnnotatedTextEdit = struct
     =
     { annotationId; newText; range }
   ;;
+end
+
+module WorkspaceEditMetadata = struct
+  type t =
+    { isRefactoring : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.WorkspaceEditMetadata.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let isRefactoring_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "isRefactoring" ->
+              (match Ppx_yojson_conv_lib.( ! ) isRefactoring_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 isRefactoring_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let isRefactoring_value = Ppx_yojson_conv_lib.( ! ) isRefactoring_field in
+             { isRefactoring =
+                 (match isRefactoring_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { isRefactoring = v_isRefactoring } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_isRefactoring
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_isRefactoring in
+           let bnd = "isRefactoring", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ?(isRefactoring : bool option) (() : unit) : t = { isRefactoring }
 end
 
 module DeleteFileOptions = struct
@@ -2641,6 +2982,233 @@ module OptionalVersionedTextDocumentIdentifier = struct
   ;;
 end
 
+module StringValue = struct
+  type t = { value : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.StringValue.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let value_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "value" ->
+              (match Ppx_yojson_conv_lib.( ! ) value_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 value_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) value_field with
+              | Ppx_yojson_conv_lib.Option.Some value_value -> { value = value_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) value_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "value" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { value = v_value } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_value in
+         ("value", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(value : string) : t = { value }
+  let yojson_of_t (t : t) : Json.t = Json.To.literal_field "kind" "snippet" yojson_of_t t
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.literal_field "t" "kind" "snippet" t_of_yojson json
+  ;;
+end
+
+module SnippetTextEdit = struct
+  type t =
+    { annotationId : ChangeAnnotationIdentifier.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; range : Range.t
+    ; snippet : StringValue.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.SnippetTextEdit.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let annotationId_field = ref Ppx_yojson_conv_lib.Option.None
+       and range_field = ref Ppx_yojson_conv_lib.Option.None
+       and snippet_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "annotationId" ->
+              (match Ppx_yojson_conv_lib.( ! ) annotationId_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ChangeAnnotationIdentifier.t_of_yojson
+                     _field_yojson
+                 in
+                 annotationId_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "range" ->
+              (match Ppx_yojson_conv_lib.( ! ) range_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Range.t_of_yojson _field_yojson in
+                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "snippet" ->
+              (match Ppx_yojson_conv_lib.( ! ) snippet_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = StringValue.t_of_yojson _field_yojson in
+                 snippet_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) annotationId_field
+                , Ppx_yojson_conv_lib.( ! ) range_field
+                , Ppx_yojson_conv_lib.( ! ) snippet_field )
+              with
+              | ( annotationId_value
+                , Ppx_yojson_conv_lib.Option.Some range_value
+                , Ppx_yojson_conv_lib.Option.Some snippet_value ) ->
+                { annotationId =
+                    (match annotationId_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; range = range_value
+                ; snippet = snippet_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) range_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "range" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) snippet_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "snippet" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { annotationId = v_annotationId; range = v_range; snippet = v_snippet } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = StringValue.yojson_of_t v_snippet in
+         ("snippet", arg) :: bnds
+       in
+       let bnds =
+         let arg = Range.yojson_of_t v_range in
+         ("range", arg) :: bnds
+       in
+       let bnds =
+         if None = v_annotationId
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t ChangeAnnotationIdentifier.yojson_of_t)
+               v_annotationId
+           in
+           let bnd = "annotationId", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(annotationId : ChangeAnnotationIdentifier.t option)
+        ~(range : Range.t)
+        ~(snippet : StringValue.t)
+        (() : unit)
+    : t
+    =
+    { annotationId; range; snippet }
+  ;;
+end
+
 module TextEdit = struct
   type t =
     { newText : string
@@ -2748,6 +3316,7 @@ module TextDocumentEdit = struct
   type edits_pvar =
     [ `TextEdit of TextEdit.t
     | `AnnotatedTextEdit of AnnotatedTextEdit.t
+    | `SnippetTextEdit of SnippetTextEdit.t
     ]
 
   let edits_pvar_of_yojson (json : Json.t) : edits_pvar =
@@ -2755,6 +3324,7 @@ module TextDocumentEdit = struct
       "edits_pvar"
       [ (fun json -> `TextEdit (TextEdit.t_of_yojson json))
       ; (fun json -> `AnnotatedTextEdit (AnnotatedTextEdit.t_of_yojson json))
+      ; (fun json -> `SnippetTextEdit (SnippetTextEdit.t_of_yojson json))
       ]
       json
   ;;
@@ -2763,6 +3333,7 @@ module TextDocumentEdit = struct
     match edits_pvar with
     | `TextEdit s -> TextEdit.yojson_of_t s
     | `AnnotatedTextEdit s -> AnnotatedTextEdit.yojson_of_t s
+    | `SnippetTextEdit s -> SnippetTextEdit.yojson_of_t s
   ;;
 
   type t =
@@ -3232,6 +3803,8 @@ module ApplyWorkspaceEditParams = struct
   type t =
     { edit : WorkspaceEdit.t
     ; label : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    ; metadata : WorkspaceEditMetadata.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -3243,6 +3816,7 @@ module ApplyWorkspaceEditParams = struct
      | `Assoc field_yojsons as yojson ->
        let edit_field = ref Ppx_yojson_conv_lib.Option.None
        and label_field = ref Ppx_yojson_conv_lib.Option.None
+       and metadata_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -3262,6 +3836,17 @@ module ApplyWorkspaceEditParams = struct
                    Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
                  in
                  label_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "metadata" ->
+              (match Ppx_yojson_conv_lib.( ! ) metadata_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     WorkspaceEditMetadata.t_of_yojson
+                     _field_yojson
+                 in
+                 metadata_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -3285,12 +3870,17 @@ module ApplyWorkspaceEditParams = struct
            | [] ->
              (match
                 ( Ppx_yojson_conv_lib.( ! ) edit_field
-                , Ppx_yojson_conv_lib.( ! ) label_field )
+                , Ppx_yojson_conv_lib.( ! ) label_field
+                , Ppx_yojson_conv_lib.( ! ) metadata_field )
               with
-              | Ppx_yojson_conv_lib.Option.Some edit_value, label_value ->
+              | Ppx_yojson_conv_lib.Option.Some edit_value, label_value, metadata_value ->
                 { edit = edit_value
                 ; label =
                     (match label_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; metadata =
+                    (match metadata_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 }
@@ -3312,8 +3902,19 @@ module ApplyWorkspaceEditParams = struct
 
   let yojson_of_t =
     (function
-     | { edit = v_edit; label = v_label } ->
+     | { edit = v_edit; label = v_label; metadata = v_metadata } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_metadata
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t WorkspaceEditMetadata.yojson_of_t)
+               v_metadata
+           in
+           let bnd = "metadata", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_label
          then bnds
@@ -3334,8 +3935,14 @@ module ApplyWorkspaceEditParams = struct
 
   [@@@end]
 
-  let create ~(edit : WorkspaceEdit.t) ?(label : string option) (() : unit) : t =
-    { edit; label }
+  let create
+        ~(edit : WorkspaceEdit.t)
+        ?(label : string option)
+        ?(metadata : WorkspaceEditMetadata.t option)
+        (() : unit)
+    : t
+    =
+    { edit; label; metadata }
   ;;
 end
 
@@ -4849,6 +5456,682 @@ module CallHierarchyPrepareParams = struct
   ;;
 end
 
+module Pattern = struct
+  type t = string [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+  let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  let _ = t_of_yojson
+  let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
+module WorkspaceFolder = struct
+  type t =
+    { name : string
+    ; uri : DocumentUri.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.WorkspaceFolder.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let name_field = ref Ppx_yojson_conv_lib.Option.None
+       and uri_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "name" ->
+              (match Ppx_yojson_conv_lib.( ! ) name_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "uri" ->
+              (match Ppx_yojson_conv_lib.( ! ) uri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
+                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                Ppx_yojson_conv_lib.( ! ) name_field, Ppx_yojson_conv_lib.( ! ) uri_field
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some name_value
+                , Ppx_yojson_conv_lib.Option.Some uri_value ) ->
+                { name = name_value; uri = uri_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) name_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "name" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) uri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "uri" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { name = v_name; uri = v_uri } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = DocumentUri.yojson_of_t v_uri in
+         ("uri", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_string v_name in
+         ("name", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(name : string) ~(uri : DocumentUri.t) : t = { name; uri }
+end
+
+module RelativePattern = struct
+  type t =
+    { baseUri : unit
+    ; pattern : Pattern.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.RelativePattern.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let baseUri_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "baseUri" ->
+              (match Ppx_yojson_conv_lib.( ! ) baseUri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = unit_of_yojson _field_yojson in
+                 baseUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Pattern.t_of_yojson _field_yojson in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) baseUri_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some baseUri_value
+                , Ppx_yojson_conv_lib.Option.Some pattern_value ) ->
+                { baseUri = baseUri_value; pattern = pattern_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) baseUri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "baseUri" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "pattern" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { baseUri = v_baseUri; pattern = v_pattern } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = Pattern.yojson_of_t v_pattern in
+         ("pattern", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_unit v_baseUri in
+         ("baseUri", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(baseUri : unit) ~(pattern : Pattern.t) : t = { baseUri; pattern }
+end
+
+module GlobPattern = struct
+  type t =
+    [ `Pattern of Pattern.t
+    | `RelativePattern of RelativePattern.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json -> `Pattern (Pattern.t_of_yojson json))
+      ; (fun json -> `RelativePattern (RelativePattern.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `Pattern s -> Pattern.yojson_of_t s
+    | `RelativePattern s -> RelativePattern.yojson_of_t s
+  ;;
+end
+
+module NotebookDocumentFilterPattern = struct
+  type t =
+    { notebookType : string Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; pattern : GlobPattern.t
+    ; scheme : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentFilterPattern.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let notebookType_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "notebookType" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookType_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 notebookType_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = GlobPattern.t_of_yojson _field_yojson in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) notebookType_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( notebookType_value
+                , Ppx_yojson_conv_lib.Option.Some pattern_value
+                , scheme_value ) ->
+                { notebookType =
+                    (match notebookType_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; pattern = pattern_value
+                ; scheme =
+                    (match scheme_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "pattern" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { notebookType = v_notebookType; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_scheme
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_scheme in
+           let bnd = "scheme", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = GlobPattern.yojson_of_t v_pattern in
+         ("pattern", arg) :: bnds
+       in
+       let bnds =
+         if None = v_notebookType
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_notebookType in
+           let bnd = "notebookType", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(notebookType : string option)
+        ~(pattern : GlobPattern.t)
+        ?(scheme : string option)
+        (() : unit)
+    : t
+    =
+    { notebookType; pattern; scheme }
+  ;;
+end
+
+module NotebookDocumentFilterScheme = struct
+  type t =
+    { notebookType : string Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; pattern : GlobPattern.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; scheme : string
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentFilterScheme.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let notebookType_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "notebookType" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookType_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 notebookType_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson GlobPattern.t_of_yojson _field_yojson
+                 in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) notebookType_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( notebookType_value
+                , pattern_value
+                , Ppx_yojson_conv_lib.Option.Some scheme_value ) ->
+                { notebookType =
+                    (match notebookType_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; pattern =
+                    (match pattern_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; scheme = scheme_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) scheme_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "scheme" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { notebookType = v_notebookType; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_scheme in
+         ("scheme", arg) :: bnds
+       in
+       let bnds =
+         if None = v_pattern
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t GlobPattern.yojson_of_t) v_pattern
+           in
+           let bnd = "pattern", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_notebookType
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_notebookType in
+           let bnd = "notebookType", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(notebookType : string option)
+        ?(pattern : GlobPattern.t option)
+        ~(scheme : string)
+        (() : unit)
+    : t
+    =
+    { notebookType; pattern; scheme }
+  ;;
+end
+
+module NotebookDocumentFilterNotebookType = struct
+  type t =
+    { notebookType : string
+    ; pattern : GlobPattern.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; scheme : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentFilterNotebookType.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let notebookType_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "notebookType" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookType_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 notebookType_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson GlobPattern.t_of_yojson _field_yojson
+                 in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) notebookType_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some notebookType_value
+                , pattern_value
+                , scheme_value ) ->
+                { notebookType = notebookType_value
+                ; pattern =
+                    (match pattern_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; scheme =
+                    (match scheme_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebookType_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebookType" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { notebookType = v_notebookType; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_scheme
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_scheme in
+           let bnd = "scheme", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_pattern
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t GlobPattern.yojson_of_t) v_pattern
+           in
+           let bnd = "pattern", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_string v_notebookType in
+         ("notebookType", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(notebookType : string)
+        ?(pattern : GlobPattern.t option)
+        ?(scheme : string option)
+        (() : unit)
+    : t
+    =
+    { notebookType; pattern; scheme }
+  ;;
+end
+
 module NotebookCellTextDocumentFilter = struct
   type notebook_pvar =
     [ `String of string
@@ -4980,6 +6263,443 @@ module NotebookCellTextDocumentFilter = struct
 
   let create ?(language : string option) ~(notebook : notebook_pvar) (() : unit) : t =
     { language; notebook }
+  ;;
+end
+
+module TextDocumentFilterPattern = struct
+  type t =
+    { language : string Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; pattern : GlobPattern.t
+    ; scheme : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilterPattern.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let language_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "language" ->
+              (match Ppx_yojson_conv_lib.( ! ) language_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = GlobPattern.t_of_yojson _field_yojson in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) language_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( language_value
+                , Ppx_yojson_conv_lib.Option.Some pattern_value
+                , scheme_value ) ->
+                { language =
+                    (match language_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; pattern = pattern_value
+                ; scheme =
+                    (match scheme_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "pattern" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { language = v_language; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_scheme
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_scheme in
+           let bnd = "scheme", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = GlobPattern.yojson_of_t v_pattern in
+         ("pattern", arg) :: bnds
+       in
+       let bnds =
+         if None = v_language
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_language in
+           let bnd = "language", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(language : string option)
+        ~(pattern : GlobPattern.t)
+        ?(scheme : string option)
+        (() : unit)
+    : t
+    =
+    { language; pattern; scheme }
+  ;;
+end
+
+module TextDocumentFilterScheme = struct
+  type t =
+    { language : string Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; pattern : GlobPattern.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; scheme : string
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilterScheme.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let language_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "language" ->
+              (match Ppx_yojson_conv_lib.( ! ) language_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson GlobPattern.t_of_yojson _field_yojson
+                 in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) language_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( language_value
+                , pattern_value
+                , Ppx_yojson_conv_lib.Option.Some scheme_value ) ->
+                { language =
+                    (match language_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; pattern =
+                    (match pattern_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; scheme = scheme_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) scheme_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "scheme" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { language = v_language; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_scheme in
+         ("scheme", arg) :: bnds
+       in
+       let bnds =
+         if None = v_pattern
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t GlobPattern.yojson_of_t) v_pattern
+           in
+           let bnd = "pattern", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_language
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_language in
+           let bnd = "language", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(language : string option)
+        ?(pattern : GlobPattern.t option)
+        ~(scheme : string)
+        (() : unit)
+    : t
+    =
+    { language; pattern; scheme }
+  ;;
+end
+
+module TextDocumentFilterLanguage = struct
+  type t =
+    { language : string
+    ; pattern : GlobPattern.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; scheme : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilterLanguage.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let language_field = ref Ppx_yojson_conv_lib.Option.None
+       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
+       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "language" ->
+              (match Ppx_yojson_conv_lib.( ! ) language_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "pattern" ->
+              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson GlobPattern.t_of_yojson _field_yojson
+                 in
+                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "scheme" ->
+              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) language_field
+                , Ppx_yojson_conv_lib.( ! ) pattern_field
+                , Ppx_yojson_conv_lib.( ! ) scheme_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some language_value
+                , pattern_value
+                , scheme_value ) ->
+                { language = language_value
+                ; pattern =
+                    (match pattern_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; scheme =
+                    (match scheme_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) language_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "language" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { language = v_language; pattern = v_pattern; scheme = v_scheme } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_scheme
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_scheme in
+           let bnd = "scheme", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_pattern
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t GlobPattern.yojson_of_t) v_pattern
+           in
+           let bnd = "pattern", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_string v_language in
+         ("language", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(language : string)
+        ?(pattern : GlobPattern.t option)
+        ?(scheme : string option)
+        (() : unit)
+    : t
+    =
+    { language; pattern; scheme }
   ;;
 end
 
@@ -5265,19 +6985,17 @@ module CancelParams = struct
   let create ~(id : Jsonrpc.Id.t) : t = { id }
 end
 
-module WorkspaceEditClientCapabilities = struct
-  type changeAnnotationSupport =
+module ChangeAnnotationsSupportOptions = struct
+  type t =
     { groupsOnLabel : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : changeAnnotationSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let changeAnnotationSupport_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.WorkspaceEditClientCapabilities.changeAnnotationSupport"
-     in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ChangeAnnotationsSupportOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let groupsOnLabel_field = ref Ppx_yojson_conv_lib.Option.None
@@ -5322,12 +7040,12 @@ module WorkspaceEditClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> changeAnnotationSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = changeAnnotationSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_changeAnnotationSupport =
+  let yojson_of_t =
     (function
      | { groupsOnLabel = v_groupsOnLabel } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -5340,29 +7058,31 @@ module WorkspaceEditClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : changeAnnotationSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_changeAnnotationSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_changeAnnotationSupport ?(groupsOnLabel : bool option) (() : unit)
-    : changeAnnotationSupport
-    =
-    { groupsOnLabel }
-  ;;
+  let create ?(groupsOnLabel : bool option) (() : unit) : t = { groupsOnLabel }
+end
 
+module WorkspaceEditClientCapabilities = struct
   type t =
-    { changeAnnotationSupport : changeAnnotationSupport Json.Nullable_option.t
+    { changeAnnotationSupport : ChangeAnnotationsSupportOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; documentChanges : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; failureHandling : FailureHandlingKind.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
+    ; metadataSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     ; normalizesLineEndings : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; resourceOperations : ResourceOperationKind.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; snippetEditSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -5376,8 +7096,10 @@ module WorkspaceEditClientCapabilities = struct
        let changeAnnotationSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and documentChanges_field = ref Ppx_yojson_conv_lib.Option.None
        and failureHandling_field = ref Ppx_yojson_conv_lib.Option.None
+       and metadataSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and normalizesLineEndings_field = ref Ppx_yojson_conv_lib.Option.None
        and resourceOperations_field = ref Ppx_yojson_conv_lib.Option.None
+       and snippetEditSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -5388,7 +7110,7 @@ module WorkspaceEditClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     changeAnnotationSupport_of_yojson
+                     ChangeAnnotationsSupportOptions.t_of_yojson
                      _field_yojson
                  in
                  changeAnnotationSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -5414,6 +7136,15 @@ module WorkspaceEditClientCapabilities = struct
                  failureHandling_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "metadataSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) metadataSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 metadataSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "normalizesLineEndings" ->
               (match Ppx_yojson_conv_lib.( ! ) normalizesLineEndings_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -5432,6 +7163,15 @@ module WorkspaceEditClientCapabilities = struct
                      _field_yojson
                  in
                  resourceOperations_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "snippetEditSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) snippetEditSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 snippetEditSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -5456,14 +7196,18 @@ module WorkspaceEditClientCapabilities = struct
              let ( changeAnnotationSupport_value
                  , documentChanges_value
                  , failureHandling_value
+                 , metadataSupport_value
                  , normalizesLineEndings_value
-                 , resourceOperations_value )
+                 , resourceOperations_value
+                 , snippetEditSupport_value )
                =
                ( Ppx_yojson_conv_lib.( ! ) changeAnnotationSupport_field
                , Ppx_yojson_conv_lib.( ! ) documentChanges_field
                , Ppx_yojson_conv_lib.( ! ) failureHandling_field
+               , Ppx_yojson_conv_lib.( ! ) metadataSupport_field
                , Ppx_yojson_conv_lib.( ! ) normalizesLineEndings_field
-               , Ppx_yojson_conv_lib.( ! ) resourceOperations_field )
+               , Ppx_yojson_conv_lib.( ! ) resourceOperations_field
+               , Ppx_yojson_conv_lib.( ! ) snippetEditSupport_field )
              in
              { changeAnnotationSupport =
                  (match changeAnnotationSupport_value with
@@ -5477,12 +7221,20 @@ module WorkspaceEditClientCapabilities = struct
                  (match failureHandling_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; metadataSupport =
+                 (match metadataSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; normalizesLineEndings =
                  (match normalizesLineEndings_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; resourceOperations =
                  (match resourceOperations_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; snippetEditSupport =
+                 (match snippetEditSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
@@ -5498,10 +7250,22 @@ module WorkspaceEditClientCapabilities = struct
      | { changeAnnotationSupport = v_changeAnnotationSupport
        ; documentChanges = v_documentChanges
        ; failureHandling = v_failureHandling
+       ; metadataSupport = v_metadataSupport
        ; normalizesLineEndings = v_normalizesLineEndings
        ; resourceOperations = v_resourceOperations
+       ; snippetEditSupport = v_snippetEditSupport
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_snippetEditSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_snippetEditSupport
+           in
+           let bnd = "snippetEditSupport", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_resourceOperations
          then bnds
@@ -5522,6 +7286,16 @@ module WorkspaceEditClientCapabilities = struct
              (Json.Nullable_option.yojson_of_t yojson_of_bool) v_normalizesLineEndings
            in
            let bnd = "normalizesLineEndings", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_metadataSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_metadataSupport
+           in
+           let bnd = "metadataSupport", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -5550,7 +7324,8 @@ module WorkspaceEditClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_changeAnnotationSupport)
+             (Json.Nullable_option.yojson_of_t
+                ChangeAnnotationsSupportOptions.yojson_of_t)
                v_changeAnnotationSupport
            in
            let bnd = "changeAnnotationSupport", arg in
@@ -5565,31 +7340,124 @@ module WorkspaceEditClientCapabilities = struct
   [@@@end]
 
   let create
-        ?(changeAnnotationSupport : changeAnnotationSupport option)
+        ?(changeAnnotationSupport : ChangeAnnotationsSupportOptions.t option)
         ?(documentChanges : bool option)
         ?(failureHandling : FailureHandlingKind.t option)
+        ?(metadataSupport : bool option)
         ?(normalizesLineEndings : bool option)
         ?(resourceOperations : ResourceOperationKind.t list option)
+        ?(snippetEditSupport : bool option)
         (() : unit)
     : t
     =
     { changeAnnotationSupport
     ; documentChanges
     ; failureHandling
+    ; metadataSupport
     ; normalizesLineEndings
     ; resourceOperations
+    ; snippetEditSupport
     }
   ;;
 end
 
-module WorkspaceSymbolClientCapabilities = struct
-  type tagSupport = { valueSet : SymbolTag.t list }
+module TextDocumentContentClientCapabilities = struct
+  type t =
+    { dynamicRegistration : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : tagSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let tagSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.WorkspaceSymbolClientCapabilities.tagSupport" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentClientCapabilities.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "dynamicRegistration" ->
+              (match Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 dynamicRegistration_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let dynamicRegistration_value =
+               Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
+             in
+             { dynamicRegistration =
+                 (match dynamicRegistration_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { dynamicRegistration = v_dynamicRegistration } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_dynamicRegistration
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_dynamicRegistration
+           in
+           let bnd = "dynamicRegistration", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ?(dynamicRegistration : bool option) (() : unit) : t =
+    { dynamicRegistration }
+  ;;
+end
+
+module ClientSymbolTagOptions = struct
+  type t = { valueSet : SymbolTag.t list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSymbolTagOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -5638,12 +7506,12 @@ module WorkspaceSymbolClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> tagSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = tagSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_tagSupport =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -5652,25 +7520,27 @@ module WorkspaceSymbolClientCapabilities = struct
          ("valueSet", arg) :: bnds
        in
        `Assoc bnds
-     : tagSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_tagSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_tagSupport ~(valueSet : SymbolTag.t list) : tagSupport = { valueSet }
+  let create ~(valueSet : SymbolTag.t list) : t = { valueSet }
+end
 
-  type symbolKind =
+module ClientSymbolKindOptions = struct
+  type t =
     { valueSet : SymbolKind.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : symbolKind) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let symbolKind_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.WorkspaceSymbolClientCapabilities.symbolKind" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSymbolKindOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -5717,12 +7587,12 @@ module WorkspaceSymbolClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> symbolKind)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = symbolKind_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_symbolKind =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -5738,24 +7608,24 @@ module WorkspaceSymbolClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : symbolKind -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_symbolKind
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_symbolKind ?(valueSet : SymbolKind.t list option) (() : unit) : symbolKind =
-    { valueSet }
-  ;;
+  let create ?(valueSet : SymbolKind.t list option) (() : unit) : t = { valueSet }
+end
 
-  type resolveSupport = { properties : string list }
+module ClientSymbolResolveOptions = struct
+  type t = { properties : string list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : resolveSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let resolveSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.WorkspaceSymbolClientCapabilities.resolveSupport" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSymbolResolveOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let properties_field = ref Ppx_yojson_conv_lib.Option.None
@@ -5804,12 +7674,12 @@ module WorkspaceSymbolClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> resolveSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = resolveSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_resolveSupport =
+  let yojson_of_t =
     (function
      | { properties = v_properties } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -5818,23 +7688,25 @@ module WorkspaceSymbolClientCapabilities = struct
          ("properties", arg) :: bnds
        in
        `Assoc bnds
-     : resolveSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_resolveSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_resolveSupport ~(properties : string list) : resolveSupport = { properties }
+  let create ~(properties : string list) : t = { properties }
+end
 
+module WorkspaceSymbolClientCapabilities = struct
   type t =
     { dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; resolveSupport : resolveSupport Json.Nullable_option.t
+    ; resolveSupport : ClientSymbolResolveOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; symbolKind : symbolKind Json.Nullable_option.t
+    ; symbolKind : ClientSymbolKindOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; tagSupport : tagSupport Json.Nullable_option.t
+    ; tagSupport : ClientSymbolTagOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -5867,7 +7739,9 @@ module WorkspaceSymbolClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson resolveSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientSymbolResolveOptions.t_of_yojson
+                     _field_yojson
                  in
                  resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -5876,7 +7750,9 @@ module WorkspaceSymbolClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) symbolKind_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson symbolKind_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientSymbolKindOptions.t_of_yojson
+                     _field_yojson
                  in
                  symbolKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -5885,7 +7761,9 @@ module WorkspaceSymbolClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson tagSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientSymbolTagOptions.t_of_yojson
+                     _field_yojson
                  in
                  tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -5956,7 +7834,8 @@ module WorkspaceSymbolClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_tagSupport) v_tagSupport
+             (Json.Nullable_option.yojson_of_t ClientSymbolTagOptions.yojson_of_t)
+               v_tagSupport
            in
            let bnd = "tagSupport", arg in
            bnd :: bnds)
@@ -5966,7 +7845,8 @@ module WorkspaceSymbolClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_symbolKind) v_symbolKind
+             (Json.Nullable_option.yojson_of_t ClientSymbolKindOptions.yojson_of_t)
+               v_symbolKind
            in
            let bnd = "symbolKind", arg in
            bnd :: bnds)
@@ -5976,7 +7856,8 @@ module WorkspaceSymbolClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_resolveSupport) v_resolveSupport
+             (Json.Nullable_option.yojson_of_t ClientSymbolResolveOptions.yojson_of_t)
+               v_resolveSupport
            in
            let bnd = "resolveSupport", arg in
            bnd :: bnds)
@@ -6001,9 +7882,9 @@ module WorkspaceSymbolClientCapabilities = struct
 
   let create
         ?(dynamicRegistration : bool option)
-        ?(resolveSupport : resolveSupport option)
-        ?(symbolKind : symbolKind option)
-        ?(tagSupport : tagSupport option)
+        ?(resolveSupport : ClientSymbolResolveOptions.t option)
+        ?(symbolKind : ClientSymbolKindOptions.t option)
+        ?(tagSupport : ClientSymbolTagOptions.t option)
         (() : unit)
     : t
     =
@@ -7106,6 +8987,8 @@ module WorkspaceClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; symbol : WorkspaceSymbolClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
+    ; textDocumentContent : TextDocumentContentClientCapabilities.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     ; workspaceEdit : WorkspaceEditClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; workspaceFolders : bool Json.Nullable_option.t
@@ -7132,6 +9015,7 @@ module WorkspaceClientCapabilities = struct
        and inlineValue_field = ref Ppx_yojson_conv_lib.Option.None
        and semanticTokens_field = ref Ppx_yojson_conv_lib.Option.None
        and symbol_field = ref Ppx_yojson_conv_lib.Option.None
+       and textDocumentContent_field = ref Ppx_yojson_conv_lib.Option.None
        and workspaceEdit_field = ref Ppx_yojson_conv_lib.Option.None
        and workspaceFolders_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
@@ -7278,6 +9162,17 @@ module WorkspaceClientCapabilities = struct
                  symbol_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "textDocumentContent" ->
+              (match Ppx_yojson_conv_lib.( ! ) textDocumentContent_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     TextDocumentContentClientCapabilities.t_of_yojson
+                     _field_yojson
+                 in
+                 textDocumentContent_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "workspaceEdit" ->
               (match Ppx_yojson_conv_lib.( ! ) workspaceEdit_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -7330,6 +9225,7 @@ module WorkspaceClientCapabilities = struct
                  , inlineValue_value
                  , semanticTokens_value
                  , symbol_value
+                 , textDocumentContent_value
                  , workspaceEdit_value
                  , workspaceFolders_value )
                =
@@ -7346,6 +9242,7 @@ module WorkspaceClientCapabilities = struct
                , Ppx_yojson_conv_lib.( ! ) inlineValue_field
                , Ppx_yojson_conv_lib.( ! ) semanticTokens_field
                , Ppx_yojson_conv_lib.( ! ) symbol_field
+               , Ppx_yojson_conv_lib.( ! ) textDocumentContent_field
                , Ppx_yojson_conv_lib.( ! ) workspaceEdit_field
                , Ppx_yojson_conv_lib.( ! ) workspaceFolders_field )
              in
@@ -7401,6 +9298,10 @@ module WorkspaceClientCapabilities = struct
                  (match symbol_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; textDocumentContent =
+                 (match textDocumentContent_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; workspaceEdit =
                  (match workspaceEdit_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
@@ -7432,6 +9333,7 @@ module WorkspaceClientCapabilities = struct
        ; inlineValue = v_inlineValue
        ; semanticTokens = v_semanticTokens
        ; symbol = v_symbol
+       ; textDocumentContent = v_textDocumentContent
        ; workspaceEdit = v_workspaceEdit
        ; workspaceFolders = v_workspaceFolders
        } ->
@@ -7456,6 +9358,18 @@ module WorkspaceClientCapabilities = struct
                v_workspaceEdit
            in
            let bnd = "workspaceEdit", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_textDocumentContent
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                TextDocumentContentClientCapabilities.yojson_of_t)
+               v_textDocumentContent
+           in
+           let bnd = "textDocumentContent", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -7628,6 +9542,7 @@ module WorkspaceClientCapabilities = struct
         ?(inlineValue : InlineValueWorkspaceClientCapabilities.t option)
         ?(semanticTokens : SemanticTokensWorkspaceClientCapabilities.t option)
         ?(symbol : WorkspaceSymbolClientCapabilities.t option)
+        ?(textDocumentContent : TextDocumentContentClientCapabilities.t option)
         ?(workspaceEdit : WorkspaceEditClientCapabilities.t option)
         ?(workspaceFolders : bool option)
         (() : unit)
@@ -7646,25 +9561,24 @@ module WorkspaceClientCapabilities = struct
     ; inlineValue
     ; semanticTokens
     ; symbol
+    ; textDocumentContent
     ; workspaceEdit
     ; workspaceFolders
     }
   ;;
 end
 
-module ShowMessageRequestClientCapabilities = struct
-  type messageActionItem =
+module ClientShowMessageActionItemOptions = struct
+  type t =
     { additionalPropertiesSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : messageActionItem) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let messageActionItem_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.ShowMessageRequestClientCapabilities.messageActionItem"
-     in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientShowMessageActionItemOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let additionalPropertiesSupport_field = ref Ppx_yojson_conv_lib.Option.None
@@ -7712,12 +9626,12 @@ module ShowMessageRequestClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> messageActionItem)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = messageActionItem_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_messageActionItem =
+  let yojson_of_t =
     (function
      | { additionalPropertiesSupport = v_additionalPropertiesSupport } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -7733,21 +9647,21 @@ module ShowMessageRequestClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : messageActionItem -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_messageActionItem
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_messageActionItem ?(additionalPropertiesSupport : bool option) (() : unit)
-    : messageActionItem
-    =
+  let create ?(additionalPropertiesSupport : bool option) (() : unit) : t =
     { additionalPropertiesSupport }
   ;;
+end
 
+module ShowMessageRequestClientCapabilities = struct
   type t =
-    { messageActionItem : messageActionItem Json.Nullable_option.t
+    { messageActionItem : ClientShowMessageActionItemOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -7769,7 +9683,7 @@ module ShowMessageRequestClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     messageActionItem_of_yojson
+                     ClientShowMessageActionItemOptions.t_of_yojson
                      _field_yojson
                  in
                  messageActionItem_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -7818,7 +9732,8 @@ module ShowMessageRequestClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_messageActionItem)
+             (Json.Nullable_option.yojson_of_t
+                ClientShowMessageActionItemOptions.yojson_of_t)
                v_messageActionItem
            in
            let bnd = "messageActionItem", arg in
@@ -7832,7 +9747,11 @@ module ShowMessageRequestClientCapabilities = struct
 
   [@@@end]
 
-  let create ?(messageActionItem : messageActionItem option) (() : unit) : t =
+  let create
+        ?(messageActionItem : ClientShowMessageActionItemOptions.t option)
+        (() : unit)
+    : t
+    =
     { messageActionItem }
   ;;
 end
@@ -8459,19 +10378,17 @@ module TextDocumentSyncClientCapabilities = struct
   ;;
 end
 
-module SignatureHelpClientCapabilities = struct
-  type parameterInformation =
+module ClientSignatureParameterInformationOptions = struct
+  type t =
     { labelOffsetSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : parameterInformation) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let parameterInformation_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.SignatureHelpClientCapabilities.parameterInformation"
-     in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSignatureParameterInformationOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let labelOffsetSupport_field = ref Ppx_yojson_conv_lib.Option.None
@@ -8518,12 +10435,12 @@ module SignatureHelpClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> parameterInformation)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = parameterInformation_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_parameterInformation =
+  let yojson_of_t =
     (function
      | { labelOffsetSupport = v_labelOffsetSupport } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -8538,48 +10455,54 @@ module SignatureHelpClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : parameterInformation -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_parameterInformation
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_parameterInformation ?(labelOffsetSupport : bool option) (() : unit)
-    : parameterInformation
-    =
-    { labelOffsetSupport }
-  ;;
+  let create ?(labelOffsetSupport : bool option) (() : unit) : t = { labelOffsetSupport }
+end
 
-  type signatureInformation =
-    { documentationFormat : MarkupKind.t list Json.Nullable_option.t
+module ClientSignatureInformationOptions = struct
+  type t =
+    { activeParameterSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; parameterInformation : parameterInformation Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; activeParameterSupport : bool Json.Nullable_option.t
+    ; documentationFormat : MarkupKind.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; noActiveParameterSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; parameterInformation :
+        ClientSignatureParameterInformationOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : signatureInformation) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let signatureInformation_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.SignatureHelpClientCapabilities.signatureInformation"
-     in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSignatureInformationOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let documentationFormat_field = ref Ppx_yojson_conv_lib.Option.None
-       and parameterInformation_field = ref Ppx_yojson_conv_lib.Option.None
-       and activeParameterSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       let activeParameterSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and documentationFormat_field = ref Ppx_yojson_conv_lib.Option.None
        and noActiveParameterSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and parameterInformation_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
+            | "activeParameterSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) activeParameterSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 activeParameterSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "documentationFormat" ->
               (match Ppx_yojson_conv_lib.( ! ) documentationFormat_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -8591,26 +10514,6 @@ module SignatureHelpClientCapabilities = struct
                  documentationFormat_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "parameterInformation" ->
-              (match Ppx_yojson_conv_lib.( ! ) parameterInformation_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     parameterInformation_of_yojson
-                     _field_yojson
-                 in
-                 parameterInformation_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "activeParameterSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) activeParameterSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 activeParameterSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "noActiveParameterSupport" ->
               (match Ppx_yojson_conv_lib.( ! ) noActiveParameterSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -8618,6 +10521,17 @@ module SignatureHelpClientCapabilities = struct
                    Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
                  in
                  noActiveParameterSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "parameterInformation" ->
+              (match Ppx_yojson_conv_lib.( ! ) parameterInformation_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientSignatureParameterInformationOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 parameterInformation_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -8639,48 +10553,60 @@ module SignatureHelpClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let ( documentationFormat_value
-                 , parameterInformation_value
-                 , activeParameterSupport_value
-                 , noActiveParameterSupport_value )
+             let ( activeParameterSupport_value
+                 , documentationFormat_value
+                 , noActiveParameterSupport_value
+                 , parameterInformation_value )
                =
-               ( Ppx_yojson_conv_lib.( ! ) documentationFormat_field
-               , Ppx_yojson_conv_lib.( ! ) parameterInformation_field
-               , Ppx_yojson_conv_lib.( ! ) activeParameterSupport_field
-               , Ppx_yojson_conv_lib.( ! ) noActiveParameterSupport_field )
+               ( Ppx_yojson_conv_lib.( ! ) activeParameterSupport_field
+               , Ppx_yojson_conv_lib.( ! ) documentationFormat_field
+               , Ppx_yojson_conv_lib.( ! ) noActiveParameterSupport_field
+               , Ppx_yojson_conv_lib.( ! ) parameterInformation_field )
              in
-             { documentationFormat =
-                 (match documentationFormat_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; parameterInformation =
-                 (match parameterInformation_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; activeParameterSupport =
+             { activeParameterSupport =
                  (match activeParameterSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; documentationFormat =
+                 (match documentationFormat_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; noActiveParameterSupport =
                  (match noActiveParameterSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; parameterInformation =
+                 (match parameterInformation_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> signatureInformation)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = signatureInformation_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_signatureInformation =
+  let yojson_of_t =
     (function
-     | { documentationFormat = v_documentationFormat
-       ; parameterInformation = v_parameterInformation
-       ; activeParameterSupport = v_activeParameterSupport
+     | { activeParameterSupport = v_activeParameterSupport
+       ; documentationFormat = v_documentationFormat
        ; noActiveParameterSupport = v_noActiveParameterSupport
+       ; parameterInformation = v_parameterInformation
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_parameterInformation
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                ClientSignatureParameterInformationOptions.yojson_of_t)
+               v_parameterInformation
+           in
+           let bnd = "parameterInformation", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_noActiveParameterSupport
          then bnds
@@ -8689,27 +10615,6 @@ module SignatureHelpClientCapabilities = struct
              (Json.Nullable_option.yojson_of_t yojson_of_bool) v_noActiveParameterSupport
            in
            let bnd = "noActiveParameterSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_activeParameterSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_activeParameterSupport
-           in
-           let bnd = "activeParameterSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_parameterInformation
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_parameterInformation)
-               v_parameterInformation
-           in
-           let bnd = "parameterInformation", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -8723,35 +10628,47 @@ module SignatureHelpClientCapabilities = struct
            let bnd = "documentationFormat", arg in
            bnd :: bnds)
        in
+       let bnds =
+         if None = v_activeParameterSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_activeParameterSupport
+           in
+           let bnd = "activeParameterSupport", arg in
+           bnd :: bnds)
+       in
        `Assoc bnds
-     : signatureInformation -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_signatureInformation
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_signatureInformation
-        ?(documentationFormat : MarkupKind.t list option)
-        ?(parameterInformation : parameterInformation option)
+  let create
         ?(activeParameterSupport : bool option)
+        ?(documentationFormat : MarkupKind.t list option)
         ?(noActiveParameterSupport : bool option)
+        ?(parameterInformation : ClientSignatureParameterInformationOptions.t option)
         (() : unit)
-    : signatureInformation
+    : t
     =
-    { documentationFormat
-    ; parameterInformation
-    ; activeParameterSupport
+    { activeParameterSupport
+    ; documentationFormat
     ; noActiveParameterSupport
+    ; parameterInformation
     }
   ;;
+end
 
+module SignatureHelpClientCapabilities = struct
   type t =
     { contextSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; signatureInformation : signatureInformation Json.Nullable_option.t
+    ; signatureInformation : ClientSignatureInformationOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -8793,7 +10710,7 @@ module SignatureHelpClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     signatureInformation_of_yojson
+                     ClientSignatureInformationOptions.t_of_yojson
                      _field_yojson
                  in
                  signatureInformation_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -8858,7 +10775,8 @@ module SignatureHelpClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_signatureInformation)
+             (Json.Nullable_option.yojson_of_t
+                ClientSignatureInformationOptions.yojson_of_t)
                v_signatureInformation
            in
            let bnd = "signatureInformation", arg in
@@ -8893,7 +10811,7 @@ module SignatureHelpClientCapabilities = struct
   let create
         ?(contextSupport : bool option)
         ?(dynamicRegistration : bool option)
-        ?(signatureInformation : signatureInformation option)
+        ?(signatureInformation : ClientSignatureInformationOptions.t option)
         (() : unit)
     : t
     =
@@ -8901,15 +10819,15 @@ module SignatureHelpClientCapabilities = struct
   ;;
 end
 
-module SemanticTokensClientCapabilities = struct
-  type full =
+module ClientSemanticTokensRequestFullDelta = struct
+  type t =
     { delta : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )] }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : full) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let full_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.SemanticTokensClientCapabilities.full" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSemanticTokensRequestFullDelta.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let delta_field = ref Ppx_yojson_conv_lib.Option.None
@@ -8954,12 +10872,12 @@ module SemanticTokensClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> full)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = full_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_full =
+  let yojson_of_t =
     (function
      | { delta = v_delta } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -8972,18 +10890,20 @@ module SemanticTokensClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : full -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_full
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_full ?(delta : bool option) (() : unit) : full = { delta }
+  let create ?(delta : bool option) (() : unit) : t = { delta }
+end
 
+module ClientSemanticTokensRequestOptions = struct
   type full_pvar =
     [ `Bool of bool
-    | `Full of full
+    | `ClientSemanticTokensRequestFullDelta of ClientSemanticTokensRequestFullDelta.t
     ]
 
   let full_pvar_of_yojson (json : Json.t) : full_pvar =
@@ -8992,44 +10912,39 @@ module SemanticTokensClientCapabilities = struct
     | _ ->
       Json.Of.untagged_union
         "full_pvar"
-        [ (fun json -> `Full (full_of_yojson json)) ]
+        [ (fun json ->
+            `ClientSemanticTokensRequestFullDelta
+              (ClientSemanticTokensRequestFullDelta.t_of_yojson json))
+        ]
         json
   ;;
 
   let yojson_of_full_pvar (full_pvar : full_pvar) : Json.t =
     match full_pvar with
     | `Bool j -> `Bool j
-    | `Full s -> yojson_of_full s
+    | `ClientSemanticTokensRequestFullDelta s ->
+      ClientSemanticTokensRequestFullDelta.yojson_of_t s
   ;;
 
-  type requests =
-    { range : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
-    ; full : full_pvar Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+  type t =
+    { full : full_pvar Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    ; range : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : requests) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let requests_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.SemanticTokensClientCapabilities.requests" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientSemanticTokensRequestOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let range_field = ref Ppx_yojson_conv_lib.Option.None
-       and full_field = ref Ppx_yojson_conv_lib.Option.None
+       let full_field = ref Ppx_yojson_conv_lib.Option.None
+       and range_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
-            | "range" ->
-              (match Ppx_yojson_conv_lib.( ! ) range_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "full" ->
               (match Ppx_yojson_conv_lib.( ! ) full_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -9037,6 +10952,15 @@ module SemanticTokensClientCapabilities = struct
                    Json.Nullable_option.t_of_yojson full_pvar_of_yojson _field_yojson
                  in
                  full_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "range" ->
+              (match Ppx_yojson_conv_lib.( ! ) range_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -9058,37 +10982,29 @@ module SemanticTokensClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let range_value, full_value =
-               Ppx_yojson_conv_lib.( ! ) range_field, Ppx_yojson_conv_lib.( ! ) full_field
+             let full_value, range_value =
+               Ppx_yojson_conv_lib.( ! ) full_field, Ppx_yojson_conv_lib.( ! ) range_field
              in
-             { range =
-                 (match range_value with
+             { full =
+                 (match full_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; full =
-                 (match full_value with
+             ; range =
+                 (match range_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> requests)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = requests_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_requests =
+  let yojson_of_t =
     (function
-     | { range = v_range; full = v_full } ->
+     | { full = v_full; range = v_range } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_full
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_full_pvar) v_full in
-           let bnd = "full", arg in
-           bnd :: bnds)
-       in
        let bnds =
          if None = v_range
          then bnds
@@ -9097,20 +11013,28 @@ module SemanticTokensClientCapabilities = struct
            let bnd = "range", arg in
            bnd :: bnds)
        in
+       let bnds =
+         if None = v_full
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_full_pvar) v_full in
+           let bnd = "full", arg in
+           bnd :: bnds)
+       in
        `Assoc bnds
-     : requests -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_requests
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_requests ?(range : bool option) ?(full : full_pvar option) (() : unit)
-    : requests
-    =
-    { range; full }
+  let create ?(full : full_pvar option) ?(range : bool option) (() : unit) : t =
+    { full; range }
   ;;
+end
 
+module SemanticTokensClientCapabilities = struct
   type t =
     { augmentsSyntaxTokens : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -9121,7 +11045,7 @@ module SemanticTokensClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; overlappingTokenSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; requests : requests
+    ; requests : ClientSemanticTokensRequestOptions.t
     ; serverCancelSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; tokenModifiers : string list
@@ -9195,7 +11119,9 @@ module SemanticTokensClientCapabilities = struct
             | "requests" ->
               (match Ppx_yojson_conv_lib.( ! ) requests_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = requests_of_yojson _field_yojson in
+                 let fvalue =
+                   ClientSemanticTokensRequestOptions.t_of_yojson _field_yojson
+                 in
                  requests_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -9346,7 +11272,7 @@ module SemanticTokensClientCapabilities = struct
            bnd :: bnds)
        in
        let bnds =
-         let arg = yojson_of_requests v_requests in
+         let arg = ClientSemanticTokensRequestOptions.yojson_of_t v_requests in
          ("requests", arg) :: bnds
        in
        let bnds =
@@ -9407,7 +11333,7 @@ module SemanticTokensClientCapabilities = struct
         ~(formats : TokenFormat.t list)
         ?(multilineTokenSupport : bool option)
         ?(overlappingTokenSupport : bool option)
-        ~(requests : requests)
+        ~(requests : ClientSemanticTokensRequestOptions.t)
         ?(serverCancelSupport : bool option)
         ~(tokenModifiers : string list)
         ~(tokenTypes : string list)
@@ -9916,14 +11842,14 @@ module DocumentRangeFormattingClientCapabilities = struct
   ;;
 end
 
-module PublishDiagnosticsClientCapabilities = struct
-  type tagSupport = { valueSet : DiagnosticTag.t list }
+module ClientDiagnosticsTagOptions = struct
+  type t = { valueSet : DiagnosticTag.t list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : tagSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let tagSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.PublishDiagnosticsClientCapabilities.tagSupport" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientDiagnosticsTagOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -9972,12 +11898,12 @@ module PublishDiagnosticsClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> tagSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = tagSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_tagSupport =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -9986,15 +11912,17 @@ module PublishDiagnosticsClientCapabilities = struct
          ("valueSet", arg) :: bnds
        in
        `Assoc bnds
-     : tagSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_tagSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_tagSupport ~(valueSet : DiagnosticTag.t list) : tagSupport = { valueSet }
+  let create ~(valueSet : DiagnosticTag.t list) : t = { valueSet }
+end
 
+module PublishDiagnosticsClientCapabilities = struct
   type t =
     { codeDescriptionSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -10002,7 +11930,7 @@ module PublishDiagnosticsClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; relatedInformation : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; tagSupport : tagSupport Json.Nullable_option.t
+    ; tagSupport : ClientDiagnosticsTagOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; versionSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -10056,7 +11984,9 @@ module PublishDiagnosticsClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson tagSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientDiagnosticsTagOptions.t_of_yojson
+                     _field_yojson
                  in
                  tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -10151,7 +12081,8 @@ module PublishDiagnosticsClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_tagSupport) v_tagSupport
+             (Json.Nullable_option.yojson_of_t ClientDiagnosticsTagOptions.yojson_of_t)
+               v_tagSupport
            in
            let bnd = "tagSupport", arg in
            bnd :: bnds)
@@ -10196,7 +12127,7 @@ module PublishDiagnosticsClientCapabilities = struct
         ?(codeDescriptionSupport : bool option)
         ?(dataSupport : bool option)
         ?(relatedInformation : bool option)
-        ?(tagSupport : tagSupport option)
+        ?(tagSupport : ClientDiagnosticsTagOptions.t option)
         ?(versionSupport : bool option)
         (() : unit)
     : t
@@ -10655,14 +12586,14 @@ module InlineCompletionClientCapabilities = struct
   ;;
 end
 
-module InlayHintClientCapabilities = struct
-  type resolveSupport = { properties : string list }
+module ClientInlayHintResolveOptions = struct
+  type t = { properties : string list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : resolveSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let resolveSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.InlayHintClientCapabilities.resolveSupport" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientInlayHintResolveOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let properties_field = ref Ppx_yojson_conv_lib.Option.None
@@ -10711,12 +12642,12 @@ module InlayHintClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> resolveSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = resolveSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_resolveSupport =
+  let yojson_of_t =
     (function
      | { properties = v_properties } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -10725,19 +12656,21 @@ module InlayHintClientCapabilities = struct
          ("properties", arg) :: bnds
        in
        `Assoc bnds
-     : resolveSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_resolveSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_resolveSupport ~(properties : string list) : resolveSupport = { properties }
+  let create ~(properties : string list) : t = { properties }
+end
 
+module InlayHintClientCapabilities = struct
   type t =
     { dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; resolveSupport : resolveSupport Json.Nullable_option.t
+    ; resolveSupport : ClientInlayHintResolveOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -10768,7 +12701,9 @@ module InlayHintClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson resolveSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientInlayHintResolveOptions.t_of_yojson
+                     _field_yojson
                  in
                  resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -10822,7 +12757,8 @@ module InlayHintClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_resolveSupport) v_resolveSupport
+             (Json.Nullable_option.yojson_of_t ClientInlayHintResolveOptions.yojson_of_t)
+               v_resolveSupport
            in
            let bnd = "resolveSupport", arg in
            bnd :: bnds)
@@ -10847,7 +12783,7 @@ module InlayHintClientCapabilities = struct
 
   let create
         ?(dynamicRegistration : bool option)
-        ?(resolveSupport : resolveSupport option)
+        ?(resolveSupport : ClientInlayHintResolveOptions.t option)
         (() : unit)
     : t
     =
@@ -11184,17 +13120,17 @@ module DocumentFormattingClientCapabilities = struct
   ;;
 end
 
-module FoldingRangeClientCapabilities = struct
-  type foldingRangeKind =
+module ClientFoldingRangeKindOptions = struct
+  type t =
     { valueSet : FoldingRangeKind.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : foldingRangeKind) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let foldingRangeKind_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.FoldingRangeClientCapabilities.foldingRangeKind" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientFoldingRangeKindOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -11241,12 +13177,12 @@ module FoldingRangeClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> foldingRangeKind)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = foldingRangeKind_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_foldingRangeKind =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -11263,29 +13199,27 @@ module FoldingRangeClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : foldingRangeKind -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_foldingRangeKind
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_foldingRangeKind ?(valueSet : FoldingRangeKind.t list option) (() : unit)
-    : foldingRangeKind
-    =
-    { valueSet }
-  ;;
+  let create ?(valueSet : FoldingRangeKind.t list option) (() : unit) : t = { valueSet }
+end
 
-  type foldingRange =
+module ClientFoldingRangeOptions = struct
+  type t =
     { collapsedText : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : foldingRange) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let foldingRange_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.FoldingRangeClientCapabilities.foldingRange" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientFoldingRangeOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let collapsedText_field = ref Ppx_yojson_conv_lib.Option.None
@@ -11330,12 +13264,12 @@ module FoldingRangeClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> foldingRange)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = foldingRange_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_foldingRange =
+  let yojson_of_t =
     (function
      | { collapsedText = v_collapsedText } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -11348,23 +13282,23 @@ module FoldingRangeClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : foldingRange -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_foldingRange
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_foldingRange ?(collapsedText : bool option) (() : unit) : foldingRange =
-    { collapsedText }
-  ;;
+  let create ?(collapsedText : bool option) (() : unit) : t = { collapsedText }
+end
 
+module FoldingRangeClientCapabilities = struct
   type t =
     { dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; foldingRange : foldingRange Json.Nullable_option.t
+    ; foldingRange : ClientFoldingRangeOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; foldingRangeKind : foldingRangeKind Json.Nullable_option.t
+    ; foldingRangeKind : ClientFoldingRangeKindOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; lineFoldingOnly : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -11401,7 +13335,9 @@ module FoldingRangeClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) foldingRange_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson foldingRange_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientFoldingRangeOptions.t_of_yojson
+                     _field_yojson
                  in
                  foldingRange_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -11411,7 +13347,7 @@ module FoldingRangeClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     foldingRangeKind_of_yojson
+                     ClientFoldingRangeKindOptions.t_of_yojson
                      _field_yojson
                  in
                  foldingRangeKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -11526,7 +13462,7 @@ module FoldingRangeClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_foldingRangeKind)
+             (Json.Nullable_option.yojson_of_t ClientFoldingRangeKindOptions.yojson_of_t)
                v_foldingRangeKind
            in
            let bnd = "foldingRangeKind", arg in
@@ -11537,7 +13473,8 @@ module FoldingRangeClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_foldingRange) v_foldingRange
+             (Json.Nullable_option.yojson_of_t ClientFoldingRangeOptions.yojson_of_t)
+               v_foldingRange
            in
            let bnd = "foldingRange", arg in
            bnd :: bnds)
@@ -11562,8 +13499,8 @@ module FoldingRangeClientCapabilities = struct
 
   let create
         ?(dynamicRegistration : bool option)
-        ?(foldingRange : foldingRange option)
-        ?(foldingRangeKind : foldingRangeKind option)
+        ?(foldingRange : ClientFoldingRangeOptions.t option)
+        ?(foldingRangeKind : ClientFoldingRangeKindOptions.t option)
         ?(lineFoldingOnly : bool option)
         ?(rangeLimit : int option)
         (() : unit)
@@ -11573,112 +13510,32 @@ module FoldingRangeClientCapabilities = struct
   ;;
 end
 
-module DocumentSymbolClientCapabilities = struct
-  type tagSupport = { valueSet : SymbolTag.t list }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : tagSupport) -> ()
-
-  let tagSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.DocumentSymbolClientCapabilities.tagSupport" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "valueSet" ->
-              (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = list_of_yojson SymbolTag.t_of_yojson _field_yojson in
-                 valueSet_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
-              | Ppx_yojson_conv_lib.Option.Some valueSet_value ->
-                { valueSet = valueSet_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) valueSet_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "valueSet" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> tagSupport)
-  ;;
-
-  let _ = tagSupport_of_yojson
-
-  let yojson_of_tagSupport =
-    (function
-     | { valueSet = v_valueSet } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_list SymbolTag.yojson_of_t v_valueSet in
-         ("valueSet", arg) :: bnds
-       in
-       `Assoc bnds
-     : tagSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_tagSupport
-
-  [@@@end]
-
-  let create_tagSupport ~(valueSet : SymbolTag.t list) : tagSupport = { valueSet }
-
-  type symbolKind =
-    { valueSet : SymbolKind.t list Json.Nullable_option.t
+module TextDocumentFilterClientCapabilities = struct
+  type t =
+    { relativePatternSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : symbolKind) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let symbolKind_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.DocumentSymbolClientCapabilities.symbolKind" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilterClientCapabilities.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
+       let relativePatternSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
-            | "valueSet" ->
-              (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+            | "relativePatternSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) relativePatternSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     (list_of_yojson SymbolKind.t_of_yojson)
-                     _field_yojson
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
                  in
-                 valueSet_field := Ppx_yojson_conv_lib.Option.Some fvalue
+                 relativePatternSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -11700,46 +13557,49 @@ module DocumentSymbolClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let valueSet_value = Ppx_yojson_conv_lib.( ! ) valueSet_field in
-             { valueSet =
-                 (match valueSet_value with
+             let relativePatternSupport_value =
+               Ppx_yojson_conv_lib.( ! ) relativePatternSupport_field
+             in
+             { relativePatternSupport =
+                 (match relativePatternSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> symbolKind)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = symbolKind_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_symbolKind =
+  let yojson_of_t =
     (function
-     | { valueSet = v_valueSet } ->
+     | { relativePatternSupport = v_relativePatternSupport } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         if None = v_valueSet
+         if None = v_relativePatternSupport
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t (yojson_of_list SymbolKind.yojson_of_t))
-               v_valueSet
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_relativePatternSupport
            in
-           let bnd = "valueSet", arg in
+           let bnd = "relativePatternSupport", arg in
            bnd :: bnds)
        in
        `Assoc bnds
-     : symbolKind -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_symbolKind
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_symbolKind ?(valueSet : SymbolKind.t list option) (() : unit) : symbolKind =
-    { valueSet }
+  let create ?(relativePatternSupport : bool option) (() : unit) : t =
+    { relativePatternSupport }
   ;;
+end
 
+module DocumentSymbolClientCapabilities = struct
   type t =
     { dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -11747,9 +13607,9 @@ module DocumentSymbolClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; labelSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; symbolKind : symbolKind Json.Nullable_option.t
+    ; symbolKind : ClientSymbolKindOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; tagSupport : tagSupport Json.Nullable_option.t
+    ; tagSupport : ClientSymbolTagOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -11804,7 +13664,9 @@ module DocumentSymbolClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) symbolKind_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson symbolKind_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientSymbolKindOptions.t_of_yojson
+                     _field_yojson
                  in
                  symbolKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -11813,7 +13675,9 @@ module DocumentSymbolClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson tagSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientSymbolTagOptions.t_of_yojson
+                     _field_yojson
                  in
                  tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -11891,7 +13755,8 @@ module DocumentSymbolClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_tagSupport) v_tagSupport
+             (Json.Nullable_option.yojson_of_t ClientSymbolTagOptions.yojson_of_t)
+               v_tagSupport
            in
            let bnd = "tagSupport", arg in
            bnd :: bnds)
@@ -11901,7 +13766,8 @@ module DocumentSymbolClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_symbolKind) v_symbolKind
+             (Json.Nullable_option.yojson_of_t ClientSymbolKindOptions.yojson_of_t)
+               v_symbolKind
            in
            let bnd = "symbolKind", arg in
            bnd :: bnds)
@@ -11947,8 +13813,8 @@ module DocumentSymbolClientCapabilities = struct
         ?(dynamicRegistration : bool option)
         ?(hierarchicalDocumentSymbolSupport : bool option)
         ?(labelSupport : bool option)
-        ?(symbolKind : symbolKind option)
-        ?(tagSupport : tagSupport option)
+        ?(symbolKind : ClientSymbolKindOptions.t option)
+        ?(tagSupport : ClientSymbolTagOptions.t option)
         (() : unit)
     : t
     =
@@ -12172,11 +14038,19 @@ end
 
 module DiagnosticClientCapabilities = struct
   type t =
-    { dynamicRegistration : bool Json.Nullable_option.t
+    { codeDescriptionSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; dataSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; markupMessageSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; relatedDocumentSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; relatedInformation : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; tagSupport : ClientDiagnosticsTagOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -12187,14 +14061,36 @@ module DiagnosticClientCapabilities = struct
     (let _tp_loc = "lsp/src/types.ml.DiagnosticClientCapabilities.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
+       let codeDescriptionSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and dataSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
        and markupMessageSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and relatedDocumentSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and relatedInformation_field = ref Ppx_yojson_conv_lib.Option.None
+       and tagSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
+            | "codeDescriptionSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) codeDescriptionSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 codeDescriptionSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "dataSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) dataSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 dataSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "dynamicRegistration" ->
               (match Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -12222,6 +14118,26 @@ module DiagnosticClientCapabilities = struct
                  relatedDocumentSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "relatedInformation" ->
+              (match Ppx_yojson_conv_lib.( ! ) relatedInformation_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 relatedInformation_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tagSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientDiagnosticsTagOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
            iter tail
          | [] -> ()
@@ -12241,15 +14157,31 @@ module DiagnosticClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let ( dynamicRegistration_value
+             let ( codeDescriptionSupport_value
+                 , dataSupport_value
+                 , dynamicRegistration_value
                  , markupMessageSupport_value
-                 , relatedDocumentSupport_value )
+                 , relatedDocumentSupport_value
+                 , relatedInformation_value
+                 , tagSupport_value )
                =
-               ( Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
+               ( Ppx_yojson_conv_lib.( ! ) codeDescriptionSupport_field
+               , Ppx_yojson_conv_lib.( ! ) dataSupport_field
+               , Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
                , Ppx_yojson_conv_lib.( ! ) markupMessageSupport_field
-               , Ppx_yojson_conv_lib.( ! ) relatedDocumentSupport_field )
+               , Ppx_yojson_conv_lib.( ! ) relatedDocumentSupport_field
+               , Ppx_yojson_conv_lib.( ! ) relatedInformation_field
+               , Ppx_yojson_conv_lib.( ! ) tagSupport_field )
              in
-             { dynamicRegistration =
+             { codeDescriptionSupport =
+                 (match codeDescriptionSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; dataSupport =
+                 (match dataSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; dynamicRegistration =
                  (match dynamicRegistration_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
@@ -12259,6 +14191,14 @@ module DiagnosticClientCapabilities = struct
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; relatedDocumentSupport =
                  (match relatedDocumentSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; relatedInformation =
+                 (match relatedInformation_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; tagSupport =
+                 (match tagSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
@@ -12271,11 +14211,36 @@ module DiagnosticClientCapabilities = struct
 
   let yojson_of_t =
     (function
-     | { dynamicRegistration = v_dynamicRegistration
+     | { codeDescriptionSupport = v_codeDescriptionSupport
+       ; dataSupport = v_dataSupport
+       ; dynamicRegistration = v_dynamicRegistration
        ; markupMessageSupport = v_markupMessageSupport
        ; relatedDocumentSupport = v_relatedDocumentSupport
+       ; relatedInformation = v_relatedInformation
+       ; tagSupport = v_tagSupport
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_tagSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t ClientDiagnosticsTagOptions.yojson_of_t)
+               v_tagSupport
+           in
+           let bnd = "tagSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_relatedInformation
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_relatedInformation
+           in
+           let bnd = "relatedInformation", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_relatedDocumentSupport
          then bnds
@@ -12306,6 +14271,24 @@ module DiagnosticClientCapabilities = struct
            let bnd = "dynamicRegistration", arg in
            bnd :: bnds)
        in
+       let bnds =
+         if None = v_dataSupport
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_dataSupport in
+           let bnd = "dataSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_codeDescriptionSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_codeDescriptionSupport
+           in
+           let bnd = "codeDescriptionSupport", arg in
+           bnd :: bnds)
+       in
        `Assoc bnds
      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
@@ -12315,13 +14298,24 @@ module DiagnosticClientCapabilities = struct
   [@@@end]
 
   let create
+        ?(codeDescriptionSupport : bool option)
+        ?(dataSupport : bool option)
         ?(dynamicRegistration : bool option)
         ?(markupMessageSupport : bool option)
         ?(relatedDocumentSupport : bool option)
+        ?(relatedInformation : bool option)
+        ?(tagSupport : ClientDiagnosticsTagOptions.t option)
         (() : unit)
     : t
     =
-    { dynamicRegistration; markupMessageSupport; relatedDocumentSupport }
+    { codeDescriptionSupport
+    ; dataSupport
+    ; dynamicRegistration
+    ; markupMessageSupport
+    ; relatedDocumentSupport
+    ; relatedInformation
+    ; tagSupport
+    }
   ;;
 end
 
@@ -12557,25 +14551,37 @@ module DeclarationClientCapabilities = struct
   ;;
 end
 
-module CompletionClientCapabilities = struct
-  type completionList =
-    { itemDefaults : string list Json.Nullable_option.t
+module CompletionListCapabilities = struct
+  type t =
+    { applyKindSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; itemDefaults : string list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : completionList) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let completionList_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionClientCapabilities.completionList" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CompletionListCapabilities.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let itemDefaults_field = ref Ppx_yojson_conv_lib.Option.None
+       let applyKindSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and itemDefaults_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
+            | "applyKindSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) applyKindSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 applyKindSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "itemDefaults" ->
               (match Ppx_yojson_conv_lib.( ! ) itemDefaults_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -12606,22 +14612,29 @@ module CompletionClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let itemDefaults_value = Ppx_yojson_conv_lib.( ! ) itemDefaults_field in
-             { itemDefaults =
+             let applyKindSupport_value, itemDefaults_value =
+               ( Ppx_yojson_conv_lib.( ! ) applyKindSupport_field
+               , Ppx_yojson_conv_lib.( ! ) itemDefaults_field )
+             in
+             { applyKindSupport =
+                 (match applyKindSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; itemDefaults =
                  (match itemDefaults_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> completionList)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = completionList_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_completionList =
+  let yojson_of_t =
     (function
-     | { itemDefaults = v_itemDefaults } ->
+     | { applyKindSupport = v_applyKindSupport; itemDefaults = v_itemDefaults } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
          if None = v_itemDefaults
@@ -12634,30 +14647,45 @@ module CompletionClientCapabilities = struct
            let bnd = "itemDefaults", arg in
            bnd :: bnds)
        in
+       let bnds =
+         if None = v_applyKindSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_applyKindSupport
+           in
+           let bnd = "applyKindSupport", arg in
+           bnd :: bnds)
+       in
        `Assoc bnds
-     : completionList -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_completionList
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_completionList ?(itemDefaults : string list option) (() : unit)
-    : completionList
+  let create
+        ?(applyKindSupport : bool option)
+        ?(itemDefaults : string list option)
+        (() : unit)
+    : t
     =
-    { itemDefaults }
+    { applyKindSupport; itemDefaults }
   ;;
+end
 
-  type completionItemKind =
+module ClientCompletionItemOptionsKind = struct
+  type t =
     { valueSet : CompletionItemKind.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : completionItemKind) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let completionItemKind_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionClientCapabilities.completionItemKind" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCompletionItemOptionsKind.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -12704,12 +14732,12 @@ module CompletionClientCapabilities = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> completionItemKind)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = completionItemKind_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_completionItemKind =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -12726,188 +14754,24 @@ module CompletionClientCapabilities = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : completionItemKind -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_completionItemKind
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_completionItemKind ?(valueSet : CompletionItemKind.t list option) (() : unit)
-    : completionItemKind
-    =
-    { valueSet }
-  ;;
+  let create ?(valueSet : CompletionItemKind.t list option) (() : unit) : t = { valueSet }
+end
 
-  type insertTextModeSupport = { valueSet : InsertTextMode.t list }
+module CompletionItemTagOptions = struct
+  type t = { valueSet : CompletionItemTag.t list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : insertTextModeSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let insertTextModeSupport_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.CompletionClientCapabilities.insertTextModeSupport"
-     in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "valueSet" ->
-              (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = list_of_yojson InsertTextMode.t_of_yojson _field_yojson in
-                 valueSet_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
-              | Ppx_yojson_conv_lib.Option.Some valueSet_value ->
-                { valueSet = valueSet_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) valueSet_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "valueSet" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> insertTextModeSupport)
-  ;;
-
-  let _ = insertTextModeSupport_of_yojson
-
-  let yojson_of_insertTextModeSupport =
-    (function
-     | { valueSet = v_valueSet } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_list InsertTextMode.yojson_of_t v_valueSet in
-         ("valueSet", arg) :: bnds
-       in
-       `Assoc bnds
-     : insertTextModeSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_insertTextModeSupport
-
-  [@@@end]
-
-  let create_insertTextModeSupport ~(valueSet : InsertTextMode.t list)
-    : insertTextModeSupport
-    =
-    { valueSet }
-  ;;
-
-  type resolveSupport = { properties : string list }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : resolveSupport) -> ()
-
-  let resolveSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionClientCapabilities.resolveSupport" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let properties_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "properties" ->
-              (match Ppx_yojson_conv_lib.( ! ) properties_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
-                 properties_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match Ppx_yojson_conv_lib.( ! ) properties_field with
-              | Ppx_yojson_conv_lib.Option.Some properties_value ->
-                { properties = properties_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) properties_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "properties" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> resolveSupport)
-  ;;
-
-  let _ = resolveSupport_of_yojson
-
-  let yojson_of_resolveSupport =
-    (function
-     | { properties = v_properties } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_list yojson_of_string v_properties in
-         ("properties", arg) :: bnds
-       in
-       `Assoc bnds
-     : resolveSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_resolveSupport
-
-  [@@@end]
-
-  let create_resolveSupport ~(properties : string list) : resolveSupport = { properties }
-
-  type tagSupport = { valueSet : CompletionItemTag.t list }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : tagSupport) -> ()
-
-  let tagSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionClientCapabilities.tagSupport" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CompletionItemTagOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -12958,12 +14822,12 @@ module CompletionClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> tagSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = tagSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_tagSupport =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -12972,152 +14836,37 @@ module CompletionClientCapabilities = struct
          ("valueSet", arg) :: bnds
        in
        `Assoc bnds
-     : tagSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_tagSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_tagSupport ~(valueSet : CompletionItemTag.t list) : tagSupport = { valueSet }
+  let create ~(valueSet : CompletionItemTag.t list) : t = { valueSet }
+end
 
-  type completionItem =
-    { snippetSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; commitCharactersSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; documentationFormat : MarkupKind.t list Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; deprecatedSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; preselectSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; tagSupport : tagSupport Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; insertReplaceSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; resolveSupport : resolveSupport Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; insertTextModeSupport : insertTextModeSupport Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; labelDetailsSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
+module ClientCompletionItemResolveOptions = struct
+  type t = { properties : string list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : completionItem) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let completionItem_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionClientCapabilities.completionItem" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCompletionItemResolveOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let snippetSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and commitCharactersSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and documentationFormat_field = ref Ppx_yojson_conv_lib.Option.None
-       and deprecatedSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and preselectSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and tagSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and insertReplaceSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and resolveSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and insertTextModeSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and labelDetailsSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       let properties_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
-            | "snippetSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) snippetSupport_field with
+            | "properties" ->
+              (match Ppx_yojson_conv_lib.( ! ) properties_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 snippetSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "commitCharactersSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) commitCharactersSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 commitCharactersSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "documentationFormat" ->
-              (match Ppx_yojson_conv_lib.( ! ) documentationFormat_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     (list_of_yojson MarkupKind.t_of_yojson)
-                     _field_yojson
-                 in
-                 documentationFormat_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "deprecatedSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) deprecatedSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 deprecatedSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "preselectSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) preselectSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 preselectSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "tagSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson tagSupport_of_yojson _field_yojson
-                 in
-                 tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "insertReplaceSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) insertReplaceSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 insertReplaceSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "resolveSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson resolveSupport_of_yojson _field_yojson
-                 in
-                 resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "insertTextModeSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) insertTextModeSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     insertTextModeSupport_of_yojson
-                     _field_yojson
-                 in
-                 insertTextModeSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "labelDetailsSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 labelDetailsSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
+                 properties_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -13139,58 +14888,324 @@ module CompletionClientCapabilities = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let ( snippetSupport_value
-                 , commitCharactersSupport_value
-                 , documentationFormat_value
+             (match Ppx_yojson_conv_lib.( ! ) properties_field with
+              | Ppx_yojson_conv_lib.Option.Some properties_value ->
+                { properties = properties_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) properties_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "properties" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { properties = v_properties } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list yojson_of_string v_properties in
+         ("properties", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(properties : string list) : t = { properties }
+end
+
+module ClientCompletionItemInsertTextModeOptions = struct
+  type t = { valueSet : InsertTextMode.t list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCompletionItemInsertTextModeOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "valueSet" ->
+              (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson InsertTextMode.t_of_yojson _field_yojson in
+                 valueSet_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+              | Ppx_yojson_conv_lib.Option.Some valueSet_value ->
+                { valueSet = valueSet_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) valueSet_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "valueSet" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { valueSet = v_valueSet } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list InsertTextMode.yojson_of_t v_valueSet in
+         ("valueSet", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(valueSet : InsertTextMode.t list) : t = { valueSet }
+end
+
+module ClientCompletionItemOptions = struct
+  type t =
+    { commitCharactersSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; deprecatedSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; documentationFormat : MarkupKind.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; insertReplaceSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; insertTextModeSupport :
+        ClientCompletionItemInsertTextModeOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; labelDetailsSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; preselectSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; resolveSupport : ClientCompletionItemResolveOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; snippetSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; tagSupport : CompletionItemTagOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCompletionItemOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let commitCharactersSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and deprecatedSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and documentationFormat_field = ref Ppx_yojson_conv_lib.Option.None
+       and insertReplaceSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and insertTextModeSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and labelDetailsSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and preselectSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and resolveSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and snippetSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and tagSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "commitCharactersSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) commitCharactersSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 commitCharactersSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "deprecatedSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) deprecatedSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 deprecatedSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "documentationFormat" ->
+              (match Ppx_yojson_conv_lib.( ! ) documentationFormat_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson MarkupKind.t_of_yojson)
+                     _field_yojson
+                 in
+                 documentationFormat_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "insertReplaceSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) insertReplaceSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 insertReplaceSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "insertTextModeSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) insertTextModeSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientCompletionItemInsertTextModeOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 insertTextModeSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "labelDetailsSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 labelDetailsSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "preselectSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) preselectSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 preselectSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "resolveSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientCompletionItemResolveOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "snippetSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) snippetSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 snippetSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tagSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     CompletionItemTagOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let ( commitCharactersSupport_value
                  , deprecatedSupport_value
-                 , preselectSupport_value
-                 , tagSupport_value
+                 , documentationFormat_value
                  , insertReplaceSupport_value
-                 , resolveSupport_value
                  , insertTextModeSupport_value
-                 , labelDetailsSupport_value )
+                 , labelDetailsSupport_value
+                 , preselectSupport_value
+                 , resolveSupport_value
+                 , snippetSupport_value
+                 , tagSupport_value )
                =
-               ( Ppx_yojson_conv_lib.( ! ) snippetSupport_field
-               , Ppx_yojson_conv_lib.( ! ) commitCharactersSupport_field
-               , Ppx_yojson_conv_lib.( ! ) documentationFormat_field
+               ( Ppx_yojson_conv_lib.( ! ) commitCharactersSupport_field
                , Ppx_yojson_conv_lib.( ! ) deprecatedSupport_field
-               , Ppx_yojson_conv_lib.( ! ) preselectSupport_field
-               , Ppx_yojson_conv_lib.( ! ) tagSupport_field
+               , Ppx_yojson_conv_lib.( ! ) documentationFormat_field
                , Ppx_yojson_conv_lib.( ! ) insertReplaceSupport_field
-               , Ppx_yojson_conv_lib.( ! ) resolveSupport_field
                , Ppx_yojson_conv_lib.( ! ) insertTextModeSupport_field
-               , Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field )
+               , Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field
+               , Ppx_yojson_conv_lib.( ! ) preselectSupport_field
+               , Ppx_yojson_conv_lib.( ! ) resolveSupport_field
+               , Ppx_yojson_conv_lib.( ! ) snippetSupport_field
+               , Ppx_yojson_conv_lib.( ! ) tagSupport_field )
              in
-             { snippetSupport =
-                 (match snippetSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; commitCharactersSupport =
+             { commitCharactersSupport =
                  (match commitCharactersSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; documentationFormat =
-                 (match documentationFormat_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; deprecatedSupport =
                  (match deprecatedSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; preselectSupport =
-                 (match preselectSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; tagSupport =
-                 (match tagSupport_value with
+             ; documentationFormat =
+                 (match documentationFormat_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; insertReplaceSupport =
                  (match insertReplaceSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; resolveSupport =
-                 (match resolveSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; insertTextModeSupport =
@@ -13201,28 +15216,85 @@ module CompletionClientCapabilities = struct
                  (match labelDetailsSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; preselectSupport =
+                 (match preselectSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; resolveSupport =
+                 (match resolveSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; snippetSupport =
+                 (match snippetSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; tagSupport =
+                 (match tagSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> completionItem)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = completionItem_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_completionItem =
+  let yojson_of_t =
     (function
-     | { snippetSupport = v_snippetSupport
-       ; commitCharactersSupport = v_commitCharactersSupport
-       ; documentationFormat = v_documentationFormat
+     | { commitCharactersSupport = v_commitCharactersSupport
        ; deprecatedSupport = v_deprecatedSupport
-       ; preselectSupport = v_preselectSupport
-       ; tagSupport = v_tagSupport
+       ; documentationFormat = v_documentationFormat
        ; insertReplaceSupport = v_insertReplaceSupport
-       ; resolveSupport = v_resolveSupport
        ; insertTextModeSupport = v_insertTextModeSupport
        ; labelDetailsSupport = v_labelDetailsSupport
+       ; preselectSupport = v_preselectSupport
+       ; resolveSupport = v_resolveSupport
+       ; snippetSupport = v_snippetSupport
+       ; tagSupport = v_tagSupport
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_tagSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t CompletionItemTagOptions.yojson_of_t)
+               v_tagSupport
+           in
+           let bnd = "tagSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_snippetSupport
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_snippetSupport in
+           let bnd = "snippetSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_resolveSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                ClientCompletionItemResolveOptions.yojson_of_t)
+               v_resolveSupport
+           in
+           let bnd = "resolveSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_preselectSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_preselectSupport
+           in
+           let bnd = "preselectSupport", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_labelDetailsSupport
          then bnds
@@ -13238,20 +15310,11 @@ module CompletionClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_insertTextModeSupport)
+             (Json.Nullable_option.yojson_of_t
+                ClientCompletionItemInsertTextModeOptions.yojson_of_t)
                v_insertTextModeSupport
            in
            let bnd = "insertTextModeSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_resolveSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_resolveSupport) v_resolveSupport
-           in
-           let bnd = "resolveSupport", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -13262,36 +15325,6 @@ module CompletionClientCapabilities = struct
              (Json.Nullable_option.yojson_of_t yojson_of_bool) v_insertReplaceSupport
            in
            let bnd = "insertReplaceSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_tagSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_tagSupport) v_tagSupport
-           in
-           let bnd = "tagSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_preselectSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_preselectSupport
-           in
-           let bnd = "preselectSupport", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_deprecatedSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_deprecatedSupport
-           in
-           let bnd = "deprecatedSupport", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -13306,6 +15339,16 @@ module CompletionClientCapabilities = struct
            bnd :: bnds)
        in
        let bnds =
+         if None = v_deprecatedSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_deprecatedSupport
+           in
+           let bnd = "deprecatedSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
          if None = v_commitCharactersSupport
          then bnds
          else (
@@ -13315,55 +15358,49 @@ module CompletionClientCapabilities = struct
            let bnd = "commitCharactersSupport", arg in
            bnd :: bnds)
        in
-       let bnds =
-         if None = v_snippetSupport
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_snippetSupport in
-           let bnd = "snippetSupport", arg in
-           bnd :: bnds)
-       in
        `Assoc bnds
-     : completionItem -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_completionItem
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_completionItem
-        ?(snippetSupport : bool option)
+  let create
         ?(commitCharactersSupport : bool option)
-        ?(documentationFormat : MarkupKind.t list option)
         ?(deprecatedSupport : bool option)
-        ?(preselectSupport : bool option)
-        ?(tagSupport : tagSupport option)
+        ?(documentationFormat : MarkupKind.t list option)
         ?(insertReplaceSupport : bool option)
-        ?(resolveSupport : resolveSupport option)
-        ?(insertTextModeSupport : insertTextModeSupport option)
+        ?(insertTextModeSupport : ClientCompletionItemInsertTextModeOptions.t option)
         ?(labelDetailsSupport : bool option)
+        ?(preselectSupport : bool option)
+        ?(resolveSupport : ClientCompletionItemResolveOptions.t option)
+        ?(snippetSupport : bool option)
+        ?(tagSupport : CompletionItemTagOptions.t option)
         (() : unit)
-    : completionItem
+    : t
     =
-    { snippetSupport
-    ; commitCharactersSupport
-    ; documentationFormat
+    { commitCharactersSupport
     ; deprecatedSupport
-    ; preselectSupport
-    ; tagSupport
+    ; documentationFormat
     ; insertReplaceSupport
-    ; resolveSupport
     ; insertTextModeSupport
     ; labelDetailsSupport
+    ; preselectSupport
+    ; resolveSupport
+    ; snippetSupport
+    ; tagSupport
     }
   ;;
+end
 
+module CompletionClientCapabilities = struct
   type t =
-    { completionItem : completionItem Json.Nullable_option.t
+    { completionItem : ClientCompletionItemOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; completionItemKind : completionItemKind Json.Nullable_option.t
+    ; completionItemKind : ClientCompletionItemOptionsKind.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; completionList : completionList Json.Nullable_option.t
+    ; completionList : CompletionListCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; contextSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -13395,7 +15432,9 @@ module CompletionClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) completionItem_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson completionItem_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientCompletionItemOptions.t_of_yojson
+                     _field_yojson
                  in
                  completionItem_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -13405,7 +15444,7 @@ module CompletionClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     completionItemKind_of_yojson
+                     ClientCompletionItemOptionsKind.t_of_yojson
                      _field_yojson
                  in
                  completionItemKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -13415,7 +15454,9 @@ module CompletionClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) completionList_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson completionList_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     CompletionListCapabilities.t_of_yojson
+                     _field_yojson
                  in
                  completionList_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -13558,7 +15599,8 @@ module CompletionClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_completionList) v_completionList
+             (Json.Nullable_option.yojson_of_t CompletionListCapabilities.yojson_of_t)
+               v_completionList
            in
            let bnd = "completionList", arg in
            bnd :: bnds)
@@ -13568,7 +15610,8 @@ module CompletionClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_completionItemKind)
+             (Json.Nullable_option.yojson_of_t
+                ClientCompletionItemOptionsKind.yojson_of_t)
                v_completionItemKind
            in
            let bnd = "completionItemKind", arg in
@@ -13579,7 +15622,8 @@ module CompletionClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_completionItem) v_completionItem
+             (Json.Nullable_option.yojson_of_t ClientCompletionItemOptions.yojson_of_t)
+               v_completionItem
            in
            let bnd = "completionItem", arg in
            bnd :: bnds)
@@ -13593,9 +15637,9 @@ module CompletionClientCapabilities = struct
   [@@@end]
 
   let create
-        ?(completionItem : completionItem option)
-        ?(completionItemKind : completionItemKind option)
-        ?(completionList : completionList option)
+        ?(completionItem : ClientCompletionItemOptions.t option)
+        ?(completionItemKind : ClientCompletionItemOptionsKind.t option)
+        ?(completionList : CompletionListCapabilities.t option)
         ?(contextSupport : bool option)
         ?(dynamicRegistration : bool option)
         ?(insertTextMode : InsertTextMode.t option)
@@ -13701,103 +15745,14 @@ module DocumentColorClientCapabilities = struct
   ;;
 end
 
-module CodeLensClientCapabilities = struct
-  type t =
-    { dynamicRegistration : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
+module ClientCodeLensResolveOptions = struct
+  type t = { properties : string list }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
 
   let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CodeLensClientCapabilities.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "dynamicRegistration" ->
-              (match Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 dynamicRegistration_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let dynamicRegistration_value =
-               Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
-             in
-             { dynamicRegistration =
-                 (match dynamicRegistration_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { dynamicRegistration = v_dynamicRegistration } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_dynamicRegistration
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_dynamicRegistration
-           in
-           let bnd = "dynamicRegistration", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ?(dynamicRegistration : bool option) (() : unit) : t =
-    { dynamicRegistration }
-  ;;
-end
-
-module CodeActionClientCapabilities = struct
-  type resolveSupport = { properties : string list }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : resolveSupport) -> ()
-
-  let resolveSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CodeActionClientCapabilities.resolveSupport" in
+    (let _tp_loc = "lsp/src/types.ml.ClientCodeLensResolveOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let properties_field = ref Ppx_yojson_conv_lib.Option.None
@@ -13846,12 +15801,12 @@ module CodeActionClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> resolveSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = resolveSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_resolveSupport =
+  let yojson_of_t =
     (function
      | { properties = v_properties } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -13860,22 +15815,309 @@ module CodeActionClientCapabilities = struct
          ("properties", arg) :: bnds
        in
        `Assoc bnds
-     : resolveSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_resolveSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_resolveSupport ~(properties : string list) : resolveSupport = { properties }
+  let create ~(properties : string list) : t = { properties }
+end
 
-  type codeActionKind = { valueSet : CodeActionKind.t list }
+module CodeLensClientCapabilities = struct
+  type t =
+    { dynamicRegistration : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; resolveSupport : ClientCodeLensResolveOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : codeActionKind) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let codeActionKind_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CodeActionClientCapabilities.codeActionKind" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CodeLensClientCapabilities.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
+       and resolveSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "dynamicRegistration" ->
+              (match Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 dynamicRegistration_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "resolveSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientCodeLensResolveOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let dynamicRegistration_value, resolveSupport_value =
+               ( Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
+               , Ppx_yojson_conv_lib.( ! ) resolveSupport_field )
+             in
+             { dynamicRegistration =
+                 (match dynamicRegistration_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; resolveSupport =
+                 (match resolveSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { dynamicRegistration = v_dynamicRegistration; resolveSupport = v_resolveSupport }
+       ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_resolveSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t ClientCodeLensResolveOptions.yojson_of_t)
+               v_resolveSupport
+           in
+           let bnd = "resolveSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_dynamicRegistration
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_dynamicRegistration
+           in
+           let bnd = "dynamicRegistration", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(dynamicRegistration : bool option)
+        ?(resolveSupport : ClientCodeLensResolveOptions.t option)
+        (() : unit)
+    : t
+    =
+    { dynamicRegistration; resolveSupport }
+  ;;
+end
+
+module CodeActionTagOptions = struct
+  type t = { valueSet : CodeActionTag.t list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CodeActionTagOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "valueSet" ->
+              (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson CodeActionTag.t_of_yojson _field_yojson in
+                 valueSet_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) valueSet_field with
+              | Ppx_yojson_conv_lib.Option.Some valueSet_value ->
+                { valueSet = valueSet_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) valueSet_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "valueSet" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { valueSet = v_valueSet } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list CodeActionTag.yojson_of_t v_valueSet in
+         ("valueSet", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(valueSet : CodeActionTag.t list) : t = { valueSet }
+end
+
+module ClientCodeActionResolveOptions = struct
+  type t = { properties : string list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCodeActionResolveOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let properties_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "properties" ->
+              (match Ppx_yojson_conv_lib.( ! ) properties_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
+                 properties_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) properties_field with
+              | Ppx_yojson_conv_lib.Option.Some properties_value ->
+                { properties = properties_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) properties_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "properties" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { properties = v_properties } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list yojson_of_string v_properties in
+         ("properties", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(properties : string list) : t = { properties }
+end
+
+module ClientCodeActionKindOptions = struct
+  type t = { valueSet : CodeActionKind.t list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCodeActionKindOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let valueSet_field = ref Ppx_yojson_conv_lib.Option.None
@@ -13924,12 +16166,12 @@ module CodeActionClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> codeActionKind)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = codeActionKind_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_codeActionKind =
+  let yojson_of_t =
     (function
      | { valueSet = v_valueSet } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -13938,26 +16180,24 @@ module CodeActionClientCapabilities = struct
          ("valueSet", arg) :: bnds
        in
        `Assoc bnds
-     : codeActionKind -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_codeActionKind
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_codeActionKind ~(valueSet : CodeActionKind.t list) : codeActionKind =
-    { valueSet }
-  ;;
+  let create ~(valueSet : CodeActionKind.t list) : t = { valueSet }
+end
 
-  type codeActionLiteralSupport = { codeActionKind : codeActionKind }
+module ClientCodeActionLiteralOptions = struct
+  type t = { codeActionKind : ClientCodeActionKindOptions.t }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : codeActionLiteralSupport) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let codeActionLiteralSupport_of_yojson =
-    (let _tp_loc =
-       "lsp/src/types.ml.CodeActionClientCapabilities.codeActionLiteralSupport"
-     in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientCodeActionLiteralOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let codeActionKind_field = ref Ppx_yojson_conv_lib.Option.None
@@ -13969,7 +16209,7 @@ module CodeActionClientCapabilities = struct
             | "codeActionKind" ->
               (match Ppx_yojson_conv_lib.( ! ) codeActionKind_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = codeActionKind_of_yojson _field_yojson in
+                 let fvalue = ClientCodeActionKindOptions.t_of_yojson _field_yojson in
                  codeActionKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -14006,39 +16246,39 @@ module CodeActionClientCapabilities = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> codeActionLiteralSupport)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = codeActionLiteralSupport_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_codeActionLiteralSupport =
+  let yojson_of_t =
     (function
      | { codeActionKind = v_codeActionKind } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = yojson_of_codeActionKind v_codeActionKind in
+         let arg = ClientCodeActionKindOptions.yojson_of_t v_codeActionKind in
          ("codeActionKind", arg) :: bnds
        in
        `Assoc bnds
-     : codeActionLiteralSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_codeActionLiteralSupport
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_codeActionLiteralSupport ~(codeActionKind : codeActionKind)
-    : codeActionLiteralSupport
-    =
-    { codeActionKind }
-  ;;
+  let create ~(codeActionKind : ClientCodeActionKindOptions.t) : t = { codeActionKind }
+end
 
+module CodeActionClientCapabilities = struct
   type t =
-    { codeActionLiteralSupport : codeActionLiteralSupport Json.Nullable_option.t
+    { codeActionLiteralSupport : ClientCodeActionLiteralOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; dataSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; disabledSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; documentationSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; dynamicRegistration : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -14046,7 +16286,9 @@ module CodeActionClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; isPreferredSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; resolveSupport : resolveSupport Json.Nullable_option.t
+    ; resolveSupport : ClientCodeActionResolveOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; tagSupport : CodeActionTagOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -14060,10 +16302,12 @@ module CodeActionClientCapabilities = struct
        let codeActionLiteralSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and dataSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and disabledSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and documentationSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and dynamicRegistration_field = ref Ppx_yojson_conv_lib.Option.None
        and honorsChangeAnnotations_field = ref Ppx_yojson_conv_lib.Option.None
        and isPreferredSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and resolveSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and tagSupport_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -14074,7 +16318,7 @@ module CodeActionClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     codeActionLiteralSupport_of_yojson
+                     ClientCodeActionLiteralOptions.t_of_yojson
                      _field_yojson
                  in
                  codeActionLiteralSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -14096,6 +16340,15 @@ module CodeActionClientCapabilities = struct
                    Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
                  in
                  disabledSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "documentationSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) documentationSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 documentationSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "dynamicRegistration" ->
@@ -14129,9 +16382,22 @@ module CodeActionClientCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) resolveSupport_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson resolveSupport_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ClientCodeActionResolveOptions.t_of_yojson
+                     _field_yojson
                  in
                  resolveSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tagSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     CodeActionTagOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -14156,18 +16422,22 @@ module CodeActionClientCapabilities = struct
              let ( codeActionLiteralSupport_value
                  , dataSupport_value
                  , disabledSupport_value
+                 , documentationSupport_value
                  , dynamicRegistration_value
                  , honorsChangeAnnotations_value
                  , isPreferredSupport_value
-                 , resolveSupport_value )
+                 , resolveSupport_value
+                 , tagSupport_value )
                =
                ( Ppx_yojson_conv_lib.( ! ) codeActionLiteralSupport_field
                , Ppx_yojson_conv_lib.( ! ) dataSupport_field
                , Ppx_yojson_conv_lib.( ! ) disabledSupport_field
+               , Ppx_yojson_conv_lib.( ! ) documentationSupport_field
                , Ppx_yojson_conv_lib.( ! ) dynamicRegistration_field
                , Ppx_yojson_conv_lib.( ! ) honorsChangeAnnotations_field
                , Ppx_yojson_conv_lib.( ! ) isPreferredSupport_field
-               , Ppx_yojson_conv_lib.( ! ) resolveSupport_field )
+               , Ppx_yojson_conv_lib.( ! ) resolveSupport_field
+               , Ppx_yojson_conv_lib.( ! ) tagSupport_field )
              in
              { codeActionLiteralSupport =
                  (match codeActionLiteralSupport_value with
@@ -14179,6 +16449,10 @@ module CodeActionClientCapabilities = struct
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; disabledSupport =
                  (match disabledSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; documentationSupport =
+                 (match documentationSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; dynamicRegistration =
@@ -14197,6 +16471,10 @@ module CodeActionClientCapabilities = struct
                  (match resolveSupport_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; tagSupport =
+                 (match tagSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
@@ -14210,18 +16488,32 @@ module CodeActionClientCapabilities = struct
      | { codeActionLiteralSupport = v_codeActionLiteralSupport
        ; dataSupport = v_dataSupport
        ; disabledSupport = v_disabledSupport
+       ; documentationSupport = v_documentationSupport
        ; dynamicRegistration = v_dynamicRegistration
        ; honorsChangeAnnotations = v_honorsChangeAnnotations
        ; isPreferredSupport = v_isPreferredSupport
        ; resolveSupport = v_resolveSupport
+       ; tagSupport = v_tagSupport
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_tagSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t CodeActionTagOptions.yojson_of_t)
+               v_tagSupport
+           in
+           let bnd = "tagSupport", arg in
+           bnd :: bnds)
+       in
        let bnds =
          if None = v_resolveSupport
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_resolveSupport) v_resolveSupport
+             (Json.Nullable_option.yojson_of_t ClientCodeActionResolveOptions.yojson_of_t)
+               v_resolveSupport
            in
            let bnd = "resolveSupport", arg in
            bnd :: bnds)
@@ -14257,6 +16549,16 @@ module CodeActionClientCapabilities = struct
            bnd :: bnds)
        in
        let bnds =
+         if None = v_documentationSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_documentationSupport
+           in
+           let bnd = "documentationSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
          if None = v_disabledSupport
          then bnds
          else (
@@ -14279,7 +16581,7 @@ module CodeActionClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_codeActionLiteralSupport)
+             (Json.Nullable_option.yojson_of_t ClientCodeActionLiteralOptions.yojson_of_t)
                v_codeActionLiteralSupport
            in
            let bnd = "codeActionLiteralSupport", arg in
@@ -14294,23 +16596,27 @@ module CodeActionClientCapabilities = struct
   [@@@end]
 
   let create
-        ?(codeActionLiteralSupport : codeActionLiteralSupport option)
+        ?(codeActionLiteralSupport : ClientCodeActionLiteralOptions.t option)
         ?(dataSupport : bool option)
         ?(disabledSupport : bool option)
+        ?(documentationSupport : bool option)
         ?(dynamicRegistration : bool option)
         ?(honorsChangeAnnotations : bool option)
         ?(isPreferredSupport : bool option)
-        ?(resolveSupport : resolveSupport option)
+        ?(resolveSupport : ClientCodeActionResolveOptions.t option)
+        ?(tagSupport : CodeActionTagOptions.t option)
         (() : unit)
     : t
     =
     { codeActionLiteralSupport
     ; dataSupport
     ; disabledSupport
+    ; documentationSupport
     ; dynamicRegistration
     ; honorsChangeAnnotations
     ; isPreferredSupport
     ; resolveSupport
+    ; tagSupport
     }
   ;;
 end
@@ -14338,6 +16644,8 @@ module TextDocumentClientCapabilities = struct
     ; documentLink : DocumentLinkClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; documentSymbol : DocumentSymbolClientCapabilities.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; filters : TextDocumentFilterClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; foldingRange : FoldingRangeClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -14400,6 +16708,7 @@ module TextDocumentClientCapabilities = struct
        and documentHighlight_field = ref Ppx_yojson_conv_lib.Option.None
        and documentLink_field = ref Ppx_yojson_conv_lib.Option.None
        and documentSymbol_field = ref Ppx_yojson_conv_lib.Option.None
+       and filters_field = ref Ppx_yojson_conv_lib.Option.None
        and foldingRange_field = ref Ppx_yojson_conv_lib.Option.None
        and formatting_field = ref Ppx_yojson_conv_lib.Option.None
        and hover_field = ref Ppx_yojson_conv_lib.Option.None
@@ -14544,6 +16853,17 @@ module TextDocumentClientCapabilities = struct
                      _field_yojson
                  in
                  documentSymbol_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "filters" ->
+              (match Ppx_yojson_conv_lib.( ! ) filters_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     TextDocumentFilterClientCapabilities.t_of_yojson
+                     _field_yojson
+                 in
+                 filters_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "foldingRange" ->
@@ -14796,6 +17116,7 @@ module TextDocumentClientCapabilities = struct
                  , documentHighlight_value
                  , documentLink_value
                  , documentSymbol_value
+                 , filters_value
                  , foldingRange_value
                  , formatting_value
                  , hover_value
@@ -14828,6 +17149,7 @@ module TextDocumentClientCapabilities = struct
                , Ppx_yojson_conv_lib.( ! ) documentHighlight_field
                , Ppx_yojson_conv_lib.( ! ) documentLink_field
                , Ppx_yojson_conv_lib.( ! ) documentSymbol_field
+               , Ppx_yojson_conv_lib.( ! ) filters_field
                , Ppx_yojson_conv_lib.( ! ) foldingRange_field
                , Ppx_yojson_conv_lib.( ! ) formatting_field
                , Ppx_yojson_conv_lib.( ! ) hover_field
@@ -14891,6 +17213,10 @@ module TextDocumentClientCapabilities = struct
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; documentSymbol =
                  (match documentSymbol_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; filters =
+                 (match filters_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; foldingRange =
@@ -14994,6 +17320,7 @@ module TextDocumentClientCapabilities = struct
        ; documentHighlight = v_documentHighlight
        ; documentLink = v_documentLink
        ; documentSymbol = v_documentSymbol
+       ; filters = v_filters
        ; foldingRange = v_foldingRange
        ; formatting = v_formatting
        ; hover = v_hover
@@ -15250,6 +17577,18 @@ module TextDocumentClientCapabilities = struct
            bnd :: bnds)
        in
        let bnds =
+         if None = v_filters
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                TextDocumentFilterClientCapabilities.yojson_of_t)
+               v_filters
+           in
+           let bnd = "filters", arg in
+           bnd :: bnds)
+       in
+       let bnds =
          if None = v_documentSymbol
          then bnds
          else (
@@ -15394,6 +17733,7 @@ module TextDocumentClientCapabilities = struct
         ?(documentHighlight : DocumentHighlightClientCapabilities.t option)
         ?(documentLink : DocumentLinkClientCapabilities.t option)
         ?(documentSymbol : DocumentSymbolClientCapabilities.t option)
+        ?(filters : TextDocumentFilterClientCapabilities.t option)
         ?(foldingRange : FoldingRangeClientCapabilities.t option)
         ?(formatting : DocumentFormattingClientCapabilities.t option)
         ?(hover : HoverClientCapabilities.t option)
@@ -15428,6 +17768,7 @@ module TextDocumentClientCapabilities = struct
     ; documentHighlight
     ; documentLink
     ; documentSymbol
+    ; filters
     ; foldingRange
     ; formatting
     ; hover
@@ -15659,9 +18000,128 @@ module NotebookDocumentClientCapabilities = struct
   ;;
 end
 
+module StaleRequestSupportOptions = struct
+  type t =
+    { cancel : bool
+    ; retryOnContentModified : string list
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.StaleRequestSupportOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let cancel_field = ref Ppx_yojson_conv_lib.Option.None
+       and retryOnContentModified_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "cancel" ->
+              (match Ppx_yojson_conv_lib.( ! ) cancel_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = bool_of_yojson _field_yojson in
+                 cancel_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "retryOnContentModified" ->
+              (match Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
+                 retryOnContentModified_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) cancel_field
+                , Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some cancel_value
+                , Ppx_yojson_conv_lib.Option.Some retryOnContentModified_value ) ->
+                { cancel = cancel_value
+                ; retryOnContentModified = retryOnContentModified_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) cancel_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "cancel" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "retryOnContentModified" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { cancel = v_cancel; retryOnContentModified = v_retryOnContentModified } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list yojson_of_string v_retryOnContentModified in
+         ("retryOnContentModified", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_bool v_cancel in
+         ("cancel", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(cancel : bool) ~(retryOnContentModified : string list) : t =
+    { cancel; retryOnContentModified }
+  ;;
+end
+
+module RegularExpressionEngineKind = struct
+  type t = string [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+  let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  let _ = t_of_yojson
+  let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
 module RegularExpressionsClientCapabilities = struct
   type t =
-    { engine : string
+    { engine : RegularExpressionEngineKind.t
     ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -15682,7 +18142,7 @@ module RegularExpressionsClientCapabilities = struct
             | "engine" ->
               (match Ppx_yojson_conv_lib.( ! ) engine_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
+                 let fvalue = RegularExpressionEngineKind.t_of_yojson _field_yojson in
                  engine_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -15754,7 +18214,7 @@ module RegularExpressionsClientCapabilities = struct
            bnd :: bnds)
        in
        let bnds =
-         let arg = yojson_of_string v_engine in
+         let arg = RegularExpressionEngineKind.yojson_of_t v_engine in
          ("engine", arg) :: bnds
        in
        `Assoc bnds
@@ -15765,7 +18225,12 @@ module RegularExpressionsClientCapabilities = struct
 
   [@@@end]
 
-  let create ~(engine : string) ?(version : string option) (() : unit) : t =
+  let create
+        ~(engine : RegularExpressionEngineKind.t)
+        ?(version : string option)
+        (() : unit)
+    : t
+    =
     { engine; version }
   ;;
 end
@@ -15920,113 +18385,6 @@ module MarkdownClientCapabilities = struct
 end
 
 module GeneralClientCapabilities = struct
-  type staleRequestSupport =
-    { cancel : bool
-    ; retryOnContentModified : string list
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : staleRequestSupport) -> ()
-
-  let staleRequestSupport_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.GeneralClientCapabilities.staleRequestSupport" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let cancel_field = ref Ppx_yojson_conv_lib.Option.None
-       and retryOnContentModified_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "cancel" ->
-              (match Ppx_yojson_conv_lib.( ! ) cancel_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = bool_of_yojson _field_yojson in
-                 cancel_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "retryOnContentModified" ->
-              (match Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
-                 retryOnContentModified_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) cancel_field
-                , Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some cancel_value
-                , Ppx_yojson_conv_lib.Option.Some retryOnContentModified_value ) ->
-                { cancel = cancel_value
-                ; retryOnContentModified = retryOnContentModified_value
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) cancel_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "cancel" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) retryOnContentModified_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "retryOnContentModified" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> staleRequestSupport)
-  ;;
-
-  let _ = staleRequestSupport_of_yojson
-
-  let yojson_of_staleRequestSupport =
-    (function
-     | { cancel = v_cancel; retryOnContentModified = v_retryOnContentModified } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_list yojson_of_string v_retryOnContentModified in
-         ("retryOnContentModified", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_bool v_cancel in
-         ("cancel", arg) :: bnds
-       in
-       `Assoc bnds
-     : staleRequestSupport -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_staleRequestSupport
-
-  [@@@end]
-
-  let create_staleRequestSupport ~(cancel : bool) ~(retryOnContentModified : string list)
-    : staleRequestSupport
-    =
-    { cancel; retryOnContentModified }
-  ;;
-
   type t =
     { markdown : MarkdownClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -16034,7 +18392,7 @@ module GeneralClientCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; regularExpressions : RegularExpressionsClientCapabilities.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; staleRequestSupport : staleRequestSupport Json.Nullable_option.t
+    ; staleRequestSupport : StaleRequestSupportOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -16092,7 +18450,7 @@ module GeneralClientCapabilities = struct
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     staleRequestSupport_of_yojson
+                     StaleRequestSupportOptions.t_of_yojson
                      _field_yojson
                  in
                  staleRequestSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -16164,7 +18522,7 @@ module GeneralClientCapabilities = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_staleRequestSupport)
+             (Json.Nullable_option.yojson_of_t StaleRequestSupportOptions.yojson_of_t)
                v_staleRequestSupport
            in
            let bnd = "staleRequestSupport", arg in
@@ -16217,7 +18575,7 @@ module GeneralClientCapabilities = struct
         ?(markdown : MarkdownClientCapabilities.t option)
         ?(positionEncodings : PositionEncodingKind.t list option)
         ?(regularExpressions : RegularExpressionsClientCapabilities.t option)
-        ?(staleRequestSupport : staleRequestSupport option)
+        ?(staleRequestSupport : StaleRequestSupportOptions.t option)
         (() : unit)
     : t
     =
@@ -16476,6 +18834,195 @@ module ClientCapabilities = struct
     =
     { experimental; general; notebookDocument; textDocument; window; workspace }
   ;;
+end
+
+module ClientInfo = struct
+  type t =
+    { name : string
+    ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ClientInfo.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let name_field = ref Ppx_yojson_conv_lib.Option.None
+       and version_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "name" ->
+              (match Ppx_yojson_conv_lib.( ! ) name_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "version" ->
+              (match Ppx_yojson_conv_lib.( ! ) version_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) name_field
+                , Ppx_yojson_conv_lib.( ! ) version_field )
+              with
+              | Ppx_yojson_conv_lib.Option.Some name_value, version_value ->
+                { name = name_value
+                ; version =
+                    (match version_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) name_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "name" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { name = v_name; version = v_version } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_version
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_version in
+           let bnd = "version", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_string v_name in
+         ("name", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(name : string) ?(version : string option) (() : unit) : t =
+    { name; version }
+  ;;
+end
+
+module CodeActionDisabled = struct
+  type t = { reason : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CodeActionDisabled.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let reason_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "reason" ->
+              (match Ppx_yojson_conv_lib.( ! ) reason_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 reason_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) reason_field with
+              | Ppx_yojson_conv_lib.Option.Some reason_value -> { reason = reason_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) reason_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "reason" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { reason = v_reason } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_reason in
+         ("reason", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(reason : string) : t = { reason }
 end
 
 module Location = struct
@@ -17224,6 +19771,7 @@ module Command = struct
           [@default None] [@yojson_drop_default ( = )]
     ; command : string
     ; title : string
+    ; tooltip : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -17236,6 +19784,7 @@ module Command = struct
        let arguments_field = ref Ppx_yojson_conv_lib.Option.None
        and command_field = ref Ppx_yojson_conv_lib.Option.None
        and title_field = ref Ppx_yojson_conv_lib.Option.None
+       and tooltip_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -17266,6 +19815,15 @@ module Command = struct
                  title_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tooltip" ->
+              (match Ppx_yojson_conv_lib.( ! ) tooltip_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 tooltip_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
            iter tail
          | [] -> ()
@@ -17288,17 +19846,23 @@ module Command = struct
              (match
                 ( Ppx_yojson_conv_lib.( ! ) arguments_field
                 , Ppx_yojson_conv_lib.( ! ) command_field
-                , Ppx_yojson_conv_lib.( ! ) title_field )
+                , Ppx_yojson_conv_lib.( ! ) title_field
+                , Ppx_yojson_conv_lib.( ! ) tooltip_field )
               with
               | ( arguments_value
                 , Ppx_yojson_conv_lib.Option.Some command_value
-                , Ppx_yojson_conv_lib.Option.Some title_value ) ->
+                , Ppx_yojson_conv_lib.Option.Some title_value
+                , tooltip_value ) ->
                 { arguments =
                     (match arguments_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; command = command_value
                 ; title = title_value
+                ; tooltip =
+                    (match tooltip_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
                 }
               | _ ->
                 Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
@@ -17322,8 +19886,20 @@ module Command = struct
 
   let yojson_of_t =
     (function
-     | { arguments = v_arguments; command = v_command; title = v_title } ->
+     | { arguments = v_arguments
+       ; command = v_command
+       ; title = v_title
+       ; tooltip = v_tooltip
+       } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_tooltip
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_tooltip in
+           let bnd = "tooltip", arg in
+           bnd :: bnds)
+       in
        let bnds =
          let arg = yojson_of_string v_title in
          ("title", arg) :: bnds
@@ -17355,104 +19931,30 @@ module Command = struct
         ?(arguments : Json.t list option)
         ~(command : string)
         ~(title : string)
+        ?(tooltip : string option)
         (() : unit)
     : t
     =
-    { arguments; command; title }
+    { arguments; command; title; tooltip }
   ;;
 end
 
 module CodeAction = struct
-  type disabled = { reason : string }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : disabled) -> ()
-
-  let disabled_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CodeAction.disabled" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let reason_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "reason" ->
-              (match Ppx_yojson_conv_lib.( ! ) reason_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 reason_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match Ppx_yojson_conv_lib.( ! ) reason_field with
-              | Ppx_yojson_conv_lib.Option.Some reason_value -> { reason = reason_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) reason_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "reason" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> disabled)
-  ;;
-
-  let _ = disabled_of_yojson
-
-  let yojson_of_disabled =
-    (function
-     | { reason = v_reason } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_string v_reason in
-         ("reason", arg) :: bnds
-       in
-       `Assoc bnds
-     : disabled -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_disabled
-
-  [@@@end]
-
-  let create_disabled ~(reason : string) : disabled = { reason }
-
   type t =
     { command : Command.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; data : Json.t option [@yojson.option]
     ; diagnostics : Diagnostic.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; disabled : disabled Json.Nullable_option.t
+    ; disabled : CodeActionDisabled.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; edit : WorkspaceEdit.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; isPreferred : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; kind : CodeActionKind.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; tags : CodeActionTag.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; title : string
     }
@@ -17471,6 +19973,7 @@ module CodeAction = struct
        and edit_field = ref Ppx_yojson_conv_lib.Option.None
        and isPreferred_field = ref Ppx_yojson_conv_lib.Option.None
        and kind_field = ref Ppx_yojson_conv_lib.Option.None
+       and tags_field = ref Ppx_yojson_conv_lib.Option.None
        and title_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
@@ -17508,7 +20011,9 @@ module CodeAction = struct
               (match Ppx_yojson_conv_lib.( ! ) disabled_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson disabled_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     CodeActionDisabled.t_of_yojson
+                     _field_yojson
                  in
                  disabled_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -17542,6 +20047,17 @@ module CodeAction = struct
                      _field_yojson
                  in
                  kind_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tags" ->
+              (match Ppx_yojson_conv_lib.( ! ) tags_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson CodeActionTag.t_of_yojson)
+                     _field_yojson
+                 in
+                 tags_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "title" ->
@@ -17578,6 +20094,7 @@ module CodeAction = struct
                 , Ppx_yojson_conv_lib.( ! ) edit_field
                 , Ppx_yojson_conv_lib.( ! ) isPreferred_field
                 , Ppx_yojson_conv_lib.( ! ) kind_field
+                , Ppx_yojson_conv_lib.( ! ) tags_field
                 , Ppx_yojson_conv_lib.( ! ) title_field )
               with
               | ( command_value
@@ -17587,6 +20104,7 @@ module CodeAction = struct
                 , edit_value
                 , isPreferred_value
                 , kind_value
+                , tags_value
                 , Ppx_yojson_conv_lib.Option.Some title_value ) ->
                 { command =
                     (match command_value with
@@ -17611,6 +20129,10 @@ module CodeAction = struct
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; kind =
                     (match kind_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; tags =
+                    (match tags_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; title = title_value
@@ -17640,12 +20162,24 @@ module CodeAction = struct
        ; edit = v_edit
        ; isPreferred = v_isPreferred
        ; kind = v_kind
+       ; tags = v_tags
        ; title = v_title
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
          let arg = yojson_of_string v_title in
          ("title", arg) :: bnds
+       in
+       let bnds =
+         if None = v_tags
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t (yojson_of_list CodeActionTag.yojson_of_t))
+               v_tags
+           in
+           let bnd = "tags", arg in
+           bnd :: bnds)
        in
        let bnds =
          if None = v_kind
@@ -17679,7 +20213,9 @@ module CodeAction = struct
          if None = v_disabled
          then bnds
          else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_disabled) v_disabled in
+           let arg =
+             (Json.Nullable_option.yojson_of_t CodeActionDisabled.yojson_of_t) v_disabled
+           in
            let bnd = "disabled", arg in
            bnd :: bnds)
        in
@@ -17722,15 +20258,16 @@ module CodeAction = struct
         ?(command : Command.t option)
         ?(data : Json.t option)
         ?(diagnostics : Diagnostic.t list option)
-        ?(disabled : disabled option)
+        ?(disabled : CodeActionDisabled.t option)
         ?(edit : WorkspaceEdit.t option)
         ?(isPreferred : bool option)
         ?(kind : CodeActionKind.t option)
+        ?(tags : CodeActionTag.t list option)
         ~(title : string)
         (() : unit)
     : t
     =
-    { command; data; diagnostics; disabled; edit; isPreferred; kind; title }
+    { command; data; diagnostics; disabled; edit; isPreferred; kind; tags; title }
   ;;
 end
 
@@ -17890,9 +20427,114 @@ module CodeActionContext = struct
   ;;
 end
 
+module CodeActionKindDocumentation = struct
+  type t =
+    { command : Command.t
+    ; kind : CodeActionKind.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CodeActionKindDocumentation.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let command_field = ref Ppx_yojson_conv_lib.Option.None
+       and kind_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "command" ->
+              (match Ppx_yojson_conv_lib.( ! ) command_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Command.t_of_yojson _field_yojson in
+                 command_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "kind" ->
+              (match Ppx_yojson_conv_lib.( ! ) kind_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = CodeActionKind.t_of_yojson _field_yojson in
+                 kind_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) command_field
+                , Ppx_yojson_conv_lib.( ! ) kind_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some command_value
+                , Ppx_yojson_conv_lib.Option.Some kind_value ) ->
+                { command = command_value; kind = kind_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) command_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "command" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) kind_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "kind" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { command = v_command; kind = v_kind } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = CodeActionKind.yojson_of_t v_kind in
+         ("kind", arg) :: bnds
+       in
+       let bnds =
+         let arg = Command.yojson_of_t v_command in
+         ("command", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(command : Command.t) ~(kind : CodeActionKind.t) : t = { command; kind }
+end
+
 module CodeActionOptions = struct
   type t =
     { codeActionKinds : CodeActionKind.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; documentation : CodeActionKindDocumentation.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; resolveProvider : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -17908,6 +20550,7 @@ module CodeActionOptions = struct
      function
      | `Assoc field_yojsons as yojson ->
        let codeActionKinds_field = ref Ppx_yojson_conv_lib.Option.None
+       and documentation_field = ref Ppx_yojson_conv_lib.Option.None
        and resolveProvider_field = ref Ppx_yojson_conv_lib.Option.None
        and workDoneProgress_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
@@ -17924,6 +20567,17 @@ module CodeActionOptions = struct
                      _field_yojson
                  in
                  codeActionKinds_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "documentation" ->
+              (match Ppx_yojson_conv_lib.( ! ) documentation_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson CodeActionKindDocumentation.t_of_yojson)
+                     _field_yojson
+                 in
+                 documentation_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "resolveProvider" ->
@@ -17963,13 +20617,22 @@ module CodeActionOptions = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let codeActionKinds_value, resolveProvider_value, workDoneProgress_value =
+             let ( codeActionKinds_value
+                 , documentation_value
+                 , resolveProvider_value
+                 , workDoneProgress_value )
+               =
                ( Ppx_yojson_conv_lib.( ! ) codeActionKinds_field
+               , Ppx_yojson_conv_lib.( ! ) documentation_field
                , Ppx_yojson_conv_lib.( ! ) resolveProvider_field
                , Ppx_yojson_conv_lib.( ! ) workDoneProgress_field )
              in
              { codeActionKinds =
                  (match codeActionKinds_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; documentation =
+                 (match documentation_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; resolveProvider =
@@ -17991,6 +20654,7 @@ module CodeActionOptions = struct
   let yojson_of_t =
     (function
      | { codeActionKinds = v_codeActionKinds
+       ; documentation = v_documentation
        ; resolveProvider = v_resolveProvider
        ; workDoneProgress = v_workDoneProgress
        } ->
@@ -18016,6 +20680,18 @@ module CodeActionOptions = struct
            bnd :: bnds)
        in
        let bnds =
+         if None = v_documentation
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                (yojson_of_list CodeActionKindDocumentation.yojson_of_t))
+               v_documentation
+           in
+           let bnd = "documentation", arg in
+           bnd :: bnds)
+       in
+       let bnds =
          if None = v_codeActionKinds
          then bnds
          else (
@@ -18037,12 +20713,13 @@ module CodeActionOptions = struct
 
   let create
         ?(codeActionKinds : CodeActionKind.t list option)
+        ?(documentation : CodeActionKindDocumentation.t list option)
         ?(resolveProvider : bool option)
         ?(workDoneProgress : bool option)
         (() : unit)
     : t
     =
-    { codeActionKinds; resolveProvider; workDoneProgress }
+    { codeActionKinds; documentation; resolveProvider; workDoneProgress }
   ;;
 end
 
@@ -18252,6 +20929,8 @@ module CodeActionRegistrationOptions = struct
     { codeActionKinds : CodeActionKind.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; documentSelector : DocumentSelector.t Json.Nullable_option.t
+    ; documentation : CodeActionKindDocumentation.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     ; resolveProvider : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; workDoneProgress : bool Json.Nullable_option.t
@@ -18267,6 +20946,7 @@ module CodeActionRegistrationOptions = struct
      | `Assoc field_yojsons as yojson ->
        let codeActionKinds_field = ref Ppx_yojson_conv_lib.Option.None
        and documentSelector_field = ref Ppx_yojson_conv_lib.Option.None
+       and documentation_field = ref Ppx_yojson_conv_lib.Option.None
        and resolveProvider_field = ref Ppx_yojson_conv_lib.Option.None
        and workDoneProgress_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
@@ -18294,6 +20974,17 @@ module CodeActionRegistrationOptions = struct
                      _field_yojson
                  in
                  documentSelector_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "documentation" ->
+              (match Ppx_yojson_conv_lib.( ! ) documentation_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson CodeActionKindDocumentation.t_of_yojson)
+                     _field_yojson
+                 in
+                 documentation_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "resolveProvider" ->
@@ -18336,11 +21027,13 @@ module CodeActionRegistrationOptions = struct
              (match
                 ( Ppx_yojson_conv_lib.( ! ) codeActionKinds_field
                 , Ppx_yojson_conv_lib.( ! ) documentSelector_field
+                , Ppx_yojson_conv_lib.( ! ) documentation_field
                 , Ppx_yojson_conv_lib.( ! ) resolveProvider_field
                 , Ppx_yojson_conv_lib.( ! ) workDoneProgress_field )
               with
               | ( codeActionKinds_value
                 , Ppx_yojson_conv_lib.Option.Some documentSelector_value
+                , documentation_value
                 , resolveProvider_value
                 , workDoneProgress_value ) ->
                 { codeActionKinds =
@@ -18348,6 +21041,10 @@ module CodeActionRegistrationOptions = struct
                      | Ppx_yojson_conv_lib.Option.None -> None
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; documentSelector = documentSelector_value
+                ; documentation =
+                    (match documentation_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; resolveProvider =
                     (match resolveProvider_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
@@ -18377,6 +21074,7 @@ module CodeActionRegistrationOptions = struct
     (function
      | { codeActionKinds = v_codeActionKinds
        ; documentSelector = v_documentSelector
+       ; documentation = v_documentation
        ; resolveProvider = v_resolveProvider
        ; workDoneProgress = v_workDoneProgress
        } ->
@@ -18399,6 +21097,18 @@ module CodeActionRegistrationOptions = struct
              (Json.Nullable_option.yojson_of_t yojson_of_bool) v_resolveProvider
            in
            let bnd = "resolveProvider", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_documentation
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                (yojson_of_list CodeActionKindDocumentation.yojson_of_t))
+               v_documentation
+           in
+           let bnd = "documentation", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -18432,12 +21142,18 @@ module CodeActionRegistrationOptions = struct
   let create
         ?(codeActionKinds : CodeActionKind.t list option)
         ?(documentSelector : DocumentSelector.t option)
+        ?(documentation : CodeActionKindDocumentation.t list option)
         ?(resolveProvider : bool option)
         ?(workDoneProgress : bool option)
         (() : unit)
     : t
     =
-    { codeActionKinds; documentSelector; resolveProvider; workDoneProgress }
+    { codeActionKinds
+    ; documentSelector
+    ; documentation
+    ; resolveProvider
+    ; workDoneProgress
+    }
   ;;
 end
 
@@ -20668,17 +23384,136 @@ module CompletionItem = struct
   ;;
 end
 
-module CompletionList = struct
-  type editRange =
+module CompletionItemApplyKinds = struct
+  type t =
+    { commitCharacters : ApplyKind.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; data : ApplyKind.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CompletionItemApplyKinds.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let commitCharacters_field = ref Ppx_yojson_conv_lib.Option.None
+       and data_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "commitCharacters" ->
+              (match Ppx_yojson_conv_lib.( ! ) commitCharacters_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson ApplyKind.t_of_yojson _field_yojson
+                 in
+                 commitCharacters_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "data" ->
+              (match Ppx_yojson_conv_lib.( ! ) data_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson ApplyKind.t_of_yojson _field_yojson
+                 in
+                 data_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let commitCharacters_value, data_value =
+               ( Ppx_yojson_conv_lib.( ! ) commitCharacters_field
+               , Ppx_yojson_conv_lib.( ! ) data_field )
+             in
+             { commitCharacters =
+                 (match commitCharacters_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; data =
+                 (match data_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { commitCharacters = v_commitCharacters; data = v_data } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_data
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t ApplyKind.yojson_of_t) v_data in
+           let bnd = "data", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_commitCharacters
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t ApplyKind.yojson_of_t) v_commitCharacters
+           in
+           let bnd = "commitCharacters", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(commitCharacters : ApplyKind.t option)
+        ?(data : ApplyKind.t option)
+        (() : unit)
+    : t
+    =
+    { commitCharacters; data }
+  ;;
+end
+
+module EditRangeWithInsertReplace = struct
+  type t =
     { insert : Range.t
     ; replace : Range.t
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : editRange) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let editRange_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionList.editRange" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.EditRangeWithInsertReplace.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let insert_field = ref Ppx_yojson_conv_lib.Option.None
@@ -20743,12 +23578,12 @@ module CompletionList = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> editRange)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = editRange_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_editRange =
+  let yojson_of_t =
     (function
      | { insert = v_insert; replace = v_replace } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -20761,27 +23596,28 @@ module CompletionList = struct
          ("insert", arg) :: bnds
        in
        `Assoc bnds
-     : editRange -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_editRange
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_editRange ~(insert : Range.t) ~(replace : Range.t) : editRange =
-    { insert; replace }
-  ;;
+  let create ~(insert : Range.t) ~(replace : Range.t) : t = { insert; replace }
+end
 
+module CompletionItemDefaults = struct
   type editRange_pvar =
     [ `Range of Range.t
-    | `EditRange of editRange
+    | `EditRangeWithInsertReplace of EditRangeWithInsertReplace.t
     ]
 
   let editRange_pvar_of_yojson (json : Json.t) : editRange_pvar =
     Json.Of.untagged_union
       "editRange_pvar"
       [ (fun json -> `Range (Range.t_of_yojson json))
-      ; (fun json -> `EditRange (editRange_of_yojson json))
+      ; (fun json ->
+          `EditRangeWithInsertReplace (EditRangeWithInsertReplace.t_of_yojson json))
       ]
       json
   ;;
@@ -20789,33 +23625,33 @@ module CompletionList = struct
   let yojson_of_editRange_pvar (editRange_pvar : editRange_pvar) : Json.t =
     match editRange_pvar with
     | `Range s -> Range.yojson_of_t s
-    | `EditRange s -> yojson_of_editRange s
+    | `EditRangeWithInsertReplace s -> EditRangeWithInsertReplace.yojson_of_t s
   ;;
 
-  type itemDefaults =
+  type t =
     { commitCharacters : string list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
+    ; data : Json.t option [@yojson.option]
     ; editRange : editRange_pvar Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; insertTextFormat : InsertTextFormat.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; insertTextMode : InsertTextMode.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; data : Json.t option [@yojson.option]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : itemDefaults) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let itemDefaults_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionList.itemDefaults" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.CompletionItemDefaults.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let commitCharacters_field = ref Ppx_yojson_conv_lib.Option.None
+       and data_field = ref Ppx_yojson_conv_lib.Option.None
        and editRange_field = ref Ppx_yojson_conv_lib.Option.None
        and insertTextFormat_field = ref Ppx_yojson_conv_lib.Option.None
        and insertTextMode_field = ref Ppx_yojson_conv_lib.Option.None
-       and data_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -20830,6 +23666,13 @@ module CompletionList = struct
                      _field_yojson
                  in
                  commitCharacters_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "data" ->
+              (match Ppx_yojson_conv_lib.( ! ) data_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Json.t_of_yojson _field_yojson in
+                 data_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "editRange" ->
@@ -20863,13 +23706,6 @@ module CompletionList = struct
                  insertTextMode_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "data" ->
-              (match Ppx_yojson_conv_lib.( ! ) data_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = Json.t_of_yojson _field_yojson in
-                 data_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
            iter tail
          | [] -> ()
@@ -20890,21 +23726,22 @@ module CompletionList = struct
                yojson
            | [] ->
              let ( commitCharacters_value
+                 , data_value
                  , editRange_value
                  , insertTextFormat_value
-                 , insertTextMode_value
-                 , data_value )
+                 , insertTextMode_value )
                =
                ( Ppx_yojson_conv_lib.( ! ) commitCharacters_field
+               , Ppx_yojson_conv_lib.( ! ) data_field
                , Ppx_yojson_conv_lib.( ! ) editRange_field
                , Ppx_yojson_conv_lib.( ! ) insertTextFormat_field
-               , Ppx_yojson_conv_lib.( ! ) insertTextMode_field
-               , Ppx_yojson_conv_lib.( ! ) data_field )
+               , Ppx_yojson_conv_lib.( ! ) insertTextMode_field )
              in
              { commitCharacters =
                  (match commitCharacters_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; data = data_value
              ; editRange =
                  (match editRange_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
@@ -20917,32 +23754,23 @@ module CompletionList = struct
                  (match insertTextMode_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; data = data_value
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> itemDefaults)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = itemDefaults_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_itemDefaults =
+  let yojson_of_t =
     (function
      | { commitCharacters = v_commitCharacters
+       ; data = v_data
        ; editRange = v_editRange
        ; insertTextFormat = v_insertTextFormat
        ; insertTextMode = v_insertTextMode
-       ; data = v_data
        } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         match v_data with
-         | Ppx_yojson_conv_lib.Option.None -> bnds
-         | Ppx_yojson_conv_lib.Option.Some v ->
-           let arg = Json.yojson_of_t v in
-           let bnd = "data", arg in
-           bnd :: bnds
-       in
        let bnds =
          if None = v_insertTextMode
          then bnds
@@ -20976,6 +23804,14 @@ module CompletionList = struct
            bnd :: bnds)
        in
        let bnds =
+         match v_data with
+         | Ppx_yojson_conv_lib.Option.None -> bnds
+         | Ppx_yojson_conv_lib.Option.Some v ->
+           let arg = Json.yojson_of_t v in
+           let bnd = "data", arg in
+           bnd :: bnds
+       in
+       let bnds =
          if None = v_commitCharacters
          then bnds
          else (
@@ -20987,28 +23823,32 @@ module CompletionList = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : itemDefaults -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_itemDefaults
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_itemDefaults
+  let create
         ?(commitCharacters : string list option)
+        ?(data : Json.t option)
         ?(editRange : editRange_pvar option)
         ?(insertTextFormat : InsertTextFormat.t option)
         ?(insertTextMode : InsertTextMode.t option)
-        ?(data : Json.t option)
         (() : unit)
-    : itemDefaults
+    : t
     =
-    { commitCharacters; editRange; insertTextFormat; insertTextMode; data }
+    { commitCharacters; data; editRange; insertTextFormat; insertTextMode }
   ;;
+end
 
+module CompletionList = struct
   type t =
-    { isIncomplete : bool
-    ; itemDefaults : itemDefaults Json.Nullable_option.t
+    { applyKind : CompletionItemApplyKinds.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; isIncomplete : bool
+    ; itemDefaults : CompletionItemDefaults.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; items : CompletionItem.t list
     }
@@ -21020,7 +23860,8 @@ module CompletionList = struct
     (let _tp_loc = "lsp/src/types.ml.CompletionList.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let isIncomplete_field = ref Ppx_yojson_conv_lib.Option.None
+       let applyKind_field = ref Ppx_yojson_conv_lib.Option.None
+       and isIncomplete_field = ref Ppx_yojson_conv_lib.Option.None
        and itemDefaults_field = ref Ppx_yojson_conv_lib.Option.None
        and items_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
@@ -21028,6 +23869,17 @@ module CompletionList = struct
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
+            | "applyKind" ->
+              (match Ppx_yojson_conv_lib.( ! ) applyKind_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     CompletionItemApplyKinds.t_of_yojson
+                     _field_yojson
+                 in
+                 applyKind_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "isIncomplete" ->
               (match Ppx_yojson_conv_lib.( ! ) isIncomplete_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -21039,7 +23891,9 @@ module CompletionList = struct
               (match Ppx_yojson_conv_lib.( ! ) itemDefaults_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson itemDefaults_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     CompletionItemDefaults.t_of_yojson
+                     _field_yojson
                  in
                  itemDefaults_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -21071,14 +23925,20 @@ module CompletionList = struct
                yojson
            | [] ->
              (match
-                ( Ppx_yojson_conv_lib.( ! ) isIncomplete_field
+                ( Ppx_yojson_conv_lib.( ! ) applyKind_field
+                , Ppx_yojson_conv_lib.( ! ) isIncomplete_field
                 , Ppx_yojson_conv_lib.( ! ) itemDefaults_field
                 , Ppx_yojson_conv_lib.( ! ) items_field )
               with
-              | ( Ppx_yojson_conv_lib.Option.Some isIncomplete_value
+              | ( applyKind_value
+                , Ppx_yojson_conv_lib.Option.Some isIncomplete_value
                 , itemDefaults_value
                 , Ppx_yojson_conv_lib.Option.Some items_value ) ->
-                { isIncomplete = isIncomplete_value
+                { applyKind =
+                    (match applyKind_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; isIncomplete = isIncomplete_value
                 ; itemDefaults =
                     (match itemDefaults_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
@@ -21107,8 +23967,11 @@ module CompletionList = struct
 
   let yojson_of_t =
     (function
-     | { isIncomplete = v_isIncomplete; itemDefaults = v_itemDefaults; items = v_items }
-       ->
+     | { applyKind = v_applyKind
+       ; isIncomplete = v_isIncomplete
+       ; itemDefaults = v_itemDefaults
+       ; items = v_items
+       } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
          let arg = yojson_of_list CompletionItem.yojson_of_t v_items in
@@ -21119,7 +23982,8 @@ module CompletionList = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_itemDefaults) v_itemDefaults
+             (Json.Nullable_option.yojson_of_t CompletionItemDefaults.yojson_of_t)
+               v_itemDefaults
            in
            let bnd = "itemDefaults", arg in
            bnd :: bnds)
@@ -21127,6 +23991,17 @@ module CompletionList = struct
        let bnds =
          let arg = yojson_of_bool v_isIncomplete in
          ("isIncomplete", arg) :: bnds
+       in
+       let bnds =
+         if None = v_applyKind
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t CompletionItemApplyKinds.yojson_of_t)
+               v_applyKind
+           in
+           let bnd = "applyKind", arg in
+           bnd :: bnds)
        in
        `Assoc bnds
      : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
@@ -21137,27 +24012,28 @@ module CompletionList = struct
   [@@@end]
 
   let create
+        ?(applyKind : CompletionItemApplyKinds.t option)
         ~(isIncomplete : bool)
-        ?(itemDefaults : itemDefaults option)
+        ?(itemDefaults : CompletionItemDefaults.t option)
         ~(items : CompletionItem.t list)
         (() : unit)
     : t
     =
-    { isIncomplete; itemDefaults; items }
+    { applyKind; isIncomplete; itemDefaults; items }
   ;;
 end
 
-module CompletionOptions = struct
-  type completionItem =
+module ServerCompletionItemOptions = struct
+  type t =
     { labelDetailsSupport : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : completionItem) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let completionItem_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionOptions.completionItem" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ServerCompletionItemOptions.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let labelDetailsSupport_field = ref Ppx_yojson_conv_lib.Option.None
@@ -21204,12 +24080,12 @@ module CompletionOptions = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> completionItem)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = completionItem_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_completionItem =
+  let yojson_of_t =
     (function
      | { labelDetailsSupport = v_labelDetailsSupport } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -21224,23 +24100,23 @@ module CompletionOptions = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : completionItem -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_completionItem
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_completionItem ?(labelDetailsSupport : bool option) (() : unit)
-    : completionItem
-    =
+  let create ?(labelDetailsSupport : bool option) (() : unit) : t =
     { labelDetailsSupport }
   ;;
+end
 
+module CompletionOptions = struct
   type t =
     { allCommitCharacters : string list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; completionItem : completionItem Json.Nullable_option.t
+    ; completionItem : ServerCompletionItemOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; resolveProvider : bool Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -21282,7 +24158,9 @@ module CompletionOptions = struct
               (match Ppx_yojson_conv_lib.( ! ) completionItem_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson completionItem_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ServerCompletionItemOptions.t_of_yojson
+                     _field_yojson
                  in
                  completionItem_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -21420,7 +24298,8 @@ module CompletionOptions = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_completionItem) v_completionItem
+             (Json.Nullable_option.yojson_of_t ServerCompletionItemOptions.yojson_of_t)
+               v_completionItem
            in
            let bnd = "completionItem", arg in
            bnd :: bnds)
@@ -21446,7 +24325,7 @@ module CompletionOptions = struct
 
   let create
         ?(allCommitCharacters : string list option)
-        ?(completionItem : completionItem option)
+        ?(completionItem : ServerCompletionItemOptions.t option)
         ?(resolveProvider : bool option)
         ?(triggerCharacters : string list option)
         ?(workDoneProgress : bool option)
@@ -21674,99 +24553,10 @@ module CompletionParams = struct
 end
 
 module CompletionRegistrationOptions = struct
-  type completionItem =
-    { labelDetailsSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : completionItem) -> ()
-
-  let completionItem_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.CompletionRegistrationOptions.completionItem" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let labelDetailsSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "labelDetailsSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 labelDetailsSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let labelDetailsSupport_value =
-               Ppx_yojson_conv_lib.( ! ) labelDetailsSupport_field
-             in
-             { labelDetailsSupport =
-                 (match labelDetailsSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> completionItem)
-  ;;
-
-  let _ = completionItem_of_yojson
-
-  let yojson_of_completionItem =
-    (function
-     | { labelDetailsSupport = v_labelDetailsSupport } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_labelDetailsSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_labelDetailsSupport
-           in
-           let bnd = "labelDetailsSupport", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : completionItem -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_completionItem
-
-  [@@@end]
-
-  let create_completionItem ?(labelDetailsSupport : bool option) (() : unit)
-    : completionItem
-    =
-    { labelDetailsSupport }
-  ;;
-
   type t =
     { allCommitCharacters : string list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; completionItem : completionItem Json.Nullable_option.t
+    ; completionItem : ServerCompletionItemOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; documentSelector : DocumentSelector.t Json.Nullable_option.t
     ; resolveProvider : bool Json.Nullable_option.t
@@ -21810,7 +24600,9 @@ module CompletionRegistrationOptions = struct
               (match Ppx_yojson_conv_lib.( ! ) completionItem_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson completionItem_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     ServerCompletionItemOptions.t_of_yojson
+                     _field_yojson
                  in
                  completionItem_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -21980,7 +24772,8 @@ module CompletionRegistrationOptions = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_completionItem) v_completionItem
+             (Json.Nullable_option.yojson_of_t ServerCompletionItemOptions.yojson_of_t)
+               v_completionItem
            in
            let bnd = "completionItem", arg in
            bnd :: bnds)
@@ -22006,7 +24799,7 @@ module CompletionRegistrationOptions = struct
 
   let create
         ?(allCommitCharacters : string list option)
-        ?(completionItem : completionItem option)
+        ?(completionItem : ServerCompletionItemOptions.t option)
         ?(documentSelector : DocumentSelector.t option)
         ?(resolveProvider : bool option)
         ?(triggerCharacters : string list option)
@@ -22220,7 +25013,8 @@ module ConfigurationParams = struct
 end
 
 module FileCreate = struct
-  type t = { uri : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+  type t = { uri : DocumentUri.t }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
 
@@ -22237,7 +25031,7 @@ module FileCreate = struct
             | "uri" ->
               (match Ppx_yojson_conv_lib.( ! ) uri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
                  uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -22283,7 +25077,7 @@ module FileCreate = struct
      | { uri = v_uri } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = yojson_of_string v_uri in
+         let arg = DocumentUri.yojson_of_t v_uri in
          ("uri", arg) :: bnds
        in
        `Assoc bnds
@@ -22294,7 +25088,7 @@ module FileCreate = struct
 
   [@@@end]
 
-  let create ~(uri : string) : t = { uri }
+  let create ~(uri : DocumentUri.t) : t = { uri }
 end
 
 module CreateFilesParams = struct
@@ -23428,7 +26222,8 @@ module DefinitionRegistrationOptions = struct
 end
 
 module FileDelete = struct
-  type t = { uri : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+  type t = { uri : DocumentUri.t }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
 
@@ -23445,7 +26240,7 @@ module FileDelete = struct
             | "uri" ->
               (match Ppx_yojson_conv_lib.( ! ) uri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
                  uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -23491,7 +26286,7 @@ module FileDelete = struct
      | { uri = v_uri } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = yojson_of_string v_uri in
+         let arg = DocumentUri.yojson_of_t v_uri in
          ("uri", arg) :: bnds
        in
        `Assoc bnds
@@ -23502,7 +26297,7 @@ module FileDelete = struct
 
   [@@@end]
 
-  let create ~(uri : string) : t = { uri }
+  let create ~(uri : DocumentUri.t) : t = { uri }
 end
 
 module DeleteFilesParams = struct
@@ -24071,6 +26866,192 @@ module DiagnosticServerCancellationData = struct
   let create ~(retriggerRequest : bool) : t = { retriggerRequest }
 end
 
+module DiagnosticsCapabilities = struct
+  type t =
+    { codeDescriptionSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; dataSupport : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; relatedInformation : bool Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; tagSupport : ClientDiagnosticsTagOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.DiagnosticsCapabilities.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let codeDescriptionSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and dataSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and relatedInformation_field = ref Ppx_yojson_conv_lib.Option.None
+       and tagSupport_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "codeDescriptionSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) codeDescriptionSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 codeDescriptionSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "dataSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) dataSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 dataSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "relatedInformation" ->
+              (match Ppx_yojson_conv_lib.( ! ) relatedInformation_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 relatedInformation_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "tagSupport" ->
+              (match Ppx_yojson_conv_lib.( ! ) tagSupport_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     ClientDiagnosticsTagOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 tagSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let ( codeDescriptionSupport_value
+                 , dataSupport_value
+                 , relatedInformation_value
+                 , tagSupport_value )
+               =
+               ( Ppx_yojson_conv_lib.( ! ) codeDescriptionSupport_field
+               , Ppx_yojson_conv_lib.( ! ) dataSupport_field
+               , Ppx_yojson_conv_lib.( ! ) relatedInformation_field
+               , Ppx_yojson_conv_lib.( ! ) tagSupport_field )
+             in
+             { codeDescriptionSupport =
+                 (match codeDescriptionSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; dataSupport =
+                 (match dataSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; relatedInformation =
+                 (match relatedInformation_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; tagSupport =
+                 (match tagSupport_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { codeDescriptionSupport = v_codeDescriptionSupport
+       ; dataSupport = v_dataSupport
+       ; relatedInformation = v_relatedInformation
+       ; tagSupport = v_tagSupport
+       } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_tagSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t ClientDiagnosticsTagOptions.yojson_of_t)
+               v_tagSupport
+           in
+           let bnd = "tagSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_relatedInformation
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_relatedInformation
+           in
+           let bnd = "relatedInformation", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_dataSupport
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_dataSupport in
+           let bnd = "dataSupport", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_codeDescriptionSupport
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_codeDescriptionSupport
+           in
+           let bnd = "codeDescriptionSupport", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(codeDescriptionSupport : bool option)
+        ?(dataSupport : bool option)
+        ?(relatedInformation : bool option)
+        ?(tagSupport : ClientDiagnosticsTagOptions.t option)
+        (() : unit)
+    : t
+    =
+    { codeDescriptionSupport; dataSupport; relatedInformation; tagSupport }
+  ;;
+end
+
 module DidChangeConfigurationParams = struct
   type t = { settings : Json.t } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -24359,149 +27340,6 @@ module VersionedNotebookDocumentIdentifier = struct
   let create ~(uri : DocumentUri.t) ~(version : int) : t = { uri; version }
 end
 
-module TextDocumentContentChangeEvent = struct
-  type t =
-    { range : Range.t Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
-    ; rangeLength : int Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; text : string
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentChangeEvent.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let range_field = ref Ppx_yojson_conv_lib.Option.None
-       and rangeLength_field = ref Ppx_yojson_conv_lib.Option.None
-       and text_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "range" ->
-              (match Ppx_yojson_conv_lib.( ! ) range_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson Range.t_of_yojson _field_yojson
-                 in
-                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "rangeLength" ->
-              (match Ppx_yojson_conv_lib.( ! ) rangeLength_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson int_of_yojson _field_yojson
-                 in
-                 rangeLength_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "text" ->
-              (match Ppx_yojson_conv_lib.( ! ) text_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) range_field
-                , Ppx_yojson_conv_lib.( ! ) rangeLength_field
-                , Ppx_yojson_conv_lib.( ! ) text_field )
-              with
-              | range_value, rangeLength_value, Ppx_yojson_conv_lib.Option.Some text_value
-                ->
-                { range =
-                    (match range_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
-                ; rangeLength =
-                    (match rangeLength_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
-                ; text = text_value
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) text_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "text" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { range = v_range; rangeLength = v_rangeLength; text = v_text } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_string v_text in
-         ("text", arg) :: bnds
-       in
-       let bnds =
-         if None = v_rangeLength
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_int) v_rangeLength in
-           let bnd = "rangeLength", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_range
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t Range.yojson_of_t) v_range in
-           let bnd = "range", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create
-        ?(range : Range.t option)
-        ?(rangeLength : int option)
-        ~(text : string)
-        (() : unit)
-    : t
-    =
-    { range; rangeLength; text }
-  ;;
-end
-
 module VersionedTextDocumentIdentifier = struct
   type t =
     { uri : DocumentUri.t
@@ -24603,6 +27441,511 @@ module VersionedTextDocumentIdentifier = struct
   [@@@end]
 
   let create ~(uri : DocumentUri.t) ~(version : int) : t = { uri; version }
+end
+
+module TextDocumentContentChangeWholeDocument = struct
+  type t = { text : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentChangeWholeDocument.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let text_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "text" ->
+              (match Ppx_yojson_conv_lib.( ! ) text_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) text_field with
+              | Ppx_yojson_conv_lib.Option.Some text_value -> { text = text_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) text_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "text" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { text = v_text } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_text in
+         ("text", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(text : string) : t = { text }
+end
+
+module TextDocumentContentChangePartial = struct
+  type t =
+    { range : Range.t
+    ; rangeLength : int Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; text : string
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentChangePartial.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let range_field = ref Ppx_yojson_conv_lib.Option.None
+       and rangeLength_field = ref Ppx_yojson_conv_lib.Option.None
+       and text_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "range" ->
+              (match Ppx_yojson_conv_lib.( ! ) range_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Range.t_of_yojson _field_yojson in
+                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "rangeLength" ->
+              (match Ppx_yojson_conv_lib.( ! ) rangeLength_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson int_of_yojson _field_yojson
+                 in
+                 rangeLength_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "text" ->
+              (match Ppx_yojson_conv_lib.( ! ) text_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) range_field
+                , Ppx_yojson_conv_lib.( ! ) rangeLength_field
+                , Ppx_yojson_conv_lib.( ! ) text_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some range_value
+                , rangeLength_value
+                , Ppx_yojson_conv_lib.Option.Some text_value ) ->
+                { range = range_value
+                ; rangeLength =
+                    (match rangeLength_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; text = text_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) range_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "range" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) text_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "text" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { range = v_range; rangeLength = v_rangeLength; text = v_text } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_text in
+         ("text", arg) :: bnds
+       in
+       let bnds =
+         if None = v_rangeLength
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_int) v_rangeLength in
+           let bnd = "rangeLength", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = Range.yojson_of_t v_range in
+         ("range", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(range : Range.t) ?(rangeLength : int option) ~(text : string) (() : unit)
+    : t
+    =
+    { range; rangeLength; text }
+  ;;
+end
+
+module TextDocumentContentChangeEvent = struct
+  type t =
+    [ `TextDocumentContentChangePartial of TextDocumentContentChangePartial.t
+    | `TextDocumentContentChangeWholeDocument of TextDocumentContentChangeWholeDocument.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `TextDocumentContentChangePartial
+            (TextDocumentContentChangePartial.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentContentChangeWholeDocument
+            (TextDocumentContentChangeWholeDocument.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `TextDocumentContentChangePartial s ->
+      TextDocumentContentChangePartial.yojson_of_t s
+    | `TextDocumentContentChangeWholeDocument s ->
+      TextDocumentContentChangeWholeDocument.yojson_of_t s
+  ;;
+end
+
+module NotebookDocumentCellContentChanges = struct
+  type t =
+    { changes : TextDocumentContentChangeEvent.t list
+    ; document : VersionedTextDocumentIdentifier.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentCellContentChanges.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let changes_field = ref Ppx_yojson_conv_lib.Option.None
+       and document_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "changes" ->
+              (match Ppx_yojson_conv_lib.( ! ) changes_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson TextDocumentContentChangeEvent.t_of_yojson _field_yojson
+                 in
+                 changes_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "document" ->
+              (match Ppx_yojson_conv_lib.( ! ) document_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = VersionedTextDocumentIdentifier.t_of_yojson _field_yojson in
+                 document_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) changes_field
+                , Ppx_yojson_conv_lib.( ! ) document_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some changes_value
+                , Ppx_yojson_conv_lib.Option.Some document_value ) ->
+                { changes = changes_value; document = document_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) changes_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "changes" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) document_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "document" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { changes = v_changes; document = v_document } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = VersionedTextDocumentIdentifier.yojson_of_t v_document in
+         ("document", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_list TextDocumentContentChangeEvent.yojson_of_t v_changes in
+         ("changes", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(changes : TextDocumentContentChangeEvent.t list)
+        ~(document : VersionedTextDocumentIdentifier.t)
+    : t
+    =
+    { changes; document }
+  ;;
+end
+
+module TextDocumentItem = struct
+  type t =
+    { languageId : LanguageKind.t
+    ; text : string
+    ; uri : DocumentUri.t
+    ; version : int
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentItem.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let languageId_field = ref Ppx_yojson_conv_lib.Option.None
+       and text_field = ref Ppx_yojson_conv_lib.Option.None
+       and uri_field = ref Ppx_yojson_conv_lib.Option.None
+       and version_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "languageId" ->
+              (match Ppx_yojson_conv_lib.( ! ) languageId_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = LanguageKind.t_of_yojson _field_yojson in
+                 languageId_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "text" ->
+              (match Ppx_yojson_conv_lib.( ! ) text_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "uri" ->
+              (match Ppx_yojson_conv_lib.( ! ) uri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
+                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "version" ->
+              (match Ppx_yojson_conv_lib.( ! ) version_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = int_of_yojson _field_yojson in
+                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) languageId_field
+                , Ppx_yojson_conv_lib.( ! ) text_field
+                , Ppx_yojson_conv_lib.( ! ) uri_field
+                , Ppx_yojson_conv_lib.( ! ) version_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some languageId_value
+                , Ppx_yojson_conv_lib.Option.Some text_value
+                , Ppx_yojson_conv_lib.Option.Some uri_value
+                , Ppx_yojson_conv_lib.Option.Some version_value ) ->
+                { languageId = languageId_value
+                ; text = text_value
+                ; uri = uri_value
+                ; version = version_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) languageId_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "languageId" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) text_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "text" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) uri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "uri" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) version_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "version" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { languageId = v_languageId; text = v_text; uri = v_uri; version = v_version } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_int v_version in
+         ("version", arg) :: bnds
+       in
+       let bnds =
+         let arg = DocumentUri.yojson_of_t v_uri in
+         ("uri", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_string v_text in
+         ("text", arg) :: bnds
+       in
+       let bnds =
+         let arg = LanguageKind.yojson_of_t v_languageId in
+         ("languageId", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(languageId : LanguageKind.t)
+        ~(text : string)
+        ~(uri : DocumentUri.t)
+        ~(version : int)
+    : t
+    =
+    { languageId; text; uri; version }
+  ;;
 end
 
 module ExecutionSummary = struct
@@ -24893,159 +28236,6 @@ module NotebookCell = struct
   ;;
 end
 
-module TextDocumentItem = struct
-  type t =
-    { languageId : string
-    ; text : string
-    ; uri : DocumentUri.t
-    ; version : int
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.TextDocumentItem.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let languageId_field = ref Ppx_yojson_conv_lib.Option.None
-       and text_field = ref Ppx_yojson_conv_lib.Option.None
-       and uri_field = ref Ppx_yojson_conv_lib.Option.None
-       and version_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "languageId" ->
-              (match Ppx_yojson_conv_lib.( ! ) languageId_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 languageId_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "text" ->
-              (match Ppx_yojson_conv_lib.( ! ) text_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "uri" ->
-              (match Ppx_yojson_conv_lib.( ! ) uri_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
-                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "version" ->
-              (match Ppx_yojson_conv_lib.( ! ) version_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = int_of_yojson _field_yojson in
-                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) languageId_field
-                , Ppx_yojson_conv_lib.( ! ) text_field
-                , Ppx_yojson_conv_lib.( ! ) uri_field
-                , Ppx_yojson_conv_lib.( ! ) version_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some languageId_value
-                , Ppx_yojson_conv_lib.Option.Some text_value
-                , Ppx_yojson_conv_lib.Option.Some uri_value
-                , Ppx_yojson_conv_lib.Option.Some version_value ) ->
-                { languageId = languageId_value
-                ; text = text_value
-                ; uri = uri_value
-                ; version = version_value
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) languageId_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "languageId" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) text_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "text" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) uri_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "uri" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) version_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "version" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { languageId = v_languageId; text = v_text; uri = v_uri; version = v_version } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_int v_version in
-         ("version", arg) :: bnds
-       in
-       let bnds =
-         let arg = DocumentUri.yojson_of_t v_uri in
-         ("uri", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_string v_text in
-         ("text", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_string v_languageId in
-         ("languageId", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create
-        ~(languageId : string)
-        ~(text : string)
-        ~(uri : DocumentUri.t)
-        ~(version : int)
-    : t
-    =
-    { languageId; text; uri; version }
-  ;;
-end
-
 module NotebookCellArrayChange = struct
   type t =
     { cells : NotebookCell.t list Json.Nullable_option.t
@@ -25190,134 +28380,25 @@ module NotebookCellArrayChange = struct
   ;;
 end
 
-module NotebookDocumentChangeEvent = struct
-  type textContent =
-    { document : VersionedTextDocumentIdentifier.t
-    ; changes : TextDocumentContentChangeEvent.t list
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : textContent) -> ()
-
-  let textContent_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentChangeEvent.textContent" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let document_field = ref Ppx_yojson_conv_lib.Option.None
-       and changes_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "document" ->
-              (match Ppx_yojson_conv_lib.( ! ) document_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = VersionedTextDocumentIdentifier.t_of_yojson _field_yojson in
-                 document_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "changes" ->
-              (match Ppx_yojson_conv_lib.( ! ) changes_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   list_of_yojson TextDocumentContentChangeEvent.t_of_yojson _field_yojson
-                 in
-                 changes_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) document_field
-                , Ppx_yojson_conv_lib.( ! ) changes_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some document_value
-                , Ppx_yojson_conv_lib.Option.Some changes_value ) ->
-                { document = document_value; changes = changes_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) document_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "document" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) changes_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "changes" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> textContent)
-  ;;
-
-  let _ = textContent_of_yojson
-
-  let yojson_of_textContent =
-    (function
-     | { document = v_document; changes = v_changes } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_list TextDocumentContentChangeEvent.yojson_of_t v_changes in
-         ("changes", arg) :: bnds
-       in
-       let bnds =
-         let arg = VersionedTextDocumentIdentifier.yojson_of_t v_document in
-         ("document", arg) :: bnds
-       in
-       `Assoc bnds
-     : textContent -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_textContent
-
-  [@@@end]
-
-  let create_textContent
-        ~(document : VersionedTextDocumentIdentifier.t)
-        ~(changes : TextDocumentContentChangeEvent.t list)
-    : textContent
-    =
-    { document; changes }
-  ;;
-
-  type structure =
+module NotebookDocumentCellChangeStructure = struct
+  type t =
     { array : NotebookCellArrayChange.t
-    ; didOpen : TextDocumentItem.t list Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
     ; didClose : TextDocumentIdentifier.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
+    ; didOpen : TextDocumentItem.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : structure) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let structure_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentChangeEvent.structure" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentCellChangeStructure.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let array_field = ref Ppx_yojson_conv_lib.Option.None
-       and didOpen_field = ref Ppx_yojson_conv_lib.Option.None
        and didClose_field = ref Ppx_yojson_conv_lib.Option.None
+       and didOpen_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
@@ -25330,17 +28411,6 @@ module NotebookDocumentChangeEvent = struct
                  array_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "didOpen" ->
-              (match Ppx_yojson_conv_lib.( ! ) didOpen_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     (list_of_yojson TextDocumentItem.t_of_yojson)
-                     _field_yojson
-                 in
-                 didOpen_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "didClose" ->
               (match Ppx_yojson_conv_lib.( ! ) didClose_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -25350,6 +28420,17 @@ module NotebookDocumentChangeEvent = struct
                      _field_yojson
                  in
                  didClose_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "didOpen" ->
+              (match Ppx_yojson_conv_lib.( ! ) didOpen_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson TextDocumentItem.t_of_yojson)
+                     _field_yojson
+                 in
+                 didOpen_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | _ -> ());
@@ -25373,18 +28454,18 @@ module NotebookDocumentChangeEvent = struct
            | [] ->
              (match
                 ( Ppx_yojson_conv_lib.( ! ) array_field
-                , Ppx_yojson_conv_lib.( ! ) didOpen_field
-                , Ppx_yojson_conv_lib.( ! ) didClose_field )
+                , Ppx_yojson_conv_lib.( ! ) didClose_field
+                , Ppx_yojson_conv_lib.( ! ) didOpen_field )
               with
-              | Ppx_yojson_conv_lib.Option.Some array_value, didOpen_value, didClose_value
+              | Ppx_yojson_conv_lib.Option.Some array_value, didClose_value, didOpen_value
                 ->
                 { array = array_value
-                ; didOpen =
-                    (match didOpen_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
                 ; didClose =
                     (match didClose_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; didOpen =
+                    (match didOpen_value with
                      | Ppx_yojson_conv_lib.Option.None -> None
                      | Ppx_yojson_conv_lib.Option.Some v -> v)
                 }
@@ -25399,27 +28480,15 @@ module NotebookDocumentChangeEvent = struct
                   ])))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> structure)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = structure_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_structure =
+  let yojson_of_t =
     (function
-     | { array = v_array; didOpen = v_didOpen; didClose = v_didClose } ->
+     | { array = v_array; didClose = v_didClose; didOpen = v_didOpen } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_didClose
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t
-                (yojson_of_list TextDocumentIdentifier.yojson_of_t))
-               v_didClose
-           in
-           let bnd = "didClose", arg in
-           bnd :: bnds)
-       in
        let bnds =
          if None = v_didOpen
          then bnds
@@ -25433,60 +28502,65 @@ module NotebookDocumentChangeEvent = struct
            bnd :: bnds)
        in
        let bnds =
+         if None = v_didClose
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                (yojson_of_list TextDocumentIdentifier.yojson_of_t))
+               v_didClose
+           in
+           let bnd = "didClose", arg in
+           bnd :: bnds)
+       in
+       let bnds =
          let arg = NotebookCellArrayChange.yojson_of_t v_array in
          ("array", arg) :: bnds
        in
        `Assoc bnds
-     : structure -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_structure
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_structure
+  let create
         ~(array : NotebookCellArrayChange.t)
-        ?(didOpen : TextDocumentItem.t list option)
         ?(didClose : TextDocumentIdentifier.t list option)
+        ?(didOpen : TextDocumentItem.t list option)
         (() : unit)
-    : structure
+    : t
     =
-    { array; didOpen; didClose }
+    { array; didClose; didOpen }
   ;;
+end
 
-  type cells =
-    { structure : structure Json.Nullable_option.t
+module NotebookDocumentCellChanges = struct
+  type t =
+    { data : NotebookCell.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; data : NotebookCell.t list Json.Nullable_option.t
+    ; structure : NotebookDocumentCellChangeStructure.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; textContent : textContent list Json.Nullable_option.t
+    ; textContent : NotebookDocumentCellContentChanges.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : cells) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let cells_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentChangeEvent.cells" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentCellChanges.t" in
      function
      | `Assoc field_yojsons as yojson ->
-       let structure_field = ref Ppx_yojson_conv_lib.Option.None
-       and data_field = ref Ppx_yojson_conv_lib.Option.None
+       let data_field = ref Ppx_yojson_conv_lib.Option.None
+       and structure_field = ref Ppx_yojson_conv_lib.Option.None
        and textContent_field = ref Ppx_yojson_conv_lib.Option.None
        and duplicates = ref []
        and extra = ref [] in
        let rec iter = function
          | (field_name, _field_yojson) :: tail ->
            (match field_name with
-            | "structure" ->
-              (match Ppx_yojson_conv_lib.( ! ) structure_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson structure_of_yojson _field_yojson
-                 in
-                 structure_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "data" ->
               (match Ppx_yojson_conv_lib.( ! ) data_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -25498,12 +28572,23 @@ module NotebookDocumentChangeEvent = struct
                  data_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "structure" ->
+              (match Ppx_yojson_conv_lib.( ! ) structure_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     NotebookDocumentCellChangeStructure.t_of_yojson
+                     _field_yojson
+                 in
+                 structure_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "textContent" ->
               (match Ppx_yojson_conv_lib.( ! ) textContent_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
                    Json.Nullable_option.t_of_yojson
-                     (list_of_yojson textContent_of_yojson)
+                     (list_of_yojson NotebookDocumentCellContentChanges.t_of_yojson)
                      _field_yojson
                  in
                  textContent_field := Ppx_yojson_conv_lib.Option.Some fvalue
@@ -25528,17 +28613,17 @@ module NotebookDocumentChangeEvent = struct
                (Ppx_yojson_conv_lib.( ! ) extra)
                yojson
            | [] ->
-             let structure_value, data_value, textContent_value =
-               ( Ppx_yojson_conv_lib.( ! ) structure_field
-               , Ppx_yojson_conv_lib.( ! ) data_field
+             let data_value, structure_value, textContent_value =
+               ( Ppx_yojson_conv_lib.( ! ) data_field
+               , Ppx_yojson_conv_lib.( ! ) structure_field
                , Ppx_yojson_conv_lib.( ! ) textContent_field )
              in
-             { structure =
-                 (match structure_value with
+             { data =
+                 (match data_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; data =
-                 (match data_value with
+             ; structure =
+                 (match structure_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; textContent =
@@ -25548,24 +28633,37 @@ module NotebookDocumentChangeEvent = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> cells)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = cells_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_cells =
+  let yojson_of_t =
     (function
-     | { structure = v_structure; data = v_data; textContent = v_textContent } ->
+     | { data = v_data; structure = v_structure; textContent = v_textContent } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
          if None = v_textContent
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t (yojson_of_list yojson_of_textContent))
+             (Json.Nullable_option.yojson_of_t
+                (yojson_of_list NotebookDocumentCellContentChanges.yojson_of_t))
                v_textContent
            in
            let bnd = "textContent", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_structure
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                NotebookDocumentCellChangeStructure.yojson_of_t)
+               v_structure
+           in
+           let bnd = "structure", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -25579,34 +28677,29 @@ module NotebookDocumentChangeEvent = struct
            let bnd = "data", arg in
            bnd :: bnds)
        in
-       let bnds =
-         if None = v_structure
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_structure) v_structure in
-           let bnd = "structure", arg in
-           bnd :: bnds)
-       in
        `Assoc bnds
-     : cells -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_cells
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_cells
-        ?(structure : structure option)
+  let create
         ?(data : NotebookCell.t list option)
-        ?(textContent : textContent list option)
+        ?(structure : NotebookDocumentCellChangeStructure.t option)
+        ?(textContent : NotebookDocumentCellContentChanges.t list option)
         (() : unit)
-    : cells
+    : t
     =
-    { structure; data; textContent }
+    { data; structure; textContent }
   ;;
+end
 
+module NotebookDocumentChangeEvent = struct
   type t =
-    { cells : cells Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    { cells : NotebookDocumentCellChanges.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
     ; metadata : Json.Object.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
@@ -25629,7 +28722,9 @@ module NotebookDocumentChangeEvent = struct
               (match Ppx_yojson_conv_lib.( ! ) cells_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson cells_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     NotebookDocumentCellChanges.t_of_yojson
+                     _field_yojson
                  in
                  cells_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -25700,7 +28795,10 @@ module NotebookDocumentChangeEvent = struct
          if None = v_cells
          then bnds
          else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_cells) v_cells in
+           let arg =
+             (Json.Nullable_option.yojson_of_t NotebookDocumentCellChanges.yojson_of_t)
+               v_cells
+           in
            let bnd = "cells", arg in
            bnd :: bnds)
        in
@@ -25712,7 +28810,12 @@ module NotebookDocumentChangeEvent = struct
 
   [@@@end]
 
-  let create ?(cells : cells option) ?(metadata : Json.Object.t option) (() : unit) : t =
+  let create
+        ?(cells : NotebookDocumentCellChanges.t option)
+        ?(metadata : Json.Object.t option)
+        (() : unit)
+    : t
+    =
     { cells; metadata }
   ;;
 end
@@ -26123,245 +29226,6 @@ module DidChangeWatchedFilesParams = struct
   [@@@end]
 
   let create ~(changes : FileEvent.t list) : t = { changes }
-end
-
-module Pattern = struct
-  type t = string [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (string_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_string : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
-module WorkspaceFolder = struct
-  type t =
-    { name : string
-    ; uri : DocumentUri.t
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.WorkspaceFolder.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let name_field = ref Ppx_yojson_conv_lib.Option.None
-       and uri_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "name" ->
-              (match Ppx_yojson_conv_lib.( ! ) name_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "uri" ->
-              (match Ppx_yojson_conv_lib.( ! ) uri_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
-                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                Ppx_yojson_conv_lib.( ! ) name_field, Ppx_yojson_conv_lib.( ! ) uri_field
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some name_value
-                , Ppx_yojson_conv_lib.Option.Some uri_value ) ->
-                { name = name_value; uri = uri_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) name_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "name" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) uri_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "uri" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { name = v_name; uri = v_uri } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = DocumentUri.yojson_of_t v_uri in
-         ("uri", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_string v_name in
-         ("name", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ~(name : string) ~(uri : DocumentUri.t) : t = { name; uri }
-end
-
-module RelativePattern = struct
-  type t =
-    { baseUri : unit
-    ; pattern : Pattern.t
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.RelativePattern.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let baseUri_field = ref Ppx_yojson_conv_lib.Option.None
-       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "baseUri" ->
-              (match Ppx_yojson_conv_lib.( ! ) baseUri_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = unit_of_yojson _field_yojson in
-                 baseUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "pattern" ->
-              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = Pattern.t_of_yojson _field_yojson in
-                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) baseUri_field
-                , Ppx_yojson_conv_lib.( ! ) pattern_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some baseUri_value
-                , Ppx_yojson_conv_lib.Option.Some pattern_value ) ->
-                { baseUri = baseUri_value; pattern = pattern_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) baseUri_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "baseUri" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "pattern" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { baseUri = v_baseUri; pattern = v_pattern } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = Pattern.yojson_of_t v_pattern in
-         ("pattern", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_unit v_baseUri in
-         ("baseUri", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ~(baseUri : unit) ~(pattern : Pattern.t) : t = { baseUri; pattern }
-end
-
-module GlobPattern = struct
-  type t =
-    [ `Pattern of Pattern.t
-    | `RelativePattern of RelativePattern.t
-    ]
-
-  let t_of_yojson (json : Json.t) : t =
-    Json.Of.untagged_union
-      "t"
-      [ (fun json -> `Pattern (Pattern.t_of_yojson json))
-      ; (fun json -> `RelativePattern (RelativePattern.t_of_yojson json))
-      ]
-      json
-  ;;
-
-  let yojson_of_t (t : t) : Json.t =
-    match t with
-    | `Pattern s -> Pattern.yojson_of_t s
-    | `RelativePattern s -> RelativePattern.yojson_of_t s
-  ;;
 end
 
 module FileSystemWatcher = struct
@@ -28910,6 +31774,32 @@ module DocumentDiagnosticReportPartialResult = struct
   let create ~(relatedDocuments : (DocumentUri.t, relatedDocuments_pvar) Json.Assoc.t) : t
     =
     { relatedDocuments }
+  ;;
+end
+
+module DocumentDiagnosticReportProgress = struct
+  type t =
+    [ `DocumentDiagnosticReport of DocumentDiagnosticReport.t
+    | `DocumentDiagnosticReportPartialResult of DocumentDiagnosticReportPartialResult.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `DocumentDiagnosticReport (DocumentDiagnosticReport.t_of_yojson json))
+      ; (fun json ->
+          `DocumentDiagnosticReportPartialResult
+            (DocumentDiagnosticReportPartialResult.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `DocumentDiagnosticReport s -> DocumentDiagnosticReport.yojson_of_t s
+    | `DocumentDiagnosticReportPartialResult s ->
+      DocumentDiagnosticReportPartialResult.yojson_of_t s
   ;;
 end
 
@@ -33435,8 +36325,8 @@ end
 
 module FileRename = struct
   type t =
-    { newUri : string
-    ; oldUri : string
+    { newUri : DocumentUri.t
+    ; oldUri : DocumentUri.t
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
@@ -33456,14 +36346,14 @@ module FileRename = struct
             | "newUri" ->
               (match Ppx_yojson_conv_lib.( ! ) newUri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
                  newUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "oldUri" ->
               (match Ppx_yojson_conv_lib.( ! ) oldUri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
                  oldUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -33518,11 +36408,11 @@ module FileRename = struct
      | { newUri = v_newUri; oldUri = v_oldUri } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = yojson_of_string v_oldUri in
+         let arg = DocumentUri.yojson_of_t v_oldUri in
          ("oldUri", arg) :: bnds
        in
        let bnds =
-         let arg = yojson_of_string v_newUri in
+         let arg = DocumentUri.yojson_of_t v_newUri in
          ("newUri", arg) :: bnds
        in
        `Assoc bnds
@@ -33533,7 +36423,7 @@ module FileRename = struct
 
   [@@@end]
 
-  let create ~(newUri : string) ~(oldUri : string) : t = { newUri; oldUri }
+  let create ~(newUri : DocumentUri.t) ~(oldUri : DocumentUri.t) : t = { newUri; oldUri }
 end
 
 module FoldingRange = struct
@@ -34167,6 +37057,109 @@ module FoldingRangeRegistrationOptions = struct
     =
     { documentSelector; id; workDoneProgress }
   ;;
+end
+
+module MarkedStringWithLanguage = struct
+  type t =
+    { language : string
+    ; value : string
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.MarkedStringWithLanguage.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let language_field = ref Ppx_yojson_conv_lib.Option.None
+       and value_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "language" ->
+              (match Ppx_yojson_conv_lib.( ! ) language_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "value" ->
+              (match Ppx_yojson_conv_lib.( ! ) value_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 value_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) language_field
+                , Ppx_yojson_conv_lib.( ! ) value_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some language_value
+                , Ppx_yojson_conv_lib.Option.Some value_value ) ->
+                { language = language_value; value = value_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) language_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "language" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) value_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "value" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { language = v_language; value = v_value } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_value in
+         ("value", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_string v_language in
+         ("language", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(language : string) ~(value : string) : t = { language; value }
 end
 
 module Hover = struct
@@ -35166,120 +38159,9 @@ module InitializeError = struct
 end
 
 module InitializeParams = struct
-  type clientInfo =
-    { name : string
-    ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : clientInfo) -> ()
-
-  let clientInfo_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.InitializeParams.clientInfo" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let name_field = ref Ppx_yojson_conv_lib.Option.None
-       and version_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "name" ->
-              (match Ppx_yojson_conv_lib.( ! ) name_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "version" ->
-              (match Ppx_yojson_conv_lib.( ! ) version_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
-                 in
-                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) name_field
-                , Ppx_yojson_conv_lib.( ! ) version_field )
-              with
-              | Ppx_yojson_conv_lib.Option.Some name_value, version_value ->
-                { name = name_value
-                ; version =
-                    (match version_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) name_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "name" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> clientInfo)
-  ;;
-
-  let _ = clientInfo_of_yojson
-
-  let yojson_of_clientInfo =
-    (function
-     | { name = v_name; version = v_version } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_version
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_version in
-           let bnd = "version", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         let arg = yojson_of_string v_name in
-         ("name", arg) :: bnds
-       in
-       `Assoc bnds
-     : clientInfo -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_clientInfo
-
-  [@@@end]
-
-  let create_clientInfo ~(name : string) ?(version : string option) (() : unit)
-    : clientInfo
-    =
-    { name; version }
-  ;;
-
   type t =
     { capabilities : ClientCapabilities.t
-    ; clientInfo : clientInfo Json.Nullable_option.t
+    ; clientInfo : ClientInfo.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; initializationOptions : Json.t option [@yojson.option]
     ; locale : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
@@ -35287,7 +38169,7 @@ module InitializeParams = struct
     ; rootPath : string Json.Nullable_option.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; rootUri : DocumentUri.t Json.Nullable_option.t
-    ; trace : TraceValues.t Json.Nullable_option.t
+    ; trace : TraceValue.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; workDoneToken : ProgressToken.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -35329,7 +38211,7 @@ module InitializeParams = struct
               (match Ppx_yojson_conv_lib.( ! ) clientInfo_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson clientInfo_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson ClientInfo.t_of_yojson _field_yojson
                  in
                  clientInfo_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -35383,7 +38265,7 @@ module InitializeParams = struct
               (match Ppx_yojson_conv_lib.( ! ) trace_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson TraceValues.t_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson TraceValue.t_of_yojson _field_yojson
                  in
                  trace_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -35546,7 +38428,7 @@ module InitializeParams = struct
          if None = v_trace
          then bnds
          else (
-           let arg = (Json.Nullable_option.yojson_of_t TraceValues.yojson_of_t) v_trace in
+           let arg = (Json.Nullable_option.yojson_of_t TraceValue.yojson_of_t) v_trace in
            let bnd = "trace", arg in
            bnd :: bnds)
        in
@@ -35591,7 +38473,7 @@ module InitializeParams = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_clientInfo) v_clientInfo
+             (Json.Nullable_option.yojson_of_t ClientInfo.yojson_of_t) v_clientInfo
            in
            let bnd = "clientInfo", arg in
            bnd :: bnds)
@@ -35610,13 +38492,13 @@ module InitializeParams = struct
 
   let create
         ~(capabilities : ClientCapabilities.t)
-        ?(clientInfo : clientInfo option)
+        ?(clientInfo : ClientInfo.t option)
         ?(initializationOptions : Json.t option)
         ?(locale : string option)
         ?(processId : int option)
         ?(rootPath : string option option)
         ?(rootUri : DocumentUri.t option)
-        ?(trace : TraceValues.t option)
+        ?(trace : TraceValue.t option)
         ?(workDoneToken : ProgressToken.t option)
         ?(workspaceFolders : WorkspaceFolder.t list option option)
         (() : unit)
@@ -35633,6 +38515,117 @@ module InitializeParams = struct
     ; workDoneToken
     ; workspaceFolders
     }
+  ;;
+end
+
+module ServerInfo = struct
+  type t =
+    { name : string
+    ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.ServerInfo.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let name_field = ref Ppx_yojson_conv_lib.Option.None
+       and version_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "name" ->
+              (match Ppx_yojson_conv_lib.( ! ) name_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "version" ->
+              (match Ppx_yojson_conv_lib.( ! ) version_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) name_field
+                , Ppx_yojson_conv_lib.( ! ) version_field )
+              with
+              | Ppx_yojson_conv_lib.Option.Some name_value, version_value ->
+                { name = name_value
+                ; version =
+                    (match version_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) name_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "name" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { name = v_name; version = v_version } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_version
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_version in
+           let bnd = "version", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_string v_name in
+         ("name", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(name : string) ?(version : string option) (() : unit) : t =
+    { name; version }
   ;;
 end
 
@@ -35896,6 +38889,386 @@ module WorkspaceFoldersServerCapabilities = struct
     : t
     =
     { changeNotifications; supported }
+  ;;
+end
+
+module TextDocumentContentRegistrationOptions = struct
+  type t =
+    { id : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    ; schemes : string list
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentRegistrationOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let id_field = ref Ppx_yojson_conv_lib.Option.None
+       and schemes_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "id" ->
+              (match Ppx_yojson_conv_lib.( ! ) id_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 id_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "schemes" ->
+              (match Ppx_yojson_conv_lib.( ! ) schemes_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
+                 schemes_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) id_field
+                , Ppx_yojson_conv_lib.( ! ) schemes_field )
+              with
+              | id_value, Ppx_yojson_conv_lib.Option.Some schemes_value ->
+                { id =
+                    (match id_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; schemes = schemes_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) schemes_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "schemes" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { id = v_id; schemes = v_schemes } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list yojson_of_string v_schemes in
+         ("schemes", arg) :: bnds
+       in
+       let bnds =
+         if None = v_id
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_id in
+           let bnd = "id", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ?(id : string option) ~(schemes : string list) (() : unit) : t =
+    { id; schemes }
+  ;;
+end
+
+module TextDocumentContentOptions = struct
+  type t = { schemes : string list }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let schemes_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "schemes" ->
+              (match Ppx_yojson_conv_lib.( ! ) schemes_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = list_of_yojson string_of_yojson _field_yojson in
+                 schemes_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) schemes_field with
+              | Ppx_yojson_conv_lib.Option.Some schemes_value ->
+                { schemes = schemes_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) schemes_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "schemes" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { schemes = v_schemes } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_list yojson_of_string v_schemes in
+         ("schemes", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(schemes : string list) : t = { schemes }
+end
+
+module WorkspaceOptions = struct
+  type textDocumentContent_pvar =
+    [ `TextDocumentContentOptions of TextDocumentContentOptions.t
+    | `TextDocumentContentRegistrationOptions of TextDocumentContentRegistrationOptions.t
+    ]
+
+  let textDocumentContent_pvar_of_yojson (json : Json.t) : textDocumentContent_pvar =
+    Json.Of.untagged_union
+      "textDocumentContent_pvar"
+      [ (fun json ->
+          `TextDocumentContentOptions (TextDocumentContentOptions.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentContentRegistrationOptions
+            (TextDocumentContentRegistrationOptions.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_textDocumentContent_pvar
+        (textDocumentContent_pvar : textDocumentContent_pvar)
+    : Json.t
+    =
+    match textDocumentContent_pvar with
+    | `TextDocumentContentOptions s -> TextDocumentContentOptions.yojson_of_t s
+    | `TextDocumentContentRegistrationOptions s ->
+      TextDocumentContentRegistrationOptions.yojson_of_t s
+  ;;
+
+  type t =
+    { fileOperations : FileOperationOptions.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; textDocumentContent : textDocumentContent_pvar Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; workspaceFolders : WorkspaceFoldersServerCapabilities.t Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.WorkspaceOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let fileOperations_field = ref Ppx_yojson_conv_lib.Option.None
+       and textDocumentContent_field = ref Ppx_yojson_conv_lib.Option.None
+       and workspaceFolders_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "fileOperations" ->
+              (match Ppx_yojson_conv_lib.( ! ) fileOperations_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     FileOperationOptions.t_of_yojson
+                     _field_yojson
+                 in
+                 fileOperations_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "textDocumentContent" ->
+              (match Ppx_yojson_conv_lib.( ! ) textDocumentContent_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     textDocumentContent_pvar_of_yojson
+                     _field_yojson
+                 in
+                 textDocumentContent_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "workspaceFolders" ->
+              (match Ppx_yojson_conv_lib.( ! ) workspaceFolders_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     WorkspaceFoldersServerCapabilities.t_of_yojson
+                     _field_yojson
+                 in
+                 workspaceFolders_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             let fileOperations_value, textDocumentContent_value, workspaceFolders_value =
+               ( Ppx_yojson_conv_lib.( ! ) fileOperations_field
+               , Ppx_yojson_conv_lib.( ! ) textDocumentContent_field
+               , Ppx_yojson_conv_lib.( ! ) workspaceFolders_field )
+             in
+             { fileOperations =
+                 (match fileOperations_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; textDocumentContent =
+                 (match textDocumentContent_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             ; workspaceFolders =
+                 (match workspaceFolders_value with
+                  | Ppx_yojson_conv_lib.Option.None -> None
+                  | Ppx_yojson_conv_lib.Option.Some v -> v)
+             }))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { fileOperations = v_fileOperations
+       ; textDocumentContent = v_textDocumentContent
+       ; workspaceFolders = v_workspaceFolders
+       } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_workspaceFolders
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                WorkspaceFoldersServerCapabilities.yojson_of_t)
+               v_workspaceFolders
+           in
+           let bnd = "workspaceFolders", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_textDocumentContent
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_textDocumentContent_pvar)
+               v_textDocumentContent
+           in
+           let bnd = "textDocumentContent", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         if None = v_fileOperations
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t FileOperationOptions.yojson_of_t)
+               v_fileOperations
+           in
+           let bnd = "fileOperations", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(fileOperations : FileOperationOptions.t option)
+        ?(textDocumentContent : textDocumentContent_pvar option)
+        ?(workspaceFolders : WorkspaceFoldersServerCapabilities.t option)
+        (() : unit)
+    : t
+    =
+    { fileOperations; textDocumentContent; workspaceFolders }
   ;;
 end
 
@@ -36965,15 +40338,15 @@ module SemanticTokensLegend = struct
   ;;
 end
 
-module SemanticTokensRegistrationOptions = struct
-  type full =
+module SemanticTokensFullDelta = struct
+  type t =
     { delta : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )] }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
-  let _ = fun (_ : full) -> ()
+  let _ = fun (_ : t) -> ()
 
-  let full_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.SemanticTokensRegistrationOptions.full" in
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.SemanticTokensFullDelta.t" in
      function
      | `Assoc field_yojsons as yojson ->
        let delta_field = ref Ppx_yojson_conv_lib.Option.None
@@ -37018,12 +40391,12 @@ module SemanticTokensRegistrationOptions = struct
              }))
      | _ as yojson ->
        Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> full)
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
   ;;
 
-  let _ = full_of_yojson
+  let _ = t_of_yojson
 
-  let yojson_of_full =
+  let yojson_of_t =
     (function
      | { delta = v_delta } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
@@ -37036,18 +40409,20 @@ module SemanticTokensRegistrationOptions = struct
            bnd :: bnds)
        in
        `Assoc bnds
-     : full -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
   ;;
 
-  let _ = yojson_of_full
+  let _ = yojson_of_t
 
   [@@@end]
 
-  let create_full ?(delta : bool option) (() : unit) : full = { delta }
+  let create ?(delta : bool option) (() : unit) : t = { delta }
+end
 
+module SemanticTokensRegistrationOptions = struct
   type full_pvar =
     [ `Bool of bool
-    | `Full of full
+    | `SemanticTokensFullDelta of SemanticTokensFullDelta.t
     ]
 
   let full_pvar_of_yojson (json : Json.t) : full_pvar =
@@ -37056,14 +40431,16 @@ module SemanticTokensRegistrationOptions = struct
     | _ ->
       Json.Of.untagged_union
         "full_pvar"
-        [ (fun json -> `Full (full_of_yojson json)) ]
+        [ (fun json ->
+            `SemanticTokensFullDelta (SemanticTokensFullDelta.t_of_yojson json))
+        ]
         json
   ;;
 
   let yojson_of_full_pvar (full_pvar : full_pvar) : Json.t =
     match full_pvar with
     | `Bool j -> `Bool j
-    | `Full s -> yojson_of_full s
+    | `SemanticTokensFullDelta s -> SemanticTokensFullDelta.yojson_of_t s
   ;;
 
   type t =
@@ -37299,88 +40676,9 @@ module SemanticTokensRegistrationOptions = struct
 end
 
 module SemanticTokensOptions = struct
-  type full =
-    { delta : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )] }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : full) -> ()
-
-  let full_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.SemanticTokensOptions.full" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let delta_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "delta" ->
-              (match Ppx_yojson_conv_lib.( ! ) delta_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 delta_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let delta_value = Ppx_yojson_conv_lib.( ! ) delta_field in
-             { delta =
-                 (match delta_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> full)
-  ;;
-
-  let _ = full_of_yojson
-
-  let yojson_of_full =
-    (function
-     | { delta = v_delta } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_delta
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_delta in
-           let bnd = "delta", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : full -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_full
-
-  [@@@end]
-
-  let create_full ?(delta : bool option) (() : unit) : full = { delta }
-
   type full_pvar =
     [ `Bool of bool
-    | `Full of full
+    | `SemanticTokensFullDelta of SemanticTokensFullDelta.t
     ]
 
   let full_pvar_of_yojson (json : Json.t) : full_pvar =
@@ -37389,14 +40687,16 @@ module SemanticTokensOptions = struct
     | _ ->
       Json.Of.untagged_union
         "full_pvar"
-        [ (fun json -> `Full (full_of_yojson json)) ]
+        [ (fun json ->
+            `SemanticTokensFullDelta (SemanticTokensFullDelta.t_of_yojson json))
+        ]
         json
   ;;
 
   let yojson_of_full_pvar (full_pvar : full_pvar) : Json.t =
     match full_pvar with
     | `Bool j -> `Bool j
-    | `Full s -> yojson_of_full s
+    | `SemanticTokensFullDelta s -> SemanticTokensFullDelta.yojson_of_t s
   ;;
 
   type t =
@@ -38024,6 +41324,373 @@ module ReferenceOptions = struct
   [@@@end]
 
   let create ?(workDoneProgress : bool option) (() : unit) : t = { workDoneProgress }
+end
+
+module NotebookCellLanguage = struct
+  type t = { language : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookCellLanguage.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let language_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "language" ->
+              (match Ppx_yojson_conv_lib.( ! ) language_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) language_field with
+              | Ppx_yojson_conv_lib.Option.Some language_value ->
+                { language = language_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) language_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "language" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { language = v_language } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_language in
+         ("language", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(language : string) : t = { language }
+end
+
+module NotebookDocumentFilterWithCells = struct
+  type notebook_pvar =
+    [ `String of string
+    | `NotebookDocumentFilter of NotebookDocumentFilter.t
+    ]
+
+  let notebook_pvar_of_yojson (json : Json.t) : notebook_pvar =
+    match json with
+    | `String j -> `String j
+    | _ ->
+      Json.Of.untagged_union
+        "notebook_pvar"
+        [ (fun json -> `NotebookDocumentFilter (NotebookDocumentFilter.t_of_yojson json))
+        ]
+        json
+  ;;
+
+  let yojson_of_notebook_pvar (notebook_pvar : notebook_pvar) : Json.t =
+    match notebook_pvar with
+    | `String j -> `String j
+    | `NotebookDocumentFilter s -> NotebookDocumentFilter.yojson_of_t s
+  ;;
+
+  type t =
+    { cells : NotebookCellLanguage.t list
+    ; notebook : notebook_pvar Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentFilterWithCells.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let cells_field = ref Ppx_yojson_conv_lib.Option.None
+       and notebook_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "cells" ->
+              (match Ppx_yojson_conv_lib.( ! ) cells_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson NotebookCellLanguage.t_of_yojson _field_yojson
+                 in
+                 cells_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "notebook" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebook_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson notebook_pvar_of_yojson _field_yojson
+                 in
+                 notebook_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) cells_field
+                , Ppx_yojson_conv_lib.( ! ) notebook_field )
+              with
+              | Ppx_yojson_conv_lib.Option.Some cells_value, notebook_value ->
+                { cells = cells_value
+                ; notebook =
+                    (match notebook_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) cells_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "cells" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { cells = v_cells; notebook = v_notebook } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_notebook
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t yojson_of_notebook_pvar) v_notebook
+           in
+           let bnd = "notebook", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_list NotebookCellLanguage.yojson_of_t v_cells in
+         ("cells", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(cells : NotebookCellLanguage.t list)
+        ?(notebook : notebook_pvar option)
+        (() : unit)
+    : t
+    =
+    { cells; notebook }
+  ;;
+end
+
+module NotebookDocumentFilterWithNotebook = struct
+  type notebook_pvar =
+    [ `String of string
+    | `NotebookDocumentFilter of NotebookDocumentFilter.t
+    ]
+
+  let notebook_pvar_of_yojson (json : Json.t) : notebook_pvar =
+    match json with
+    | `String j -> `String j
+    | _ ->
+      Json.Of.untagged_union
+        "notebook_pvar"
+        [ (fun json -> `NotebookDocumentFilter (NotebookDocumentFilter.t_of_yojson json))
+        ]
+        json
+  ;;
+
+  let yojson_of_notebook_pvar (notebook_pvar : notebook_pvar) : Json.t =
+    match notebook_pvar with
+    | `String j -> `String j
+    | `NotebookDocumentFilter s -> NotebookDocumentFilter.yojson_of_t s
+  ;;
+
+  type t =
+    { cells : NotebookCellLanguage.t list Json.Nullable_option.t
+          [@default None] [@yojson_drop_default ( = )]
+    ; notebook : notebook_pvar
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentFilterWithNotebook.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let cells_field = ref Ppx_yojson_conv_lib.Option.None
+       and notebook_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "cells" ->
+              (match Ppx_yojson_conv_lib.( ! ) cells_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson
+                     (list_of_yojson NotebookCellLanguage.t_of_yojson)
+                     _field_yojson
+                 in
+                 cells_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "notebook" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebook_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = notebook_pvar_of_yojson _field_yojson in
+                 notebook_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) cells_field
+                , Ppx_yojson_conv_lib.( ! ) notebook_field )
+              with
+              | cells_value, Ppx_yojson_conv_lib.Option.Some notebook_value ->
+                { cells =
+                    (match cells_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; notebook = notebook_value
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebook_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebook" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { cells = v_cells; notebook = v_notebook } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_notebook_pvar v_notebook in
+         ("notebook", arg) :: bnds
+       in
+       let bnds =
+         if None = v_cells
+         then bnds
+         else (
+           let arg =
+             (Json.Nullable_option.yojson_of_t
+                (yojson_of_list NotebookCellLanguage.yojson_of_t))
+               v_cells
+           in
+           let bnd = "cells", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(cells : NotebookCellLanguage.t list option)
+        ~(notebook : notebook_pvar)
+        (() : unit)
+    : t
+    =
+    { cells; notebook }
+  ;;
 end
 
 module MonikerRegistrationOptions = struct
@@ -39125,304 +42792,6 @@ module InlayHintOptions = struct
 end
 
 module ServerCapabilities = struct
-  type workspace =
-    { workspaceFolders : WorkspaceFoldersServerCapabilities.t Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    ; fileOperations : FileOperationOptions.t Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : workspace) -> ()
-
-  let workspace_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.ServerCapabilities.workspace" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let workspaceFolders_field = ref Ppx_yojson_conv_lib.Option.None
-       and fileOperations_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "workspaceFolders" ->
-              (match Ppx_yojson_conv_lib.( ! ) workspaceFolders_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     WorkspaceFoldersServerCapabilities.t_of_yojson
-                     _field_yojson
-                 in
-                 workspaceFolders_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "fileOperations" ->
-              (match Ppx_yojson_conv_lib.( ! ) fileOperations_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson
-                     FileOperationOptions.t_of_yojson
-                     _field_yojson
-                 in
-                 fileOperations_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let workspaceFolders_value, fileOperations_value =
-               ( Ppx_yojson_conv_lib.( ! ) workspaceFolders_field
-               , Ppx_yojson_conv_lib.( ! ) fileOperations_field )
-             in
-             { workspaceFolders =
-                 (match workspaceFolders_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; fileOperations =
-                 (match fileOperations_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> workspace)
-  ;;
-
-  let _ = workspace_of_yojson
-
-  let yojson_of_workspace =
-    (function
-     | { workspaceFolders = v_workspaceFolders; fileOperations = v_fileOperations } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_fileOperations
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t FileOperationOptions.yojson_of_t)
-               v_fileOperations
-           in
-           let bnd = "fileOperations", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_workspaceFolders
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t
-                WorkspaceFoldersServerCapabilities.yojson_of_t)
-               v_workspaceFolders
-           in
-           let bnd = "workspaceFolders", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : workspace -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_workspace
-
-  [@@@end]
-
-  let create_workspace
-        ?(workspaceFolders : WorkspaceFoldersServerCapabilities.t option)
-        ?(fileOperations : FileOperationOptions.t option)
-        (() : unit)
-    : workspace
-    =
-    { workspaceFolders; fileOperations }
-  ;;
-
-  type diagnostic =
-    { markupMessageSupport : bool Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : diagnostic) -> ()
-
-  let diagnostic_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.ServerCapabilities.diagnostic" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let markupMessageSupport_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "markupMessageSupport" ->
-              (match Ppx_yojson_conv_lib.( ! ) markupMessageSupport_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
-                 in
-                 markupMessageSupport_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let markupMessageSupport_value =
-               Ppx_yojson_conv_lib.( ! ) markupMessageSupport_field
-             in
-             { markupMessageSupport =
-                 (match markupMessageSupport_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> diagnostic)
-  ;;
-
-  let _ = diagnostic_of_yojson
-
-  let yojson_of_diagnostic =
-    (function
-     | { markupMessageSupport = v_markupMessageSupport } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_markupMessageSupport
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_bool) v_markupMessageSupport
-           in
-           let bnd = "markupMessageSupport", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : diagnostic -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_diagnostic
-
-  [@@@end]
-
-  let create_diagnostic ?(markupMessageSupport : bool option) (() : unit) : diagnostic =
-    { markupMessageSupport }
-  ;;
-
-  type textDocument =
-    { diagnostic : diagnostic Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : textDocument) -> ()
-
-  let textDocument_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.ServerCapabilities.textDocument" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let diagnostic_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "diagnostic" ->
-              (match Ppx_yojson_conv_lib.( ! ) diagnostic_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson diagnostic_of_yojson _field_yojson
-                 in
-                 diagnostic_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             let diagnostic_value = Ppx_yojson_conv_lib.( ! ) diagnostic_field in
-             { diagnostic =
-                 (match diagnostic_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
-             }))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> textDocument)
-  ;;
-
-  let _ = textDocument_of_yojson
-
-  let yojson_of_textDocument =
-    (function
-     | { diagnostic = v_diagnostic } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_diagnostic
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_diagnostic) v_diagnostic
-           in
-           let bnd = "diagnostic", arg in
-           bnd :: bnds)
-       in
-       `Assoc bnds
-     : textDocument -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_textDocument
-
-  [@@@end]
-
-  let create_textDocument ?(diagnostic : diagnostic option) (() : unit) : textDocument =
-    { diagnostic }
-  ;;
-
   type callHierarchyProvider_pvar =
     [ `Bool of bool
     | `CallHierarchyOptions of CallHierarchyOptions.t
@@ -40228,15 +43597,13 @@ module ServerCapabilities = struct
           [@default None] [@yojson_drop_default ( = )]
     ; signatureHelpProvider : SignatureHelpOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; textDocument : textDocument Json.Nullable_option.t
-          [@default None] [@yojson_drop_default ( = )]
     ; textDocumentSync : textDocumentSync_pvar Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; typeDefinitionProvider : typeDefinitionProvider_pvar Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; typeHierarchyProvider : typeHierarchyProvider_pvar Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
-    ; workspace : workspace Json.Nullable_option.t
+    ; workspace : WorkspaceOptions.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; workspaceSymbolProvider : workspaceSymbolProvider_pvar Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -40280,7 +43647,6 @@ module ServerCapabilities = struct
        and selectionRangeProvider_field = ref Ppx_yojson_conv_lib.Option.None
        and semanticTokensProvider_field = ref Ppx_yojson_conv_lib.Option.None
        and signatureHelpProvider_field = ref Ppx_yojson_conv_lib.Option.None
-       and textDocument_field = ref Ppx_yojson_conv_lib.Option.None
        and textDocumentSync_field = ref Ppx_yojson_conv_lib.Option.None
        and typeDefinitionProvider_field = ref Ppx_yojson_conv_lib.Option.None
        and typeHierarchyProvider_field = ref Ppx_yojson_conv_lib.Option.None
@@ -40632,15 +43998,6 @@ module ServerCapabilities = struct
                  signatureHelpProvider_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "textDocument" ->
-              (match Ppx_yojson_conv_lib.( ! ) textDocument_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson textDocument_of_yojson _field_yojson
-                 in
-                 textDocument_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
             | "textDocumentSync" ->
               (match Ppx_yojson_conv_lib.( ! ) textDocumentSync_field with
                | Ppx_yojson_conv_lib.Option.None ->
@@ -40678,7 +44035,9 @@ module ServerCapabilities = struct
               (match Ppx_yojson_conv_lib.( ! ) workspace_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson workspace_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson
+                     WorkspaceOptions.t_of_yojson
+                     _field_yojson
                  in
                  workspace_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -40744,7 +44103,6 @@ module ServerCapabilities = struct
                  , selectionRangeProvider_value
                  , semanticTokensProvider_value
                  , signatureHelpProvider_value
-                 , textDocument_value
                  , textDocumentSync_value
                  , typeDefinitionProvider_value
                  , typeHierarchyProvider_value
@@ -40782,7 +44140,6 @@ module ServerCapabilities = struct
                , Ppx_yojson_conv_lib.( ! ) selectionRangeProvider_field
                , Ppx_yojson_conv_lib.( ! ) semanticTokensProvider_field
                , Ppx_yojson_conv_lib.( ! ) signatureHelpProvider_field
-               , Ppx_yojson_conv_lib.( ! ) textDocument_field
                , Ppx_yojson_conv_lib.( ! ) textDocumentSync_field
                , Ppx_yojson_conv_lib.( ! ) typeDefinitionProvider_field
                , Ppx_yojson_conv_lib.( ! ) typeHierarchyProvider_field
@@ -40910,10 +44267,6 @@ module ServerCapabilities = struct
                  (match signatureHelpProvider_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
                   | Ppx_yojson_conv_lib.Option.Some v -> v)
-             ; textDocument =
-                 (match textDocument_value with
-                  | Ppx_yojson_conv_lib.Option.None -> None
-                  | Ppx_yojson_conv_lib.Option.Some v -> v)
              ; textDocumentSync =
                  (match textDocumentSync_value with
                   | Ppx_yojson_conv_lib.Option.None -> None
@@ -40975,7 +44328,6 @@ module ServerCapabilities = struct
        ; selectionRangeProvider = v_selectionRangeProvider
        ; semanticTokensProvider = v_semanticTokensProvider
        ; signatureHelpProvider = v_signatureHelpProvider
-       ; textDocument = v_textDocument
        ; textDocumentSync = v_textDocumentSync
        ; typeDefinitionProvider = v_typeDefinitionProvider
        ; typeHierarchyProvider = v_typeHierarchyProvider
@@ -40998,7 +44350,9 @@ module ServerCapabilities = struct
          if None = v_workspace
          then bnds
          else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_workspace) v_workspace in
+           let arg =
+             (Json.Nullable_option.yojson_of_t WorkspaceOptions.yojson_of_t) v_workspace
+           in
            let bnd = "workspace", arg in
            bnd :: bnds)
        in
@@ -41033,16 +44387,6 @@ module ServerCapabilities = struct
                v_textDocumentSync
            in
            let bnd = "textDocumentSync", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         if None = v_textDocument
-         then bnds
-         else (
-           let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_textDocument) v_textDocument
-           in
-           let bnd = "textDocument", arg in
            bnd :: bnds)
        in
        let bnds =
@@ -41425,11 +44769,10 @@ module ServerCapabilities = struct
         ?(selectionRangeProvider : selectionRangeProvider_pvar option)
         ?(semanticTokensProvider : semanticTokensProvider_pvar option)
         ?(signatureHelpProvider : SignatureHelpOptions.t option)
-        ?(textDocument : textDocument option)
         ?(textDocumentSync : textDocumentSync_pvar option)
         ?(typeDefinitionProvider : typeDefinitionProvider_pvar option)
         ?(typeHierarchyProvider : typeHierarchyProvider_pvar option)
-        ?(workspace : workspace option)
+        ?(workspace : WorkspaceOptions.t option)
         ?(workspaceSymbolProvider : workspaceSymbolProvider_pvar option)
         (() : unit)
     : t
@@ -41465,7 +44808,6 @@ module ServerCapabilities = struct
     ; selectionRangeProvider
     ; semanticTokensProvider
     ; signatureHelpProvider
-    ; textDocument
     ; textDocumentSync
     ; typeDefinitionProvider
     ; typeHierarchyProvider
@@ -41476,120 +44818,9 @@ module ServerCapabilities = struct
 end
 
 module InitializeResult = struct
-  type serverInfo =
-    { name : string
-    ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : serverInfo) -> ()
-
-  let serverInfo_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.InitializeResult.serverInfo" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let name_field = ref Ppx_yojson_conv_lib.Option.None
-       and version_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "name" ->
-              (match Ppx_yojson_conv_lib.( ! ) name_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "version" ->
-              (match Ppx_yojson_conv_lib.( ! ) version_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
-                 in
-                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) name_field
-                , Ppx_yojson_conv_lib.( ! ) version_field )
-              with
-              | Ppx_yojson_conv_lib.Option.Some name_value, version_value ->
-                { name = name_value
-                ; version =
-                    (match version_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) name_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "name" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> serverInfo)
-  ;;
-
-  let _ = serverInfo_of_yojson
-
-  let yojson_of_serverInfo =
-    (function
-     | { name = v_name; version = v_version } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_version
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_version in
-           let bnd = "version", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         let arg = yojson_of_string v_name in
-         ("name", arg) :: bnds
-       in
-       `Assoc bnds
-     : serverInfo -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_serverInfo
-
-  [@@@end]
-
-  let create_serverInfo ~(name : string) ?(version : string option) (() : unit)
-    : serverInfo
-    =
-    { name; version }
-  ;;
-
   type t =
     { capabilities : ServerCapabilities.t
-    ; serverInfo : serverInfo Json.Nullable_option.t
+    ; serverInfo : ServerInfo.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -41618,7 +44849,7 @@ module InitializeResult = struct
               (match Ppx_yojson_conv_lib.( ! ) serverInfo_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson serverInfo_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson ServerInfo.t_of_yojson _field_yojson
                  in
                  serverInfo_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -41678,7 +44909,7 @@ module InitializeResult = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_serverInfo) v_serverInfo
+             (Json.Nullable_option.yojson_of_t ServerInfo.yojson_of_t) v_serverInfo
            in
            let bnd = "serverInfo", arg in
            bnd :: bnds)
@@ -41697,7 +44928,7 @@ module InitializeResult = struct
 
   let create
         ~(capabilities : ServerCapabilities.t)
-        ?(serverInfo : serverInfo option)
+        ?(serverInfo : ServerInfo.t option)
         (() : unit)
     : t
     =
@@ -41706,120 +44937,9 @@ module InitializeResult = struct
 end
 
 module InitializedParams_ = struct
-  type clientInfo =
-    { name : string
-    ; version : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : clientInfo) -> ()
-
-  let clientInfo_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.InitializedParams_.clientInfo" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let name_field = ref Ppx_yojson_conv_lib.Option.None
-       and version_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "name" ->
-              (match Ppx_yojson_conv_lib.( ! ) name_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 name_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "version" ->
-              (match Ppx_yojson_conv_lib.( ! ) version_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue =
-                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
-                 in
-                 version_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) name_field
-                , Ppx_yojson_conv_lib.( ! ) version_field )
-              with
-              | Ppx_yojson_conv_lib.Option.Some name_value, version_value ->
-                { name = name_value
-                ; version =
-                    (match version_value with
-                     | Ppx_yojson_conv_lib.Option.None -> None
-                     | Ppx_yojson_conv_lib.Option.Some v -> v)
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) name_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "name" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> clientInfo)
-  ;;
-
-  let _ = clientInfo_of_yojson
-
-  let yojson_of_clientInfo =
-    (function
-     | { name = v_name; version = v_version } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         if None = v_version
-         then bnds
-         else (
-           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_version in
-           let bnd = "version", arg in
-           bnd :: bnds)
-       in
-       let bnds =
-         let arg = yojson_of_string v_name in
-         ("name", arg) :: bnds
-       in
-       `Assoc bnds
-     : clientInfo -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_clientInfo
-
-  [@@@end]
-
-  let create_clientInfo ~(name : string) ?(version : string option) (() : unit)
-    : clientInfo
-    =
-    { name; version }
-  ;;
-
   type t =
     { capabilities : ClientCapabilities.t
-    ; clientInfo : clientInfo Json.Nullable_option.t
+    ; clientInfo : ClientInfo.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; initializationOptions : Json.t option [@yojson.option]
     ; locale : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
@@ -41827,7 +44947,7 @@ module InitializedParams_ = struct
     ; rootPath : string Json.Nullable_option.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; rootUri : DocumentUri.t Json.Nullable_option.t
-    ; trace : TraceValues.t Json.Nullable_option.t
+    ; trace : TraceValue.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; workDoneToken : ProgressToken.t Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -41865,7 +44985,7 @@ module InitializedParams_ = struct
               (match Ppx_yojson_conv_lib.( ! ) clientInfo_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson clientInfo_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson ClientInfo.t_of_yojson _field_yojson
                  in
                  clientInfo_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -41919,7 +45039,7 @@ module InitializedParams_ = struct
               (match Ppx_yojson_conv_lib.( ! ) trace_field with
                | Ppx_yojson_conv_lib.Option.None ->
                  let fvalue =
-                   Json.Nullable_option.t_of_yojson TraceValues.t_of_yojson _field_yojson
+                   Json.Nullable_option.t_of_yojson TraceValue.t_of_yojson _field_yojson
                  in
                  trace_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
@@ -42050,7 +45170,7 @@ module InitializedParams_ = struct
          if None = v_trace
          then bnds
          else (
-           let arg = (Json.Nullable_option.yojson_of_t TraceValues.yojson_of_t) v_trace in
+           let arg = (Json.Nullable_option.yojson_of_t TraceValue.yojson_of_t) v_trace in
            let bnd = "trace", arg in
            bnd :: bnds)
        in
@@ -42095,7 +45215,7 @@ module InitializedParams_ = struct
          then bnds
          else (
            let arg =
-             (Json.Nullable_option.yojson_of_t yojson_of_clientInfo) v_clientInfo
+             (Json.Nullable_option.yojson_of_t ClientInfo.yojson_of_t) v_clientInfo
            in
            let bnd = "clientInfo", arg in
            bnd :: bnds)
@@ -42114,13 +45234,13 @@ module InitializedParams_ = struct
 
   let create
         ~(capabilities : ClientCapabilities.t)
-        ?(clientInfo : clientInfo option)
+        ?(clientInfo : ClientInfo.t option)
         ?(initializationOptions : Json.t option)
         ?(locale : string option)
         ?(processId : int option)
         ?(rootPath : string option option)
         ?(rootUri : DocumentUri.t option)
-        ?(trace : TraceValues.t option)
+        ?(trace : TraceValue.t option)
         ?(workDoneToken : ProgressToken.t option)
         (() : unit)
     : t
@@ -43034,89 +46154,6 @@ module InlineCompletionContext = struct
     : t
     =
     { selectedCompletionInfo; triggerKind }
-  ;;
-end
-
-module StringValue = struct
-  type t = { value : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.StringValue.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let value_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "value" ->
-              (match Ppx_yojson_conv_lib.( ! ) value_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = string_of_yojson _field_yojson in
-                 value_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match Ppx_yojson_conv_lib.( ! ) value_field with
-              | Ppx_yojson_conv_lib.Option.Some value_value -> { value = value_value }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) value_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "value" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { value = v_value } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_string v_value in
-         ("value", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ~(value : string) : t = { value }
-  let yojson_of_t (t : t) : Json.t = Json.To.literal_field "kind" "snippet" yojson_of_t t
-
-  let t_of_yojson (json : Json.t) : t =
-    Json.Of.literal_field "t" "kind" "snippet" t_of_yojson json
   ;;
 end
 
@@ -44639,6 +47676,85 @@ module LinkedEditingRanges = struct
   ;;
 end
 
+module LocationUriOnly = struct
+  type t = { uri : DocumentUri.t }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.LocationUriOnly.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let uri_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "uri" ->
+              (match Ppx_yojson_conv_lib.( ! ) uri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
+                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) uri_field with
+              | Ppx_yojson_conv_lib.Option.Some uri_value -> { uri = uri_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) uri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "uri" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { uri = v_uri } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = DocumentUri.yojson_of_t v_uri in
+         ("uri", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(uri : DocumentUri.t) : t = { uri }
+end
+
 module LogMessageParams = struct
   type t =
     { message : string
@@ -45527,6 +48643,86 @@ module PartialResultParams = struct
   ;;
 end
 
+module PrepareRenameDefaultBehavior = struct
+  type t = { defaultBehavior : bool }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.PrepareRenameDefaultBehavior.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let defaultBehavior_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "defaultBehavior" ->
+              (match Ppx_yojson_conv_lib.( ! ) defaultBehavior_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = bool_of_yojson _field_yojson in
+                 defaultBehavior_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) defaultBehavior_field with
+              | Ppx_yojson_conv_lib.Option.Some defaultBehavior_value ->
+                { defaultBehavior = defaultBehavior_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) defaultBehavior_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "defaultBehavior" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { defaultBehavior = v_defaultBehavior } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_bool v_defaultBehavior in
+         ("defaultBehavior", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(defaultBehavior : bool) : t = { defaultBehavior }
+end
+
 module PrepareRenameParams = struct
   type t =
     { position : Position.t
@@ -45671,6 +48867,109 @@ module PrepareRenameParams = struct
     =
     { position; textDocument; workDoneToken }
   ;;
+end
+
+module PrepareRenamePlaceholder = struct
+  type t =
+    { placeholder : string
+    ; range : Range.t
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.PrepareRenamePlaceholder.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let placeholder_field = ref Ppx_yojson_conv_lib.Option.None
+       and range_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "placeholder" ->
+              (match Ppx_yojson_conv_lib.( ! ) placeholder_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 placeholder_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "range" ->
+              (match Ppx_yojson_conv_lib.( ! ) range_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = Range.t_of_yojson _field_yojson in
+                 range_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) placeholder_field
+                , Ppx_yojson_conv_lib.( ! ) range_field )
+              with
+              | ( Ppx_yojson_conv_lib.Option.Some placeholder_value
+                , Ppx_yojson_conv_lib.Option.Some range_value ) ->
+                { placeholder = placeholder_value; range = range_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) placeholder_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "placeholder" )
+                  ; ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) range_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "range" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { placeholder = v_placeholder; range = v_range } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = Range.yojson_of_t v_range in
+         ("range", arg) :: bnds
+       in
+       let bnds =
+         let arg = yojson_of_string v_placeholder in
+         ("placeholder", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(placeholder : string) ~(range : Range.t) : t = { placeholder; range }
 end
 
 module PreviousResultId = struct
@@ -48393,7 +51692,7 @@ module SemanticTokensRangeParams = struct
 end
 
 module SetTraceParams = struct
-  type t = { value : TraceValues.t }
+  type t = { value : TraceValue.t }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
 
   let _ = fun (_ : t) -> ()
@@ -48411,7 +51710,7 @@ module SetTraceParams = struct
             | "value" ->
               (match Ppx_yojson_conv_lib.( ! ) value_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = TraceValues.t_of_yojson _field_yojson in
+                 let fvalue = TraceValue.t_of_yojson _field_yojson in
                  value_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -48457,7 +51756,7 @@ module SetTraceParams = struct
      | { value = v_value } ->
        let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
        let bnds =
-         let arg = TraceValues.yojson_of_t v_value in
+         let arg = TraceValue.yojson_of_t v_value in
          ("value", arg) :: bnds
        in
        `Assoc bnds
@@ -48468,7 +51767,7 @@ module SetTraceParams = struct
 
   [@@@end]
 
-  let create ~(value : TraceValues.t) : t = { value }
+  let create ~(value : TraceValue.t) : t = { value }
 end
 
 module ShowDocumentParams = struct
@@ -50318,6 +53617,242 @@ module TextDocumentChangeRegistrationOptions = struct
     =
     { documentSelector; syncKind }
   ;;
+end
+
+module TextDocumentContentParams = struct
+  type t = { uri : DocumentUri.t }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentParams.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let uri_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "uri" ->
+              (match Ppx_yojson_conv_lib.( ! ) uri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
+                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) uri_field with
+              | Ppx_yojson_conv_lib.Option.Some uri_value -> { uri = uri_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) uri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "uri" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { uri = v_uri } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = DocumentUri.yojson_of_t v_uri in
+         ("uri", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(uri : DocumentUri.t) : t = { uri }
+end
+
+module TextDocumentContentRefreshParams = struct
+  type t = { uri : DocumentUri.t }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentRefreshParams.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let uri_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "uri" ->
+              (match Ppx_yojson_conv_lib.( ! ) uri_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = DocumentUri.t_of_yojson _field_yojson in
+                 uri_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) uri_field with
+              | Ppx_yojson_conv_lib.Option.Some uri_value -> { uri = uri_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) uri_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "uri" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { uri = v_uri } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = DocumentUri.yojson_of_t v_uri in
+         ("uri", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(uri : DocumentUri.t) : t = { uri }
+end
+
+module TextDocumentContentResult = struct
+  type t = { text : string } [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.TextDocumentContentResult.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let text_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "text" ->
+              (match Ppx_yojson_conv_lib.( ! ) text_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue = string_of_yojson _field_yojson in
+                 text_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match Ppx_yojson_conv_lib.( ! ) text_field with
+              | Ppx_yojson_conv_lib.Option.Some text_value -> { text = text_value }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) text_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "text" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { text = v_text } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         let arg = yojson_of_string v_text in
+         ("text", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create ~(text : string) : t = { text }
 end
 
 module TextDocumentPositionParams = struct
@@ -53365,12 +56900,32 @@ module WorkspaceFoldersInitializeParams = struct
 end
 
 module WorkspaceSymbol = struct
+  type location_pvar =
+    [ `Location of Location.t
+    | `LocationUriOnly of LocationUriOnly.t
+    ]
+
+  let location_pvar_of_yojson (json : Json.t) : location_pvar =
+    Json.Of.untagged_union
+      "location_pvar"
+      [ (fun json -> `Location (Location.t_of_yojson json))
+      ; (fun json -> `LocationUriOnly (LocationUriOnly.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_location_pvar (location_pvar : location_pvar) : Json.t =
+    match location_pvar with
+    | `Location s -> Location.yojson_of_t s
+    | `LocationUriOnly s -> LocationUriOnly.yojson_of_t s
+  ;;
+
   type t =
     { containerName : string Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
     ; data : Json.t option [@yojson.option]
     ; kind : SymbolKind.t
-    ; location : Location.t
+    ; location : location_pvar
     ; name : string
     ; tags : SymbolTag.t list Json.Nullable_option.t
           [@default None] [@yojson_drop_default ( = )]
@@ -53420,7 +56975,7 @@ module WorkspaceSymbol = struct
             | "location" ->
               (match Ppx_yojson_conv_lib.( ! ) location_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = Location.t_of_yojson _field_yojson in
+                 let fvalue = location_pvar_of_yojson _field_yojson in
                  location_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -53538,7 +57093,7 @@ module WorkspaceSymbol = struct
          ("name", arg) :: bnds
        in
        let bnds =
-         let arg = Location.yojson_of_t v_location in
+         let arg = yojson_of_location_pvar v_location in
          ("location", arg) :: bnds
        in
        let bnds =
@@ -53575,7 +57130,7 @@ module WorkspaceSymbol = struct
         ?(containerName : string option)
         ?(data : Json.t option)
         ~(kind : SymbolKind.t)
-        ~(location : Location.t)
+        ~(location : location_pvar)
         ~(name : string)
         ?(tags : SymbolTag.t list option)
         (() : unit)

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -60,6 +60,14 @@ module TextDocumentFilter : sig
 end
 
 (*$ Lsp_gen.print_mli () *)
+module ApplyKind : sig
+  type t =
+    | Replace
+    | Merge
+
+  include Json.Jsonable.S with type t := t
+end
+
 module SymbolTag : sig
   type t = Deprecated
 
@@ -200,6 +208,12 @@ module CompletionItemTag : sig
   include Json.Jsonable.S with type t := t
 end
 
+module CodeActionTag : sig
+  type t = LLMGenerated
+
+  include Json.Jsonable.S with type t := t
+end
+
 module CodeActionKind : sig
   type t =
     | Empty
@@ -207,10 +221,12 @@ module CodeActionKind : sig
     | Refactor
     | RefactorExtract
     | RefactorInline
+    | RefactorMove
     | RefactorRewrite
     | Source
     | SourceOrganizeImports
     | SourceFixAll
+    | Notebook
     | Other of string
 
   include Json.Jsonable.S with type t := t
@@ -257,6 +273,75 @@ module InsertTextFormat : sig
   type t =
     | PlainText
     | Snippet
+
+  include Json.Jsonable.S with type t := t
+end
+
+module LanguageKind : sig
+  type t =
+    | ABAP
+    | WindowsBat
+    | BibTeX
+    | Clojure
+    | Coffeescript
+    | C
+    | CPP
+    | CSharp
+    | CSS
+    | D
+    | Delphi
+    | Diff
+    | Dart
+    | Dockerfile
+    | Elixir
+    | Erlang
+    | FSharp
+    | GitCommit
+    | GitRebase
+    | Go
+    | Groovy
+    | Handlebars
+    | Haskell
+    | HTML
+    | Ini
+    | Java
+    | JavaScript
+    | JavaScriptReact
+    | JSON
+    | LaTeX
+    | Less
+    | Lua
+    | Makefile
+    | Markdown
+    | ObjectiveC
+    | ObjectiveCPP
+    | Pascal
+    | Perl
+    | Perl6
+    | PHP
+    | Plaintext
+    | Powershell
+    | Pug
+    | Python
+    | R
+    | Razor
+    | Ruby
+    | Rust
+    | SCSS
+    | SASS
+    | Scala
+    | ShaderLab
+    | ShellScript
+    | SQL
+    | Swift
+    | TypeScript
+    | TypeScriptReact
+    | TeX
+    | VisualBasic
+    | XML
+    | XSL
+    | YAML
+    | Other of string
 
   include Json.Jsonable.S with type t := t
 end
@@ -313,7 +398,7 @@ module FileOperationPatternKind : sig
   include Json.Jsonable.S with type t := t
 end
 
-module TraceValues : sig
+module TraceValue : sig
   type t =
     | Compact
     | Off
@@ -420,6 +505,7 @@ module SemanticTokenTypes : sig
     | Regexp
     | Operator
     | Decorator
+    | Label
 
   include Json.Jsonable.S with type t := t
 end
@@ -482,6 +568,14 @@ module AnnotatedTextEdit : sig
     -> newText:string
     -> range:Range.t
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module WorkspaceEditMetadata : sig
+  type t = { isRefactoring : bool option }
+
+  val create : ?isRefactoring:bool -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -583,6 +677,31 @@ module OptionalVersionedTextDocumentIdentifier : sig
   include Json.Jsonable.S with type t := t
 end
 
+module StringValue : sig
+  type t = { value : string }
+
+  val create : value:string -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module SnippetTextEdit : sig
+  type t =
+    { annotationId : ChangeAnnotationIdentifier.t option
+    ; range : Range.t
+    ; snippet : StringValue.t
+    }
+
+  val create
+    :  ?annotationId:ChangeAnnotationIdentifier.t
+    -> range:Range.t
+    -> snippet:StringValue.t
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module TextEdit : sig
   type t =
     { newText : string
@@ -596,12 +715,22 @@ end
 
 module TextDocumentEdit : sig
   type t =
-    { edits : [ `TextEdit of TextEdit.t | `AnnotatedTextEdit of AnnotatedTextEdit.t ] list
+    { edits :
+        [ `TextEdit of TextEdit.t
+        | `AnnotatedTextEdit of AnnotatedTextEdit.t
+        | `SnippetTextEdit of SnippetTextEdit.t
+        ]
+          list
     ; textDocument : OptionalVersionedTextDocumentIdentifier.t
     }
 
   val create
-    :  edits:[ `TextEdit of TextEdit.t | `AnnotatedTextEdit of AnnotatedTextEdit.t ] list
+    :  edits:
+         [ `TextEdit of TextEdit.t
+         | `AnnotatedTextEdit of AnnotatedTextEdit.t
+         | `SnippetTextEdit of SnippetTextEdit.t
+         ]
+           list
     -> textDocument:OptionalVersionedTextDocumentIdentifier.t
     -> t
 
@@ -655,9 +784,15 @@ module ApplyWorkspaceEditParams : sig
   type t =
     { edit : WorkspaceEdit.t
     ; label : string option
+    ; metadata : WorkspaceEditMetadata.t option
     }
 
-  val create : edit:WorkspaceEdit.t -> ?label:string -> unit -> t
+  val create
+    :  edit:WorkspaceEdit.t
+    -> ?label:string
+    -> ?metadata:WorkspaceEditMetadata.t
+    -> unit
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -817,6 +952,94 @@ module CallHierarchyPrepareParams : sig
   include Json.Jsonable.S with type t := t
 end
 
+module Pattern : sig
+  type t = string
+
+  include Json.Jsonable.S with type t := t
+end
+
+module WorkspaceFolder : sig
+  type t =
+    { name : string
+    ; uri : DocumentUri.t
+    }
+
+  val create : name:string -> uri:DocumentUri.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module RelativePattern : sig
+  type t =
+    { baseUri : unit
+    ; pattern : Pattern.t
+    }
+
+  val create : baseUri:unit -> pattern:Pattern.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module GlobPattern : sig
+  type t =
+    [ `Pattern of Pattern.t
+    | `RelativePattern of RelativePattern.t
+    ]
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilterPattern : sig
+  type t =
+    { notebookType : string option
+    ; pattern : GlobPattern.t
+    ; scheme : string option
+    }
+
+  val create
+    :  ?notebookType:string
+    -> pattern:GlobPattern.t
+    -> ?scheme:string
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilterScheme : sig
+  type t =
+    { notebookType : string option
+    ; pattern : GlobPattern.t option
+    ; scheme : string
+    }
+
+  val create
+    :  ?notebookType:string
+    -> ?pattern:GlobPattern.t
+    -> scheme:string
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilterNotebookType : sig
+  type t =
+    { notebookType : string
+    ; pattern : GlobPattern.t option
+    ; scheme : string option
+    }
+
+  val create
+    :  notebookType:string
+    -> ?pattern:GlobPattern.t
+    -> ?scheme:string
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module NotebookCellTextDocumentFilter : sig
   type t =
     { language : string option
@@ -830,6 +1053,42 @@ module NotebookCellTextDocumentFilter : sig
          [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentFilterPattern : sig
+  type t =
+    { language : string option
+    ; pattern : GlobPattern.t
+    ; scheme : string option
+    }
+
+  val create : ?language:string -> pattern:GlobPattern.t -> ?scheme:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentFilterScheme : sig
+  type t =
+    { language : string option
+    ; pattern : GlobPattern.t option
+    ; scheme : string
+    }
+
+  val create : ?language:string -> ?pattern:GlobPattern.t -> scheme:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentFilterLanguage : sig
+  type t =
+    { language : string
+    ; pattern : GlobPattern.t option
+    ; scheme : string option
+    }
+
+  val create : language:string -> ?pattern:GlobPattern.t -> ?scheme:string -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -874,59 +1133,84 @@ module CancelParams : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ChangeAnnotationsSupportOptions : sig
+  type t = { groupsOnLabel : bool option }
+
+  val create : ?groupsOnLabel:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module WorkspaceEditClientCapabilities : sig
-  type changeAnnotationSupport = { groupsOnLabel : bool option }
-
-  val create_changeAnnotationSupport
-    :  ?groupsOnLabel:bool
-    -> unit
-    -> changeAnnotationSupport
-
   type t =
-    { changeAnnotationSupport : changeAnnotationSupport option
+    { changeAnnotationSupport : ChangeAnnotationsSupportOptions.t option
     ; documentChanges : bool option
     ; failureHandling : FailureHandlingKind.t option
+    ; metadataSupport : bool option
     ; normalizesLineEndings : bool option
     ; resourceOperations : ResourceOperationKind.t list option
+    ; snippetEditSupport : bool option
     }
 
   val create
-    :  ?changeAnnotationSupport:changeAnnotationSupport
+    :  ?changeAnnotationSupport:ChangeAnnotationsSupportOptions.t
     -> ?documentChanges:bool
     -> ?failureHandling:FailureHandlingKind.t
+    -> ?metadataSupport:bool
     -> ?normalizesLineEndings:bool
     -> ?resourceOperations:ResourceOperationKind.t list
+    -> ?snippetEditSupport:bool
     -> unit
     -> t
 
   include Json.Jsonable.S with type t := t
 end
 
+module TextDocumentContentClientCapabilities : sig
+  type t = { dynamicRegistration : bool option }
+
+  val create : ?dynamicRegistration:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSymbolTagOptions : sig
+  type t = { valueSet : SymbolTag.t list }
+
+  val create : valueSet:SymbolTag.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSymbolKindOptions : sig
+  type t = { valueSet : SymbolKind.t list option }
+
+  val create : ?valueSet:SymbolKind.t list -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSymbolResolveOptions : sig
+  type t = { properties : string list }
+
+  val create : properties:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module WorkspaceSymbolClientCapabilities : sig
-  type tagSupport = { valueSet : SymbolTag.t list }
-
-  val create_tagSupport : valueSet:SymbolTag.t list -> tagSupport
-
-  type symbolKind = { valueSet : SymbolKind.t list option }
-
-  val create_symbolKind : ?valueSet:SymbolKind.t list -> unit -> symbolKind
-
-  type resolveSupport = { properties : string list }
-
-  val create_resolveSupport : properties:string list -> resolveSupport
-
   type t =
     { dynamicRegistration : bool option
-    ; resolveSupport : resolveSupport option
-    ; symbolKind : symbolKind option
-    ; tagSupport : tagSupport option
+    ; resolveSupport : ClientSymbolResolveOptions.t option
+    ; symbolKind : ClientSymbolKindOptions.t option
+    ; tagSupport : ClientSymbolTagOptions.t option
     }
 
   val create
     :  ?dynamicRegistration:bool
-    -> ?resolveSupport:resolveSupport
-    -> ?symbolKind:symbolKind
-    -> ?tagSupport:tagSupport
+    -> ?resolveSupport:ClientSymbolResolveOptions.t
+    -> ?symbolKind:ClientSymbolKindOptions.t
+    -> ?tagSupport:ClientSymbolTagOptions.t
     -> unit
     -> t
 
@@ -1048,6 +1332,7 @@ module WorkspaceClientCapabilities : sig
     ; inlineValue : InlineValueWorkspaceClientCapabilities.t option
     ; semanticTokens : SemanticTokensWorkspaceClientCapabilities.t option
     ; symbol : WorkspaceSymbolClientCapabilities.t option
+    ; textDocumentContent : TextDocumentContentClientCapabilities.t option
     ; workspaceEdit : WorkspaceEditClientCapabilities.t option
     ; workspaceFolders : bool option
     }
@@ -1066,6 +1351,7 @@ module WorkspaceClientCapabilities : sig
     -> ?inlineValue:InlineValueWorkspaceClientCapabilities.t
     -> ?semanticTokens:SemanticTokensWorkspaceClientCapabilities.t
     -> ?symbol:WorkspaceSymbolClientCapabilities.t
+    -> ?textDocumentContent:TextDocumentContentClientCapabilities.t
     -> ?workspaceEdit:WorkspaceEditClientCapabilities.t
     -> ?workspaceFolders:bool
     -> unit
@@ -1074,17 +1360,18 @@ module WorkspaceClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ClientShowMessageActionItemOptions : sig
+  type t = { additionalPropertiesSupport : bool option }
+
+  val create : ?additionalPropertiesSupport:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module ShowMessageRequestClientCapabilities : sig
-  type messageActionItem = { additionalPropertiesSupport : bool option }
+  type t = { messageActionItem : ClientShowMessageActionItemOptions.t option }
 
-  val create_messageActionItem
-    :  ?additionalPropertiesSupport:bool
-    -> unit
-    -> messageActionItem
-
-  type t = { messageActionItem : messageActionItem option }
-
-  val create : ?messageActionItem:messageActionItem -> unit -> t
+  val create : ?messageActionItem:ClientShowMessageActionItemOptions.t -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1152,39 +1439,74 @@ module TextDocumentSyncClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
-module SignatureHelpClientCapabilities : sig
-  type parameterInformation = { labelOffsetSupport : bool option }
+module ClientSignatureParameterInformationOptions : sig
+  type t = { labelOffsetSupport : bool option }
 
-  val create_parameterInformation
-    :  ?labelOffsetSupport:bool
-    -> unit
-    -> parameterInformation
+  val create : ?labelOffsetSupport:bool -> unit -> t
 
-  type signatureInformation =
-    { documentationFormat : MarkupKind.t list option
-    ; parameterInformation : parameterInformation option
-    ; activeParameterSupport : bool option
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSignatureInformationOptions : sig
+  type t =
+    { activeParameterSupport : bool option
+    ; documentationFormat : MarkupKind.t list option
     ; noActiveParameterSupport : bool option
+    ; parameterInformation : ClientSignatureParameterInformationOptions.t option
     }
 
-  val create_signatureInformation
-    :  ?documentationFormat:MarkupKind.t list
-    -> ?parameterInformation:parameterInformation
-    -> ?activeParameterSupport:bool
+  val create
+    :  ?activeParameterSupport:bool
+    -> ?documentationFormat:MarkupKind.t list
     -> ?noActiveParameterSupport:bool
+    -> ?parameterInformation:ClientSignatureParameterInformationOptions.t
     -> unit
-    -> signatureInformation
+    -> t
 
+  include Json.Jsonable.S with type t := t
+end
+
+module SignatureHelpClientCapabilities : sig
   type t =
     { contextSupport : bool option
     ; dynamicRegistration : bool option
-    ; signatureInformation : signatureInformation option
+    ; signatureInformation : ClientSignatureInformationOptions.t option
     }
 
   val create
     :  ?contextSupport:bool
     -> ?dynamicRegistration:bool
-    -> ?signatureInformation:signatureInformation
+    -> ?signatureInformation:ClientSignatureInformationOptions.t
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSemanticTokensRequestFullDelta : sig
+  type t = { delta : bool option }
+
+  val create : ?delta:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientSemanticTokensRequestOptions : sig
+  type t =
+    { full :
+        [ `Bool of bool
+        | `ClientSemanticTokensRequestFullDelta of ClientSemanticTokensRequestFullDelta.t
+        ]
+          option
+    ; range : bool option
+    }
+
+  val create
+    :  ?full:
+         [ `Bool of bool
+         | `ClientSemanticTokensRequestFullDelta of ClientSemanticTokensRequestFullDelta.t
+         ]
+    -> ?range:bool
     -> unit
     -> t
 
@@ -1192,28 +1514,13 @@ module SignatureHelpClientCapabilities : sig
 end
 
 module SemanticTokensClientCapabilities : sig
-  type full = { delta : bool option }
-
-  val create_full : ?delta:bool -> unit -> full
-
-  type requests =
-    { range : bool option
-    ; full : [ `Bool of bool | `Full of full ] option
-    }
-
-  val create_requests
-    :  ?range:bool
-    -> ?full:[ `Bool of bool | `Full of full ]
-    -> unit
-    -> requests
-
   type t =
     { augmentsSyntaxTokens : bool option
     ; dynamicRegistration : bool option
     ; formats : TokenFormat.t list
     ; multilineTokenSupport : bool option
     ; overlappingTokenSupport : bool option
-    ; requests : requests
+    ; requests : ClientSemanticTokensRequestOptions.t
     ; serverCancelSupport : bool option
     ; tokenModifiers : string list
     ; tokenTypes : string list
@@ -1225,7 +1532,7 @@ module SemanticTokensClientCapabilities : sig
     -> formats:TokenFormat.t list
     -> ?multilineTokenSupport:bool
     -> ?overlappingTokenSupport:bool
-    -> requests:requests
+    -> requests:ClientSemanticTokensRequestOptions.t
     -> ?serverCancelSupport:bool
     -> tokenModifiers:string list
     -> tokenTypes:string list
@@ -1281,16 +1588,20 @@ module DocumentRangeFormattingClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ClientDiagnosticsTagOptions : sig
+  type t = { valueSet : DiagnosticTag.t list }
+
+  val create : valueSet:DiagnosticTag.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module PublishDiagnosticsClientCapabilities : sig
-  type tagSupport = { valueSet : DiagnosticTag.t list }
-
-  val create_tagSupport : valueSet:DiagnosticTag.t list -> tagSupport
-
   type t =
     { codeDescriptionSupport : bool option
     ; dataSupport : bool option
     ; relatedInformation : bool option
-    ; tagSupport : tagSupport option
+    ; tagSupport : ClientDiagnosticsTagOptions.t option
     ; versionSupport : bool option
     }
 
@@ -1298,7 +1609,7 @@ module PublishDiagnosticsClientCapabilities : sig
     :  ?codeDescriptionSupport:bool
     -> ?dataSupport:bool
     -> ?relatedInformation:bool
-    -> ?tagSupport:tagSupport
+    -> ?tagSupport:ClientDiagnosticsTagOptions.t
     -> ?versionSupport:bool
     -> unit
     -> t
@@ -1346,17 +1657,25 @@ module InlineCompletionClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ClientInlayHintResolveOptions : sig
+  type t = { properties : string list }
+
+  val create : properties:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module InlayHintClientCapabilities : sig
-  type resolveSupport = { properties : string list }
-
-  val create_resolveSupport : properties:string list -> resolveSupport
-
   type t =
     { dynamicRegistration : bool option
-    ; resolveSupport : resolveSupport option
+    ; resolveSupport : ClientInlayHintResolveOptions.t option
     }
 
-  val create : ?dynamicRegistration:bool -> ?resolveSupport:resolveSupport -> unit -> t
+  val create
+    :  ?dynamicRegistration:bool
+    -> ?resolveSupport:ClientInlayHintResolveOptions.t
+    -> unit
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1391,30 +1710,35 @@ module DocumentFormattingClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ClientFoldingRangeKindOptions : sig
+  type t = { valueSet : FoldingRangeKind.t list option }
+
+  val create : ?valueSet:FoldingRangeKind.t list -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientFoldingRangeOptions : sig
+  type t = { collapsedText : bool option }
+
+  val create : ?collapsedText:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module FoldingRangeClientCapabilities : sig
-  type foldingRangeKind = { valueSet : FoldingRangeKind.t list option }
-
-  val create_foldingRangeKind
-    :  ?valueSet:FoldingRangeKind.t list
-    -> unit
-    -> foldingRangeKind
-
-  type foldingRange = { collapsedText : bool option }
-
-  val create_foldingRange : ?collapsedText:bool -> unit -> foldingRange
-
   type t =
     { dynamicRegistration : bool option
-    ; foldingRange : foldingRange option
-    ; foldingRangeKind : foldingRangeKind option
+    ; foldingRange : ClientFoldingRangeOptions.t option
+    ; foldingRangeKind : ClientFoldingRangeKindOptions.t option
     ; lineFoldingOnly : bool option
     ; rangeLimit : int option
     }
 
   val create
     :  ?dynamicRegistration:bool
-    -> ?foldingRange:foldingRange
-    -> ?foldingRangeKind:foldingRangeKind
+    -> ?foldingRange:ClientFoldingRangeOptions.t
+    -> ?foldingRangeKind:ClientFoldingRangeKindOptions.t
     -> ?lineFoldingOnly:bool
     -> ?rangeLimit:int
     -> unit
@@ -1423,29 +1747,29 @@ module FoldingRangeClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module TextDocumentFilterClientCapabilities : sig
+  type t = { relativePatternSupport : bool option }
+
+  val create : ?relativePatternSupport:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module DocumentSymbolClientCapabilities : sig
-  type tagSupport = { valueSet : SymbolTag.t list }
-
-  val create_tagSupport : valueSet:SymbolTag.t list -> tagSupport
-
-  type symbolKind = { valueSet : SymbolKind.t list option }
-
-  val create_symbolKind : ?valueSet:SymbolKind.t list -> unit -> symbolKind
-
   type t =
     { dynamicRegistration : bool option
     ; hierarchicalDocumentSymbolSupport : bool option
     ; labelSupport : bool option
-    ; symbolKind : symbolKind option
-    ; tagSupport : tagSupport option
+    ; symbolKind : ClientSymbolKindOptions.t option
+    ; tagSupport : ClientSymbolTagOptions.t option
     }
 
   val create
     :  ?dynamicRegistration:bool
     -> ?hierarchicalDocumentSymbolSupport:bool
     -> ?labelSupport:bool
-    -> ?symbolKind:symbolKind
-    -> ?tagSupport:tagSupport
+    -> ?symbolKind:ClientSymbolKindOptions.t
+    -> ?tagSupport:ClientSymbolTagOptions.t
     -> unit
     -> t
 
@@ -1473,15 +1797,23 @@ end
 
 module DiagnosticClientCapabilities : sig
   type t =
-    { dynamicRegistration : bool option
+    { codeDescriptionSupport : bool option
+    ; dataSupport : bool option
+    ; dynamicRegistration : bool option
     ; markupMessageSupport : bool option
     ; relatedDocumentSupport : bool option
+    ; relatedInformation : bool option
+    ; tagSupport : ClientDiagnosticsTagOptions.t option
     }
 
   val create
-    :  ?dynamicRegistration:bool
+    :  ?codeDescriptionSupport:bool
+    -> ?dataSupport:bool
+    -> ?dynamicRegistration:bool
     -> ?markupMessageSupport:bool
     -> ?relatedDocumentSupport:bool
+    -> ?relatedInformation:bool
+    -> ?tagSupport:ClientDiagnosticsTagOptions.t
     -> unit
     -> t
 
@@ -1510,72 +1842,94 @@ module DeclarationClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
-module CompletionClientCapabilities : sig
-  type completionList = { itemDefaults : string list option }
-
-  val create_completionList : ?itemDefaults:string list -> unit -> completionList
-
-  type completionItemKind = { valueSet : CompletionItemKind.t list option }
-
-  val create_completionItemKind
-    :  ?valueSet:CompletionItemKind.t list
-    -> unit
-    -> completionItemKind
-
-  type insertTextModeSupport = { valueSet : InsertTextMode.t list }
-
-  val create_insertTextModeSupport
-    :  valueSet:InsertTextMode.t list
-    -> insertTextModeSupport
-
-  type resolveSupport = { properties : string list }
-
-  val create_resolveSupport : properties:string list -> resolveSupport
-
-  type tagSupport = { valueSet : CompletionItemTag.t list }
-
-  val create_tagSupport : valueSet:CompletionItemTag.t list -> tagSupport
-
-  type completionItem =
-    { snippetSupport : bool option
-    ; commitCharactersSupport : bool option
-    ; documentationFormat : MarkupKind.t list option
-    ; deprecatedSupport : bool option
-    ; preselectSupport : bool option
-    ; tagSupport : tagSupport option
-    ; insertReplaceSupport : bool option
-    ; resolveSupport : resolveSupport option
-    ; insertTextModeSupport : insertTextModeSupport option
-    ; labelDetailsSupport : bool option
+module CompletionListCapabilities : sig
+  type t =
+    { applyKindSupport : bool option
+    ; itemDefaults : string list option
     }
 
-  val create_completionItem
-    :  ?snippetSupport:bool
-    -> ?commitCharactersSupport:bool
-    -> ?documentationFormat:MarkupKind.t list
-    -> ?deprecatedSupport:bool
-    -> ?preselectSupport:bool
-    -> ?tagSupport:tagSupport
-    -> ?insertReplaceSupport:bool
-    -> ?resolveSupport:resolveSupport
-    -> ?insertTextModeSupport:insertTextModeSupport
-    -> ?labelDetailsSupport:bool
-    -> unit
-    -> completionItem
+  val create : ?applyKindSupport:bool -> ?itemDefaults:string list -> unit -> t
 
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCompletionItemOptionsKind : sig
+  type t = { valueSet : CompletionItemKind.t list option }
+
+  val create : ?valueSet:CompletionItemKind.t list -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module CompletionItemTagOptions : sig
+  type t = { valueSet : CompletionItemTag.t list }
+
+  val create : valueSet:CompletionItemTag.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCompletionItemResolveOptions : sig
+  type t = { properties : string list }
+
+  val create : properties:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCompletionItemInsertTextModeOptions : sig
+  type t = { valueSet : InsertTextMode.t list }
+
+  val create : valueSet:InsertTextMode.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCompletionItemOptions : sig
   type t =
-    { completionItem : completionItem option
-    ; completionItemKind : completionItemKind option
-    ; completionList : completionList option
+    { commitCharactersSupport : bool option
+    ; deprecatedSupport : bool option
+    ; documentationFormat : MarkupKind.t list option
+    ; insertReplaceSupport : bool option
+    ; insertTextModeSupport : ClientCompletionItemInsertTextModeOptions.t option
+    ; labelDetailsSupport : bool option
+    ; preselectSupport : bool option
+    ; resolveSupport : ClientCompletionItemResolveOptions.t option
+    ; snippetSupport : bool option
+    ; tagSupport : CompletionItemTagOptions.t option
+    }
+
+  val create
+    :  ?commitCharactersSupport:bool
+    -> ?deprecatedSupport:bool
+    -> ?documentationFormat:MarkupKind.t list
+    -> ?insertReplaceSupport:bool
+    -> ?insertTextModeSupport:ClientCompletionItemInsertTextModeOptions.t
+    -> ?labelDetailsSupport:bool
+    -> ?preselectSupport:bool
+    -> ?resolveSupport:ClientCompletionItemResolveOptions.t
+    -> ?snippetSupport:bool
+    -> ?tagSupport:CompletionItemTagOptions.t
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module CompletionClientCapabilities : sig
+  type t =
+    { completionItem : ClientCompletionItemOptions.t option
+    ; completionItemKind : ClientCompletionItemOptionsKind.t option
+    ; completionList : CompletionListCapabilities.t option
     ; contextSupport : bool option
     ; dynamicRegistration : bool option
     ; insertTextMode : InsertTextMode.t option
     }
 
   val create
-    :  ?completionItem:completionItem
-    -> ?completionItemKind:completionItemKind
-    -> ?completionList:completionList
+    :  ?completionItem:ClientCompletionItemOptions.t
+    -> ?completionItemKind:ClientCompletionItemOptionsKind.t
+    -> ?completionList:CompletionListCapabilities.t
     -> ?contextSupport:bool
     -> ?dynamicRegistration:bool
     -> ?insertTextMode:InsertTextMode.t
@@ -1593,47 +1947,84 @@ module DocumentColorClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
-module CodeLensClientCapabilities : sig
-  type t = { dynamicRegistration : bool option }
+module ClientCodeLensResolveOptions : sig
+  type t = { properties : string list }
 
-  val create : ?dynamicRegistration:bool -> unit -> t
+  val create : properties:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module CodeLensClientCapabilities : sig
+  type t =
+    { dynamicRegistration : bool option
+    ; resolveSupport : ClientCodeLensResolveOptions.t option
+    }
+
+  val create
+    :  ?dynamicRegistration:bool
+    -> ?resolveSupport:ClientCodeLensResolveOptions.t
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module CodeActionTagOptions : sig
+  type t = { valueSet : CodeActionTag.t list }
+
+  val create : valueSet:CodeActionTag.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCodeActionResolveOptions : sig
+  type t = { properties : string list }
+
+  val create : properties:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCodeActionKindOptions : sig
+  type t = { valueSet : CodeActionKind.t list }
+
+  val create : valueSet:CodeActionKind.t list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientCodeActionLiteralOptions : sig
+  type t = { codeActionKind : ClientCodeActionKindOptions.t }
+
+  val create : codeActionKind:ClientCodeActionKindOptions.t -> t
 
   include Json.Jsonable.S with type t := t
 end
 
 module CodeActionClientCapabilities : sig
-  type resolveSupport = { properties : string list }
-
-  val create_resolveSupport : properties:string list -> resolveSupport
-
-  type codeActionKind = { valueSet : CodeActionKind.t list }
-
-  val create_codeActionKind : valueSet:CodeActionKind.t list -> codeActionKind
-
-  type codeActionLiteralSupport = { codeActionKind : codeActionKind }
-
-  val create_codeActionLiteralSupport
-    :  codeActionKind:codeActionKind
-    -> codeActionLiteralSupport
-
   type t =
-    { codeActionLiteralSupport : codeActionLiteralSupport option
+    { codeActionLiteralSupport : ClientCodeActionLiteralOptions.t option
     ; dataSupport : bool option
     ; disabledSupport : bool option
+    ; documentationSupport : bool option
     ; dynamicRegistration : bool option
     ; honorsChangeAnnotations : bool option
     ; isPreferredSupport : bool option
-    ; resolveSupport : resolveSupport option
+    ; resolveSupport : ClientCodeActionResolveOptions.t option
+    ; tagSupport : CodeActionTagOptions.t option
     }
 
   val create
-    :  ?codeActionLiteralSupport:codeActionLiteralSupport
+    :  ?codeActionLiteralSupport:ClientCodeActionLiteralOptions.t
     -> ?dataSupport:bool
     -> ?disabledSupport:bool
+    -> ?documentationSupport:bool
     -> ?dynamicRegistration:bool
     -> ?honorsChangeAnnotations:bool
     -> ?isPreferredSupport:bool
-    -> ?resolveSupport:resolveSupport
+    -> ?resolveSupport:ClientCodeActionResolveOptions.t
+    -> ?tagSupport:CodeActionTagOptions.t
     -> unit
     -> t
 
@@ -1653,6 +2044,7 @@ module TextDocumentClientCapabilities : sig
     ; documentHighlight : DocumentHighlightClientCapabilities.t option
     ; documentLink : DocumentLinkClientCapabilities.t option
     ; documentSymbol : DocumentSymbolClientCapabilities.t option
+    ; filters : TextDocumentFilterClientCapabilities.t option
     ; foldingRange : FoldingRangeClientCapabilities.t option
     ; formatting : DocumentFormattingClientCapabilities.t option
     ; hover : HoverClientCapabilities.t option
@@ -1687,6 +2079,7 @@ module TextDocumentClientCapabilities : sig
     -> ?documentHighlight:DocumentHighlightClientCapabilities.t
     -> ?documentLink:DocumentLinkClientCapabilities.t
     -> ?documentSymbol:DocumentSymbolClientCapabilities.t
+    -> ?filters:TextDocumentFilterClientCapabilities.t
     -> ?foldingRange:FoldingRangeClientCapabilities.t
     -> ?formatting:DocumentFormattingClientCapabilities.t
     -> ?hover:HoverClientCapabilities.t
@@ -1732,13 +2125,30 @@ module NotebookDocumentClientCapabilities : sig
   include Json.Jsonable.S with type t := t
 end
 
+module StaleRequestSupportOptions : sig
+  type t =
+    { cancel : bool
+    ; retryOnContentModified : string list
+    }
+
+  val create : cancel:bool -> retryOnContentModified:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module RegularExpressionEngineKind : sig
+  type t = string
+
+  include Json.Jsonable.S with type t := t
+end
+
 module RegularExpressionsClientCapabilities : sig
   type t =
-    { engine : string
+    { engine : RegularExpressionEngineKind.t
     ; version : string option
     }
 
-  val create : engine:string -> ?version:string -> unit -> t
+  val create : engine:RegularExpressionEngineKind.t -> ?version:string -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1756,28 +2166,18 @@ module MarkdownClientCapabilities : sig
 end
 
 module GeneralClientCapabilities : sig
-  type staleRequestSupport =
-    { cancel : bool
-    ; retryOnContentModified : string list
-    }
-
-  val create_staleRequestSupport
-    :  cancel:bool
-    -> retryOnContentModified:string list
-    -> staleRequestSupport
-
   type t =
     { markdown : MarkdownClientCapabilities.t option
     ; positionEncodings : PositionEncodingKind.t list option
     ; regularExpressions : RegularExpressionsClientCapabilities.t option
-    ; staleRequestSupport : staleRequestSupport option
+    ; staleRequestSupport : StaleRequestSupportOptions.t option
     }
 
   val create
     :  ?markdown:MarkdownClientCapabilities.t
     -> ?positionEncodings:PositionEncodingKind.t list
     -> ?regularExpressions:RegularExpressionsClientCapabilities.t
-    -> ?staleRequestSupport:staleRequestSupport
+    -> ?staleRequestSupport:StaleRequestSupportOptions.t
     -> unit
     -> t
 
@@ -1803,6 +2203,25 @@ module ClientCapabilities : sig
     -> ?workspace:WorkspaceClientCapabilities.t
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ClientInfo : sig
+  type t =
+    { name : string
+    ; version : string option
+    }
+
+  val create : name:string -> ?version:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module CodeActionDisabled : sig
+  type t = { reason : string }
+
+  val create : reason:string -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1882,26 +2301,30 @@ module Command : sig
     { arguments : Json.t list option
     ; command : string
     ; title : string
+    ; tooltip : string option
     }
 
-  val create : ?arguments:Json.t list -> command:string -> title:string -> unit -> t
+  val create
+    :  ?arguments:Json.t list
+    -> command:string
+    -> title:string
+    -> ?tooltip:string
+    -> unit
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
 
 module CodeAction : sig
-  type disabled = { reason : string }
-
-  val create_disabled : reason:string -> disabled
-
   type t =
     { command : Command.t option
     ; data : Json.t option
     ; diagnostics : Diagnostic.t list option
-    ; disabled : disabled option
+    ; disabled : CodeActionDisabled.t option
     ; edit : WorkspaceEdit.t option
     ; isPreferred : bool option
     ; kind : CodeActionKind.t option
+    ; tags : CodeActionTag.t list option
     ; title : string
     }
 
@@ -1909,10 +2332,11 @@ module CodeAction : sig
     :  ?command:Command.t
     -> ?data:Json.t
     -> ?diagnostics:Diagnostic.t list
-    -> ?disabled:disabled
+    -> ?disabled:CodeActionDisabled.t
     -> ?edit:WorkspaceEdit.t
     -> ?isPreferred:bool
     -> ?kind:CodeActionKind.t
+    -> ?tags:CodeActionTag.t list
     -> title:string
     -> unit
     -> t
@@ -1937,15 +2361,28 @@ module CodeActionContext : sig
   include Json.Jsonable.S with type t := t
 end
 
+module CodeActionKindDocumentation : sig
+  type t =
+    { command : Command.t
+    ; kind : CodeActionKind.t
+    }
+
+  val create : command:Command.t -> kind:CodeActionKind.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module CodeActionOptions : sig
   type t =
     { codeActionKinds : CodeActionKind.t list option
+    ; documentation : CodeActionKindDocumentation.t list option
     ; resolveProvider : bool option
     ; workDoneProgress : bool option
     }
 
   val create
     :  ?codeActionKinds:CodeActionKind.t list
+    -> ?documentation:CodeActionKindDocumentation.t list
     -> ?resolveProvider:bool
     -> ?workDoneProgress:bool
     -> unit
@@ -1979,6 +2416,7 @@ module CodeActionRegistrationOptions : sig
   type t =
     { codeActionKinds : CodeActionKind.t list option
     ; documentSelector : DocumentSelector.t option
+    ; documentation : CodeActionKindDocumentation.t list option
     ; resolveProvider : bool option
     ; workDoneProgress : bool option
     }
@@ -1986,6 +2424,7 @@ module CodeActionRegistrationOptions : sig
   val create
     :  ?codeActionKinds:CodeActionKind.t list
     -> ?documentSelector:DocumentSelector.t
+    -> ?documentation:CodeActionKindDocumentation.t list
     -> ?resolveProvider:bool
     -> ?workDoneProgress:bool
     -> unit
@@ -2201,40 +2640,68 @@ module CompletionItem : sig
   include Json.Jsonable.S with type t := t
 end
 
-module CompletionList : sig
-  type editRange =
+module CompletionItemApplyKinds : sig
+  type t =
+    { commitCharacters : ApplyKind.t option
+    ; data : ApplyKind.t option
+    }
+
+  val create : ?commitCharacters:ApplyKind.t -> ?data:ApplyKind.t -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module EditRangeWithInsertReplace : sig
+  type t =
     { insert : Range.t
     ; replace : Range.t
     }
 
-  val create_editRange : insert:Range.t -> replace:Range.t -> editRange
+  val create : insert:Range.t -> replace:Range.t -> t
 
-  type itemDefaults =
+  include Json.Jsonable.S with type t := t
+end
+
+module CompletionItemDefaults : sig
+  type t =
     { commitCharacters : string list option
-    ; editRange : [ `Range of Range.t | `EditRange of editRange ] option
+    ; data : Json.t option
+    ; editRange :
+        [ `Range of Range.t
+        | `EditRangeWithInsertReplace of EditRangeWithInsertReplace.t
+        ]
+          option
     ; insertTextFormat : InsertTextFormat.t option
     ; insertTextMode : InsertTextMode.t option
-    ; data : Json.t option
     }
 
-  val create_itemDefaults
+  val create
     :  ?commitCharacters:string list
-    -> ?editRange:[ `Range of Range.t | `EditRange of editRange ]
+    -> ?data:Json.t
+    -> ?editRange:
+         [ `Range of Range.t
+         | `EditRangeWithInsertReplace of EditRangeWithInsertReplace.t
+         ]
     -> ?insertTextFormat:InsertTextFormat.t
     -> ?insertTextMode:InsertTextMode.t
-    -> ?data:Json.t
     -> unit
-    -> itemDefaults
+    -> t
 
+  include Json.Jsonable.S with type t := t
+end
+
+module CompletionList : sig
   type t =
-    { isIncomplete : bool
-    ; itemDefaults : itemDefaults option
+    { applyKind : CompletionItemApplyKinds.t option
+    ; isIncomplete : bool
+    ; itemDefaults : CompletionItemDefaults.t option
     ; items : CompletionItem.t list
     }
 
   val create
-    :  isIncomplete:bool
-    -> ?itemDefaults:itemDefaults
+    :  ?applyKind:CompletionItemApplyKinds.t
+    -> isIncomplete:bool
+    -> ?itemDefaults:CompletionItemDefaults.t
     -> items:CompletionItem.t list
     -> unit
     -> t
@@ -2242,14 +2709,18 @@ module CompletionList : sig
   include Json.Jsonable.S with type t := t
 end
 
+module ServerCompletionItemOptions : sig
+  type t = { labelDetailsSupport : bool option }
+
+  val create : ?labelDetailsSupport:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module CompletionOptions : sig
-  type completionItem = { labelDetailsSupport : bool option }
-
-  val create_completionItem : ?labelDetailsSupport:bool -> unit -> completionItem
-
   type t =
     { allCommitCharacters : string list option
-    ; completionItem : completionItem option
+    ; completionItem : ServerCompletionItemOptions.t option
     ; resolveProvider : bool option
     ; triggerCharacters : string list option
     ; workDoneProgress : bool option
@@ -2257,7 +2728,7 @@ module CompletionOptions : sig
 
   val create
     :  ?allCommitCharacters:string list
-    -> ?completionItem:completionItem
+    -> ?completionItem:ServerCompletionItemOptions.t
     -> ?resolveProvider:bool
     -> ?triggerCharacters:string list
     -> ?workDoneProgress:bool
@@ -2289,13 +2760,9 @@ module CompletionParams : sig
 end
 
 module CompletionRegistrationOptions : sig
-  type completionItem = { labelDetailsSupport : bool option }
-
-  val create_completionItem : ?labelDetailsSupport:bool -> unit -> completionItem
-
   type t =
     { allCommitCharacters : string list option
-    ; completionItem : completionItem option
+    ; completionItem : ServerCompletionItemOptions.t option
     ; documentSelector : DocumentSelector.t option
     ; resolveProvider : bool option
     ; triggerCharacters : string list option
@@ -2304,7 +2771,7 @@ module CompletionRegistrationOptions : sig
 
   val create
     :  ?allCommitCharacters:string list
-    -> ?completionItem:completionItem
+    -> ?completionItem:ServerCompletionItemOptions.t
     -> ?documentSelector:DocumentSelector.t
     -> ?resolveProvider:bool
     -> ?triggerCharacters:string list
@@ -2335,9 +2802,9 @@ module ConfigurationParams : sig
 end
 
 module FileCreate : sig
-  type t = { uri : string }
+  type t = { uri : DocumentUri.t }
 
-  val create : uri:string -> t
+  val create : uri:DocumentUri.t -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -2482,9 +2949,9 @@ module DefinitionRegistrationOptions : sig
 end
 
 module FileDelete : sig
-  type t = { uri : string }
+  type t = { uri : DocumentUri.t }
 
-  val create : uri:string -> t
+  val create : uri:DocumentUri.t -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -2547,6 +3014,25 @@ module DiagnosticServerCancellationData : sig
   include Json.Jsonable.S with type t := t
 end
 
+module DiagnosticsCapabilities : sig
+  type t =
+    { codeDescriptionSupport : bool option
+    ; dataSupport : bool option
+    ; relatedInformation : bool option
+    ; tagSupport : ClientDiagnosticsTagOptions.t option
+    }
+
+  val create
+    :  ?codeDescriptionSupport:bool
+    -> ?dataSupport:bool
+    -> ?relatedInformation:bool
+    -> ?tagSupport:ClientDiagnosticsTagOptions.t
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module DidChangeConfigurationParams : sig
   type t = { settings : Json.t }
 
@@ -2574,18 +3060,6 @@ module VersionedNotebookDocumentIdentifier : sig
   include Json.Jsonable.S with type t := t
 end
 
-module TextDocumentContentChangeEvent : sig
-  type t =
-    { range : Range.t option
-    ; rangeLength : int option
-    ; text : string
-    }
-
-  val create : ?range:Range.t -> ?rangeLength:int -> text:string -> unit -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
 module VersionedTextDocumentIdentifier : sig
   type t =
     { uri : DocumentUri.t
@@ -2593,6 +3067,67 @@ module VersionedTextDocumentIdentifier : sig
     }
 
   val create : uri:DocumentUri.t -> version:int -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentChangeWholeDocument : sig
+  type t = { text : string }
+
+  val create : text:string -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentChangePartial : sig
+  type t =
+    { range : Range.t
+    ; rangeLength : int option
+    ; text : string
+    }
+
+  val create : range:Range.t -> ?rangeLength:int -> text:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentChangeEvent : sig
+  type t =
+    [ `TextDocumentContentChangePartial of TextDocumentContentChangePartial.t
+    | `TextDocumentContentChangeWholeDocument of TextDocumentContentChangeWholeDocument.t
+    ]
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentCellContentChanges : sig
+  type t =
+    { changes : TextDocumentContentChangeEvent.t list
+    ; document : VersionedTextDocumentIdentifier.t
+    }
+
+  val create
+    :  changes:TextDocumentContentChangeEvent.t list
+    -> document:VersionedTextDocumentIdentifier.t
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentItem : sig
+  type t =
+    { languageId : LanguageKind.t
+    ; text : string
+    ; uri : DocumentUri.t
+    ; version : int
+    }
+
+  val create
+    :  languageId:LanguageKind.t
+    -> text:string
+    -> uri:DocumentUri.t
+    -> version:int
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -2627,19 +3162,6 @@ module NotebookCell : sig
   include Json.Jsonable.S with type t := t
 end
 
-module TextDocumentItem : sig
-  type t =
-    { languageId : string
-    ; text : string
-    ; uri : DocumentUri.t
-    ; version : int
-    }
-
-  val create : languageId:string -> text:string -> uri:DocumentUri.t -> version:int -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
 module NotebookCellArrayChange : sig
   type t =
     { cells : NotebookCell.t list option
@@ -2652,49 +3174,51 @@ module NotebookCellArrayChange : sig
   include Json.Jsonable.S with type t := t
 end
 
-module NotebookDocumentChangeEvent : sig
-  type textContent =
-    { document : VersionedTextDocumentIdentifier.t
-    ; changes : TextDocumentContentChangeEvent.t list
-    }
-
-  val create_textContent
-    :  document:VersionedTextDocumentIdentifier.t
-    -> changes:TextDocumentContentChangeEvent.t list
-    -> textContent
-
-  type structure =
-    { array : NotebookCellArrayChange.t
-    ; didOpen : TextDocumentItem.t list option
-    ; didClose : TextDocumentIdentifier.t list option
-    }
-
-  val create_structure
-    :  array:NotebookCellArrayChange.t
-    -> ?didOpen:TextDocumentItem.t list
-    -> ?didClose:TextDocumentIdentifier.t list
-    -> unit
-    -> structure
-
-  type cells =
-    { structure : structure option
-    ; data : NotebookCell.t list option
-    ; textContent : textContent list option
-    }
-
-  val create_cells
-    :  ?structure:structure
-    -> ?data:NotebookCell.t list
-    -> ?textContent:textContent list
-    -> unit
-    -> cells
-
+module NotebookDocumentCellChangeStructure : sig
   type t =
-    { cells : cells option
+    { array : NotebookCellArrayChange.t
+    ; didClose : TextDocumentIdentifier.t list option
+    ; didOpen : TextDocumentItem.t list option
+    }
+
+  val create
+    :  array:NotebookCellArrayChange.t
+    -> ?didClose:TextDocumentIdentifier.t list
+    -> ?didOpen:TextDocumentItem.t list
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentCellChanges : sig
+  type t =
+    { data : NotebookCell.t list option
+    ; structure : NotebookDocumentCellChangeStructure.t option
+    ; textContent : NotebookDocumentCellContentChanges.t list option
+    }
+
+  val create
+    :  ?data:NotebookCell.t list
+    -> ?structure:NotebookDocumentCellChangeStructure.t
+    -> ?textContent:NotebookDocumentCellContentChanges.t list
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentChangeEvent : sig
+  type t =
+    { cells : NotebookDocumentCellChanges.t option
     ; metadata : Json.Object.t option
     }
 
-  val create : ?cells:cells -> ?metadata:Json.Object.t -> unit -> t
+  val create
+    :  ?cells:NotebookDocumentCellChanges.t
+    -> ?metadata:Json.Object.t
+    -> unit
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -2742,43 +3266,6 @@ module DidChangeWatchedFilesParams : sig
   type t = { changes : FileEvent.t list }
 
   val create : changes:FileEvent.t list -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
-module Pattern : sig
-  type t = string
-
-  include Json.Jsonable.S with type t := t
-end
-
-module WorkspaceFolder : sig
-  type t =
-    { name : string
-    ; uri : DocumentUri.t
-    }
-
-  val create : name:string -> uri:DocumentUri.t -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
-module RelativePattern : sig
-  type t =
-    { baseUri : unit
-    ; pattern : Pattern.t
-    }
-
-  val create : baseUri:unit -> pattern:Pattern.t -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
-module GlobPattern : sig
-  type t =
-    [ `Pattern of Pattern.t
-    | `RelativePattern of RelativePattern.t
-    ]
 
   include Json.Jsonable.S with type t := t
 end
@@ -3077,6 +3564,15 @@ module DocumentDiagnosticReportPartialResult : sig
              ] )
            Json.Assoc.t
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module DocumentDiagnosticReportProgress : sig
+  type t =
+    [ `DocumentDiagnosticReport of DocumentDiagnosticReport.t
+    | `DocumentDiagnosticReportPartialResult of DocumentDiagnosticReportPartialResult.t
+    ]
 
   include Json.Jsonable.S with type t := t
 end
@@ -3547,11 +4043,11 @@ end
 
 module FileRename : sig
   type t =
-    { newUri : string
-    ; oldUri : string
+    { newUri : DocumentUri.t
+    ; oldUri : DocumentUri.t
     }
 
-  val create : newUri:string -> oldUri:string -> t
+  val create : newUri:DocumentUri.t -> oldUri:DocumentUri.t -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -3617,6 +4113,17 @@ module FoldingRangeRegistrationOptions : sig
     -> ?workDoneProgress:bool
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module MarkedStringWithLanguage : sig
+  type t =
+    { language : string
+    ; value : string
+    }
+
+  val create : language:string -> value:string -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -3733,39 +4240,43 @@ module InitializeError : sig
 end
 
 module InitializeParams : sig
-  type clientInfo =
-    { name : string
-    ; version : string option
-    }
-
-  val create_clientInfo : name:string -> ?version:string -> unit -> clientInfo
-
   type t =
     { capabilities : ClientCapabilities.t
-    ; clientInfo : clientInfo option
+    ; clientInfo : ClientInfo.t option
     ; initializationOptions : Json.t option
     ; locale : string option
     ; processId : int option
     ; rootPath : string option option
     ; rootUri : DocumentUri.t option
-    ; trace : TraceValues.t option
+    ; trace : TraceValue.t option
     ; workDoneToken : ProgressToken.t option
     ; workspaceFolders : WorkspaceFolder.t list option option
     }
 
   val create
     :  capabilities:ClientCapabilities.t
-    -> ?clientInfo:clientInfo
+    -> ?clientInfo:ClientInfo.t
     -> ?initializationOptions:Json.t
     -> ?locale:string
     -> ?processId:int
     -> ?rootPath:string option
     -> ?rootUri:DocumentUri.t
-    -> ?trace:TraceValues.t
+    -> ?trace:TraceValue.t
     -> ?workDoneToken:ProgressToken.t
     -> ?workspaceFolders:WorkspaceFolder.t list option
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module ServerInfo : sig
+  type t =
+    { name : string
+    ; version : string option
+    }
+
+  val create : name:string -> ?version:string -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -3790,6 +4301,51 @@ module WorkspaceFoldersServerCapabilities : sig
   val create
     :  ?changeNotifications:[ `String of string | `Bool of bool ]
     -> ?supported:bool
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentRegistrationOptions : sig
+  type t =
+    { id : string option
+    ; schemes : string list
+    }
+
+  val create : ?id:string -> schemes:string list -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentOptions : sig
+  type t = { schemes : string list }
+
+  val create : schemes:string list -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module WorkspaceOptions : sig
+  type t =
+    { fileOperations : FileOperationOptions.t option
+    ; textDocumentContent :
+        [ `TextDocumentContentOptions of TextDocumentContentOptions.t
+        | `TextDocumentContentRegistrationOptions of
+            TextDocumentContentRegistrationOptions.t
+        ]
+          option
+    ; workspaceFolders : WorkspaceFoldersServerCapabilities.t option
+    }
+
+  val create
+    :  ?fileOperations:FileOperationOptions.t
+    -> ?textDocumentContent:
+         [ `TextDocumentContentOptions of TextDocumentContentOptions.t
+         | `TextDocumentContentRegistrationOptions of
+             TextDocumentContentRegistrationOptions.t
+         ]
+    -> ?workspaceFolders:WorkspaceFoldersServerCapabilities.t
     -> unit
     -> t
 
@@ -3903,14 +4459,19 @@ module SemanticTokensLegend : sig
   include Json.Jsonable.S with type t := t
 end
 
+module SemanticTokensFullDelta : sig
+  type t = { delta : bool option }
+
+  val create : ?delta:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module SemanticTokensRegistrationOptions : sig
-  type full = { delta : bool option }
-
-  val create_full : ?delta:bool -> unit -> full
-
   type t =
     { documentSelector : DocumentSelector.t option
-    ; full : [ `Bool of bool | `Full of full ] option
+    ; full :
+        [ `Bool of bool | `SemanticTokensFullDelta of SemanticTokensFullDelta.t ] option
     ; id : string option
     ; legend : SemanticTokensLegend.t
     ; range : bool option
@@ -3919,7 +4480,7 @@ module SemanticTokensRegistrationOptions : sig
 
   val create
     :  ?documentSelector:DocumentSelector.t
-    -> ?full:[ `Bool of bool | `Full of full ]
+    -> ?full:[ `Bool of bool | `SemanticTokensFullDelta of SemanticTokensFullDelta.t ]
     -> ?id:string
     -> legend:SemanticTokensLegend.t
     -> ?range:bool
@@ -3931,19 +4492,16 @@ module SemanticTokensRegistrationOptions : sig
 end
 
 module SemanticTokensOptions : sig
-  type full = { delta : bool option }
-
-  val create_full : ?delta:bool -> unit -> full
-
   type t =
-    { full : [ `Bool of bool | `Full of full ] option
+    { full :
+        [ `Bool of bool | `SemanticTokensFullDelta of SemanticTokensFullDelta.t ] option
     ; legend : SemanticTokensLegend.t
     ; range : bool option
     ; workDoneProgress : bool option
     }
 
   val create
-    :  ?full:[ `Bool of bool | `Full of full ]
+    :  ?full:[ `Bool of bool | `SemanticTokensFullDelta of SemanticTokensFullDelta.t ]
     -> legend:SemanticTokensLegend.t
     -> ?range:bool
     -> ?workDoneProgress:bool
@@ -3993,6 +4551,48 @@ module ReferenceOptions : sig
   type t = { workDoneProgress : bool option }
 
   val create : ?workDoneProgress:bool -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookCellLanguage : sig
+  type t = { language : string }
+
+  val create : language:string -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilterWithCells : sig
+  type t =
+    { cells : NotebookCellLanguage.t list
+    ; notebook :
+        [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ] option
+    }
+
+  val create
+    :  cells:NotebookCellLanguage.t list
+    -> ?notebook:
+         [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilterWithNotebook : sig
+  type t =
+    { cells : NotebookCellLanguage.t list option
+    ; notebook :
+        [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
+    }
+
+  val create
+    :  ?cells:NotebookCellLanguage.t list
+    -> notebook:
+         [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
+    -> unit
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -4105,25 +4705,6 @@ module InlayHintOptions : sig
 end
 
 module ServerCapabilities : sig
-  type workspace =
-    { workspaceFolders : WorkspaceFoldersServerCapabilities.t option
-    ; fileOperations : FileOperationOptions.t option
-    }
-
-  val create_workspace
-    :  ?workspaceFolders:WorkspaceFoldersServerCapabilities.t
-    -> ?fileOperations:FileOperationOptions.t
-    -> unit
-    -> workspace
-
-  type diagnostic = { markupMessageSupport : bool option }
-
-  val create_diagnostic : ?markupMessageSupport:bool -> unit -> diagnostic
-
-  type textDocument = { diagnostic : diagnostic option }
-
-  val create_textDocument : ?diagnostic:diagnostic -> unit -> textDocument
-
   type t =
     { callHierarchyProvider :
         [ `Bool of bool
@@ -4232,7 +4813,6 @@ module ServerCapabilities : sig
         ]
           option
     ; signatureHelpProvider : SignatureHelpOptions.t option
-    ; textDocument : textDocument option
     ; textDocumentSync :
         [ `TextDocumentSyncOptions of TextDocumentSyncOptions.t
         | `TextDocumentSyncKind of TextDocumentSyncKind.t
@@ -4250,7 +4830,7 @@ module ServerCapabilities : sig
         | `TypeHierarchyRegistrationOptions of TypeHierarchyRegistrationOptions.t
         ]
           option
-    ; workspace : workspace option
+    ; workspace : WorkspaceOptions.t option
     ; workspaceSymbolProvider :
         [ `Bool of bool | `WorkspaceSymbolOptions of WorkspaceSymbolOptions.t ] option
     }
@@ -4345,7 +4925,6 @@ module ServerCapabilities : sig
          | `SemanticTokensRegistrationOptions of SemanticTokensRegistrationOptions.t
          ]
     -> ?signatureHelpProvider:SignatureHelpOptions.t
-    -> ?textDocument:textDocument
     -> ?textDocumentSync:
          [ `TextDocumentSyncOptions of TextDocumentSyncOptions.t
          | `TextDocumentSyncKind of TextDocumentSyncKind.t
@@ -4360,7 +4939,7 @@ module ServerCapabilities : sig
          | `TypeHierarchyOptions of TypeHierarchyOptions.t
          | `TypeHierarchyRegistrationOptions of TypeHierarchyRegistrationOptions.t
          ]
-    -> ?workspace:workspace
+    -> ?workspace:WorkspaceOptions.t
     -> ?workspaceSymbolProvider:
          [ `Bool of bool | `WorkspaceSymbolOptions of WorkspaceSymbolOptions.t ]
     -> unit
@@ -4370,52 +4949,38 @@ module ServerCapabilities : sig
 end
 
 module InitializeResult : sig
-  type serverInfo =
-    { name : string
-    ; version : string option
-    }
-
-  val create_serverInfo : name:string -> ?version:string -> unit -> serverInfo
-
   type t =
     { capabilities : ServerCapabilities.t
-    ; serverInfo : serverInfo option
+    ; serverInfo : ServerInfo.t option
     }
 
-  val create : capabilities:ServerCapabilities.t -> ?serverInfo:serverInfo -> unit -> t
+  val create : capabilities:ServerCapabilities.t -> ?serverInfo:ServerInfo.t -> unit -> t
 
   include Json.Jsonable.S with type t := t
 end
 
 module InitializedParams_ : sig
-  type clientInfo =
-    { name : string
-    ; version : string option
-    }
-
-  val create_clientInfo : name:string -> ?version:string -> unit -> clientInfo
-
   type t =
     { capabilities : ClientCapabilities.t
-    ; clientInfo : clientInfo option
+    ; clientInfo : ClientInfo.t option
     ; initializationOptions : Json.t option
     ; locale : string option
     ; processId : int option
     ; rootPath : string option option
     ; rootUri : DocumentUri.t option
-    ; trace : TraceValues.t option
+    ; trace : TraceValue.t option
     ; workDoneToken : ProgressToken.t option
     }
 
   val create
     :  capabilities:ClientCapabilities.t
-    -> ?clientInfo:clientInfo
+    -> ?clientInfo:ClientInfo.t
     -> ?initializationOptions:Json.t
     -> ?locale:string
     -> ?processId:int
     -> ?rootPath:string option
     -> ?rootUri:DocumentUri.t
-    -> ?trace:TraceValues.t
+    -> ?trace:TraceValue.t
     -> ?workDoneToken:ProgressToken.t
     -> unit
     -> t
@@ -4508,14 +5073,6 @@ module InlineCompletionContext : sig
     -> triggerKind:InlineCompletionTriggerKind.t
     -> unit
     -> t
-
-  include Json.Jsonable.S with type t := t
-end
-
-module StringValue : sig
-  type t = { value : string }
-
-  val create : value:string -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -4690,6 +5247,14 @@ module LinkedEditingRanges : sig
   include Json.Jsonable.S with type t := t
 end
 
+module LocationUriOnly : sig
+  type t = { uri : DocumentUri.t }
+
+  val create : uri:DocumentUri.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module LogMessageParams : sig
   type t =
     { message : string
@@ -4781,6 +5346,14 @@ module PartialResultParams : sig
   include Json.Jsonable.S with type t := t
 end
 
+module PrepareRenameDefaultBehavior : sig
+  type t = { defaultBehavior : bool }
+
+  val create : defaultBehavior:bool -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module PrepareRenameParams : sig
   type t =
     { position : Position.t
@@ -4794,6 +5367,17 @@ module PrepareRenameParams : sig
     -> ?workDoneToken:ProgressToken.t
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module PrepareRenamePlaceholder : sig
+  type t =
+    { placeholder : string
+    ; range : Range.t
+    }
+
+  val create : placeholder:string -> range:Range.t -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -5077,9 +5661,9 @@ module SemanticTokensRangeParams : sig
 end
 
 module SetTraceParams : sig
-  type t = { value : TraceValues.t }
+  type t = { value : TraceValue.t }
 
-  val create : value:TraceValues.t -> t
+  val create : value:TraceValue.t -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -5274,6 +5858,30 @@ module TextDocumentChangeRegistrationOptions : sig
     -> syncKind:TextDocumentSyncKind.t
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentParams : sig
+  type t = { uri : DocumentUri.t }
+
+  val create : uri:DocumentUri.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentRefreshParams : sig
+  type t = { uri : DocumentUri.t }
+
+  val create : uri:DocumentUri.t -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentContentResult : sig
+  type t = { text : string }
+
+  val create : text:string -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -5598,7 +6206,7 @@ module WorkspaceSymbol : sig
     { containerName : string option
     ; data : Json.t option
     ; kind : SymbolKind.t
-    ; location : Location.t
+    ; location : [ `Location of Location.t | `LocationUriOnly of LocationUriOnly.t ]
     ; name : string
     ; tags : SymbolTag.t list option
     }
@@ -5607,7 +6215,7 @@ module WorkspaceSymbol : sig
     :  ?containerName:string
     -> ?data:Json.t
     -> kind:SymbolKind.t
-    -> location:Location.t
+    -> location:[ `Location of Location.t | `LocationUriOnly of LocationUriOnly.t ]
     -> name:string
     -> ?tags:SymbolTag.t list
     -> unit

--- a/lsp/test/diff_tests.ml
+++ b/lsp/test/diff_tests.ml
@@ -7,6 +7,7 @@ include struct
   module TextDocumentContentChangeEvent = TextDocumentContentChangeEvent
   module TextDocumentItem = TextDocumentItem
   module DidOpenTextDocumentParams = DidOpenTextDocumentParams
+  module LanguageKind = LanguageKind
 end
 
 let test ~from ~to_ =
@@ -15,7 +16,11 @@ let test ~from ~to_ =
   Yojson.Safe.pretty_to_string ~std:false json |> print_endline;
   let textDocument =
     let uri = Lsp.Uri.of_path "/tmp/test" in
-    TextDocumentItem.create ~languageId:"test" ~text:from ~uri ~version:1
+    TextDocumentItem.create
+      ~languageId:(LanguageKind.Other "test")
+      ~text:from
+      ~uri
+      ~version:1
   in
   let text_document =
     Text_document.make

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -15,16 +15,24 @@ let tuple_range start end_ =
   }
 ;;
 
+let content_change ?range ~text () : TextDocumentContentChangeEvent.t =
+  match range with
+  | None ->
+    `TextDocumentContentChangeWholeDocument
+      (TextDocumentContentChangeWholeDocument.create ~text)
+  | Some range ->
+    `TextDocumentContentChangePartial
+      (TextDocumentContentChangePartial.create ~range ~text ())
+;;
+
 let make_document ?(position_encoding = `UTF8) uri ~text =
   let td =
     let version = 1 in
-    let languageId = "fake language" in
+    let languageId = LanguageKind.Other "fake language" in
     let textDocument = { TextDocumentItem.uri; version; languageId; text } in
     Text_document.make ~position_encoding { DidOpenTextDocumentParams.textDocument }
   in
-  Text_document.apply_content_changes
-    td
-    [ TextDocumentContentChangeEvent.create ~text () ]
+  Text_document.apply_content_changes td [ content_change ~text () ]
 ;;
 
 let test_general text changes =
@@ -32,15 +40,14 @@ let test_general text changes =
     let td =
       let uri = DocumentUri.of_path "" in
       let version = 1 in
-      let languageId = "fake language" in
+      let languageId = LanguageKind.Other "fake language" in
       let textDocument = { TextDocumentItem.uri; version; languageId; text } in
       Text_document.make ~position_encoding { DidOpenTextDocumentParams.textDocument }
     in
     let td =
       Text_document.apply_content_changes
         td
-        (ListLabels.map changes ~f:(fun (range, text) ->
-           TextDocumentContentChangeEvent.create ?range ~text ()))
+        (ListLabels.map changes ~f:(fun (range, text) -> content_change ?range ~text ()))
     in
     Text_document.text td
   in
@@ -304,7 +311,7 @@ let%expect_test "replace second line first line is \\n" =
 let%expect_test "get position after change" =
   let range = tuple_range (1, 2) (1, 2) in
   let doc = make_document (Uri.of_path "foo.ml") ~text:"\nfoo\nbar\nbaz\n" in
-  let edit = TextDocumentContentChangeEvent.create ~text:"change" ~range () in
+  let edit = content_change ~text:"change" ~range () in
   let new_doc = Text_document.apply_content_changes doc [ edit ] in
   let pos = Text_document.absolute_position new_doc range.start in
   new_doc |> Text_document.text |> String.escaped |> print_endline;

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -365,7 +365,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
         ~title:action_title
         ~kind:CodeActionKind.RefactorInline
         ~isPreferred:false
-        ~disabled:(CodeAction.create_disabled ~reason:(string_of_error error))
+        ~disabled:(CodeActionDisabled.create ~reason:(string_of_error error))
         ()
     in
     Some action

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -410,7 +410,8 @@ let resolve doc (compl : CompletionItem.t) (resolve : Resolve.t) query_doc ~mark
           { position with character = position.character + String.length suffix }
         in
         let range = Range.create ~start ~end_ in
-        TextDocumentContentChangeEvent.create ~range ~text:compl.label ()
+        `TextDocumentContentChangePartial
+          (TextDocumentContentChangePartial.create ~range ~text:compl.label ())
       in
       Document.update_text (Document.Merlin.to_doc doc) [ complete ]
     in

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -328,6 +328,7 @@ include struct
   end
 
   module CodeAction = CodeAction
+  module CodeActionDisabled = CodeActionDisabled
   module CodeActionKind = CodeActionKind
   module CodeActionOptions = CodeActionOptions
   module CodeActionParams = CodeActionParams
@@ -369,6 +370,7 @@ include struct
   module InlayHintParams = InlayHintParams
   module InitializeParams = InitializeParams
   module InitializeResult = InitializeResult
+  module LanguageKind = LanguageKind
   module Location = Location
   module LogMessageParams = LogMessageParams
   module MarkupContent = MarkupContent
@@ -391,6 +393,7 @@ include struct
   module SelectionRangeParams = SelectionRangeParams
   module SemanticTokens = SemanticTokens
   module SemanticTokensEdit = SemanticTokensEdit
+  module SemanticTokensFullDelta = SemanticTokensFullDelta
   module SemanticTokensLegend = SemanticTokensLegend
   module SemanticTokensDelta = SemanticTokensDelta
   module SemanticTokensDeltaParams = SemanticTokensDeltaParams
@@ -399,6 +402,7 @@ include struct
   module SemanticTokensParams = SemanticTokensParams
   module SemanticTokenTypes = SemanticTokenTypes
   module ServerCapabilities = ServerCapabilities
+  module ServerInfo = ServerInfo
   module Server_notification = Lsp.Server_notification
   module SetTraceParams = SetTraceParams
   module ShowDocumentClientCapabilities = ShowDocumentClientCapabilities
@@ -413,6 +417,8 @@ include struct
   module SymbolKind = SymbolKind
   module TextDocumentClientCapabilities = TextDocumentClientCapabilities
   module TextDocumentContentChangeEvent = TextDocumentContentChangeEvent
+  module TextDocumentContentChangePartial = TextDocumentContentChangePartial
+  module TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument
   module TextDocumentEdit = TextDocumentEdit
   module TextDocumentFilter = TextDocumentFilter
   module TextDocumentIdentifier = TextDocumentIdentifier
@@ -422,11 +428,7 @@ include struct
   module TextDocumentSyncOptions = TextDocumentSyncOptions
   module TextDocumentSyncClientCapabilities = TextDocumentSyncClientCapabilities
   module TextEdit = TextEdit
-
-  (** deprecated *)
-  module TraceValue = TraceValues
-
-  module TraceValues = TraceValues
+  module TraceValue = TraceValue
   module Unregistration = Unregistration
   module UnregistrationParams = UnregistrationParams
   module VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier
@@ -439,6 +441,7 @@ include struct
   module WorkspaceFoldersChangeEvent = WorkspaceFoldersChangeEvent
   module WorkspaceSymbolParams = WorkspaceSymbolParams
   module WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities
+  module WorkspaceOptions = WorkspaceOptions
 end
 
 let task_if_running pool ~f =

--- a/ocaml-lsp-server/src/inference.ml
+++ b/ocaml-lsp-server/src/inference.ml
@@ -86,7 +86,7 @@ let open_document_from_file (state : State.t) uri =
         Log.msg "Unable to open file" [ "filename", `String filename ]);
       Fiber.return None
     | Ok text ->
-      let languageId = language_id_of_fname filename in
+      let languageId = LanguageKind.Other (language_id_of_fname filename) in
       let text_document = TextDocumentItem.create ~uri ~languageId ~version:0 ~text in
       let params = DidOpenTextDocumentParams.create ~textDocument:text_document in
       let+ doc =

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -71,7 +71,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
         ~changeNotifications:(`Bool true)
         ()
     in
-    ServerCapabilities.create_workspace ~workspaceFolders ()
+    WorkspaceOptions.create ~workspaceFolders ()
   in
   let capabilities =
     let experimental =
@@ -120,7 +120,9 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       ExecuteCommandOptions.create ~commands ()
     in
     let semanticTokensProvider =
-      let full = `Full (SemanticTokensOptions.create_full ~delta:true ()) in
+      let full =
+        `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
+      in
       `SemanticTokensOptions
         (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ())
     in
@@ -162,7 +164,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
   in
   let serverInfo =
     let version = Version.get () in
-    InitializeResult.create_serverInfo ~name:"ocamllsp" ~version ()
+    ServerInfo.create ~name:"ocamllsp" ~version ()
   in
   InitializeResult.create ~capabilities ~serverInfo ()
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -1762,6 +1762,8 @@ let apply_code_action ?diagnostics title source range =
       List.map x.edits ~f:(function
         | `AnnotatedTextEdit (a : AnnotatedTextEdit.t) ->
           TextEdit.create ~newText:a.newText ~range:a.range
+        | `SnippetTextEdit (s : SnippetTextEdit.t) ->
+          TextEdit.create ~newText:s.snippet.value ~range:s.range
         | `TextEdit e -> e)
     | `CreateFile _ | `DeleteFile _ | `RenameFile _ -> [])
   |> Test.apply_edits source
@@ -1814,7 +1816,8 @@ let print_inferred_intf_edits source path range =
                  (`List
                      (List.map text_document_edit.edits ~f:(function
                         | `TextEdit edit -> TextEdit.yojson_of_t edit
-                        | `AnnotatedTextEdit edit -> AnnotatedTextEdit.yojson_of_t edit)))
+                        | `AnnotatedTextEdit edit -> AnnotatedTextEdit.yojson_of_t edit
+                        | `SnippetTextEdit edit -> SnippetTextEdit.yojson_of_t edit)))
              | `CreateFile _ | `RenameFile _ | `DeleteFile _ -> None)
          in
          Test.print_result (`List edits)))
@@ -2382,7 +2385,7 @@ let f = function
       let textDocument =
         TextDocumentItem.create
           ~uri:Helpers.uri
-          ~languageId:"ocaml"
+          ~languageId:(LanguageKind.Other "ocaml")
           ~version:0
           ~text:source
       in
@@ -2398,7 +2401,9 @@ let f = function
         range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
       in
       let contentChanges =
-        [ TextDocumentContentChangeEvent.create ~range:edit_range ~text:" " () ]
+        [ `TextDocumentContentChangePartial
+            (TextDocumentContentChangePartial.create ~range:edit_range ~text:" " ())
+        ]
       in
       let textDocument =
         VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1

--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -43,7 +43,11 @@ let%expect_test "returns location of a declaration" =
    let run =
      let* (_ : InitializeResult.t) = Client.initialized client in
      let textDocument =
-       TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:source
+       TextDocumentItem.create
+         ~uri
+         ~languageId:(LanguageKind.Other "ocaml")
+         ~version:0
+         ~text:source
      in
      let* () =
        Client.notification

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -29,7 +29,7 @@ let test source =
       let textDocument =
         TextDocumentItem.create
           ~uri:Helpers.uri
-          ~languageId:"ocaml"
+          ~languageId:(LanguageKind.Other "ocaml")
           ~version:0
           ~text:source
       in
@@ -196,7 +196,7 @@ end
       let textDocument =
         TextDocumentItem.create
           ~uri:Helpers.uri
-          ~languageId:"ocaml"
+          ~languageId:(LanguageKind.Other "ocaml")
           ~version:0
           ~text:source
       in

--- a/ocaml-lsp-server/test/e2e-new/document_flow.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_flow.ml
@@ -40,7 +40,11 @@ let%expect_test "it should allow double opening the same document" =
      let uri = DocumentUri.of_path "foo.ml" in
      let open_ text =
        let textDocument =
-         TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text
+         TextDocumentItem.create
+           ~uri
+           ~languageId:(LanguageKind.Other "ocaml")
+           ~version:0
+           ~text
        in
        Client.notification
          client

--- a/ocaml-lsp-server/test/e2e-new/document_sync.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_sync.ml
@@ -12,7 +12,11 @@ let print_document = function
 
 let open_document client source =
   let textDocument =
-    TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:source
+    TextDocumentItem.create
+      ~uri
+      ~languageId:(LanguageKind.Other "ocaml")
+      ~version:0
+      ~text:source
   in
   Client.notification
     client
@@ -22,7 +26,16 @@ let open_document client source =
 let change_document ?range ?rangeLength client ~version ~text =
   let textDocument = VersionedTextDocumentIdentifier.create ~uri ~version in
   let contentChanges =
-    [ TextDocumentContentChangeEvent.create ?range ?rangeLength ~text () ]
+    let change : TextDocumentContentChangeEvent.t =
+      match range with
+      | None ->
+        `TextDocumentContentChangeWholeDocument
+          (TextDocumentContentChangeWholeDocument.create ~text)
+      | Some range ->
+        `TextDocumentContentChangePartial
+          (TextDocumentContentChangePartial.create ?rangeLength ~range ~text ())
+    in
+    [ change ]
   in
   Client.notification
     client

--- a/ocaml-lsp-server/test/e2e-new/helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/helpers.ml
@@ -18,7 +18,11 @@ let test
     let run () =
       let* (_ : InitializeResult.t) = Client.initialized client in
       let textDocument =
-        TextDocumentItem.create ~uri ~languageId:language_id ~version:0 ~text
+        TextDocumentItem.create
+          ~uri
+          ~languageId:(LanguageKind.Other language_id)
+          ~version:0
+          ~text
       in
       let* () =
         Client.notification

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
@@ -4,7 +4,11 @@ let change_config ~client params = Client.notification client (ChangeConfigurati
 
 let open_document ~language_id ~client ~uri ~source =
   let textDocument =
-    TextDocumentItem.create ~uri ~languageId:language_id ~version:0 ~text:source
+    TextDocumentItem.create
+      ~uri
+      ~languageId:(LanguageKind.Other language_id)
+      ~version:0
+      ~text:source
   in
   Client.notification
     client

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -102,7 +102,11 @@ let test
     let run () =
       let* (initializeResult : InitializeResult.t) = Client.initialized client in
       let textDocument =
-        TextDocumentItem.create ~uri:Helpers.uri ~languageId:"ocaml" ~version:0 ~text:src
+        TextDocumentItem.create
+          ~uri:Helpers.uri
+          ~languageId:(LanguageKind.Other "ocaml")
+          ~version:0
+          ~text:src
       in
       let* () =
         Client.notification

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -2,12 +2,10 @@ open Test.Import
 
 let capabilities =
   let parameterInformation =
-    SignatureHelpClientCapabilities.create_parameterInformation
-      ~labelOffsetSupport:true
-      ()
+    ClientSignatureParameterInformationOptions.create ~labelOffsetSupport:true ()
   in
   let signatureInformation =
-    SignatureHelpClientCapabilities.create_signatureInformation
+    ClientSignatureInformationOptions.create
       ~documentationFormat:[ MarkupKind.Markdown; MarkupKind.PlainText ]
       ~parameterInformation
       ()

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -31,10 +31,8 @@ let%expect_test "start/stop" =
        let textDocument =
          let codeAction =
            let codeActionLiteralSupport =
-             let codeActionKind =
-               CodeActionClientCapabilities.create_codeActionKind ~valueSet:[]
-             in
-             CodeActionClientCapabilities.create_codeActionLiteralSupport ~codeActionKind
+             let codeActionKind = ClientCodeActionKindOptions.create ~valueSet:[] in
+             ClientCodeActionLiteralOptions.create ~codeActionKind
            in
            CodeActionClientCapabilities.create ~codeActionLiteralSupport ()
          in

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -12,7 +12,11 @@ let uri_of_ext dir ext = DocumentUri.of_path (Stdlib.Filename.concat dir ("test.
 
 let open_document client uri =
   let textDocument =
-    TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:""
+    TextDocumentItem.create
+      ~uri
+      ~languageId:(LanguageKind.Other "ocaml")
+      ~version:0
+      ~text:""
   in
   Client.notification
     client

--- a/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
@@ -26,7 +26,11 @@ let run_test text req =
     let run () =
       let* (_ : InitializeResult.t) = Client.initialized client in
       let textDocument =
-        TextDocumentItem.create ~uri:Helpers.uri ~languageId:"ocaml" ~version:0 ~text
+        TextDocumentItem.create
+          ~uri:Helpers.uri
+          ~languageId:(LanguageKind.Other "ocaml")
+          ~version:0
+          ~text
       in
       let* () =
         Client.notification

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -233,7 +233,11 @@ let custom_request client meth params =
 
 let openDocument ~client ~uri ~source =
   let textDocument =
-    TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text:source
+    TextDocumentItem.create
+      ~uri
+      ~languageId:(LanguageKind.Other "ocaml")
+      ~version:0
+      ~text:source
   in
   Client.notification
     client

--- a/ocaml-lsp-server/test/e2e-new/with_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_pp.ml
@@ -35,7 +35,11 @@ let%expect_test "with-pp" =
       let* (_ : InitializeResult.t) = Client.initialized client in
       let textDocument =
         let text = Io.String_path.read_file path in
-        TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text
+        TextDocumentItem.create
+          ~uri
+          ~languageId:(LanguageKind.Other "ocaml")
+          ~version:0
+          ~text
       in
       let* () =
         Client.notification

--- a/ocaml-lsp-server/test/e2e-new/with_ppx.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_ppx.ml
@@ -45,7 +45,11 @@ let%expect_test "with-ppx" =
       let* (_ : InitializeResult.t) = Client.initialized client in
       let textDocument =
         let text = Io.String_path.read_file path in
-        TextDocumentItem.create ~uri ~languageId:"ocaml" ~version:0 ~text
+        TextDocumentItem.create
+          ~uri
+          ~languageId:(LanguageKind.Other "ocaml")
+          ~version:0
+          ~text
       in
       let* () =
         Client.notification


### PR DESCRIPTION
- Update the bundled meta-model from LSP 3.17 to the official LSP 3.18.0 model and regenerate the OCaml types.
- Add the 3.18 workspace text-document-content requests, named capability records, open language kinds, code-action tags/documentation, completion defaults/apply kinds, snippet edits, workspace-edit metadata, and related protocol additions.
- Follow the generated 3.18 API shapes, including named helper records, partial/whole-document change variants, and `LocationUriOnly` workspace symbols; downstream OCaml call sites are updated rather than compatibility-shimmed.
- Retain the wire-level `"compact"` trace extension and the document-selector/document-link URI protocol corrections.
