### PR TITLE
test(lsp): reproduce negative array-view mutation regression

### DIFF
--- a/lsp/test/array_view_tests.ml
+++ b/lsp/test/array_view_tests.ml
@@ -15,3 +15,14 @@ let%expect_test "subviews stay within their parent view" =
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
   [%expect {| value: 3 |}]
 ;;
+
+let%expect_test "negative mutations do not escape an array view" =
+  let backing = [| 0; 1; 2; 3 |] in
+  let view = Array_view.make backing ~pos:1 ~len:2 in
+  (match Array_view.set view (-1) 9 with
+   | () ->
+     Array.iter (Printf.printf "%d ") backing;
+     print_newline ()
+   | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
+  [%expect {| 9 1 2 3 |}]
+;;


### PR DESCRIPTION
`Array_view.set` does not reject negative view-relative indices. When the view starts inside a larger backing array, setting index `-1` mutates the element immediately before the view.