### PR TITLE
fix(lsp): decode URI fragments before serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
+- Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/lsp/src/uri_lexer.mll
+++ b/lsp/src/uri_lexer.mll
@@ -104,6 +104,7 @@ and uri = parse
     | None -> None
     | Some c -> Some (query (Buffer.create (String.length c)) (Lexing.from_string c))
   in
+  let fragment = fragment |> Option.map decode in
   { scheme; authority; path; query; fragment }
 }
 

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -92,8 +92,8 @@ let%expect_test "a percent-encoded URI fragment round trips" =
     (Uri.to_string uri);
   [%expect
     {|
-    fragment: heading%201
-    serialized: file:///foo.ml#heading%25201
+    fragment: heading 1
+    serialized: file:///foo.ml#heading%201
     |}]
 ;;
 


### PR DESCRIPTION
URI fragments remained percent-encoded after parsing, so serializing them escaped each percent sign again and broke round trips. Decode fragments before storing them, consistently with other URI components.

Regression coverage landed in #1788.
