### PR TITLE
fix(lsp): decode workspace diagnostic refresh requests

### DIFF
--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -95,6 +95,7 @@ let of_jsonrpc (r : Jsonrpc.Request.t) : (packed, string) Result.t =
     E (WorkDoneProgressCreate params)
   | "workspace/codeLens/refresh" -> Ok (E CodeLensRefresh)
   | "workspace/semanticTokens/refresh" -> Ok (E SemanticTokensRefresh)
+  | "workspace/diagnostic/refresh" -> Ok (E WorkspaceDiagnosticRefresh)
   | "workspace/foldingRange/refresh" -> Ok (E WorkspaceFoldingRangeRefresh)
   | "workspace/inlayHint/refresh" -> Ok (E WorkspaceInlayHintRefresh)
   | "workspace/inlineValue/refresh" -> Ok (E WorkspaceInlineValueRefresh)


### PR DESCRIPTION
`Server_request` already exposes `WorkspaceDiagnosticRefresh`, but its JSON-RPC
decoder omitted the corresponding method. Incoming
`workspace/diagnostic/refresh` requests were therefore represented as
`UnknownRequest` instead of the typed constructor.

Add the missing decoder case.
