### PR TITLE
test(lsp): reproduce loss of drive-like URI paths

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -97,6 +97,17 @@ let%expect_test "a percent-encoded URI fragment round trips" =
     |}]
 ;;
 
+let%expect_test "serialization preserves a non-letter drive-like path" =
+  let source = "file:///1%3A/foo.ml" in
+  let serialized = Uri.of_string source |> Uri.to_string in
+  Printf.printf "source: %s\nserialized: %s\n" source serialized;
+  [%expect
+    {|
+    source: file:///1%3A/foo.ml
+    serialized: file://
+    |}]
+;;
+
 let uri_of_path =
   let test path =
     let uri = Uri.of_path path in


### PR DESCRIPTION
Record the current behavior for a URI path whose first segment resembles a Windows drive prefix but begins with a non-letter. Serialization selects the drive-path branch and emits no path.

This is a test-only reproduction; the expectation intentionally captures the faulty output.
