### PR TITLE
test(e2e): prioritize explicit environment variables

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -77,8 +77,7 @@ end = struct
     let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
     let pid =
       let env =
-        let current = Unix.environment () in
-        Array.to_list current @ extra_env |> Spawn.Env.of_list
+        extra_env @ Array.to_list (Unix.environment ()) |> Spawn.Env.of_list
       in
       Spawn.spawn ~env ~prog:bin ~argv:[ bin ] ~stdin:stdin_i ~stdout:stdout_o ~stderr ()
     in


### PR DESCRIPTION
`Test.run ~extra_env` previously placed explicit entries after the inherited
environment. When a variable occurred in both lists, the spawned language
server observed the inherited value first.

Place `extra_env` before the inherited environment so explicitly supplied
values take precedence.
