### PR TITLE
fix(lsp): preserve Unicode URI queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)
 - Preserve URI paths whose first segment resembles a non-letter Windows drive. (#1800, @rgrinberg)
+- Preserve unescaped Unicode in URI query components. (#1799, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/uri_lexer.mll
+++ b/lsp/src/uri_lexer.mll
@@ -19,15 +19,6 @@ let int_of_hex_char c =
   else
     None
 
-let value_exn = function
-   | None -> assert false
-   | Some s -> s
-
-let char_of_hexdigits high low =
-  let high = value_exn (int_of_hex_char high) in
-  let low = value_exn (int_of_hex_char low) in
-  Char.chr (high lsl 4 + low)
-
 (* https://github.com/mirage/ocaml-uri/blob/master/lib/uri.ml#L318 *)
 let decode b =
   let len = String.length b in
@@ -69,19 +60,7 @@ let decode b =
   Buffer.contents buf
 }
 
-let hexdigit = ['a'-'f' 'A'-'F' '0'-'9']
-let unreserved = [ 'A'-'Z' 'a'-'z' '0'-'9' '-' '.' '_' '~' ]
-let sub_delim = [ '!' '$' '&' '\'' '(' ')' '*' '+' ';' '=' ]
-
-rule query b = parse
-| (['/' '?' ':' '@'] | unreserved | sub_delim) as c { Buffer.add_char b c; query b lexbuf }
-| "%" (hexdigit as high) (hexdigit as low)
-  { Buffer.add_char b (char_of_hexdigits high low);
-    query b lexbuf
-  }
-| "" | "#" | eof { Buffer.contents b }
-
-and uri = parse
+rule uri = parse
 ([^':' '/' '?' '#']+ as scheme ':') ?
 ("//" ([^ '/' '?' '#']* as authority)) ?
 ([^ '?' '#']* as path)
@@ -99,11 +78,7 @@ and uri = parse
       String.add_prefix_if_not_exists path ~prefix:"/"
     | _ -> path
   in
-  let query =
-    match raw_query with
-    | None -> None
-    | Some c -> Some (query (Buffer.create (String.length c)) (Lexing.from_string c))
-  in
+  let query = raw_query |> Option.map decode in
   let fragment = fragment |> Option.map decode in
   { scheme; authority; path; query; fragment }
 }

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -116,8 +116,8 @@ let%expect_test "an unescaped Unicode URI query is preserved" =
     (Uri.to_string uri);
   [%expect
     {|
-    query: search=
-    serialized: file:///foo.ml?search%3D
+    query: search=😀&limit=1
+    serialized: file:///foo.ml?search%3D%F0%9F%98%80%26limit%3D1
     |}]
 ;;
 


### PR DESCRIPTION
The query-specific lexer accepted only selected ASCII bytes and silently stopped at unescaped Unicode. Decode the already-delimited query component with the common percent decoder instead.

Regression coverage landed in #1791.
