### PR TITLE
test(completion): expose remaining completion edge cases

### DIFF
--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -93,6 +93,10 @@ let range_prefix (lsp_position : Position.t) prefix : Range.t =
 
 let sortText_of_index idx = Printf.sprintf "%04d" idx
 
+module For_tests = struct
+  let sortText_of_index = sortText_of_index
+end
+
 module Complete_by_prefix = struct
   let completionItem_of_completion_entry
         idx

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -44,3 +44,7 @@ val prefix_of_position : short_path:bool -> Msource.t -> [< Msource.position ] -
 
     @return identifier unless none is found *)
 val reconstruct_ident : Msource.t -> [< Msource.position ] -> string option
+
+module For_tests : sig
+  val sortText_of_index : int -> string
+end

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -1129,6 +1129,54 @@ let%expect_test "completion doesn't autocomplete record fields" =
   [%expect {| No completions |}]
 ;;
 
+let%expect_test "does not complete `in` in a top-level binding" =
+  let source = "let item = i" in
+  let position = Position.create ~line:0 ~character:12 in
+  let only_in =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "in")
+  in
+  print_completions ~pre_print:only_in source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "kind": 14,
+      "label": "in",
+      "textEdit": {
+        "newText": "in",
+        "range": {
+          "end": { "character": 12, "line": 0 },
+          "start": { "character": 11, "line": 0 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "does not complete `in` before an existing `in`" =
+  let source = "let f () =\n  let x = i in\n  x" in
+  let position = Position.create ~line:1 ~character:11 in
+  let only_in =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "in")
+  in
+  print_completions ~pre_print:only_in source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "kind": 14,
+      "label": "in",
+      "textEdit": {
+        "newText": "in",
+        "range": {
+          "end": { "character": 11, "line": 1 },
+          "start": { "character": 10, "line": 1 }
+        }
+      }
+    }
+    |}]
+;;
+
 let%expect_test "completion for `in` keyword - no prefix" =
   let source =
     {ocaml|

--- a/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
@@ -38,6 +38,97 @@ let%expect_test "can get documentation for the end of document" =
     |}]
 ;;
 
+let%expect_test "completion resolve after its document changes" =
+  let capabilities =
+    let resolveSupport =
+      ClientCompletionItemResolveOptions.create ~properties:[ "documentation" ]
+    in
+    let completionItem = ClientCompletionItemOptions.create ~resolveSupport () in
+    let completion = CompletionClientCapabilities.create ~completionItem () in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let source = "(** old docs *)\nlet old_value = 1\nlet _ = old_" in
+  let req client =
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let params =
+      CompletionParams.create
+        ~textDocument
+        ~position:(Position.create ~line:2 ~character:12)
+        ()
+    in
+    let* completions = Client.request client (TextDocumentCompletion params) in
+    let items =
+      match completions with
+      | None -> failwith "missing completions"
+      | Some (`CompletionList { items; _ } | `List items) -> items
+    in
+    let item =
+      List.find items ~f:(fun (item : CompletionItem.t) ->
+        String.equal item.label "old_value")
+      |> Option.value_exn
+    in
+    print_endline "Completion item before document update:";
+    print_completion_item item;
+    let textDocument =
+      VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
+    in
+    let contentChanges =
+      [ `TextDocumentContentChangeWholeDocument
+          (TextDocumentContentChangeWholeDocument.create
+             ~text:"(** new docs *)\nlet old_value = 1\nlet _ = old_")
+      ]
+    in
+    let* () =
+      Client.notification
+        client
+        (TextDocumentDidChange
+           (DidChangeTextDocumentParams.create ~textDocument ~contentChanges))
+    in
+    let* item = Client.request client (CompletionItemResolve item) in
+    print_endline "Same item resolved after document update to version 1:";
+    print_completion_item item;
+    Fiber.return ()
+  in
+  Helpers.test ~capabilities source req;
+  [%expect
+    {|
+    Completion item before document update:
+    {
+      "data": {
+        "position": { "character": 12, "line": 2 },
+        "textDocument": { "uri": "file:///test.ml" }
+      },
+      "detail": "int",
+      "kind": 12,
+      "label": "old_value",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "old_value",
+        "range": {
+          "end": { "character": 12, "line": 2 },
+          "start": { "character": 8, "line": 2 }
+        }
+      }
+    }
+    Same item resolved after document update to version 1:
+    {
+      "detail": "int",
+      "documentation": { "kind": "markdown", "value": "new docs" },
+      "kind": 12,
+      "label": "old_value",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "old_value",
+        "range": {
+          "end": { "character": 12, "line": 2 },
+          "start": { "character": 8, "line": 2 }
+        }
+      }
+    }
+    |}]
+;;
+
 let%expect_test "can get documentation at arbitrary position" =
   let source =
     {ocaml|List.fld((=) 0) [1; 2; 3]

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -99,3 +99,17 @@ let%expect_test "let+$% thing" =
   prefix_test "let+$%" (`Logical (1, 6));
   [%expect "let+$%"]
 ;;
+
+let%expect_test "completion sort text preserves order above 9999 items" =
+  [ 9998; 9999; 10_000; 10_001 ]
+  |> List.map (fun index -> index, Testing.Compl.For_tests.sortText_of_index index)
+  |> List.sort (fun (_, left) (_, right) -> String.compare left right)
+  |> List.iter (fun (index, _) -> Printf.printf "%d\n" index);
+  [%expect
+    {|
+    10000
+    10001
+    9998
+    9999
+    |}]
+;;


### PR DESCRIPTION
Adds expectation tests that capture four current completion edge cases:

- context-insensitive `in` suggestions at top level and before an existing `in`;
- completion resolution against a document modified after completion;
- lexical `sortText` ordering after 9,999 entries.

A narrow `For_tests` hook makes the internal ordering behavior directly testable without changing server behavior.
