### PR TITLE
fix(lsp): preserve string-zipper absolute offsets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)
 - Preserve URI paths whose first segment resembles a non-letter Windows drive. (#1800, @rgrinberg)
 - Preserve unescaped Unicode in URI query components. (#1799, @rgrinberg)
+- Preserve document offsets across incremental text edits. (#1777, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/string_zipper.ml
+++ b/lsp/src/string_zipper.ml
@@ -112,7 +112,7 @@ let insert t (x : string) =
     then { t with current; right = cons t.current t.right }
     else if t.rel_pos = Substring.length t.current
     then (
-      let abs_pos = t.rel_pos + Substring.length t.current in
+      let abs_pos = t.abs_pos + t.rel_pos in
       { t with current; rel_pos = 0; left = cons t.current t.left; abs_pos })
     else (
       let l, r = Substring.split_at t.current t.rel_pos in
@@ -187,7 +187,7 @@ let rec prev_newline t =
              current
            ; left
            ; rel_pos = Substring.length current
-           ; abs_pos = t.abs_pos + Substring.length t.current
+           ; abs_pos = t.abs_pos - Substring.length current
            ; right = t.current :: t.right
            }))
 ;;
@@ -294,16 +294,16 @@ let drop_until from until =
   else (
     let right = cons (Substring.drop until.current until.rel_pos) until.right in
     let left = cons (Substring.take from.current from.rel_pos) from.left in
+    let prefix_length = from.abs_pos + from.rel_pos in
     match right with
     | current :: right ->
-      let abs_pos = from.abs_pos + Substring.length from.current in
-      { from with right; left; abs_pos; current; rel_pos = 0 }
+      { from with right; left; abs_pos = prefix_length; current; rel_pos = 0 }
     | [] ->
       (match left with
        | [] -> empty
        | current :: left ->
          let rel_pos = Substring.length current in
-         let abs_pos = from.abs_pos + rel_pos in
+         let abs_pos = prefix_length - rel_pos in
          { from with right; left; current; rel_pos; abs_pos }))
 ;;
 

--- a/lsp/test/string_zipper_tests.ml
+++ b/lsp/test/string_zipper_tests.ml
@@ -185,7 +185,5 @@ let%expect_test "drop_until bug" =
     {|
     "foo\nbar\n|" |}];
   printfn "abs_pos: %d" (String_zipper.Private.reflect t).abs_pos;
-  [%expect
-    {|
-    abs_pos: 8 |}]
+  [%expect {| abs_pos: 0 |}]
 ;;

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -319,6 +319,6 @@ let%expect_test "get position after change" =
   [%expect
     {|
     \nfochangeo\nbar\nbaz\n
-    pos: 22
+    pos: 3
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -2454,5 +2454,29 @@ let f = function
     let* response = Client.request client (CodeAction params) in
     print_code_action_result ~filter:(find_action "combine-cases") response;
     Test.exit_client client);
-  [%expect {| No code actions |}]
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "  | A | B -> 1\n",
+                "range": {
+                  "end": { "character": 0, "line": 4 },
+                  "start": { "character": 0, "line": 2 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///test.ml", "version": 1 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "combine-cases",
+      "title": "Combine-cases"
+    }
+    |}]
 ;;


### PR DESCRIPTION
Several string-zipper transitions recompute `abs_pos` from the current substring or mix absolute and relative positions. After dropping or inserting text away from the first chunk, subsequent LSP positions can therefore point far beyond the requested location.

Maintain the absolute-position invariant from the existing cursor and prefix length in insertion, backward line navigation, and `drop_until`. This restores incremental document offsets and code actions after edits. The regressions were added in #1732.
