### PR TITLE
test(completion): reproduce UTF-16 prefix regression

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -48,6 +48,28 @@ let print_completions
          if originalLength > limit then print_endline "............."))
 ;;
 
+let%expect_test "completion uses UTF-16 positions for Unicode prefixes" =
+  let source = "let café = 1\nlet _ = café" in
+  let position = Position.create ~line:1 ~character:12 in
+  print_completions ~limit:1 source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "kind": 14,
+      "label": "in",
+      "textEdit": {
+        "newText": "in",
+        "range": {
+          "end": { "character": 12, "line": 1 },
+          "start": { "character": 12, "line": 1 }
+        }
+      }
+    }
+    .............
+    |}]
+;;
+
 let%expect_test "can start completion at arbitrary position (before the dot)" =
   let source = {ocaml|Strin.func|ocaml} in
   let position = Position.create ~line:0 ~character:5 in


### PR DESCRIPTION
Completion passes an LSP UTF-16 character offset directly to Merlin as a byte column. Completing the Unicode identifier `café` consequently fails to return the identifier and produces only the keyword completion.

This adds a single promoted end-to-end expect test recording one minimized reproduction of #1733.