### PR TITLE
fix(code-actions): respect requested action kinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@
 - Report a missing project build-system executable as a diagnostic without
   discarding the opened document. (#1814, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
+- Respect hierarchical code-action kind filters from clients. (#1802, @rgrinberg)
 - Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
   within its `range`, so clients no longer reject the document outline.
   (#1775, fixes #1560, @Leonard013)

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -26,15 +26,10 @@ module Code_action_error_monoid = struct
 end
 
 let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
-  let action_is_enabled =
-    match params.context.only with
-    | None -> fun _ -> true
-    | Some set ->
-      fun (action : Code_action.t) -> List.mem set action.kind ~equal:Poly.equal
-  in
   let enabled_actions =
     List.filter
-      ~f:action_is_enabled
+      ~f:(fun (action : Code_action.t) ->
+        Code_action.kind_is_requested params.context.only action.kind)
       [ Action_destruct_line.t state
       ; Action_destruct.t state
       ; Action_update_signature.t state
@@ -101,8 +96,21 @@ let compute server (params : CodeActionParams.t) =
     let store = state.store in
     Document_store.get_opt store uri
   in
-  let dune_actions = Dune.code_actions (State.dune state) params.textDocument.uri in
-  let actions = function
+  let kind_is_requested = Code_action.kind_is_requested params.context.only in
+  let dune_actions =
+    if kind_is_requested CodeActionKind.QuickFix
+    then Dune.code_actions (State.dune state) params.textDocument.uri
+    else []
+  in
+  let actions xs =
+    let xs =
+      match params.context.only with
+      | None -> xs
+      | Some _ ->
+        List.filter xs ~f:(fun (action : CodeAction.t) ->
+          Option.exists action.kind ~f:kind_is_requested)
+    in
+    match xs with
     | [] -> None
     | xs -> Some (List.map ~f:(fun a -> `CodeAction a) xs)
   in
@@ -114,17 +122,25 @@ let compute server (params : CodeActionParams.t) =
       let* window = (State.client_capabilities state).window in
       window.showDocument
     in
-    let open_related = Action_open_related.for_uri capabilities doc in
-    let open_dune = Action_open_dune.for_uri capabilities uri in
-    let* merlin_jumps =
-      match state.configuration.data.merlin_jump_code_actions with
-      | Some { enable = true } -> Action_jump.code_actions doc params capabilities
-      | Some { enable = false } | None -> Fiber.return []
+    let open_related =
+      if kind_is_requested Action_open_related.kind
+      then Action_open_related.for_uri capabilities doc
+      else []
+    in
+    let open_dune =
+      if kind_is_requested Action_open_dune.kind
+      then Action_open_dune.for_uri capabilities uri
+      else []
     in
     (match Document.syntax doc with
      | Ocamllex | Menhir | Cram | Dune ->
        Fiber.return (Reply.now (actions (dune_actions @ open_related @ open_dune)), state)
      | Ocaml | Reason | Mlx ->
+       let* merlin_jumps =
+         match state.configuration.data.merlin_jump_code_actions with
+         | Some { enable = true } -> Action_jump.code_actions doc params capabilities
+         | Some { enable = false } | None -> Fiber.return []
+       in
        let reply () =
          let+ code_action_results = compute_ocaml_code_actions params state doc in
          List.concat

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -63,8 +63,12 @@ let code_actions
       (params : CodeActionParams.t)
       (capabilities : ShowDocumentClientCapabilities.t option)
   =
-  match Document.kind doc with
-  | `Merlin merlin when available capabilities ->
+  let targets =
+    List.filter targets ~f:(fun target ->
+      Code_action.kind_is_requested params.context.only (kind target))
+  in
+  match Document.kind doc, targets with
+  | `Merlin merlin, _ :: _ when available capabilities ->
     let+ actions =
       (* TODO: Merlin Jump command that returns all available jump locations for a source code buffer. *)
       Fiber.parallel_map targets ~f:(fun target ->
@@ -79,11 +83,7 @@ let code_actions
           let arguments = [ DocumentUri.yojson_of_t uri; Range.yojson_of_t range ] in
           Command.create ~title ~command:command_name ~arguments ()
         in
-        CodeAction.create
-          ~title
-          ~kind:(CodeActionKind.Other (sprintf "merlin-jump-%s" (rename_target target)))
-          ~command
-          ())
+        CodeAction.create ~title ~kind:(kind target) ~command ())
     in
     List.filter_opt actions
   | _ -> Fiber.return []

--- a/ocaml-lsp-server/src/code_actions/action_open_related.ml
+++ b/ocaml-lsp-server/src/code_actions/action_open_related.ml
@@ -2,6 +2,7 @@ open Import
 open Fiber.O
 
 let command_name = "ocamllsp/open-related-source"
+let kind = CodeActionKind.Other "switch"
 
 let command_run server (params : ExecuteCommandParams.t) =
   let uri =
@@ -59,5 +60,5 @@ let for_uri (capabilities : ShowDocumentClientCapabilities.t option) doc =
           let documentChanges = [ `CreateFile (CreateFile.create ~uri ()) ] in
           Some (WorkspaceEdit.create ~documentChanges ())
       in
-      CodeAction.create ?edit ~title ~kind:(CodeActionKind.Other "switch") ~command ())
+      CodeAction.create ?edit ~title ~kind ~command ())
 ;;

--- a/ocaml-lsp-server/src/code_actions/action_open_related.mli
+++ b/ocaml-lsp-server/src/code_actions/action_open_related.mli
@@ -1,6 +1,7 @@
 open Import
 
 val command_name : string
+val kind : CodeActionKind.t
 val available : ShowDocumentClientCapabilities.t option -> bool
 val command_run : _ Server.t -> ExecuteCommandParams.t -> Json.t Fiber.t
 val for_uri : ShowDocumentClientCapabilities.t option -> Document.t -> CodeAction.t list

--- a/ocaml-lsp-server/src/code_actions/code_action.ml
+++ b/ocaml-lsp-server/src/code_actions/code_action.ml
@@ -17,6 +17,21 @@ type t =
 let batchable kind run = { kind; run = `Batchable run }
 let non_batchable kind run = { kind; run = `Non_batchable run }
 
+let kind_is_requested only kind =
+  match only with
+  | None -> true
+  | Some only ->
+    let to_string kind =
+      match CodeActionKind.yojson_of_t kind with
+      | `String kind -> kind
+      | _ -> assert false
+    in
+    let kind = to_string kind in
+    List.exists only ~f:(fun requested ->
+      let requested = to_string requested in
+      String.equal requested kind || String.is_prefix kind ~prefix:(requested ^ "."))
+;;
+
 let source_text doc (loc : Loc.t) =
   let open Option.O in
   let source = Document.source doc in

--- a/ocaml-lsp-server/src/code_actions/code_action.mli
+++ b/ocaml-lsp-server/src/code_actions/code_action.mli
@@ -23,4 +23,7 @@ val non_batchable
   -> (Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t)
   -> t
 
+(** Whether [kind] is included by the requested code action kinds. *)
+val kind_is_requested : CodeActionKind.t list option -> CodeActionKind.t -> bool
+
 val source_text : Document.t -> Loc.t -> string option

--- a/ocaml-lsp-server/test/e2e-new/code_actions_annotations.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_annotations.ml
@@ -78,17 +78,27 @@ let%expect_test "code action only includes nested kinds" =
     {|
     Code actions:
     {
-      "command": {
-        "arguments": [ "file:///foo.mli" ],
-        "command": "ocamllsp/open-related-source",
-        "title": "Create foo.mli"
-      },
       "edit": {
-        "documentChanges": [ { "kind": "create", "uri": "file:///foo.mli" } ]
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "(0)",
+                "range": {
+                  "end": { "character": 3, "line": 2 },
+                  "start": { "character": 2, "line": 2 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
       },
-      "kind": "switch",
-      "title": "Create foo.mli"
-    } |}]
+      "isPreferred": false,
+      "kind": "refactor.inline",
+      "title": "Inline into uses"
+    }
+    |}]
 ;;
 
 let%expect_test "can type-annotate a function argument" =


### PR DESCRIPTION
The LSP 3.18 specification defines [code action kinds as hierarchical identifiers separated by `.`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionKind), while [`CodeActionContext.only` requests the kinds of actions to return](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionContext).

This matches requested parent kinds such as `refactor` against nested kinds such as `refactor.inline`, and applies the filtering consistently to regular, Dune, open-related, and Merlin jump actions. It follows the regression test added in #1774.
