### PR TITLE
fix(document-symbol): ensure selectionRange is contained in range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 ## Fixes
 
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
+- Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
+  within its `range`, so clients no longer reject the document outline.
+  (#1775, fixes #1560, @Leonard013)
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -12,16 +12,36 @@ let symbol_kind_of_outline_kind = function
   | `Method -> Method
 ;;
 
+let normalize_selection_range ~(range : Range.t) = function
+  | None -> range
+  | Some (selection_range : Range.t) ->
+    let selection_is_valid =
+      match Position.compare selection_range.start selection_range.end_ with
+      | Lt | Eq -> true
+      | Gt -> false
+    in
+    if selection_is_valid && Range.contains range selection_range
+    then selection_range
+    else Option.value (Range.intersection range selection_range) ~default:range
+;;
+
 let rec items_to_symbols items =
   List.rev_map
     ~f:
       (fun
         { Query_protocol.outline_name; outline_kind; location; selection; children; _ } ->
+      let range = Range.of_loc location in
+      (* The LSP spec requires [selectionRange] to be contained in [range].
+         Preserve valid selections, clip non-empty overlaps, and fall back to
+         [range] for ghost, invalid, touching, or disjoint selections. *)
+      let selectionRange =
+        normalize_selection_range ~range (Range.of_loc_opt selection)
+      in
       DocumentSymbol.create
         ~name:outline_name
         ~kind:(symbol_kind_of_outline_kind outline_kind)
-        ~range:(Range.of_loc location)
-        ~selectionRange:(Range.of_loc selection)
+        ~range
+        ~selectionRange
         ~children:(items_to_symbols children)
         ())
     items

--- a/ocaml-lsp-server/src/document_symbol.mli
+++ b/ocaml-lsp-server/src/document_symbol.mli
@@ -1,5 +1,7 @@
 open Import
 
+val normalize_selection_range : range:Range.t -> Range.t option -> Range.t
+
 val run
   :  ClientCapabilities.t
   -> Document.t

--- a/ocaml-lsp-server/src/position.ml
+++ b/ocaml-lsp-server/src/position.ml
@@ -44,6 +44,18 @@ let compare ({ line; character } : t) (t : t) : Ordering.t =
   | r -> r
 ;;
 
+let max x y =
+  match compare x y with
+  | Lt -> y
+  | Eq | Gt -> x
+;;
+
+let min x y =
+  match compare x y with
+  | Lt | Eq -> x
+  | Gt -> y
+;;
+
 let compare_inclusion (t : t) (r : Lsp.Types.Range.t) =
   match compare t r.start, compare t r.end_ with
   | Lt, Lt -> `Outside (abs (r.start - t))

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -7,6 +7,8 @@ val compare_inclusion : t -> Lsp.Types.Range.t -> [ `Inside | `Outside of t ]
 
 val ( - ) : t -> t -> t
 val compare : t -> t -> Ordering.t
+val max : t -> t -> t
+val min : t -> t -> t
 val logical : t -> [> `Logical of int * int ]
 val of_lexical_position : Lexing.position -> t option
 val start : t

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -18,6 +18,14 @@ let contains (x : t) (y : t) =
   | _ -> false
 ;;
 
+let intersection (x : t) (y : t) =
+  let start = Position.max x.start y.start in
+  let end_ = Position.min x.end_ y.end_ in
+  match Position.compare start end_ with
+  | Lt -> Some { start; end_ }
+  | Eq | Gt -> None
+;;
+
 (* Compares ranges by their lengths*)
 let compare_size (x : t) (y : t) =
   let dx = Position.(x.end_ - x.start) in

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -8,6 +8,10 @@ val compare : t -> t -> Ordering.t
 (** [contains r1 r2] returns true if [r1] contains [r2]. *)
 val contains : t -> t -> bool
 
+(** [intersection r1 r2] is the non-empty intersection of [r1] and [r2], if
+    one exists. *)
+val intersection : t -> t -> t option
+
 val to_dyn : t -> Dyn.t
 val compare_size : t -> t -> Ordering.t
 val first_line : t

--- a/ocaml-lsp-server/src/testing.ml
+++ b/ocaml-lsp-server/src/testing.ml
@@ -1,6 +1,7 @@
 (**WARNING: This is for internal use in testing only *)
 
 module Compl = Compl
+module Document_symbol = Document_symbol
 module Merlin_kernel = Merlin_kernel
 module Prefix_parser = Prefix_parser
 module Position = Position

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -754,7 +754,7 @@ let g childs = List.map f childs
     {|
     f: ok
     g: ok
-    arg: selectionRange not contained in range
+    arg: ok
     |}]
 ;;
 
@@ -881,14 +881,14 @@ let
   [%expect
     {|
     contained: range=((0, 0), (0, 11)) selection=((0, 4), (0, 5))
-    overlap before: range=((0, 2), (1, 3)) selection=((0, 0), (0, 6))
-    overlap after: range=((0, 0), (0, 5)) selection=((0, 2), (0, 8))
-    enclosing: range=((0, 2), (0, 5)) selection=((0, 0), (0, 6))
-    touch before: range=((0, 6), (1, 3)) selection=((0, 0), (0, 6))
-    touch after: range=((0, 0), (0, 6)) selection=((0, 6), (0, 12))
-    disjoint before: range=((0, 7), (1, 3)) selection=((0, 0), (0, 6))
-    disjoint after: range=((0, 0), (0, 3)) selection=((0, 10), (0, 16))
-    ghost: range=((1, 24), (1, 25)) selection=((0, 0), (1, 0))
-    ghost overlapping first line: range=((0, 41), (2, 1)) selection=((0, 0), (1, 0))
+    overlap before: range=((0, 2), (1, 3)) selection=((0, 2), (0, 6))
+    overlap after: range=((0, 0), (0, 5)) selection=((0, 2), (0, 5))
+    enclosing: range=((0, 2), (0, 5)) selection=((0, 2), (0, 5))
+    touch before: range=((0, 6), (1, 3)) selection=((0, 6), (1, 3))
+    touch after: range=((0, 0), (0, 6)) selection=((0, 0), (0, 6))
+    disjoint before: range=((0, 7), (1, 3)) selection=((0, 7), (1, 3))
+    disjoint after: range=((0, 0), (0, 3)) selection=((0, 0), (0, 3))
+    ghost: range=((1, 24), (1, 25)) selection=((1, 24), (1, 25))
+    ghost overlapping first line: range=((0, 41), (2, 1)) selection=((0, 41), (2, 1))
     |}]
 ;;

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -81,6 +81,48 @@ let%expect_test "document-symbol selection range relationships" =
     |}]
 ;;
 
+let%expect_test "normalize document-symbol selection ranges" =
+  let range start_line start_character end_line end_character =
+    let start = Position.create ~line:start_line ~character:start_character in
+    let end_ = Position.create ~line:end_line ~character:end_character in
+    Range.create ~start ~end_
+  in
+  let full_range = range 1 2 3 8 in
+  let print label selection_range =
+    let normalized =
+      Ocaml_lsp_server.Testing.Document_symbol.normalize_selection_range
+        ~range:full_range
+        selection_range
+    in
+    Printf.printf "%s: %s\n" label (Ocaml_lsp_server.Testing.Range.to_string normalized)
+  in
+  print "contained" (Some (range 1 4 2 6));
+  print "contained empty" (Some (range 2 4 2 4));
+  print "overlap before" (Some (range 0 9 1 5));
+  print "overlap after" (Some (range 3 4 4 1));
+  print "enclosing" (Some (range 0 0 4 0));
+  print "touch before" (Some (range 0 0 1 2));
+  print "touch after" (Some (range 3 8 4 0));
+  print "disjoint before" (Some (range 0 0 1 1));
+  print "disjoint after" (Some (range 3 9 4 0));
+  print "ghost" None;
+  print "reversed" (Some (range 2 6 2 4));
+  [%expect
+    {|
+    contained: ((1, 4), (2, 6))
+    contained empty: ((2, 4), (2, 4))
+    overlap before: ((1, 2), (1, 5))
+    overlap after: ((3, 4), (3, 8))
+    enclosing: ((1, 2), (3, 8))
+    touch before: ((1, 2), (3, 8))
+    touch after: ((1, 2), (3, 8))
+    disjoint before: ((1, 2), (3, 8))
+    disjoint after: ((1, 2), (3, 8))
+    ghost: ((1, 2), (3, 8))
+    reversed: ((1, 2), (3, 8))
+    |}]
+;;
+
 let%expect_test "eat_message tests" =
   let test e1 e2 expected =
     let result = Ocaml_lsp_server.Diagnostics.equal_message e1 e2 in


### PR DESCRIPTION
`textDocument/documentSymbol` can return a `selectionRange` outside its `range` when Merlin emits a ghost or otherwise out-of-bounds selection. Clients such as VS Code reject the entire document-symbol response when this invariant is violated.

Preserve selections that are already contained, clip non-empty overlaps to the symbol range, and fall back to the full range for ghost, invalid, touching, or disjoint selections.

Fixes #1560.
