### PR TITLE
test(lsp): cover workspace diagnostic JSON

### DIFF
--- a/lsp/test/diagnostic_tests.ml
+++ b/lsp/test/diagnostic_tests.ml
@@ -1,0 +1,27 @@
+open Lsp.Types
+
+let print json = Yojson.Safe.pretty_to_string json |> print_endline
+
+let%expect_test "workspace diagnostic reports with absent versions" =
+  let uri = Lsp.Uri.of_path "/workspace/test.ml" in
+  WorkspaceFullDocumentDiagnosticReport.create ~items:[] ~resultId:"full-result" ~uri ()
+  |> WorkspaceFullDocumentDiagnosticReport.yojson_of_t
+  |> print;
+  WorkspaceUnchangedDocumentDiagnosticReport.create ~resultId:"unchanged-result" ~uri ()
+  |> WorkspaceUnchangedDocumentDiagnosticReport.yojson_of_t
+  |> print;
+  [%expect
+    {|
+    {
+      "kind": "full",
+      "items": [],
+      "resultId": "full-result",
+      "uri": "file:///workspace/test.ml"
+    }
+    {
+      "kind": "unchanged",
+      "resultId": "unchanged-result",
+      "uri": "file:///workspace/test.ml"
+    }
+    |}]
+;;


### PR DESCRIPTION
Adds expect coverage for full and unchanged workspace diagnostic reports when their versions are absent. The promoted expectations record the current serialization behavior independently from the fix in #1751.
