### PR TITLE
fix(lsp): disambiguate URI paths that begin with slashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
+- Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -98,7 +98,11 @@ let to_string { scheme; authority; path; query; fragment } =
   then (
     Buffer.add_string buff scheme;
     Buffer.add_char buff ':');
-  if (not (String.is_empty authority)) || scheme = "file" then Buffer.add_string buff "//";
+  if
+    (not (String.is_empty authority))
+    || scheme = "file"
+    || String.is_prefix path ~prefix:"//"
+  then Buffer.add_string buff "//";
   (*TODO: implement full logic:
     https://github.com/microsoft/vscode-uri/blob/96acdc0be5f9d5f2640e1c1f6733bbf51ec95177/src/uri.ts#L605 *)
   if not (String.is_empty authority)

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -79,8 +79,8 @@ let%expect_test "serialization disambiguates a path beginning with two slashes" 
     (Uri.equal uri round_trip);
   [%expect
     {|
-    serialized: untitled://Module.ml
-    round trip equal: false
+    serialized: untitled:////Module.ml
+    round trip equal: true
     |}]
 ;;
 


### PR DESCRIPTION
Decoded paths beginning with `//` need an explicit empty-authority marker. Emit the authority delimiter for these paths so reparsing does not interpret the first path segment as the authority.

Regression coverage landed in #1790.
