### PR TITLE
test(document-symbol): cover selection range relationships

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -757,3 +757,138 @@ let g childs = List.map f childs
     arg: selectionRange not contained in range
     |}]
 ;;
+
+let%expect_test "normalizes document-symbol selection ranges from Merlin" =
+  let capabilities =
+    let documentSymbol =
+      DocumentSymbolClientCapabilities.create ~hierarchicalDocumentSymbolSupport:true ()
+    in
+    let textDocument = TextDocumentClientCapabilities.create ~documentSymbol () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let rec find_symbol name = function
+    | [] -> None
+    | (symbol : DocumentSymbol.t) :: symbols ->
+      if String.equal symbol.name name
+      then Some symbol
+      else (
+        match find_symbol name (Option.value symbol.children ~default:[]) with
+        | Some _ as result -> result
+        | None -> find_symbol name symbols)
+  in
+  let run (label, name, source) =
+    let request client =
+      let open Fiber.O in
+      let+ response = Util.call_document_symbol client in
+      match response with
+      | Some (`DocumentSymbol symbols) ->
+        (match find_symbol name symbols with
+         | None -> Printf.printf "%s: symbol not found\n" label
+         | Some symbol ->
+           Printf.printf
+             "%s: range=%s selection=%s\n"
+             label
+             (Ocaml_lsp_server.Testing.Range.to_string symbol.range)
+             (Ocaml_lsp_server.Testing.Range.to_string symbol.selectionRange))
+      | Some (`SymbolInformation _) | None ->
+        Printf.printf "%s: unexpected response\n" label
+    in
+    Helpers.test ~capabilities source request
+  in
+  (* Line directives make Merlin report positions that exercise each possible
+     relationship between a symbol's range and selection range. *)
+  List.iter
+    [ "contained", "f", "let f x = x\n"
+    ; ( "overlap before"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+  let
+# 1 "test.ml"
+foobar =
+# 2 "test.ml"
+  1
+|ocaml}
+      )
+    ; ( "overlap after"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+let
+# 1 "test.ml"
+  foobar =
+# 1 "test.ml"
+    1
+|ocaml}
+      )
+    ; ( "enclosing"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+  let
+# 1 "test.ml"
+foobar =
+# 1 "test.ml"
+    1
+|ocaml}
+      )
+    ; ( "touch before"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+      let
+# 1 "test.ml"
+foobar =
+# 2 "test.ml"
+  1
+|ocaml}
+      )
+    ; ( "touch after"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+let
+# 1 "test.ml"
+      foobar =
+# 1 "test.ml"
+     1
+|ocaml}
+      )
+    ; ( "disjoint before"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+       let
+# 1 "test.ml"
+foobar =
+# 2 "test.ml"
+  1
+|ocaml}
+      )
+    ; ( "disjoint after"
+      , "foobar"
+      , {ocaml|# 1 "test.ml"
+let
+# 1 "test.ml"
+          foobar =
+# 1 "test.ml"
+  1
+|ocaml}
+      )
+    ; "ghost", "arg", "let f ?x _ = x\nlet g childs = List.map f childs\n"
+    ; ( "ghost overlapping first line"
+      , "arg"
+      , "let f ?x _ = x;; let g childs = List.map (\n  f\n) childs\n" )
+    ]
+    ~f:run;
+  (* Merlin selection locations come from a single token, so a reversed
+     selection cannot be produced from source text. The unit test covers that
+     defensive case directly. *)
+  [%expect
+    {|
+    contained: range=((0, 0), (0, 11)) selection=((0, 4), (0, 5))
+    overlap before: range=((0, 2), (1, 3)) selection=((0, 0), (0, 6))
+    overlap after: range=((0, 0), (0, 5)) selection=((0, 2), (0, 8))
+    enclosing: range=((0, 2), (0, 5)) selection=((0, 0), (0, 6))
+    touch before: range=((0, 6), (1, 3)) selection=((0, 0), (0, 6))
+    touch after: range=((0, 0), (0, 6)) selection=((0, 6), (0, 12))
+    disjoint before: range=((0, 7), (1, 3)) selection=((0, 0), (0, 6))
+    disjoint after: range=((0, 0), (0, 3)) selection=((0, 10), (0, 16))
+    ghost: range=((1, 24), (1, 25)) selection=((0, 0), (1, 0))
+    ghost overlapping first line: range=((0, 41), (2, 1)) selection=((0, 0), (1, 0))
+    |}]
+;;

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -18,6 +18,69 @@ let%expect_test "replacement ranges use UTF-16 character units" =
   [%expect {| ((2, 5), (2, 9)) |}]
 ;;
 
+let%expect_test "document-symbol selection range relationships" =
+  let range start_line start_character end_line end_character =
+    let start = Position.create ~line:start_line ~character:start_character in
+    let end_ = Position.create ~line:end_line ~character:end_character in
+    Range.create ~start ~end_
+  in
+  let compare_position (x : Position.t) (y : Position.t) =
+    Stdlib.compare (x.line, x.character) (y.line, y.character)
+  in
+  let full_range = range 1 2 3 8 in
+  let relation = function
+    | None -> "ghost"
+    | Some (selection_range : Range.t) ->
+      if compare_position selection_range.start selection_range.end_ > 0
+      then "invalid"
+      else if Ocaml_lsp_server.Testing.Range.contains full_range selection_range
+      then "contained"
+      else (
+        let start =
+          if compare_position full_range.start selection_range.start >= 0
+          then full_range.start
+          else selection_range.start
+        in
+        let end_ =
+          if compare_position full_range.end_ selection_range.end_ <= 0
+          then full_range.end_
+          else selection_range.end_
+        in
+        match compare_position start end_ with
+        | n when n < 0 -> "overlap"
+        | 0 -> "touch"
+        | _ -> "disjoint")
+  in
+  let print label selection_range =
+    Printf.printf "%s: %s\n" label (relation selection_range)
+  in
+  print "contained" (Some (range 1 4 2 6));
+  print "contained empty" (Some (range 2 4 2 4));
+  print "overlap before" (Some (range 0 9 1 5));
+  print "overlap after" (Some (range 3 4 4 1));
+  print "enclosing" (Some (range 0 0 4 0));
+  print "touch before" (Some (range 0 0 1 2));
+  print "touch after" (Some (range 3 8 4 0));
+  print "disjoint before" (Some (range 0 0 1 1));
+  print "disjoint after" (Some (range 3 9 4 0));
+  print "ghost" None;
+  print "reversed" (Some (range 2 6 2 4));
+  [%expect
+    {|
+    contained: contained
+    contained empty: contained
+    overlap before: overlap
+    overlap after: overlap
+    enclosing: overlap
+    touch before: touch
+    touch after: touch
+    disjoint before: disjoint
+    disjoint after: disjoint
+    ghost: ghost
+    reversed: invalid
+    |}]
+;;
+
 let%expect_test "eat_message tests" =
   let test e1 e2 expected =
     let result = Ocaml_lsp_server.Diagnostics.equal_message e1 e2 in


### PR DESCRIPTION
Add passing regressions that record how document symbols currently behave when Merlin returns contained, overlapping, enclosing, touching, disjoint, or ghost selection ranges.

The end-to-end cases use line directives to reproduce each relationship through Merlin. Unit cases cover the same geometry plus empty and reversed ranges.
