### PR TITLE
feat(diagnostics): support document diagnostic pulls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - Add a code action to open the closest Dune file for the current document.
   (#1817, fixes #1491, @rgrinberg)
 - Distinguish operators from functions in semantic highlighting. (#1831, @rgrinberg)
+- Support LSP 3.17 `textDocument/diagnostic` pull requests by combining Dune
+  and Merlin diagnostics. (#1782, @rgrinberg)
 
 ## Fixes
 

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -111,90 +111,96 @@ let create
   }
 ;;
 
-let send =
-  let module Range_map = Stdlib.MoreLabels.Map.Make (struct
-      include Range
+module Range_map = Stdlib.MoreLabels.Map.Make (struct
+    include Range
 
-      let compare = Lsp.Range.compare
-    end)
-  in
-  (* TODO deduplicate related errors as well *)
-  let add_dune_diagnostic pending uri (diagnostic : Diagnostic.t) =
-    let value =
-      match Hashtbl.find pending uri with
-      | None -> Range_map.singleton diagnostic.range [ diagnostic ]
-      | Some map ->
-        Range_map.update map ~key:diagnostic.range ~f:(fun diagnostics ->
-          Some
-            (match diagnostics with
-             | None -> [ diagnostic ]
-             | Some diagnostics ->
-               if
-                 List.exists diagnostics ~f:(fun (d : Diagnostic.t) ->
-                   match d.source with
-                   | None -> assert false
-                   | Some source ->
-                     String.equal ocamllsp_source source
-                     &&
-                       (match d.message, diagnostic.message with
-                       | `String m1, `String m2 -> equal_message m1 m2
-                       | `MarkupContent { kind; value }, `MarkupContent mc ->
-                         Poly.equal kind mc.kind && equal_message value mc.value
-                       | _, _ -> false))
-               then diagnostics
-               else diagnostic :: diagnostics))
+    let compare = Lsp.Range.compare
+  end)
+
+let range_map_of_diagnostics diagnostics =
+  List.rev_map diagnostics ~f:(fun (d : Diagnostic.t) -> d.range, d)
+  |> List.fold_left ~init:Range_map.empty ~f:(fun acc (key, diagnostic) ->
+    Range_map.update acc ~key ~f:(function
+      | None -> Some [ diagnostic ]
+      | Some diagnostics -> Some (diagnostic :: diagnostics)))
+;;
+
+(* TODO deduplicate related errors as well *)
+let add_dune_diagnostic diagnostics (diagnostic : Diagnostic.t) =
+  Range_map.update diagnostics ~key:diagnostic.range ~f:(fun existing ->
+    Some
+      (match existing with
+       | None -> [ diagnostic ]
+       | Some existing ->
+         if
+           List.exists existing ~f:(fun (merlin : Diagnostic.t) ->
+             match merlin.source with
+             | Some source when String.equal ocamllsp_source source ->
+               (match merlin.message, diagnostic.message with
+                | `String m1, `String m2 -> equal_message m1 m2
+                | `MarkupContent { kind; value }, `MarkupContent mc ->
+                  Poly.equal kind mc.kind && equal_message value mc.value
+                | _, _ -> false)
+             | None | Some _ -> false)
+         then existing
+         else diagnostic :: existing))
+;;
+
+let diagnostics_of_range_map diagnostics =
+  Range_map.to_list diagnostics |> List.concat_map ~f:snd
+;;
+
+let merge ~merlin ~dune =
+  List.fold_left dune ~init:(range_map_of_diagnostics merlin) ~f:add_dune_diagnostic
+  |> diagnostics_of_range_map
+;;
+
+let send t which =
+  Fiber.of_thunk (fun () ->
+    let add_pending_dune_diagnostic pending uri diagnostic =
+      let diagnostics =
+        Hashtbl.find pending uri |> Option.value ~default:Range_map.empty
+      in
+      let diagnostics = add_dune_diagnostic diagnostics diagnostic in
+      Hashtbl.set pending ~key:uri ~data:diagnostics
     in
-    Hashtbl.set pending ~key:uri ~data:value
-  in
-  let range_map_of_unduplicated_diagnostics diagnostics =
-    List.rev_map diagnostics ~f:(fun (d : Diagnostic.t) -> d.range, d)
-    |> List.fold_left ~init:Range_map.empty ~f:(fun acc (key, v) ->
-      Range_map.update ~key acc ~f:(function
-        | None -> Some [ v ]
-        | Some xs -> Some (v :: xs)))
-  in
-  fun t which ->
-    Fiber.of_thunk (fun () ->
-      let dirty_uris =
-        match which with
-        | `All -> t.dirty_uris
-        | `One uri -> Set.singleton (module Uri) uri
-      in
-      let pending = Hashtbl.create (module Uri) in
-      Set.iter dirty_uris ~f:(fun uri ->
-        let diagnostics = Hashtbl.find_multi t.merlin uri in
-        Hashtbl.set
-          pending
-          ~key:uri
-          ~data:(range_map_of_unduplicated_diagnostics diagnostics));
-      let set_dune_source =
-        let annotate_dune_pid = Hashtbl.length t.dune > 1 in
-        if annotate_dune_pid
-        then
-          fun pid (d : Diagnostic.t) ->
-            let source = Some (sprintf "dune (pid=%d)" (Pid.to_int pid)) in
-            { d with source }
-        else fun _pid x -> x
-      in
-      if t.report_dune_diagnostics
+    let dirty_uris =
+      match which with
+      | `All -> t.dirty_uris
+      | `One uri -> Set.singleton (module Uri) uri
+    in
+    let pending = Hashtbl.create (module Uri) in
+    Set.iter dirty_uris ~f:(fun uri ->
+      let diagnostics = Hashtbl.find_multi t.merlin uri in
+      Hashtbl.set pending ~key:uri ~data:(range_map_of_diagnostics diagnostics));
+    let set_dune_source =
+      let annotate_dune_pid = Hashtbl.length t.dune > 1 in
+      if annotate_dune_pid
       then
-        Hashtbl.fold ~init:() t.dune ~f:(fun ~key:dune ~data:per_dune () ->
-          Hashtbl.iter per_dune ~f:(fun (uri, diagnostic) ->
-            if Set.mem dirty_uris uri
-            then (
-              let diagnostic = set_dune_source dune.pid diagnostic in
-              add_dune_diagnostic pending uri diagnostic)));
-      t.dirty_uris
-      <- (match which with
-          | `All -> Set.empty (module Uri)
-          | `One uri -> Set.remove t.dirty_uris uri);
-      Hashtbl.fold pending ~init:[] ~f:(fun ~key:uri ~data:diagnostics acc ->
-        let diagnostics = Range_map.to_list diagnostics |> List.concat_map ~f:snd in
-        (* we don't include a version because some of the diagnostics might
-           come from dune which reads from the file system and not from the
-           editor's view *)
-        PublishDiagnosticsParams.create ~uri ~diagnostics () :: acc)
-      |> t.send)
+        fun pid (d : Diagnostic.t) ->
+          let source = Some (sprintf "dune (pid=%d)" (Pid.to_int pid)) in
+          { d with source }
+      else fun _pid x -> x
+    in
+    if t.report_dune_diagnostics
+    then
+      Hashtbl.fold ~init:() t.dune ~f:(fun ~key:dune ~data:per_dune () ->
+        Hashtbl.iter per_dune ~f:(fun (uri, diagnostic) ->
+          if Set.mem dirty_uris uri
+          then (
+            let diagnostic = set_dune_source dune.pid diagnostic in
+            add_pending_dune_diagnostic pending uri diagnostic)));
+    t.dirty_uris
+    <- (match which with
+        | `All -> Set.empty (module Uri)
+        | `One uri -> Set.remove t.dirty_uris uri);
+    Hashtbl.fold pending ~init:[] ~f:(fun ~key:uri ~data:diagnostics acc ->
+      let diagnostics = diagnostics_of_range_map diagnostics in
+      (* we don't include a version because some of the diagnostics might
+         come from dune which reads from the file system and not from the
+         editor's view *)
+      PublishDiagnosticsParams.create ~uri ~diagnostics () :: acc)
+    |> t.send)
 ;;
 
 let set t what =
@@ -374,9 +380,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
     ()
 ;;
 
-let merlin_diagnostics diagnostics merlin =
-  let doc = Document.Merlin.to_doc merlin in
-  let uri = Document.uri doc in
+let compute_merlin_diagnostics diagnostics merlin =
   let source = Document.Merlin.source merlin in
   let create_diagnostic = Diagnostic.create ~source:ocamllsp_source in
   let open Fiber.O in
@@ -420,6 +424,13 @@ let merlin_diagnostics diagnostics merlin =
         |> List.sort ~compare:(fun (d1 : Diagnostic.t) (d2 : Diagnostic.t) ->
           Lsp.Range.compare d1.range d2.range))
   in
+  all_diagnostics
+;;
+
+let merlin_diagnostics diagnostics merlin =
+  let open Fiber.O in
+  let uri = Document.Merlin.to_doc merlin |> Document.uri in
+  let+ all_diagnostics = compute_merlin_diagnostics diagnostics merlin in
   set diagnostics (`Merlin (uri, all_diagnostics))
 ;;
 

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -36,7 +36,9 @@ val tags_of_message
   -> string
   -> DiagnosticTag.t list option
 
+val compute_merlin_diagnostics : t -> Document.Merlin.t -> Diagnostic.t list Fiber.t
 val merlin_diagnostics : t -> Document.Merlin.t -> unit Fiber.t
+val merge : merlin:Diagnostic.t list -> dune:Diagnostic.t list -> Diagnostic.t list
 val set_report_dune_diagnostics : t -> report_dune_diagnostics:bool -> unit Fiber.t
 val set_shorten_merlin_diagnostics : t -> shorten_merlin_diagnostics:bool -> unit Fiber.t
 

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -141,6 +141,8 @@ module Instance : sig
   val create : Registry.Dune.t -> config -> t
   val promotions : t -> Drpc.Diagnostic.Promotion.t Map.M(String).t
   val client : t -> Client.t option
+  val pull_diagnostics : t -> (Drpc.Diagnostic.t list, string) result Fiber.t
+  val lsp_of_dune : t -> Drpc.Diagnostic.t -> Uri.t * Diagnostic.t
 end = struct
   module Id = Id.Make ()
 
@@ -181,7 +183,7 @@ end = struct
 
   let source t = t.source
 
-  let lsp_of_dune diagnostics ~include_promotions diagnostic =
+  let diagnostic_to_lsp diagnostics ~include_promotions diagnostic =
     let module D = Drpc.Diagnostic in
     let range_of_loc loc =
       let loc =
@@ -263,6 +265,22 @@ end = struct
     trace ~message ~verbose
   ;;
 
+  let uri_of_dune t diagnostic =
+    match Drpc.Diagnostic.loc diagnostic with
+    | None -> Registry.Dune.root t.source |> Uri.of_path
+    | Some loc ->
+      let { Lexing.pos_fname; _ } = Drpc.Loc.start loc in
+      Uri.of_path pos_fname
+  ;;
+
+  let lsp_of_dune t diagnostic =
+    ( uri_of_dune t diagnostic
+    , diagnostic_to_lsp
+        t.config.diagnostics
+        ~include_promotions:t.config.include_promotions
+        diagnostic )
+  ;;
+
   let progress_loop client diagnostics document_store progress trace source =
     (* We get all the progress updates even if the user can't see them to
        refresh the merlin config at the end of every build. Not very clean, but
@@ -297,7 +315,7 @@ end = struct
           Some ())
   ;;
 
-  let diagnostic_loop ~dune_root client config (running : running) diagnostics =
+  let diagnostic_loop t client config (running : running) diagnostics =
     let* res = Client.poll client Drpc.Sub.diagnostic in
     let send_diagnostics evs =
       let promotions, add, remove =
@@ -347,23 +365,10 @@ end = struct
                       assert false
                     | None -> Map.add_exn ps ~key:source ~data:promotion, promotion :: acc)
               in
-              let uri : Uri.t =
-                match Drpc.Diagnostic.loc d with
-                | None -> dune_root
-                | Some loc ->
-                  let { Lexing.pos_fname; _ } = Drpc.Loc.start loc in
-                  Uri.of_path pos_fname
-              in
+              let uri, diagnostic = lsp_of_dune t d in
               Diagnostics.set
                 diagnostics
-                (`Dune
-                    ( running.diagnostics_id
-                    , id
-                    , uri
-                    , lsp_of_dune
-                        diagnostics
-                        ~include_promotions:config.include_promotions
-                        d ));
+                (`Dune (running.diagnostics_id, id, uri, diagnostic));
               promotions, requests :: add, remove)
       in
       promotions, List.concat add, List.concat remove
@@ -533,14 +538,24 @@ end = struct
                  config.trace
                  source
              in
-             let diagnostics =
-               let dune_root = DocumentUri.of_path (Registry.Dune.root source) in
-               diagnostic_loop ~dune_root client config running diagnostics
-             in
+             let diagnostics = diagnostic_loop t client config running diagnostics in
              Fiber.all_concurrently_unit [ progress; diagnostics; Fiber.Ivar.read finish ]))
         ]
     in
     Progress.end_build_if_running progress
+  ;;
+
+  let pull_diagnostics t =
+    match t.state with
+    | Running { client = Some client; _ } ->
+      let* request = Client.Versioned.prepare_request client Drpc.Request.diagnostics in
+      (match request with
+       | Error error -> Fiber.return (Error (Drpc.Version_error.message error))
+       | Ok request ->
+         let+ response = Client.request client request () in
+         Result.map_error response ~f:Drpc.Response.Error.message)
+    | Connected _ | Idle | Finished | Running _ ->
+      Fiber.return (Error "Dune RPC instance is not ready")
   ;;
 
   let format_dune_file t doc =
@@ -856,6 +871,49 @@ let update_workspaces t workspaces =
   | Active active -> active.workspaces <- workspaces
 ;;
 
+let instances_for_uri active uri =
+  Map.fold active.instances ~init:[] ~f:(fun ~key:_ ~data:instance acc ->
+    if uri_dune_overlap uri (Instance.source instance) then instance :: acc else acc)
+;;
+
+let pull_diagnostics ?uri t =
+  match !t with
+  | Closed -> Fiber.return (Ok [])
+  | Active active ->
+    let instances =
+      match uri with
+      | None -> Map.data active.instances
+      | Some uri -> instances_for_uri active uri
+    in
+    let annotate_dune_pid = List.length instances > 1 in
+    let* results =
+      Fiber.parallel_map instances ~f:(fun instance ->
+        let+ diagnostics = Instance.pull_diagnostics instance in
+        instance, diagnostics)
+    in
+    let rec collect acc = function
+      | [] -> Ok (List.rev acc)
+      | (instance, Error message) :: _ ->
+        let root = Instance.source instance |> Registry.Dune.root in
+        Error (sprintf "unable to pull diagnostics from Dune at %s: %s" root message)
+      | (instance, Ok diagnostics) :: rest ->
+        let diagnostics =
+          List.map diagnostics ~f:(fun dune_diagnostic ->
+            let uri, diagnostic = Instance.lsp_of_dune instance dune_diagnostic in
+            let diagnostic =
+              if annotate_dune_pid
+              then (
+                let pid = Instance.source instance |> Registry.Dune.pid in
+                { diagnostic with source = Some (sprintf "dune (pid=%d)" pid) })
+              else diagnostic
+            in
+            uri, diagnostic)
+        in
+        collect (List.rev_append diagnostics acc) rest
+    in
+    Fiber.return (collect [] results)
+;;
+
 module Promote = struct
   module Input = struct
     type t =
@@ -963,8 +1021,5 @@ let on_command t (cmd : ExecuteCommandParams.t) =
 let for_doc t doc =
   match !t with
   | Closed -> []
-  | Active t ->
-    let uri = Document.Dune.uri doc in
-    Map.fold t.instances ~init:[] ~f:(fun ~key:_ ~data:instance acc ->
-      if uri_dune_overlap uri (Instance.source instance) then instance :: acc else acc)
+  | Active active -> instances_for_uri active (Document.Dune.uri doc)
 ;;

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -22,6 +22,12 @@ val create
   -> t
 
 val update_workspaces : t -> Workspaces.t -> unit
+
+val pull_diagnostics
+  :  ?uri:Uri.t
+  -> t
+  -> ((Uri.t * Diagnostic.t) list, string) result Fiber.t
+
 val stop : t -> unit Fiber.t
 val commands : string list
 val on_command : t -> ExecuteCommandParams.t -> Json.t Fiber.t

--- a/ocaml-lsp-server/src/dune_pull_diagnostics.ml
+++ b/ocaml-lsp-server/src/dune_pull_diagnostics.ml
@@ -1,0 +1,28 @@
+open Import
+
+let identifier = "ocamllsp"
+let diagnostic_json diagnostic = Diagnostic.yojson_of_t diagnostic |> Json.to_string
+
+let sort_diagnostics diagnostics =
+  List.map diagnostics ~f:(fun diagnostic -> diagnostic_json diagnostic, diagnostic)
+  |> List.sort ~compare:(fun (x, _) (y, _) -> Poly.compare x y)
+  |> List.map ~f:snd
+;;
+
+let result_id diagnostics =
+  let json = `List (List.map diagnostics ~f:Diagnostic.yojson_of_t) in
+  let digest = Json.to_string json |> Stdlib.Digest.string |> Stdlib.Digest.to_hex in
+  identifier ^ ":" ^ digest
+;;
+
+let document diagnostics (params : DocumentDiagnosticParams.t) =
+  let items = sort_diagnostics diagnostics in
+  let result_id = result_id items in
+  match params.previousResultId with
+  | Some previous when String.equal previous result_id ->
+    `RelatedUnchangedDocumentDiagnosticReport
+      (RelatedUnchangedDocumentDiagnosticReport.create ~resultId:result_id ())
+  | None | Some _ ->
+    `RelatedFullDocumentDiagnosticReport
+      (RelatedFullDocumentDiagnosticReport.create ~items ~resultId:result_id ())
+;;

--- a/ocaml-lsp-server/src/dune_pull_diagnostics.mli
+++ b/ocaml-lsp-server/src/dune_pull_diagnostics.mli
@@ -1,0 +1,8 @@
+open Import
+
+val identifier : string
+
+val document
+  :  Diagnostic.t list
+  -> DocumentDiagnosticParams.t
+  -> DocumentDiagnosticReport.t

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -215,7 +215,9 @@ include struct
   module ConfigurationParams = ConfigurationParams
   module CreateFile = CreateFile
   module Diagnostic = Diagnostic
+  module DiagnosticOptions = DiagnosticOptions
   module DiagnosticRelatedInformation = DiagnosticRelatedInformation
+  module DiagnosticServerCancellationData = DiagnosticServerCancellationData
   module DiagnosticSeverity = DiagnosticSeverity
   module DiagnosticTag = DiagnosticTag
   module DidChangeConfigurationParams = DidChangeConfigurationParams
@@ -225,6 +227,8 @@ include struct
   module DocumentFilter = DocumentFilter
   module DocumentHighlight = DocumentHighlight
   module DocumentHighlightKind = DocumentHighlightKind
+  module DocumentDiagnosticParams = DocumentDiagnosticParams
+  module DocumentDiagnosticReport = DocumentDiagnosticReport
   module DocumentHighlightParams = DocumentHighlightParams
   module DocumentSymbol = DocumentSymbol
   module DocumentUri = DocumentUri
@@ -255,6 +259,11 @@ include struct
   module PublishDiagnosticsParams = PublishDiagnosticsParams
   module PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities
   module ReferenceParams = ReferenceParams
+  module RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport
+
+  module RelatedUnchangedDocumentDiagnosticReport =
+    RelatedUnchangedDocumentDiagnosticReport
+
   module Registration = Registration
   module RegistrationParams = RegistrationParams
   module RenameOptions = RenameOptions
@@ -311,8 +320,8 @@ include struct
   module WorkspaceEdit = WorkspaceEdit
   module WorkspaceFolder = WorkspaceFolder
   module WorkspaceFoldersChangeEvent = WorkspaceFoldersChangeEvent
-  module WorkspaceSymbolParams = WorkspaceSymbolParams
   module WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities
+  module WorkspaceSymbolParams = WorkspaceSymbolParams
   module WorkspaceOptions = WorkspaceOptions
 end
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -1,6 +1,7 @@
 open Import
 module Version = Version
 module Diagnostics = Diagnostics
+module Dune_pull_diagnostics = Dune_pull_diagnostics
 module Position = Position
 module Doc_to_md = Doc_to_md
 module Diff = Diff
@@ -66,6 +67,18 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
          ())
   in
   let codeLensProvider = CodeLensOptions.create ~resolveProvider:false () in
+  let diagnosticProvider =
+    match client_capabilities.textDocument with
+    | Some { diagnostic = Some _; _ } ->
+      Some
+        (`DiagnosticOptions
+            (DiagnosticOptions.create
+               ~identifier:Dune_pull_diagnostics.identifier
+               ~interFileDependencies:true
+               ~workspaceDiagnostics:false
+               ()))
+    | None | Some _ -> None
+  in
   let completionProvider =
     CompletionOptions.create ~triggerCharacters:[ "."; "#" ] ~resolveProvider:true ()
   in
@@ -171,6 +184,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       ~declarationProvider:(`Bool true)
       ~definitionProvider:(`Bool true)
       ~typeDefinitionProvider:(`Bool true)
+      ?diagnosticProvider
       ~completionProvider
       ~signatureHelpProvider
       ~codeActionProvider
@@ -201,6 +215,28 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
 
 let ocamlmerlin_reason = "ocamlmerlin-reason"
 
+let no_reason_merlin_diagnostic () =
+  let message =
+    `String (sprintf "Could not detect %s. Please install reason" ocamlmerlin_reason)
+  in
+  Diagnostic.create
+    ~source:Diagnostics.ocamllsp_source
+    ~range:Lsp.Range.first_line
+    ~message
+    ()
+;;
+
+let compute_document_merlin_diagnostics diagnostics doc =
+  match Document.kind doc with
+  | `Other -> Fiber.return []
+  | `Merlin merlin ->
+    (match Document.syntax doc with
+     | Dune | Cram | Menhir | Ocamllex -> Fiber.return []
+     | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
+       Fiber.return [ no_reason_merlin_diagnostic () ]
+     | Reason | Ocaml | Mlx -> Diagnostics.compute_merlin_diagnostics diagnostics merlin)
+;;
+
 let set_diagnostics detached diagnostics doc =
   let uri = Document.uri doc in
   match Document.kind doc with
@@ -221,23 +257,10 @@ let set_diagnostics detached diagnostics doc =
     in
     (match Document.syntax doc with
      | Dune | Cram | Menhir | Ocamllex -> Fiber.return ()
-     | Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
-       let no_reason_merlin =
-         let message =
-           `String
-             (sprintf "Could not detect %s. Please install reason" ocamlmerlin_reason)
-         in
-         Diagnostic.create
-           ~source:Diagnostics.ocamllsp_source
-           ~range:Lsp.Range.first_line
-           ~message
-           ()
-       in
-       Diagnostics.set diagnostics (`Merlin (uri, [ no_reason_merlin ]));
-       async (fun () -> Diagnostics.send diagnostics (`One uri))
      | Reason | Ocaml | Mlx ->
        async (fun () ->
-         let* () = Diagnostics.merlin_diagnostics diagnostics merlin in
+         let* merlin = compute_document_merlin_diagnostics diagnostics doc in
+         Diagnostics.set diagnostics (`Merlin (uri, merlin));
          Diagnostics.send diagnostics (`One uri)))
 ;;
 
@@ -278,21 +301,29 @@ let on_initialize server (ip : InitializeParams.t) =
     let shorten_merlin_diagnostics =
       Configuration.shorten_merlin_diagnostics state.configuration
     in
+    let pull_diagnostics =
+      match ip.capabilities.textDocument with
+      | Some { diagnostic = Some _; _ } -> true
+      | None | Some _ -> false
+    in
     Diagnostics.create
       ~report_dune_diagnostics
       ~shorten_merlin_diagnostics
       (let open Option.O in
        let* td = ip.capabilities.textDocument in
        td.publishDiagnostics)
-      (function
-        | [] -> Fiber.return ()
-        | diagnostics ->
-          let state = Server.state server in
-          task_if_running state.detached ~f:(fun () ->
-            let batch = Server.Batch.create server in
-            List.iter diagnostics ~f:(fun d ->
-              Server.Batch.notification batch (PublishDiagnostics d));
-            Server.Batch.submit batch))
+      (if pull_diagnostics
+       then fun _ -> Fiber.return ()
+       else
+         function
+         | [] -> Fiber.return ()
+         | diagnostics ->
+           let state = Server.state server in
+           task_if_running state.detached ~f:(fun () ->
+             let batch = Server.Batch.create server in
+             List.iter diagnostics ~f:(fun d ->
+               Server.Batch.notification batch (PublishDiagnostics d));
+             Server.Batch.submit batch))
   in
   let+ dune =
     let progress =
@@ -565,6 +596,31 @@ let document_symbol (state : State.t) uri =
   Document_symbol.run client_capabilities doc uri
 ;;
 
+let validate_diagnostic_identifier = function
+  | None -> ()
+  | Some identifier when String.equal identifier Dune_pull_diagnostics.identifier -> ()
+  | Some identifier ->
+    Jsonrpc.Response.Error.raise
+      (make_error
+         ~code:InvalidParams
+         ~message:(sprintf "unknown diagnostic provider %S" identifier)
+         ())
+;;
+
+let pull_dune_diagnostics (state : State.t) uri =
+  if Configuration.report_dune_diagnostics state.configuration
+  then Dune.pull_diagnostics ~uri (State.dune state)
+  else Fiber.return (Ok [])
+;;
+
+let raise_diagnostic_pull_error message =
+  let data =
+    DiagnosticServerCancellationData.create ~retriggerRequest:true
+    |> DiagnosticServerCancellationData.yojson_of_t
+  in
+  Jsonrpc.Response.Error.raise (make_error ~code:ServerCancelled ~message ~data ())
+;;
+
 let on_request
   : type resp.
     State.t Server.t -> resp Client_request.t -> (resp Reply.t * State.t) Fiber.t
@@ -768,7 +824,27 @@ let on_request
   | WillRenameFiles _ -> not_supported ()
   | WillDeleteFiles _ -> not_supported ()
   | InlayHintResolve _ -> not_supported ()
-  | TextDocumentDiagnostic _ -> not_supported ()
+  | TextDocumentDiagnostic params ->
+    later
+      (fun state params ->
+         validate_diagnostic_identifier params.DocumentDiagnosticParams.identifier;
+         let uri = params.textDocument.uri in
+         let doc = Document_store.get state.store uri in
+         let* dune, merlin =
+           Fiber.fork_and_join
+             (fun () -> pull_dune_diagnostics state uri)
+             (fun () -> compute_document_merlin_diagnostics (State.diagnostics state) doc)
+         in
+         match dune with
+         | Error message -> raise_diagnostic_pull_error message
+         | Ok dune ->
+           let dune =
+             List.filter_map dune ~f:(fun (diagnostic_uri, diagnostic) ->
+               Option.some_if (Uri.equal diagnostic_uri uri) diagnostic)
+           in
+           let diagnostics = Diagnostics.merge ~merlin ~dune in
+           Fiber.return (Dune_pull_diagnostics.document diagnostics params))
+      params
   | TextDocumentInlineCompletion _ -> not_supported ()
   | TextDocumentInlineValue _ -> not_supported ()
   | WorkspaceSymbolResolve _ -> not_supported ()

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -1,6 +1,7 @@
 val run : Lsp.Cli.Channel.t -> prefer_dot_merlin:bool -> unit -> unit
 
 module Diagnostics = Diagnostics
+module Dune_pull_diagnostics = Dune_pull_diagnostics
 module Version = Version
 module Position = Position
 module Doc_to_md = Doc_to_md

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -1,6 +1,7 @@
 (library
  (modules
   destruct_line_quickcheck_tests
+  dune_pull_diagnostics_tests
   ocaml_lsp_tests
   position_prefix_tests
   semantic_tokens_quickcheck_tests)

--- a/ocaml-lsp-server/test/dune_pull_diagnostics_tests.ml
+++ b/ocaml-lsp-server/test/dune_pull_diagnostics_tests.ml
@@ -1,0 +1,70 @@
+open Lsp.Types
+module Diagnostics = Ocaml_lsp_server.Diagnostics
+module Pull = Ocaml_lsp_server.Dune_pull_diagnostics
+
+let range =
+  let start = Position.create ~line:0 ~character:0 in
+  let end_ = Position.create ~line:0 ~character:1 in
+  Range.create ~start ~end_
+;;
+
+let diagnostic ?source message =
+  Diagnostic.create ?source ~range ~message:(`String message) ()
+;;
+
+let%expect_test "document diagnostics deduplicate Dune and Merlin" =
+  let merlin = diagnostic ~source:Diagnostics.ocamllsp_source "duplicate" in
+  let dune =
+    [ diagnostic ~source:Diagnostics.dune_source "duplicate"
+    ; diagnostic ~source:Diagnostics.dune_source "Dune only"
+    ]
+  in
+  let merged = Diagnostics.merge ~merlin:[ merlin ] ~dune in
+  let count_source source =
+    List.filter
+      (fun diagnostic ->
+         Option.equal String.equal diagnostic.Diagnostic.source (Some source))
+      merged
+    |> List.length
+  in
+  Printf.printf
+    "items=%d merlin=%d dune=%d\n"
+    (List.length merged)
+    (count_source Diagnostics.ocamllsp_source)
+    (count_source Diagnostics.dune_source);
+  [%expect {| items=2 merlin=1 dune=1 |}]
+;;
+
+let%expect_test "diagnostics without a source are preserved" =
+  let merlin = diagnostic "same message" in
+  let dune = diagnostic ~source:Diagnostics.dune_source "same message" in
+  let merged = Diagnostics.merge ~merlin:[ merlin ] ~dune:[ dune ] in
+  Printf.printf "items=%d\n" (List.length merged);
+  [%expect {| items=2 |}]
+;;
+
+let%expect_test "document diagnostics use a stable empty result" =
+  let uri = Lsp.Uri.of_path "/workspace/clean.ml" in
+  let params previousResultId =
+    DocumentDiagnosticParams.create
+      ~identifier:Pull.identifier
+      ?previousResultId
+      ~textDocument:(TextDocumentIdentifier.create ~uri)
+      ()
+  in
+  let first = Pull.document [] (params None) in
+  let result_id =
+    match first with
+    | `RelatedFullDocumentDiagnosticReport report ->
+      Printf.printf "full items=%d\n" (List.length report.items);
+      Option.get report.resultId
+    | `RelatedUnchangedDocumentDiagnosticReport _ -> assert false
+  in
+  (match Pull.document [] (params (Some result_id)) with
+   | `RelatedUnchangedDocumentDiagnosticReport _ -> print_endline "unchanged"
+   | `RelatedFullDocumentDiagnosticReport _ -> assert false);
+  [%expect
+    {|
+    full items=0
+    unchanged |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -113,6 +113,7 @@
     document_symbol
     merlin_jump
     phrase
+    pull_diagnostics
     type_expression
     typed_holes
     unsupported_requests

--- a/ocaml-lsp-server/test/e2e-new/pull_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/pull_diagnostics.ml
@@ -1,0 +1,109 @@
+open Test.Import
+open Dune_rpc_test
+
+let client_capabilities =
+  let diagnostic = DiagnosticClientCapabilities.create () in
+  let textDocument = TextDocumentClientCapabilities.create ~diagnostic () in
+  ClientCapabilities.create ~textDocument ()
+;;
+
+let rec wait_for_failed_build progress =
+  let* (params : Lsp.Progress.t ProgressParams.t) = Mailbox.wait progress in
+  match params.value with
+  | End { message = Some "Build failed" } -> Fiber.return ()
+  | Begin _ | Report _ | End _ -> wait_for_failed_build progress
+;;
+
+let pull_document_diagnostics client uri previousResultId =
+  let textDocument = TextDocumentIdentifier.create ~uri in
+  let params =
+    DocumentDiagnosticParams.create
+      ~identifier:"ocamllsp"
+      ?previousResultId
+      ~textDocument
+      ()
+  in
+  Client.request client (TextDocumentDiagnostic params)
+;;
+
+let%expect_test "advertises document pull diagnostics" =
+  (Test.run_initialized ~capabilities:client_capabilities
+   @@ fun client ->
+   let* initialized = Client.initialized client in
+   (match initialized.capabilities.diagnosticProvider with
+    | Some (`DiagnosticOptions options) ->
+      DiagnosticOptions.yojson_of_t options |> Test.print_result
+    | Some (`DiagnosticRegistrationOptions _) | None -> assert false);
+   Client.stop client);
+  [%expect
+    {|
+    {
+      "identifier": "ocamllsp",
+      "interFileDependencies": true,
+      "workspaceDiagnostics": false
+    }
+    |}]
+;;
+
+let%expect_test "pulls Merlin document diagnostics" =
+  (Test.run_initialized ~capabilities:client_capabilities
+   @@ fun client ->
+   let uri = Helpers.uri in
+   let* () =
+     Test.open_document
+       ~client
+       ~uri
+       ~source:"let x : int = \"only Merlin sees this\"\n"
+       ()
+   in
+   let* first = pull_document_diagnostics client uri None in
+   let result_id =
+     match first with
+     | `RelatedFullDocumentDiagnosticReport report ->
+       let has_merlin =
+         List.exists report.items ~f:(fun diagnostic ->
+           Option.equal String.equal diagnostic.Diagnostic.source (Some "ocamllsp"))
+       in
+       Printf.printf "full items=%d merlin=%b\n" (List.length report.items) has_merlin;
+       Option.value_exn report.resultId
+     | `RelatedUnchangedDocumentDiagnosticReport _ ->
+       failwith "expected full document diagnostics"
+   in
+   let* unchanged = pull_document_diagnostics client uri (Some result_id) in
+   (match unchanged with
+    | `RelatedUnchangedDocumentDiagnosticReport _ -> print_endline "unchanged"
+    | `RelatedFullDocumentDiagnosticReport _ ->
+      failwith "expected unchanged document diagnostics");
+   Client.stop client);
+  [%expect
+    {|
+    full items=1 merlin=true
+    unchanged |}]
+;;
+
+let%expect_test "pulls Dune document diagnostics" =
+  let project = create_project "pull-diagnostics" in
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       let window = WindowClientCapabilities.create ~workDoneProgress:true () in
+       let capabilities = { client_capabilities with window = Some window } in
+       run ~capabilities project events ~f:(fun client _workspace ->
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         let uri = Uri.of_path project.expected in
+         let* () = open_document client ~uri ~text:project.old_source in
+         Test.write_file project.gate "";
+         let* () = wait_for_failed_build (Events.progress events.dune) in
+         let+ report = pull_document_diagnostics client uri None in
+         match report with
+         | `RelatedFullDocumentDiagnosticReport report ->
+           let dune =
+             List.count report.items ~f:(fun (diagnostic : Diagnostic.t) ->
+               Option.equal String.equal diagnostic.source (Some "dune"))
+           in
+           Printf.printf "full items=%d dune=%d\n" (List.length report.items) dune
+         | `RelatedUnchangedDocumentDiagnosticReport _ ->
+           failwith "expected full document diagnostics"));
+  [%expect {| full items=1 dune=1 |}]
+;;


### PR DESCRIPTION
Implement the LSP 3.17 `textDocument/diagnostic` pull request.

Document pulls query Dune RPC for its latest diagnostic snapshot, filter it to
the requested URI, and combine it with freshly computed Merlin diagnostics.
Equivalent Dune and Merlin errors are deduplicated, and deterministic result
identifiers allow clients to receive unchanged reports.

Transient Dune RPC failures produce retriggerable server cancellations. Existing
push diagnostics remain unchanged.
