### PR TITLE
test(lsp): reproduce negative substring index regression

### DIFF
--- a/lsp/test/substring_tests.ml
+++ b/lsp/test/substring_tests.ml
@@ -42,6 +42,14 @@ let%expect_test "rindex is relative to a slice" =
   [%expect {| 3 |}]
 ;;
 
+let%expect_test "negative indices do not escape a substring" =
+  let substring = Substring.of_slice "xabc" ~pos:1 ~len:3 in
+  (match Substring.get_exn substring (-1) with
+   | character -> printf "character: %C\n" character
+   | exception Invalid_argument message -> printf "invalid: %s\n" message);
+  [%expect {| character: 'x' |}]
+;;
+
 let%expect_test "index_from" =
   let test sub pos char =
     match Substring.index_from sub ~pos char with


### PR DESCRIPTION
`Substring.get_exn` checks only the upper bound. A negative slice-relative index can therefore read data preceding the slice in its backing string.

This adds a single promoted expect test recording the escaped read for a follow-up fix.