### PR TITLE
test(code-actions): reproduce trailing-newline range regression

### DIFF
--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -1,3 +1,14 @@
+open Lsp.Types
+
+let%expect_test "replacement ranges preserve trailing newlines" =
+  let start = Position.create ~line:2 ~character:5 in
+  let range = Range.create ~start ~end_:start in
+  let edit = TextEdit.create ~range ~newText:"x\n" in
+  let range = Ocaml_lsp_server.Testing.Range.resize_for_edit edit in
+  print_endline (Ocaml_lsp_server.Testing.Range.to_string range);
+  [%expect {| ((2, 5), (2, 6)) |}]
+;;
+
 let%expect_test "eat_message tests" =
   let test e1 e2 expected =
     let result = Ocaml_lsp_server.Diagnostics.equal_message e1 e2 in


### PR DESCRIPTION
`Range.resize_for_edit` drops the final empty line of replacement text ending in a newline. Inserting `"x\n"` at `(2, 5)` reports an endpoint of `(2, 6)` instead of `(3, 0)`.

This adds a single promoted expect test recording the regression for a follow-up fix.