### PR TITLE
refactor(test): share e2e client lifecycle helpers

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -2401,63 +2401,51 @@ let f = function
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read first_diagnostics in
-      let settings = `Assoc [ "diagnostics_delay", `Float 10.0 ] in
-      let* () = Client.notification client (ChangeConfiguration { settings }) in
-      let edit_range =
-        range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
-      in
-      let contentChanges =
-        [ `TextDocumentContentChangePartial
-            (TextDocumentContentChangePartial.create ~range:edit_range ~text:" " ())
-        ]
-      in
-      let textDocument =
-        VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
-      in
-      let change = DidChangeTextDocumentParams.create ~textDocument ~contentChanges in
-      let* () = Client.notification client (TextDocumentDidChange change) in
-      let query_range =
-        range ~start_line:2 ~start_character:0 ~end_line:4 ~end_character:0
-      in
-      let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
-      let context =
-        CodeActionContext.create
-          ~diagnostics:[]
-          ~only:[ CodeActionKind.Other "combine-cases" ]
-          ()
-      in
-      let params = CodeActionParams.create ~textDocument ~range:query_range ~context () in
-      let* response = Client.request client (CodeAction params) in
-      let available =
-        response
-        |> Option.value ~default:[]
-        |> List.exists ~f:(find_action "combine-cases")
-      in
-      Printf.printf "combine-cases available: %b\n" available;
-      let* () = Client.request client Shutdown in
-      Client.notification client Exit
+    let* () = Fiber.Ivar.read first_diagnostics in
+    let settings = `Assoc [ "diagnostics_delay", `Float 10.0 ] in
+    let* () = Client.notification client (ChangeConfiguration { settings }) in
+    let edit_range =
+      range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
     in
-    Fiber.fork_and_join_unit run_client run);
+    let contentChanges =
+      [ `TextDocumentContentChangePartial
+          (TextDocumentContentChangePartial.create ~range:edit_range ~text:" " ())
+      ]
+    in
+    let textDocument =
+      VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
+    in
+    let change = DidChangeTextDocumentParams.create ~textDocument ~contentChanges in
+    let* () = Client.notification client (TextDocumentDidChange change) in
+    let query_range =
+      range ~start_line:2 ~start_character:0 ~end_line:4 ~end_character:0
+    in
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let context =
+      CodeActionContext.create
+        ~diagnostics:[]
+        ~only:[ CodeActionKind.Other "combine-cases" ]
+        ()
+    in
+    let params = CodeActionParams.create ~textDocument ~range:query_range ~context () in
+    let* response = Client.request client (CodeAction params) in
+    let available =
+      response |> Option.value ~default:[] |> List.exists ~f:(find_action "combine-cases")
+    in
+    Printf.printf "combine-cases available: %b\n" available;
+    Test.exit_client client);
   [%expect {| combine-cases available: false |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/debug_echo.ml
+++ b/ocaml-lsp-server/test/e2e-new/debug_echo.ml
@@ -1,15 +1,10 @@
 open Test.Import
 
 let%expect_test "debug/echo" =
-  (Test.run
+  (Test.run_initialized
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let* response = Client.request client (DebugEcho { message = "testing" }) in
-     print_endline response.message;
-     Client.request client Shutdown
-   in
-   Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client));
+   let* response = Client.request client (DebugEcho { message = "testing" }) in
+   print_endline response.message;
+   Test.shutdown_client client);
   [%expect {| testing |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -37,38 +37,33 @@ let%expect_test "returns location of a declaration" =
   let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  (Test.run ~stderr ~handler
+  (Test.run_initialized ~stderr ~handler
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let textDocument =
-       TextDocumentItem.create
-         ~uri
-         ~languageId:(LanguageKind.Other "ocaml")
-         ~version:0
-         ~text:source
-     in
-     let* () =
-       Client.notification
-         client
-         (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-     in
-     let textDocument = TextDocumentIdentifier.create ~uri in
-     let* response =
-       Client.request
-         client
-         (TextDocumentDeclaration
-            (TextDocumentPositionParams.create
-               ~textDocument
-               ~position:(Position.create ~line:0 ~character:13)))
-     in
-     print_locations response;
-     let* () = Client.request client Shutdown in
-     let* () = Fiber.Ivar.read diagnostics in
-     Client.stop client
+   let textDocument =
+     TextDocumentItem.create
+       ~uri
+       ~languageId:(LanguageKind.Other "ocaml")
+       ~version:0
+       ~text:source
    in
-   Fiber.fork_and_join_unit run_client (fun () -> run));
+   let* () =
+     Client.notification
+       client
+       (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+   in
+   let textDocument = TextDocumentIdentifier.create ~uri in
+   let* response =
+     Client.request
+       client
+       (TextDocumentDeclaration
+          (TextDocumentPositionParams.create
+             ~textDocument
+             ~position:(Position.create ~line:0 ~character:13)))
+   in
+   print_locations response;
+   let* () = Client.request client Shutdown in
+   let* () = Fiber.Ivar.read diagnostics in
+   Client.stop client);
   Unix.close stderr;
   [%expect
     {|

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -18,32 +18,22 @@ let test source =
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* params = Fiber.Ivar.read diagnostics in
-      print_diagnostics params;
-      let* () = Client.request client Shutdown in
-      Client.stop client
-    in
-    Fiber.fork_and_join_unit run_client run)
+    let* params = Fiber.Ivar.read diagnostics in
+    print_diagnostics params;
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "has related diagnostics" =
@@ -185,37 +175,27 @@ end
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read first_diagnostics in
-      let settings =
-        `Assoc [ "shortenMerlinDiagnostics", `Assoc [ "enable", `Bool true ] ]
-      in
-      let* () = Client.notification client (ChangeConfiguration { settings }) in
-      let* () = Lev_fiber.Timer.sleepf 0.05 in
-      print_endline ("diagnostic publications: " ^ Int.to_string !publications);
-      let* () = Client.request client Shutdown in
-      Client.stop client
+    let* () = Fiber.Ivar.read first_diagnostics in
+    let settings =
+      `Assoc [ "shortenMerlinDiagnostics", `Assoc [ "enable", `Bool true ] ]
     in
-    Fiber.fork_and_join_unit run_client run);
+    let* () = Client.notification client (ChangeConfiguration { settings }) in
+    let* () = Lev_fiber.Timer.sleepf 0.05 in
+    print_endline ("diagnostic publications: " ^ Int.to_string !publications);
+    Test.shutdown_client client);
   [%expect {| diagnostic publications: 1 |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/document_flow.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_flow.ml
@@ -23,39 +23,32 @@ let%expect_test "it should allow double opening the same document" =
       ~on_request:{ Client.Handler.on_request }
       ()
   in
-  (Test.run ~handler
+  let capabilities =
+    let window =
+      let showDocument = ShowDocumentClientCapabilities.create ~support:true in
+      WindowClientCapabilities.create ~showDocument ()
+    in
+    ClientCapabilities.create ~window ()
+  in
+  (Test.run_initialized ~handler ~capabilities
    @@ fun client ->
-   let run_client () =
-     let capabilities =
-       let window =
-         let showDocument = ShowDocumentClientCapabilities.create ~support:true in
-         WindowClientCapabilities.create ~showDocument ()
-       in
-       ClientCapabilities.create ~window ()
+   let uri = DocumentUri.of_path "foo.ml" in
+   let open_ text =
+     let textDocument =
+       TextDocumentItem.create
+         ~uri
+         ~languageId:(LanguageKind.Other "ocaml")
+         ~version:0
+         ~text
      in
-     Test.start_client ~capabilities client
+     Client.notification
+       client
+       (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
    in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let uri = DocumentUri.of_path "foo.ml" in
-     let open_ text =
-       let textDocument =
-         TextDocumentItem.create
-           ~uri
-           ~languageId:(LanguageKind.Other "ocaml")
-           ~version:0
-           ~text
-       in
-       Client.notification
-         client
-         (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-     in
-     let* () = open_ "text 1" in
-     let* () = drain_diagnostics () in
-     let+ () = open_ "text 2" in
-     ()
-   in
-   Fiber.fork_and_join_unit run_client (fun () ->
-     run >>> drain_diagnostics () >>> Client.stop client));
+   let* () = open_ "text 1" in
+   let* () = drain_diagnostics () in
+   let* () = open_ "text 2" in
+   let* () = drain_diagnostics () in
+   Client.stop client);
   [%expect {| |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/document_sync.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_sync.ml
@@ -53,17 +53,11 @@ let get_document client =
 
 let run_document_test f =
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
-  Test.run ~handler
+  Test.run_initialized ~handler
   @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
-    let* () = f client in
-    let* () = Lev_fiber.Timer.sleepf 0.1 in
-    let* () = Client.request client Shutdown in
-    Client.notification client Exit
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+  let* () = f client in
+  let* () = Lev_fiber.Timer.sleepf 0.1 in
+  Test.exit_client client
 ;;
 
 let%expect_test "Manages unicode character ranges correctly" =

--- a/ocaml-lsp-server/test/e2e-new/helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/helpers.ml
@@ -13,26 +13,21 @@ let test
   =
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  Test.run ~handler ?extra_env (fun client ->
-    let run_client () = Test.start_client ~capabilities client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other language_id)
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = req client in
-      let* () = Client.request client Shutdown in
-      let* () = Fiber.Ivar.read diagnostics in
-      Client.stop client
+  Test.run_initialized ~handler ~capabilities ?extra_env (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other language_id)
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run)
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = req client in
+    let* () = Client.request client Shutdown in
+    let* () = Fiber.Ivar.read diagnostics in
+    Client.stop client)
 ;;

--- a/ocaml-lsp-server/test/e2e-new/metrics.ml
+++ b/ocaml-lsp-server/test/e2e-new/metrics.ml
@@ -26,18 +26,14 @@ let%expect_test "metrics" =
     in
     Client.Handler.make ~on_request ~on_notification ()
   in
-  (Test.run ~handler
+  (Test.run_initialized ~handler
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let view_metrics = ExecuteCommandParams.create ~command:"ocamllsp/view-metrics" () in
-     let+ res = Client.request client (ExecuteCommand view_metrics) in
-     print_endline "server: receiving response";
-     Yojson.Safe.to_channel stdout res;
-     print_endline ""
-   in
-   Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client));
+   let view_metrics = ExecuteCommandParams.create ~command:"ocamllsp/view-metrics" () in
+   let* res = Client.request client (ExecuteCommand view_metrics) in
+   print_endline "server: receiving response";
+   Yojson.Safe.to_channel stdout res;
+   print_endline "";
+   Client.stop client);
   [%expect
     {|
       client: received show document params

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -38,20 +38,15 @@ let run_switch_test files_to_create ~from =
   let dir = setup_files files_to_create in
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  Test.run ~handler
+  Test.run_initialized ~handler
   @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
-    let uri = uri_of_ext dir from in
-    let* () = open_document client uri in
-    let* response = switch_impl_intf client uri in
-    print_response response;
-    let* () = Client.request client Shutdown in
-    let* () = Fiber.Ivar.read diagnostics in
-    Client.stop client
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+  let uri = uri_of_ext dir from in
+  let* () = open_document client uri in
+  let* response = switch_impl_intf client uri in
+  print_response response;
+  let* () = Client.request client Shutdown in
+  let* () = Fiber.Ivar.read diagnostics in
+  Client.stop client
 ;;
 
 let%expect_test "test switches (mli => ml)" =
@@ -88,17 +83,11 @@ let%expect_test "test switches (mli, ml, mll => ml, mll)" =
 ;;
 
 let run_switch_request uri =
-  Test.run
-  @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
+  Test.run_initialized (fun client ->
     let* response = switch_impl_intf client uri in
     print_response response;
     let* () = Client.request client Shutdown in
-    Client.stop client
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+    Client.stop client)
 ;;
 
 let%expect_test "can switch from file URI with non-file scheme" =

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -86,8 +86,7 @@ let run_switch_request uri =
   Test.run_initialized (fun client ->
     let* response = switch_impl_intf client uri in
     print_response response;
-    let* () = Client.request client Shutdown in
-    Client.stop client)
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "can switch from file URI with non-file scheme" =

--- a/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
@@ -21,27 +21,21 @@ let run_test text req =
         Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = req client in
-      let* () = Client.request client Shutdown in
-      Client.stop client
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run)
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = req client in
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "syntax doc should display" =

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -63,6 +63,11 @@ let shutdown_client client =
   Client.stop client
 ;;
 
+let exit_client client =
+  let* () = Client.request client Shutdown in
+  Client.notification client Exit
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -58,6 +58,11 @@ let start_client ?(capabilities = ClientCapabilities.create ()) ?workspaceFolder
   Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ())
 ;;
 
+let shutdown_client client =
+  let* () = Client.request client Shutdown in
+  Client.stop client
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -54,6 +54,10 @@ end
 
 open Import
 
+let start_client ?(capabilities = ClientCapabilities.create ()) ?workspaceFolders client =
+  Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ())
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list
@@ -66,6 +70,17 @@ module T : sig
     :  ?extra_env:string list
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
+    -> (unit Client.t -> 'a Fiber.t)
+    -> 'a
+
+  (** Run a test after starting and initializing its client. The test remains
+      responsible for shutting the client down. *)
+  val run_initialized
+    :  ?extra_env:string list
+    -> ?handler:unit Client.Handler.t
+    -> ?stderr:Unix.file_descr
+    -> ?capabilities:ClientCapabilities.t
+    -> ?workspaceFolders:WorkspaceFolder.t list option
     -> (unit Client.t -> 'a Fiber.t)
     -> 'a
 end = struct
@@ -141,6 +156,25 @@ end = struct
   let run ?extra_env ?handler ?stderr f =
     snd @@ run_with_status ?extra_env ?handler ?stderr f
   ;;
+
+  let run_initialized
+        ?extra_env
+        ?handler
+        ?stderr
+        ?(capabilities = ClientCapabilities.create ())
+        ?workspaceFolders
+        f
+    =
+    run ?extra_env ?handler ?stderr
+    @@ fun client ->
+    let run_client () = start_client ~capabilities ?workspaceFolders client in
+    let run_test () =
+      let* (_ : InitializeResult.t) = Client.initialized client in
+      f client
+    in
+    let+ (), result = Fiber.fork_and_join run_client run_test in
+    result
+  ;;
 end
 
 include T
@@ -177,10 +211,6 @@ let run_command ?cwd command =
 
 let null_device = if Sys.win32 then "NUL" else "/dev/null"
 
-let start_client ?(capabilities = ClientCapabilities.create ()) ?workspaceFolders client =
-  Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ())
-;;
-
 let drain_diagnostics () =
   let diagnostics = Fiber.Ivar.create () in
   let on_notification _ = function
@@ -197,33 +227,25 @@ let drain_diagnostics () =
 let run_request ?(prep = fun _ -> Fiber.return ()) ?settings request =
   let on_notification, diagnostics = drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  run ~handler
+  let capabilities =
+    let window =
+      let showDocument = ShowDocumentClientCapabilities.create ~support:true in
+      WindowClientCapabilities.create ~showDocument ()
+    in
+    ClientCapabilities.create ~window ()
+  in
+  run_initialized ~handler ~capabilities
   @@ fun client ->
-  let run_client () =
-    let capabilities =
-      let window =
-        let showDocument = ShowDocumentClientCapabilities.create ~support:true in
-        WindowClientCapabilities.create ~showDocument ()
-      in
-      ClientCapabilities.create ~window ()
-    in
-    start_client ~capabilities client
+  let* () = prep client in
+  let* () =
+    match settings with
+    | Some settings -> Client.notification client (ChangeConfiguration { settings })
+    | None -> Fiber.return ()
   in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
-    let* () = prep client in
-    let* () =
-      match settings with
-      | Some settings -> Client.notification client (ChangeConfiguration { settings })
-      | None -> Fiber.return ()
-    in
-    Client.request client request
-  in
-  Fiber.fork_and_join_unit run_client (fun () ->
-    let* ret = run in
-    let* () = Fiber.Ivar.read diagnostics in
-    let+ () = Client.stop client in
-    ret)
+  let* ret = Client.request client request in
+  let* () = Fiber.Ivar.read diagnostics in
+  let+ () = Client.stop client in
+  ret
 ;;
 
 let custom_request client meth params =

--- a/ocaml-lsp-server/test/e2e-new/with_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_pp.ml
@@ -28,34 +28,28 @@ let%expect_test "with-pp" =
       ()
   in
   let output =
-    Test.run ~handler
+    Test.run_initialized ~handler
     @@ fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        let text = Io.String_path.read_file path in
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () =
-        let+ resp = Hover_helpers.hover ~uri client position in
-        Hover_helpers.print_hover resp
-      in
-      let output = [%expect.output] in
-      let* () = Client.request client Shutdown in
-      let+ () = Client.stop client in
-      output
+    let textDocument =
+      let text = Io.String_path.read_file path in
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () =
+      let+ resp = Hover_helpers.hover ~uri client position in
+      Hover_helpers.print_hover resp
+    in
+    let output = [%expect.output] in
+    let+ () = Test.shutdown_client client in
+    output
   in
   let (_ : string) = [%expect.output] in
   print_endline output;

--- a/ocaml-lsp-server/test/e2e-new/with_ppx.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_ppx.ml
@@ -38,35 +38,29 @@ let%expect_test "with-ppx" =
     Client.Handler.make ~on_notification ()
   in
   let output =
-    Test.run ~handler
+    Test.run_initialized ~handler
     @@ fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        let text = Io.String_path.read_file path in
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read diagnostics in
-      let* () =
-        let+ resp = Hover_helpers.hover ~uri client position in
-        Hover_helpers.print_hover resp
-      in
-      let output = [%expect.output] in
-      let* () = Client.request client Shutdown in
-      let+ () = Client.stop client in
-      output
+    let textDocument =
+      let text = Io.String_path.read_file path in
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = Fiber.Ivar.read diagnostics in
+    let* () =
+      let+ resp = Hover_helpers.hover ~uri client position in
+      Hover_helpers.print_hover resp
+    in
+    let output = [%expect.output] in
+    let+ () = Test.shutdown_client client in
+    output
   in
   let (_ : string) = [%expect.output] in
   print_endline output;

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -13,25 +13,14 @@ let%expect_test "can add the first workspace folder after initialization" =
   in
   let stderr = Unix.descr_of_out_channel stderr_chan in
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
-  Test.run ~handler ~stderr (fun client ->
-    let run_client () =
-      let capabilities = ClientCapabilities.create () in
-      Client.start
-        client
-        (InitializeParams.create ~capabilities ~workspaceFolders:None ())
+  Test.run_initialized ~handler ~stderr ~workspaceFolders:None (fun client ->
+    let folder =
+      WorkspaceFolder.create ~uri:(DocumentUri.of_path "/tmp/new-workspace") ~name:"new"
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let folder =
-        WorkspaceFolder.create ~uri:(DocumentUri.of_path "/tmp/new-workspace") ~name:"new"
-      in
-      let event = WorkspaceFoldersChangeEvent.create ~added:[ folder ] ~removed:[] in
-      let change = DidChangeWorkspaceFoldersParams.create ~event in
-      let* () = Client.notification client (ChangeWorkspaceFolders change) in
-      let* () = Client.request client Shutdown in
-      Client.notification client Exit
-    in
-    Fiber.fork_and_join_unit run_client run);
+    let event = WorkspaceFoldersChangeEvent.create ~added:[ folder ] ~removed:[] in
+    let change = DidChangeWorkspaceFoldersParams.create ~event in
+    let* () = Client.notification client (ChangeWorkspaceFolders change) in
+    Test.exit_client client);
   Stdlib.close_out stderr_chan;
   let stderr = Io.String_path.read_file stderr_path in
   Stdlib.Sys.remove stderr_path;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -252,20 +252,12 @@ let workspace_symbol client query =
 
 let run ?on_notification workspaces f =
   let handler = Client.Handler.make ?on_notification () in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Test.start_client
-        ~workspaceFolders:
-          (Some (List.map workspaces ~f:(fun workspace -> workspace.folder)))
-        client
-    in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let* () = f client in
-      let* () = Client.request client Shutdown in
-      Client.stop client
-    in
-    Fiber.fork_and_join_unit run_client run)
+  let workspaceFolders =
+    Some (List.map workspaces ~f:(fun workspace -> workspace.folder))
+  in
+  Test.run_initialized ~handler ~workspaceFolders (fun client ->
+    let* () = f client in
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "returns all symbols from workspace" =


### PR DESCRIPTION
Factor the e2e lifecycle cleanup into four focused refactors:

- add an initialized runner and use it in the shared request helper;
- reuse initialized setup for tests with explicit or diagnostic-synchronized teardown;
- share the graceful `shutdown`-then-stop sequence;
- share the LSP `shutdown`-and-`exit` sequence.

Each migrated test retains its existing shutdown, exit, and diagnostic synchronization order. The raw runner remains available for lifecycle-sensitive tests.
