### PR TITLE
test(code-actions): reproduce eager inline edit resolution

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
@@ -1,12 +1,6 @@
 open Test.Import
 open Lsp_helpers
 
-let range ~start_line ~start_character ~end_line ~end_character =
-  let start = Position.create ~line:start_line ~character:start_character in
-  let end_ = Position.create ~line:end_line ~character:end_character in
-  Range.create ~start ~end_
-;;
-
 let code_action_capabilities ?resolveSupport () =
   let window =
     let showDocument = ShowDocumentClientCapabilities.create ~support:true in
@@ -112,7 +106,9 @@ let f (x : t) =
   | Bar _ -> 0
 |ocaml}
   in
-  let range = range ~start_line:3 ~start_character:4 ~end_line:3 ~end_character:4 in
+  let range =
+    Code_actions.range ~start_line:3 ~start_character:4 ~end_line:3 ~end_character:4
+  in
   print_pipeline_count ~prep:activate_jump ~name:"unknown" ~only:jump_kinds ~source range;
   [%expect {| unknown pipelines: 7 |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
@@ -1,0 +1,77 @@
+open Test.Import
+open Lsp_helpers
+
+let code_action_capabilities resolveSupport =
+  let codeActionLiteralSupport =
+    let codeActionKind = ClientCodeActionKindOptions.create ~valueSet:[] in
+    ClientCodeActionLiteralOptions.create ~codeActionKind
+  in
+  let codeAction =
+    CodeActionClientCapabilities.create
+      ~codeActionLiteralSupport
+      ~dataSupport:true
+      ~resolveSupport
+      ()
+  in
+  let textDocument = TextDocumentClientCapabilities.create ~codeAction () in
+  ClientCapabilities.create ~textDocument ()
+;;
+
+let print_resolve_state prefix (action : CodeAction.t) =
+  Printf.printf
+    "%s: edit=%b data=%b\n"
+    prefix
+    (Option.is_some action.edit)
+    (Option.is_some action.data)
+;;
+
+let%expect_test "inline edit is computed eagerly despite resolve support" =
+  let resolveSupport = ClientCodeActionResolveOptions.create ~properties:[ "edit" ] in
+  let capabilities = code_action_capabilities resolveSupport in
+  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
+  (Test.run ~handler
+   @@ fun client ->
+   let run_client () = Test.start_client ~capabilities client in
+   let run () =
+     let* initialized = Client.initialized client in
+     let resolveProvider =
+       match initialized.capabilities.codeActionProvider with
+       | Some (`CodeActionOptions { resolveProvider = Some true; _ }) -> true
+       | None | Some (`Bool _) | Some (`CodeActionOptions _) -> false
+     in
+     Printf.printf "resolve provider: %b\n" resolveProvider;
+     let uri = DocumentUri.of_path "resolve.ml" in
+     let source =
+       {ocaml|let _ =
+  let x = 0 in
+  x + 1
+|ocaml}
+     in
+     let* () = open_document ~language_id:"ocaml" ~client ~uri ~source in
+     let range =
+       Code_actions.range ~start_line:1 ~start_character:6 ~end_line:1 ~end_character:7
+     in
+     let textDocument = TextDocumentIdentifier.create ~uri in
+     let context =
+       CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.RefactorInline ] ()
+     in
+     let params = CodeActionParams.create ~textDocument ~range ~context () in
+     let* response = Client.request client (CodeAction params) in
+     let action =
+       response
+       |> Option.value_exn
+       |> List.find_map ~f:(function
+         | `CodeAction ({ CodeAction.title = "Inline into uses"; _ } as action) ->
+           Some action
+         | `CodeAction _ | `Command _ -> None)
+       |> Option.value_exn
+     in
+     print_resolve_state "initial response" action;
+     Fiber.return ()
+   in
+   Fiber.fork_and_join_unit run_client (fun () -> run () >>> Client.stop client));
+  [%expect
+    {|
+    resolve provider: false
+    initial response: edit=true data=false |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -1,5 +1,12 @@
 open Test.Import
 
+val range
+  :  start_line:int
+  -> start_character:int
+  -> end_line:int
+  -> end_character:int
+  -> Range.t
+
 val iter_code_actions
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -44,6 +44,7 @@
     action_inline
     action_mark_remove
     code_action_protocol
+    code_action_resolve
     code_actions
     code_lens
     completion


### PR DESCRIPTION
The LSP 3.18 specification supports [resolving additional code action properties lazily](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionResolveRequest) through `codeAction/resolve`.

This adds a focused regression test showing that, even when the client supports resolving edits, ocamllsp does not advertise a resolve provider and returns the inline edit eagerly in the initial code-action response. It also exposes the existing test range constructor so the code-action protocol tests can share it.
