### PR TITLE
test(lsp): reproduce negative array-view index regression

### DIFF
--- a/lsp/test/array_view_tests.ml
+++ b/lsp/test/array_view_tests.ml
@@ -1,0 +1,9 @@
+module Array_view = Lsp.Private.Array_view
+
+let%expect_test "negative indices do not escape an array view" =
+  let view = Array_view.make [| 0; 1; 2; 3 |] ~pos:1 ~len:2 in
+  (match Array_view.get view (-1) with
+   | value -> Printf.printf "value: %d\n" value
+   | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
+  [%expect {| value: 0 |}]
+;;


### PR DESCRIPTION
`Array_view.get` does not reject negative view-relative indices. When the view starts inside a larger backing array, index `-1` reads the element immediately before the view.

This adds a single promoted expect test recording the escaped read for a follow-up fix.