### PR TITLE
chore: disable macos runners for now

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
           - windows-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
#1699 introduced this issue when porting the test to OCaml.

#1770 attempts to fix this, but we don't have enough capacity to confirm
this.

For now, we disable the tests