### PR TITLE
test(lsp): reproduce escaping array-subview regression

### DIFF
--- a/lsp/test/array_view_tests.ml
+++ b/lsp/test/array_view_tests.ml
@@ -7,3 +7,11 @@ let%expect_test "negative indices do not escape an array view" =
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
   [%expect {| value: 0 |}]
 ;;
+
+let%expect_test "subviews stay within their parent view" =
+  let parent = Array_view.make [| 0; 1; 2; 3; 4 |] ~pos:1 ~len:2 in
+  (match Array_view.sub parent ~pos:2 ~len:1 with
+   | child -> Printf.printf "value: %d\n" (Array_view.get child 0)
+   | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
+  [%expect {| value: 3 |}]
+;;


### PR DESCRIPTION
`Array_view.sub` checks the requested length but not `pos + len` against the parent view. A child can therefore escape the parent and expose another element from the backing array.

This adds a single promoted expect test recording the regression for a follow-up fix.