### PR TITLE
fix(document-symbol): ensure selectionRange is contained in range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Fixes
 
+- Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
+  within its `range`, so clients no longer reject the document outline.
+  (fixes #1560)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)
 - Point workspace symbols for generated sources to their files in the build

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -17,11 +17,21 @@ let rec items_to_symbols items =
     ~f:
       (fun
         { Query_protocol.outline_name; outline_kind; location; selection; children; _ } ->
+      let range = Range.of_loc location in
+      (* The LSP spec requires [selectionRange] to be contained in [range].
+         Merlin can return a [selection] that violates this invariant (e.g. for
+         the synthetic binding of an optional argument the selection is a ghost
+         location), which makes some clients reject the whole response. Fall
+         back to [range] when containment does not hold. *)
+      let selectionRange =
+        let selectionRange = Range.of_loc selection in
+        if Range.contains range selectionRange then selectionRange else range
+      in
       DocumentSymbol.create
         ~name:outline_name
         ~kind:(symbol_kind_of_outline_kind outline_kind)
-        ~range:(Range.of_loc location)
-        ~selectionRange:(Range.of_loc selection)
+        ~range
+        ~selectionRange
         ~children:(items_to_symbols children)
         ())
     items

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -712,3 +712,48 @@ let%expect_test "documentOutline with nested recursive definition and methods" =
     ]
     |}]
 ;;
+
+let%expect_test "optional argument keeps selectionRange within range (#1560)" =
+  let source =
+    {ocaml|let f ?x _ = x
+let g childs = List.map f childs
+|ocaml}
+  in
+  let capabilities =
+    let documentSymbol =
+      DocumentSymbolClientCapabilities.create ~hierarchicalDocumentSymbolSupport:true ()
+    in
+    let textDocument = TextDocumentClientCapabilities.create ~documentSymbol () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let request client =
+    let open Fiber.O in
+    let+ response = Util.call_document_symbol client in
+    let le a b =
+      match Position.compare a b with
+      | Gt -> false
+      | Lt | Eq -> true
+    in
+    let rec check (symbol : DocumentSymbol.t) =
+      let range = symbol.range
+      and selection = symbol.selectionRange in
+      let status =
+        if le range.start selection.start && le selection.end_ range.end_
+        then "ok"
+        else "selectionRange not contained in range"
+      in
+      print_endline (symbol.name ^ ": " ^ status);
+      List.iter (Option.value symbol.children ~default:[]) ~f:check
+    in
+    match response with
+    | Some (`DocumentSymbol symbols) -> List.iter symbols ~f:check
+    | Some (`SymbolInformation _) | None -> print_endline "unexpected response"
+  in
+  Helpers.test ~capabilities source request;
+  [%expect
+    {|
+    f: ok
+    g: ok
+    arg: ok
+    |}]
+;;


### PR DESCRIPTION
# fix(document-symbol): ensure `selectionRange` is contained in `range`

Fixes #1560

## Problem

`textDocument/documentSymbol` could return a `DocumentSymbol` whose
`selectionRange` is **not** contained within its `range`. The LSP spec requires
`selectionRange` to be contained by `range`, and VS Code's client library
enforces this: when the invariant is broken it throws
`Error: selectionRange must be contained in fullRange` and **drops the entire
response**, so no outline/symbols are shown for the file at all.

Minimal reproduction (from the issue thread):

```ocaml
let f ?x _ = x
let g childs = List.map f childs
```

## Root cause

`ocaml-lsp-server/src/document_symbol.ml`, function `items_to_symbols`.

PR #1529 ("Delegate outline generation to Merlin") replaced the previous
in-house, `Parsetree`-based outline (which derived `selectionRange` from the
*name* location, guaranteed to sit inside the declaration location) with a
direct pass-through of Merlin's `Query_protocol.Outline` `location`/`selection`
fields:

```ocaml
~range:(Range.of_loc location)
~selectionRange:(Range.of_loc selection)
```

Nothing re-establishes the LSP containment invariant. For the example above,
Merlin emits a synthetic outline item named `arg` (the compiler-generated
binding for the optional argument `?x`) as a child of `g`. Its `selection` is a
ghost/dummy location, so `Range.of_loc` falls back to `Range.first_line`
(`((0,0),(1,0))`), which lies outside the item's `range`:

```
arg.range          = ((line 1, char 24), (line 1, char 25))   (* the `f` argument *)
arg.selectionRange = ((line 0, char 0),  (line 1, char 0))    (* Range.first_line *)
```

`selectionRange.start (0,0)` precedes `range.start (1,24)` → containment
violated → VS Code rejects the whole response.

Keeping the fix in `ocaml-lsp-server` (rather than in Merlin/`Typedtree`) is in
line with `CONTRIBUTING.md`, which states the server should not build logic on
top of `Typedtree`.

## Fix

In `items_to_symbols`, fall back to `range` as the `selectionRange` whenever
the value Merlin returns is not contained in `range`. A range trivially
contains itself, so the LSP invariant always holds:

```ocaml
let range = Range.of_loc location in
let selectionRange =
  let selectionRange = Range.of_loc selection in
  if Range.contains range selectionRange then selectionRange else range
in
```

`Range.contains` already exists in `ocaml-lsp-server/src/range.ml`. Well-formed
symbols (the overwhelmingly common case) are unaffected — their Merlin
`selection` is already contained, so `selectionRange` is unchanged.

## Tests

Added a regression test in `ocaml-lsp-server/test/e2e-new/document_symbol.ml`
that requests hierarchical document symbols for the reproduction snippet and
asserts, for every symbol (recursively), that `selectionRange` is contained in
`range`.

## Verification

Toolchain: local opam switch, `ocaml-base-compiler.5.5.0`, `merlin-lib.5.8-505`,
`dune 3.24.0`.

Before the fix (regression test fails):

```
-    arg: ok
+    arg: selectionRange not contained in range
```

After the fix (`dune runtest ocaml-lsp-server/test/e2e-new`, exit 0):

```
f: ok
g: ok
arg: ok
```

All existing `document_symbol.ml` e2e tests continue to pass. `dune build @check`
and `dune build @fmt` both pass.

## Compatibility

No public API change; behavior only changes for symbols that previously
violated the LSP invariant (they now get a valid, self-contained
`selectionRange` instead of one that crashes the client). Merlin still emits the
spurious `arg` symbol for optional arguments — that is a separate, cosmetic
upstream concern and is intentionally left untouched here to keep this fix
minimal and localized to the reported crash.
