### PR TITLE
test(lsp): reproduce authority ambiguity after path decoding

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -69,6 +69,21 @@ let%expect_test "a URI query is not part of its filesystem path" =
     |}]
 ;;
 
+let%expect_test "serialization disambiguates a path beginning with two slashes" =
+  let uri = Uri.of_string "untitled:///%2FModule.ml" in
+  let serialized = Uri.to_string uri in
+  let round_trip = Uri.of_string serialized in
+  Printf.printf
+    "serialized: %s\nround trip equal: %b\n"
+    serialized
+    (Uri.equal uri round_trip);
+  [%expect
+    {|
+    serialized: untitled://Module.ml
+    round trip equal: false
+    |}]
+;;
+
 let uri_of_path =
   let test path =
     let uri = Uri.of_path path in


### PR DESCRIPTION
Record the current behavior when decoding an escaped slash produces a path beginning with `//`. Serializing and reparsing the URI interprets the first path segment as its authority instead of preserving the original components.

This is a test-only reproduction; the expectation intentionally captures the faulty output.
