### PR TITLE
refactor(test): share graceful e2e exit

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
@@ -61,13 +61,9 @@ let metric_count metrics name =
 let print_pipeline_count ?(prep = fun _ -> Fiber.return ()) ~name ~only ~source range =
   let contents = Fiber.Ivar.create () in
   let handler = metrics_handler contents in
-  Test.run ~handler
+  Test.run_initialized ~handler ~capabilities:(code_action_capabilities ())
   @@ fun client ->
-  let run_client () =
-    Test.start_client ~capabilities:(code_action_capabilities ()) client
-  in
   let run () =
-    let* (_ : InitializeResult.t) = Client.initialized client in
     let* () = prep client in
     let uri = DocumentUri.of_path "metrics.ml" in
     let* () = open_document ~language_id:"ocaml" ~client ~uri ~source in
@@ -80,11 +76,7 @@ let print_pipeline_count ?(prep = fun _ -> Fiber.return ()) ~name ~only ~source 
     let+ metrics = Fiber.Ivar.read contents in
     Printf.printf "%s pipelines: %d\n" name (metric_count metrics name)
   in
-  let shutdown () =
-    let* () = Client.request client Shutdown in
-    Client.notification client Exit
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> Fiber.finalize run ~finally:shutdown)
+  Fiber.finalize run ~finally:(fun () -> Test.exit_client client)
 ;;
 
 let jump_kinds =

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -2401,63 +2401,51 @@ let f = function
          | _ -> Fiber.return ())
       ()
   in
-  Test.run ~handler (fun client ->
-    let run_client () =
-      Client.start
+  Test.run_initialized ~handler (fun client ->
+    let textDocument =
+      TextDocumentItem.create
+        ~uri:Helpers.uri
+        ~languageId:(LanguageKind.Other "ocaml")
+        ~version:0
+        ~text:source
+    in
+    let* () =
+      Client.notification
         client
-        (InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ())
+        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let textDocument =
-        TextDocumentItem.create
-          ~uri:Helpers.uri
-          ~languageId:(LanguageKind.Other "ocaml")
-          ~version:0
-          ~text:source
-      in
-      let* () =
-        Client.notification
-          client
-          (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
-      in
-      let* () = Fiber.Ivar.read first_diagnostics in
-      let settings = `Assoc [ "diagnostics_delay", `Float 10.0 ] in
-      let* () = Client.notification client (ChangeConfiguration { settings }) in
-      let edit_range =
-        range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
-      in
-      let contentChanges =
-        [ `TextDocumentContentChangePartial
-            (TextDocumentContentChangePartial.create ~range:edit_range ~text:" " ())
-        ]
-      in
-      let textDocument =
-        VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
-      in
-      let change = DidChangeTextDocumentParams.create ~textDocument ~contentChanges in
-      let* () = Client.notification client (TextDocumentDidChange change) in
-      let query_range =
-        range ~start_line:2 ~start_character:0 ~end_line:4 ~end_character:0
-      in
-      let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
-      let context =
-        CodeActionContext.create
-          ~diagnostics:[]
-          ~only:[ CodeActionKind.Other "combine-cases" ]
-          ()
-      in
-      let params = CodeActionParams.create ~textDocument ~range:query_range ~context () in
-      let* response = Client.request client (CodeAction params) in
-      let available =
-        response
-        |> Option.value ~default:[]
-        |> List.exists ~f:(find_action "combine-cases")
-      in
-      Printf.printf "combine-cases available: %b\n" available;
-      let* () = Client.request client Shutdown in
-      Client.notification client Exit
+    let* () = Fiber.Ivar.read first_diagnostics in
+    let settings = `Assoc [ "diagnostics_delay", `Float 10.0 ] in
+    let* () = Client.notification client (ChangeConfiguration { settings }) in
+    let edit_range =
+      range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:8
     in
-    Fiber.fork_and_join_unit run_client run);
+    let contentChanges =
+      [ `TextDocumentContentChangePartial
+          (TextDocumentContentChangePartial.create ~range:edit_range ~text:" " ())
+      ]
+    in
+    let textDocument =
+      VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:1
+    in
+    let change = DidChangeTextDocumentParams.create ~textDocument ~contentChanges in
+    let* () = Client.notification client (TextDocumentDidChange change) in
+    let query_range =
+      range ~start_line:2 ~start_character:0 ~end_line:4 ~end_character:0
+    in
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let context =
+      CodeActionContext.create
+        ~diagnostics:[]
+        ~only:[ CodeActionKind.Other "combine-cases" ]
+        ()
+    in
+    let params = CodeActionParams.create ~textDocument ~range:query_range ~context () in
+    let* response = Client.request client (CodeAction params) in
+    let available =
+      response |> Option.value ~default:[] |> List.exists ~f:(find_action "combine-cases")
+    in
+    Printf.printf "combine-cases available: %b\n" available;
+    Test.exit_client client);
   [%expect {| combine-cases available: false |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/document_sync.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_sync.ml
@@ -53,17 +53,11 @@ let get_document client =
 
 let run_document_test f =
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
-  Test.run ~handler
+  Test.run_initialized ~handler
   @@ fun client ->
-  let run_client () = Test.start_client client in
-  let run =
-    let* (_ : InitializeResult.t) = Client.initialized client in
-    let* () = f client in
-    let* () = Lev_fiber.Timer.sleepf 0.1 in
-    let* () = Client.request client Shutdown in
-    Client.notification client Exit
-  in
-  Fiber.fork_and_join_unit run_client (fun () -> run)
+  let* () = f client in
+  let* () = Lev_fiber.Timer.sleepf 0.1 in
+  Test.exit_client client
 ;;
 
 let%expect_test "Manages unicode character ranges correctly" =

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -63,6 +63,11 @@ let shutdown_client client =
   Client.stop client
 ;;
 
+let exit_client client =
+  let* () = Client.request client Shutdown in
+  Client.notification client Exit
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -13,25 +13,14 @@ let%expect_test "can add the first workspace folder after initialization" =
   in
   let stderr = Unix.descr_of_out_channel stderr_chan in
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
-  Test.run ~handler ~stderr (fun client ->
-    let run_client () =
-      let capabilities = ClientCapabilities.create () in
-      Client.start
-        client
-        (InitializeParams.create ~capabilities ~workspaceFolders:None ())
+  Test.run_initialized ~handler ~stderr ~workspaceFolders:None (fun client ->
+    let folder =
+      WorkspaceFolder.create ~uri:(DocumentUri.of_path "/tmp/new-workspace") ~name:"new"
     in
-    let run () =
-      let* (_ : InitializeResult.t) = Client.initialized client in
-      let folder =
-        WorkspaceFolder.create ~uri:(DocumentUri.of_path "/tmp/new-workspace") ~name:"new"
-      in
-      let event = WorkspaceFoldersChangeEvent.create ~added:[ folder ] ~removed:[] in
-      let change = DidChangeWorkspaceFoldersParams.create ~event in
-      let* () = Client.notification client (ChangeWorkspaceFolders change) in
-      let* () = Client.request client Shutdown in
-      Client.notification client Exit
-    in
-    Fiber.fork_and_join_unit run_client run);
+    let event = WorkspaceFoldersChangeEvent.create ~added:[ folder ] ~removed:[] in
+    let change = DidChangeWorkspaceFoldersParams.create ~event in
+    let* () = Client.notification client (ChangeWorkspaceFolders change) in
+    Test.exit_client client);
   Stdlib.close_out stderr_chan;
   let stderr = Io.String_path.read_file stderr_path in
   Stdlib.Sys.remove stderr_path;


### PR DESCRIPTION
Add `Test.exit_client` for the common LSP `shutdown` request followed by the `exit` notification, and reuse it with `Test.run_initialized` in tests that follow this lifecycle.

This also migrates the newly added code-action protocol test while preserving its `Fiber.finalize` cleanup guarantee.
