### PR TITLE
test(lsp): reproduce fragment escape instability

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -84,6 +84,19 @@ let%expect_test "serialization disambiguates a path beginning with two slashes" 
     |}]
 ;;
 
+let%expect_test "a percent-encoded URI fragment round trips" =
+  let uri = Uri.of_string "file:///foo.ml#heading%201" in
+  Printf.printf
+    "fragment: %s\nserialized: %s\n"
+    (Option.value ~default:"<none>" (Uri.fragment uri))
+    (Uri.to_string uri);
+  [%expect
+    {|
+    fragment: heading%201
+    serialized: file:///foo.ml#heading%25201
+    |}]
+;;
+
 let uri_of_path =
   let test path =
     let uri = Uri.of_path path in


### PR DESCRIPTION
Record the current behavior when a URI fragment contains a percent escape: parsing leaves the escape encoded, and serializing the URI escapes the percent sign a second time.

This is a test-only reproduction; the expectation intentionally captures the faulty output.
