### PR TITLE
fix(diagnostics): recompute diagnostics when shortening changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 - Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
   within its `range`, so clients no longer reject the document outline.
   (#1775, fixes #1560, @Leonard013)
+- Recompute Merlin diagnostics when diagnostic shortening changes. (#1804, @rgrinberg)
 - Keep URI query parameters separate from filesystem paths. (#1776, @rgrinberg)
 - Preserve URI paths beginning with two slashes across serialization. (#1798, @rgrinberg)
 - Preserve percent-encoded URI fragments across parsing and serialization. (#1801, @rgrinberg)

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -435,12 +435,6 @@ let set_report_dune_diagnostics t ~report_dune_diagnostics =
 ;;
 
 let set_shorten_merlin_diagnostics t ~shorten_merlin_diagnostics =
-  if t.shorten_merlin_diagnostics = shorten_merlin_diagnostics
-  then Fiber.return ()
-  else (
-    t.shorten_merlin_diagnostics <- shorten_merlin_diagnostics;
-    Hashtbl.iter t.dune ~f:(fun per_dune ->
-      Hashtbl.iter per_dune ~f:(fun (uri, _diagnostic) ->
-        t.dirty_uris <- Set.add t.dirty_uris uri));
-    send t `All)
+  t.shorten_merlin_diagnostics <- shorten_merlin_diagnostics;
+  Fiber.return ()
 ;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -813,20 +813,36 @@ let on_notification server (notification : Client_notification.t) : State.t Fibe
     state
   | CancelRequest _ -> Fiber.return state
   | ChangeConfiguration req ->
+    let previous_shorten_merlin_diagnostics =
+      Configuration.shorten_merlin_diagnostics state.configuration
+    in
     let* configuration = Configuration.update state.configuration req in
+    let diagnostics = State.diagnostics state in
     let* () =
       let report_dune_diagnostics = Configuration.report_dune_diagnostics configuration in
-      Diagnostics.set_report_dune_diagnostics
-        ~report_dune_diagnostics
-        (State.diagnostics state)
+      Diagnostics.set_report_dune_diagnostics ~report_dune_diagnostics diagnostics
+    in
+    let shorten_merlin_diagnostics =
+      Configuration.shorten_merlin_diagnostics configuration
+    in
+    let* () =
+      Diagnostics.set_shorten_merlin_diagnostics ~shorten_merlin_diagnostics diagnostics
     in
     let+ () =
-      let shorten_merlin_diagnostics =
-        Configuration.shorten_merlin_diagnostics configuration
-      in
-      Diagnostics.set_shorten_merlin_diagnostics
-        ~shorten_merlin_diagnostics
-        (State.diagnostics state)
+      if previous_shorten_merlin_diagnostics = shorten_merlin_diagnostics
+      then Fiber.return ()
+      else
+        let* () =
+          Document_store.parallel_iter store ~f:(fun doc ->
+            match Document.kind doc, Document.syntax doc with
+            | `Other, _ -> Fiber.return ()
+            | `Merlin _, Reason when Option.is_none (Bin.which ocamlmerlin_reason) ->
+              Fiber.return ()
+            | `Merlin merlin, (Reason | Ocaml | Mlx) ->
+              Diagnostics.merlin_diagnostics diagnostics merlin
+            | `Merlin _, (Dune | Cram | Menhir | Ocamllex) -> assert false)
+        in
+        Diagnostics.send diagnostics `All
     in
     { state with configuration }
   | DidSaveTextDocument { textDocument = { uri }; _ } ->

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -243,6 +243,33 @@ end
       ],
       "uri": "file:///test.ml"
     }
+    textDocument/publishDiagnostics
+    {
+      "diagnostics": [
+        {
+          "message": "Signature mismatch:\nModules do not match:\n  sig val x : int end\nis not included in\n  sig val x : unit end\nValues do not match: val x : int is not included in val x : unit\nThe type int is not compatible with the type unit\nFile \"test.ml\", line 2, characters 2-14: Expected declaration\nFile \"test.ml\", line 4, characters 6-7: Actual declaration",
+          "range": {
+            "end": { "character": 0, "line": 3 },
+            "start": { "character": 6, "line": 2 }
+          },
+          "relatedInformation": [
+            {
+              "location": {
+                "range": {
+                  "end": { "character": 3, "line": 4 },
+                  "start": { "character": 6, "line": 2 }
+                },
+                "uri": "file:///test.ml"
+              },
+              "message": "Original error span"
+            }
+          ],
+          "severity": 1,
+          "source": "ocamllsp"
+        }
+      ],
+      "uri": "file:///test.ml"
+    }
     |}]
 ;;
 


### PR DESCRIPTION
Changing `shortenMerlinDiagnostics` updated the selected mode but marked only Dune diagnostic URIs dirty and resent cached diagnostics. Open Merlin documents therefore retained diagnostics computed with the previous mode until another document event triggered analysis.

Recompute diagnostics for every open Merlin document when the setting changes, then publish the updated aggregate. The regression from #1731, strengthened in #1796, now records the second publication and verifies its shortened range and original-span information.
