### PR TITLE
refactor(test): share graceful e2e shutdown

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/debug_echo.ml
+++ b/ocaml-lsp-server/test/e2e-new/debug_echo.ml
@@ -1,15 +1,10 @@
 open Test.Import
 
 let%expect_test "debug/echo" =
-  (Test.run
+  (Test.run_initialized
    @@ fun client ->
-   let run_client () = Test.start_client client in
-   let run =
-     let* (_ : InitializeResult.t) = Client.initialized client in
-     let* response = Client.request client (DebugEcho { message = "testing" }) in
-     print_endline response.message;
-     Client.request client Shutdown
-   in
-   Fiber.fork_and_join_unit run_client (fun () -> run >>> Client.stop client));
+   let* response = Client.request client (DebugEcho { message = "testing" }) in
+   print_endline response.message;
+   Test.shutdown_client client);
   [%expect {| testing |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -18,32 +18,22 @@ let test source =
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* params = Fiber.Ivar.read diagnostics in
-      print_diagnostics params;
-      let* () = Client.request client Shutdown in
-      Client.stop client
-    in
-    Fiber.fork_and_join_unit run_client run)
+    let* params = Fiber.Ivar.read diagnostics in
+    print_diagnostics params;
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "has related diagnostics" =
@@ -185,37 +175,27 @@ end
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read first_diagnostics in
-      let settings =
-        `Assoc [ "shortenMerlinDiagnostics", `Assoc [ "enable", `Bool true ] ]
-      in
-      let* () = Client.notification client (ChangeConfiguration { settings }) in
-      let* () = Lev_fiber.Timer.sleepf 0.05 in
-      print_endline ("diagnostic publications: " ^ Int.to_string !publications);
-      let* () = Client.request client Shutdown in
-      Client.stop client
+    let* () = Fiber.Ivar.read first_diagnostics in
+    let settings =
+      `Assoc [ "shortenMerlinDiagnostics", `Assoc [ "enable", `Bool true ] ]
     in
-    Fiber.fork_and_join_unit run_client run);
+    let* () = Client.notification client (ChangeConfiguration { settings }) in
+    let* () = Lev_fiber.Timer.sleepf 0.05 in
+    print_endline ("diagnostic publications: " ^ Int.to_string !publications);
+    Test.shutdown_client client);
   [%expect {| diagnostic publications: 1 |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -86,8 +86,7 @@ let run_switch_request uri =
   Test.run_initialized (fun client ->
     let* response = switch_impl_intf client uri in
     print_response response;
-    let* () = Client.request client Shutdown in
-    Client.stop client)
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "can switch from file URI with non-file scheme" =

--- a/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
@@ -21,27 +21,21 @@ let run_test text req =
         Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = req client in
-      let* () = Client.request client Shutdown in
-      Client.stop client
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run)
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = req client in
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "syntax doc should display" =

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -58,6 +58,11 @@ let start_client ?(capabilities = ClientCapabilities.create ()) ?workspaceFolder
   Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ())
 ;;
 
+let shutdown_client client =
+  let* () = Client.request client Shutdown in
+  Client.stop client
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list

--- a/ocaml-lsp-server/test/e2e-new/with_pp.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_pp.ml
@@ -28,34 +28,28 @@ let%expect_test "with-pp" =
       ()
   in
   let output =
-    Test.run ~handler
+    Test.run_initialized ~handler
     @@ fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        let text = Io.String_path.read_file path in
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () =
-        let+ resp = Hover_helpers.hover ~uri client position in
-        Hover_helpers.print_hover resp
-      in
-      let output = [%expect.output] in
-      let* () = Client.request client Shutdown in
-      let+ () = Client.stop client in
-      output
+    let textDocument =
+      let text = Io.String_path.read_file path in
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () =
+      let+ resp = Hover_helpers.hover ~uri client position in
+      Hover_helpers.print_hover resp
+    in
+    let output = [%expect.output] in
+    let+ () = Test.shutdown_client client in
+    output
   in
   let (_ : string) = [%expect.output] in
   print_endline output;

--- a/ocaml-lsp-server/test/e2e-new/with_ppx.ml
+++ b/ocaml-lsp-server/test/e2e-new/with_ppx.ml
@@ -38,35 +38,29 @@ let%expect_test "with-ppx" =
     Client.Handler.make ~on_notification ()
   in
   let output =
-    Test.run ~handler
+    Test.run_initialized ~handler
     @@ fun client ->
-    let run_client () = Test.start_client client in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        let text = Io.String_path.read_file path in
-        TextDocumentItem.create
-          ~uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read diagnostics in
-      let* () =
-        let+ resp = Hover_helpers.hover ~uri client position in
-        Hover_helpers.print_hover resp
-      in
-      let output = [%expect.output] in
-      let* () = Client.request client Shutdown in
-      let+ () = Client.stop client in
-      output
+    let textDocument =
+      let text = Io.String_path.read_file path in
+      TextDocumentItem.create
+        ~uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text
     in
-    Fiber.fork_and_join_unit run_client run
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+    in
+    let* () = Fiber.Ivar.read diagnostics in
+    let* () =
+      let+ resp = Hover_helpers.hover ~uri client position in
+      Hover_helpers.print_hover resp
+    in
+    let output = [%expect.output] in
+    let+ () = Test.shutdown_client client in
+    output
   in
   let (_ : string) = [%expect.output] in
   print_endline output;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -252,20 +252,12 @@ let workspace_symbol client query =
 
 let run ?on_notification workspaces f =
   let handler = Client.Handler.make ?on_notification () in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Test.start_client
-        ~workspaceFolders:
-          (Some (List.map workspaces ~f:(fun workspace -> workspace.folder)))
-        client
-    in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let* () = f client in
-      let* () = Client.request client Shutdown in
-      Client.stop client
-    in
-    Fiber.fork_and_join_unit run_client run)
+  let workspaceFolders =
+    Some (List.map workspaces ~f:(fun workspace -> workspace.folder))
+  in
+  Test.run_initialized ~handler ~workspaceFolders (fun client ->
+    let* () = f client in
+    Test.shutdown_client client)
 ;;
 
 let%expect_test "returns all symbols from workspace" =


### PR DESCRIPTION
Add `Test.shutdown_client` for the common LSP `shutdown` request followed by client transport shutdown, and reuse it with `Test.run_initialized` in tests that follow this lifecycle.

The migrations retain each test's existing request, diagnostic, and expect-output ordering.
