### PR TITLE
fix(code-actions): advertise all supported kinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -8,6 +8,8 @@ let targets =
 ;;
 
 let rename_target target = String.chop_prefix_if_exists target ~prefix:"match-"
+let kind target = CodeActionKind.Other (sprintf "merlin-jump-%s" (rename_target target))
+let kinds = List.map targets ~f:kind
 
 let available (capabilities : ShowDocumentClientCapabilities.t option) =
   match capabilities with

--- a/ocaml-lsp-server/src/code_actions/action_jump.mli
+++ b/ocaml-lsp-server/src/code_actions/action_jump.mli
@@ -1,6 +1,7 @@
 open Import
 
 val command_name : string
+val kinds : CodeActionKind.t list
 val available : ShowDocumentClientCapabilities.t option -> bool
 val command_run : 'a Server.t -> ExecuteCommandParams.t -> Json.t Fiber.t
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -29,18 +29,25 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
     match client_capabilities.textDocument with
     | Some { codeAction = Some { codeActionLiteralSupport = Some _; _ }; _ } ->
       let codeActionKinds =
-        Action_inferred_intf.kind
-        :: Action_destruct.kind
-        :: List.map
-             ~f:(fun (c : Code_action.t) -> c.kind)
-             [ Action_type_annotate.t
-             ; Action_remove_type_annotation.t
-             ; Action_construct.t
-             ; Action_refactor_open.unqualify
-             ; Action_refactor_open.qualify
-             ; Action_add_rec.t
-             ; Action_inline.t
-             ]
+        [ Action_destruct_line.kind
+        ; Action_destruct.kind
+        ; Action_update_signature.kind
+        ; Action_combine_cases.kind
+        ; Action_inferred_intf.kind
+        ; CodeActionKind.Other "switch"
+        ; CodeActionKind.QuickFix
+        ; CodeActionKind.RefactorExtract
+        ]
+        @ Action_jump.kinds
+        @ List.map
+            ~f:(fun (c : Code_action.t) -> c.kind)
+            [ Action_type_annotate.t
+            ; Action_remove_type_annotation.t
+            ; Action_construct.t
+            ; Action_refactor_open.unqualify
+            ; Action_refactor_open.qualify
+            ; Action_inline.t
+            ]
         |> List.sort_uniq ~compare:Poly.compare
       in
       `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -58,20 +58,7 @@ let%expect_test "advertises every code action kind that the server may return" =
      Client.request client Shutdown
    in
    Fiber.fork_and_join_unit run_client (fun () -> run () >>> Client.stop client));
-  [%expect
-    {|
-    missing: refactor.extract
-    missing: combine-cases
-    missing: destruct-line (enumerate cases, use existing match)
-    missing: update_intf
-    missing: switch
-    missing: merlin-jump-fun
-    missing: merlin-jump-match
-    missing: merlin-jump-let
-    missing: merlin-jump-module
-    missing: merlin-jump-module-type
-    missing: merlin-jump-next-case
-    missing: merlin-jump-prev-case |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "start/stop" =
@@ -129,11 +116,15 @@ let%expect_test "start/stop" =
       "capabilities": {
         "codeActionProvider": {
           "codeActionKinds": [
-            "quickfix", "refactor.inline", "construct",
-            "destruct (enumerate cases)", "inferred_intf",
+            "quickfix", "refactor.extract", "refactor.inline", "combine-cases",
+            "construct", "destruct (enumerate cases)",
+            "destruct-line (enumerate cases, use existing match)",
+            "inferred_intf", "merlin-jump-fun", "merlin-jump-let",
+            "merlin-jump-match", "merlin-jump-module", "merlin-jump-module-type",
+            "merlin-jump-next-case", "merlin-jump-prev-case",
             "put module name in identifiers",
             "remove module name from identifiers", "remove type annotation",
-            "type-annotate"
+            "switch", "type-annotate", "update_intf"
           ]
         },
         "codeLensProvider": { "resolveProvider": false },


### PR DESCRIPTION
The LSP 3.18 specification says [`CodeActionOptions.codeActionKinds` lists the code action kinds a server may return](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionOptions).

This advertises the previously omitted extract, combine-cases, destruct-line, update-interface, switch, and Merlin jump kinds during initialization. It follows the regression test added in #1783.
