### PR TITLE
refactor(test): share setup for explicitly stopped clients

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -37,38 +37,33 @@ let%expect_test "returns location of a declaration" =
   let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  (Test.run ~stderr ~handler
+  (Test.run_initialized ~stderr ~handler
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let textDocument =
-       TextDocumentItem.create
-         ~uri
-         ~languageId:(LanguageKind.Other "ocaml")
-         ~version:0
-         ~text:source
-     in
-     let* () =
-       Client.notification
-         client
-         (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-     in
-     let textDocument = TextDocumentIdentifier.create ~uri in
-     let* response =
-       Client.request
-         client
-         (TextDocumentDeclaration
-            (TextDocumentPositionParams.create
-               ~textDocument
-               ~position:(Position.create ~line:0 ~character:13)))
-     in
-     print_locations response;
-     let* () = Client.request client Shutdown in
-     let* () = Fiber.Ivar.read diagnostics in
-     Client.stop client
+   let textDocument =
+     TextDocumentItem.create
+       ~uri
+       ~languageId:(LanguageKind.Other "ocaml")
+       ~version:0
+       ~text:source
    in
-   Fiber.fork_and_join_unit run_client (fun () -> run));
+   let* () =
+     Client.notification
+       client
+       (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+   in
+   let textDocument = TextDocumentIdentifier.create ~uri in
+   let* response =
+     Client.request
+       client
+       (TextDocumentDeclaration
+          (TextDocumentPositionParams.create
+             ~textDocument
+             ~position:(Position.create ~line:0 ~character:13)))
+   in
+   print_locations response;
+   let* () = Client.request client Shutdown in
+   let* () = Fiber.Ivar.read diagnostics in
+   Client.stop client);
   Unix.close stderr;
   [%expect
     {|

--- a/ocaml-lsp-server/test/e2e-new/document_flow.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_flow.ml
@@ -23,39 +23,32 @@ let%expect_test "it should allow double opening the same document" =
       ~on_request:{ Client.Handler.on_request }
       ()
   in
-  (Test.run ~handler
+  let capabilities =
+    let window =
+      let showDocument = ShowDocumentClientCapabilities.create ~support:true in
+      WindowClientCapabilities.create ~showDocument ()
+    in
+    ClientCapabilities.create ~window ()
+  in
+  (Test.run_initialized ~handler ~capabilities
    @@ fun client ->
-   let run_client () =
-     let capabilities =
-       let window =
-         let showDocument = ShowDocumentClientCapabilities.create ~support:true in
-         WindowClientCapabilities.create ~showDocument ()
-       in
-       ClientCapabilities.create ~window ()
+   let uri = DocumentUri.of_path "foo.ml" in
+   let open_ text =
+     let textDocument =
+       TextDocumentItem.create
+         ~uri
+         ~languageId:(LanguageKind.Other "ocaml")
+         ~version:0
+         ~text
      in
-     Test.start_client ~capabilities client
+     Client.notification
+       client
+       (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
    in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let uri = DocumentUri.of_path "foo.ml" in
-     let open_ text =
-       let textDocument =
-         TextDocumentItem.create
-           ~uri
-           ~languageId:(LanguageKind.Other "ocaml")
-           ~version:0
-           ~text
-       in
-       Client.notification
-         client
-         (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-     in
-     let* () = open_ "text 1" in
-     let* () = drain_diagnostics () in
-     let+ () = open_ "text 2" in
-     ()
-   in
-   Fiber.fork_and_join_unit run_client (fun () ->
-     run >>> drain_diagnostics () >>> Client.stop client));
+   let* () = open_ "text 1" in
+   let* () = drain_diagnostics () in
+   let* () = open_ "text 2" in
+   let* () = drain_diagnostics () in
+   Client.stop client);
   [%expect {| |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/helpers.ml
@@ -13,26 +13,21 @@ let test
   =
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  Test.run ~handler ?extra_env (fun client ->
-    let run_client () = Test.start_client ~capabilities client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other language_id)
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = req client in
-      let* () = Client.request client Shutdown in
-      let* () = Fiber.Ivar.read diagnostics in
-      Client.stop client
+  Test.run_initialized ~handler ~capabilities ?extra_env (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other language_id)
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run)
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = req client in
+    let* () = Client.request client Shutdown in
+    let* () = Fiber.Ivar.read diagnostics in
+    Client.stop client)
 ;;

--- a/ocaml-lsp-server/test/e2e-new/metrics.ml
+++ b/ocaml-lsp-server/test/e2e-new/metrics.ml
@@ -26,18 +26,14 @@ let%expect_test "metrics" =
     in
     Client.Handler.make ~on_request ~on_notification ()
   in
-  (Test.run ~handler
+  (Test.run_initialized ~handler
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let view_metrics = ExecuteCommandParams.create ~command:"ocamllsp/view-metrics" () in
-     let+ res = Client.request client (ExecuteCommand view_metrics) in
-     print_endline "server: receiving response";
-     Yojson.Safe.to_channel stdout res;
-     print_endline ""
-   in
-   Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client));
+   let view_metrics = ExecuteCommandParams.create ~command:"ocamllsp/view-metrics" () in
+   let* res = Client.request client (ExecuteCommand view_metrics) in
+   print_endline "server: receiving response";
+   Yojson.Safe.to_channel stdout res;
+   print_endline "";
+   Client.stop client);
   [%expect
     {|
       client: received show document params

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -38,20 +38,15 @@ let run_switch_test files_to_create ~from =
   let dir = setup_files files_to_create in
   let on_notification, diagnostics = Test.drain_diagnostics () in
   let handler = Client.Handler.make ~on_notification () in
-  Test.run ~handler
+  Test.run_initialized ~handler
   @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
-    let uri = uri_of_ext dir from in
-    let* () = open_document client uri in
-    let* response = switch_impl_intf client uri in
-    print_response response;
-    let* () = Client.request client Shutdown in
-    let* () = Fiber.Ivar.read diagnostics in
-    Client.stop client
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+  let uri = uri_of_ext dir from in
+  let* () = open_document client uri in
+  let* response = switch_impl_intf client uri in
+  print_response response;
+  let* () = Client.request client Shutdown in
+  let* () = Fiber.Ivar.read diagnostics in
+  Client.stop client
 ;;
 
 let%expect_test "test switches (mli => ml)" =
@@ -88,17 +83,11 @@ let%expect_test "test switches (mli, ml, mll => ml, mll)" =
 ;;
 
 let run_switch_request uri =
-  Test.run
-  @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
+  Test.run_initialized (fun client ->
     let* response = switch_impl_intf client uri in
     print_response response;
     let* () = Client.request client Shutdown in
-    Client.stop client
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+    Client.stop client)
 ;;
 
 let%expect_test "can switch from file URI with non-file scheme" =


### PR DESCRIPTION
Reuse `Test.run_initialized` in e2e tests that retain explicit teardown control.

The migrations preserve each test's existing ordering, including waiting for diagnostics after `shutdown`, draining queued diagnostics before stopping, and directly stopping the client transport where required.
