### PR TITLE
fix(lsp): exclude URI queries from filesystem paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -1,7 +1,5 @@
 (* This module is based on the [vscode-uri] implementation:
-   https://github.com/microsoft/vscode-uri/blob/main/src/uri.ts. It only
-   supports scheme, authority and path. Query, port and fragment are not
-   implemented *)
+   https://github.com/microsoft/vscode-uri/blob/main/src/uri.ts. *)
 
 open Import
 
@@ -32,40 +30,28 @@ let slash_to_backslash =
     | c -> c)
 ;;
 
+let is_drive_letter = function
+  | 'A' .. 'Z' | 'a' .. 'z' -> true
+  | _ -> false
+;;
+
 let of_path path =
   let path = if !Private.win32 then backslash_to_slash path else path in
   Uri_lexer.of_path path
 ;;
 
-let to_path { path; authority; scheme; query; _ } =
+let to_path { path; authority; scheme; _ } =
+  let len = String.length path in
   let path =
-    let len = String.length path in
     if len = 0
     then "/"
-    else (
-      let buff = Buffer.create 64 in
-      if (not (String.is_empty authority)) && len > 1 && scheme = "file"
-      then (
-        Buffer.add_string buff "//";
-        Buffer.add_string buff authority;
-        Buffer.add_string buff path)
-      else if len < 3
-      then Buffer.add_string buff path
-      else (
-        let c0 = path.[0] in
-        let c1 = path.[1] in
-        let c2 = path.[2] in
-        if c0 = '/' && ((c1 >= 'A' && c1 <= 'Z') || (c1 >= 'a' && c1 <= 'z')) && c2 = ':'
-        then (
-          Buffer.add_char buff (Char.lowercase_ascii c1);
-          Buffer.add_substring buff path 2 (String.length path - 2))
-        else Buffer.add_string buff path);
-      (match query with
-       | None -> ()
-       | Some query ->
-         Buffer.add_char buff '?';
-         Buffer.add_string buff query);
-      Buffer.contents buff)
+    else if (not (String.is_empty authority)) && len > 1 && scheme = "file"
+    then "//" ^ authority ^ path
+    else if
+      len >= 3 && path.[0] = '/' && is_drive_letter path.[1] && Char.equal path.[2] ':'
+    then
+      String.make 1 (Char.lowercase_ascii path.[1]) ^ String.sub path ~pos:2 ~len:(len - 2)
+    else path
   in
   if !Private.win32 then slash_to_backslash path else path
 ;;
@@ -127,7 +113,7 @@ let to_string { scheme; authority; path; query; fragment } =
     if len >= 3 && path.[0] = '/' && path.[2] = ':'
     then (
       let drive_letter = Char.lowercase_ascii path.[1] in
-      if drive_letter >= 'a' && drive_letter <= 'z'
+      if is_drive_letter drive_letter
       then (
         Buffer.add_char buff '/';
         Buffer.add_char buff drive_letter;
@@ -137,7 +123,7 @@ let to_string { scheme; authority; path; query; fragment } =
     else if len >= 2 && path.[1] = ':'
     then (
       let drive_letter = Char.lowercase_ascii path.[0] in
-      if drive_letter >= 'a' && drive_letter <= 'z'
+      if is_drive_letter drive_letter
       then (
         Buffer.add_char buff drive_letter;
         Buffer.add_string buff encoded_colon;

--- a/lsp/src/uri0.mli
+++ b/lsp/src/uri0.mli
@@ -7,7 +7,10 @@ include Json.Jsonable.S with type t := t
 val compare : t -> t -> int
 val equal : t -> t -> bool
 val hash : t -> int
+
+(** Return the URI's filesystem path. Query and fragment components are ignored. *)
 val to_path : t -> string
+
 val of_path : string -> t
 val to_string : t -> string
 val of_string : string -> t

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -34,24 +34,24 @@ let%expect_test "test uri parsing" =
     Unix:
     file:///Users/foo -> /Users/foo
     file:///c:/Users/foo -> c:/Users/foo
-    file:///foo?x=y -> /foo?x=y
+    file:///foo?x=y -> /foo
     query: x=y
-    http://xyz?foo# -> /?foo
+    http://xyz?foo# -> /
     query: foo
-    http://xxx? -> /?
+    http://xxx? -> /
     query:
-    http://xyz?ab%3D1%23 -> /?ab=1#
+    http://xyz?ab%3D1%23 -> /
     query: ab=1#
     Windows:
     file:///Users/foo -> \Users\foo
     file:///c:/Users/foo -> c:\Users\foo
-    file:///foo?x=y -> \foo?x=y
+    file:///foo?x=y -> \foo
     query: x=y
-    http://xyz?foo# -> \?foo
+    http://xyz?foo# -> \
     query: foo
-    http://xxx? -> \?
+    http://xxx? -> \
     query:
-    http://xyz?ab%3D1%23 -> \?ab=1#
+    http://xyz?ab%3D1%23 -> \
     query: ab=1# |}]
 ;;
 
@@ -64,7 +64,7 @@ let%expect_test "a URI query is not part of its filesystem path" =
     (Option.value ~default:"<none>" (Uri.query uri));
   [%expect
     {|
-    path: /foo.ml?revision=1
+    path: /foo.ml
     query: revision=1
     |}]
 ;;


### PR DESCRIPTION
`Uri.to_path` currently appends the parsed query to the URI path. Query parameters often carry revision metadata and are not part of the filename, so this produces paths that cannot exist on disk.

Query support in #1125 added the suffix to both `Uri.to_string` and `Uri.to_path`, although `to_path` was originally modeled on vscode-uri's query-free `fsPath`. Keep complete URI serialization in `to_string`, while `to_path` constructs only the filesystem path and leaves the query available through `Uri.query`. The implementation now shares only drive-letter recognition between the two conversions and documents their different contracts.

The regression was added in #1727.
