### PR TITLE
fix(lsp): preserve non-letter drive-like URI paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)
+- Preserve URI paths whose first segment resembles a non-letter Windows drive. (#1800, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/uri0.ml
+++ b/lsp/src/uri0.ml
@@ -114,25 +114,19 @@ let to_string { scheme; authority; path; query; fragment } =
     let encode = encode ~allow_slash:true in
     let encoded_colon = "%3A" in
     let len = String.length path in
-    if len >= 3 && path.[0] = '/' && path.[2] = ':'
+    if len >= 3 && path.[0] = '/' && path.[2] = ':' && is_drive_letter path.[1]
     then (
-      let drive_letter = Char.lowercase_ascii path.[1] in
-      if is_drive_letter drive_letter
-      then (
-        Buffer.add_char buff '/';
-        Buffer.add_char buff drive_letter;
-        Buffer.add_string buff encoded_colon;
-        let s = String.sub path ~pos:3 ~len:(len - 3) in
-        Buffer.add_string buff (encode s)))
-    else if len >= 2 && path.[1] = ':'
+      Buffer.add_char buff '/';
+      Buffer.add_char buff (Char.lowercase_ascii path.[1]);
+      Buffer.add_string buff encoded_colon;
+      let s = String.sub path ~pos:3 ~len:(len - 3) in
+      Buffer.add_string buff (encode s))
+    else if len >= 2 && path.[1] = ':' && is_drive_letter path.[0]
     then (
-      let drive_letter = Char.lowercase_ascii path.[0] in
-      if is_drive_letter drive_letter
-      then (
-        Buffer.add_char buff drive_letter;
-        Buffer.add_string buff encoded_colon;
-        let s = String.sub path ~pos:2 ~len:(len - 2) in
-        Buffer.add_string buff (encode s)))
+      Buffer.add_char buff (Char.lowercase_ascii path.[0]);
+      Buffer.add_string buff encoded_colon;
+      let s = String.sub path ~pos:2 ~len:(len - 2) in
+      Buffer.add_string buff (encode s))
     else Buffer.add_string buff (encode path));
   (match query with
    | None -> ()

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -104,7 +104,7 @@ let%expect_test "serialization preserves a non-letter drive-like path" =
   [%expect
     {|
     source: file:///1%3A/foo.ml
-    serialized: file://
+    serialized: file:///1%3A/foo.ml
     |}]
 ;;
 


### PR DESCRIPTION
Drive-letter serialization selected its special case from the colon position before validating the drive letter, causing invalid candidates to emit no path. Validate the drive letter in the branch condition so other paths use normal percent encoding.

Regression coverage landed in #1789.
