### PR TITLE
test(lsp): reproduce truncation of Unicode URI queries

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -108,6 +108,19 @@ let%expect_test "serialization preserves a non-letter drive-like path" =
     |}]
 ;;
 
+let%expect_test "an unescaped Unicode URI query is preserved" =
+  let uri = Uri.of_string "file:///foo.ml?search=😀&limit=1" in
+  Printf.printf
+    "query: %s\nserialized: %s\n"
+    (Option.value ~default:"<none>" (Uri.query uri))
+    (Uri.to_string uri);
+  [%expect
+    {|
+    query: search=
+    serialized: file:///foo.ml?search%3D
+    |}]
+;;
+
 let uri_of_path =
   let test path =
     let uri = Uri.of_path path in


### PR DESCRIPTION
Record the current behavior for an unescaped Unicode value in a URI query. The query parser stops at the first Unicode byte and silently drops it and the remainder of the component.

This is a test-only reproduction; the expectation intentionally captures the faulty output.
