### PR TITLE
test(lsp): reproduce slice-relative rindex regression

### DIFF
--- a/lsp/test/substring_tests.ml
+++ b/lsp/test/substring_tests.ml
@@ -36,6 +36,12 @@ let%expect_test "split_at" =
   [%expect {| l = "f" r = "oo|bar" |}]
 ;;
 
+let%expect_test "rindex is relative to a slice" =
+  let substring = Substring.of_slice "xxabc" ~pos:2 ~len:3 in
+  Substring.rindex substring 'b' |> Option.iter (printf "%d\n");
+  [%expect {| 3 |}]
+;;
+
 let%expect_test "index_from" =
   let test sub pos char =
     match Substring.index_from sub ~pos char with


### PR DESCRIPTION
`Substring.rindex` should return an index relative to its slice. For a slice beginning at backing offset 2, searching for its middle character returns 3 instead of 1.

This adds a single promoted expect test recording the regression for a follow-up fix.