### PR TITLE
fix(lsp): enforce slice position invariants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ all:
 # results in a conflict
 .PHONY: install-test-deps
 install-test-deps:
-	opam install --yes cinaps 'ppx_expect>=v0.17.0' \
-		ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat)
+	opam install --yes 'base_quickcheck>=v0.17.0' cinaps 'ppx_expect>=v0.17.0' \
+		'ppx_sexp_conv>=v0.17.0' ocamlformat.$$(awk -F = '$$1 == "version" {print $$2}' .ocamlformat)
 
 .PHONY: dev
 dev: ## Setup a development environment

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,9 @@ possible and does not make any assumptions about IO.
   yojson
   (ppx_yojson_conv_lib (>= "v0.14"))
   (cinaps :with-test)
+  (base_quickcheck (and (>= v0.17.0) :with-test))
   (ppx_expect (and (>= v0.17.0) :with-test))
+  (ppx_sexp_conv (and (>= v0.17.0) :with-test))
   (top-closure (or :with-test :with-dev-setup))
   (uutf (>= 1.0.2))
   (odoc :with-doc)

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,9 @@
             in [
               p.stdune
               p.cinaps
+              p.base_quickcheck
               p.ppx_expect
+              p.ppx_sexp_conv
               p.ppx_yojson_conv
               p.top-closure
               (ocamlformat pkgs)

--- a/lsp.opam
+++ b/lsp.opam
@@ -28,7 +28,9 @@ depends: [
   "yojson"
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "cinaps" {with-test}
+  "base_quickcheck" {>= "v0.17.0" & with-test}
   "ppx_expect" {>= "v0.17.0" & with-test}
+  "ppx_sexp_conv" {>= "v0.17.0" & with-test}
   "top-closure" {with-test | with-dev-setup}
   "uutf" {>= "1.0.2"}
   "odoc" {with-doc}

--- a/lsp/src/array_view.ml
+++ b/lsp/src/array_view.ml
@@ -14,20 +14,23 @@ let make ?len arr ~pos =
          arr_len
          pos);
   let length = Option.value len ~default:(arr_len - pos) in
-  let view_last_idx = pos + length in
-  if view_last_idx > arr_len
+  if length < 0
+  then invalid_arg (Printf.sprintf "Array_view.make: negative length %d" length);
+  if length > arr_len - pos
   then
     invalid_arg
       (Printf.sprintf
-         "Array_view.make: view's last idx = %d occurs after the array length = %d"
-         view_last_idx
+         "Array_view.make: view's length %d at position %d exceeds the array length %d"
+         length
+         pos
          arr_len);
   { arr; start = pos; end_excl = pos + length }
 ;;
 
 let offset_index t i =
-  let ix = t.start + i in
-  if ix < t.end_excl then ix else invalid_arg "subarray index out of bounds"
+  if i < 0 || i >= t.end_excl - t.start
+  then invalid_arg "subarray index out of bounds"
+  else t.start + i
 ;;
 
 let get t i = t.arr.(offset_index t i)
@@ -62,7 +65,9 @@ let iteri t ~f =
 ;;
 
 let sub t ~pos ~len =
-  assert (len <= length t);
+  let view_length = length t in
+  if pos < 0 || pos > view_length || len < 0 || len > view_length - pos
+  then invalid_arg "Array_view.sub: invalid bounds";
   let pos = t.start + pos in
   make t.arr ~pos ~len
 ;;

--- a/lsp/src/array_view.mli
+++ b/lsp/src/array_view.mli
@@ -8,7 +8,8 @@ type 'a t
     array, the array will be alive in memory as long as the view is alive.
 
     @raise Invalid_argument
-      if [pos + len > Array.length arr] or [pos < 0 || pos >= Array.length arr]*)
+      if [len < 0], [pos + len > Array.length arr], or
+      [pos < 0 || pos > Array.length arr].*)
 val make : ?len:int -> 'a array -> pos:int -> 'a t
 
 val get : 'a t -> int -> 'a

--- a/lsp/src/substring.ml
+++ b/lsp/src/substring.ml
@@ -104,7 +104,9 @@ let rindex_from =
 ;;
 
 let get_exn t i =
-  if i < t.len then t.base.[t.pos + i] else invalid_arg "Substring.get: out of bounds"
+  if i >= 0 && i < t.len
+  then t.base.[t.pos + i]
+  else invalid_arg "Substring.get: out of bounds"
 ;;
 
 let rindex =
@@ -115,7 +117,10 @@ let rindex =
     then Some pos
     else loop s (pos - 1) outside c
   in
-  fun t c -> loop t.base (t.len + t.pos - 1) (t.pos - 1) c
+  fun t c ->
+    match loop t.base (t.len + t.pos - 1) (t.pos - 1) c with
+    | None -> None
+    | Some pos -> Some (pos - t.pos)
 ;;
 
 let blit t ~dst ~dst_pos =

--- a/lsp/test/array_view_tests.ml
+++ b/lsp/test/array_view_tests.ml
@@ -5,7 +5,7 @@ let%expect_test "negative indices do not escape an array view" =
   (match Array_view.get view (-1) with
    | value -> Printf.printf "value: %d\n" value
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
-  [%expect {| value: 0 |}]
+  [%expect {| invalid: subarray index out of bounds |}]
 ;;
 
 let%expect_test "subviews stay within their parent view" =
@@ -13,7 +13,7 @@ let%expect_test "subviews stay within their parent view" =
   (match Array_view.sub parent ~pos:2 ~len:1 with
    | child -> Printf.printf "value: %d\n" (Array_view.get child 0)
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
-  [%expect {| value: 3 |}]
+  [%expect {| invalid: Array_view.sub: invalid bounds |}]
 ;;
 
 let%expect_test "negative mutations do not escape an array view" =
@@ -24,12 +24,12 @@ let%expect_test "negative mutations do not escape an array view" =
      Array.iter (Printf.printf "%d ") backing;
      print_newline ()
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
-  [%expect {| 9 1 2 3 |}]
+  [%expect {| invalid: subarray index out of bounds |}]
 ;;
 
 let%expect_test "negative lengths are rejected" =
   (match Array_view.make [||] ~pos:0 ~len:(-1) with
    | view -> Printf.printf "length: %d\n" (Array_view.length view)
    | exception Invalid_argument message -> Printf.printf "invalid: %s\n" message);
-  [%expect {| length: -1 |}]
+  [%expect {| invalid: Array_view.make: negative length -1 |}]
 ;;

--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -11,8 +11,10 @@
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   base
+  base_quickcheck
   ppx_expect.config
   ppx_expect.config_types
-  ppx_inline_test.config)
+  ppx_inline_test.config
+  ppx_sexp_conv.runtime-lib)
  (preprocess
-  (pps ppx_expect)))
+  (pps ppx_expect base_quickcheck.ppx_quickcheck ppx_sexp_conv)))

--- a/lsp/test/slice_quickcheck_tests.ml
+++ b/lsp/test/slice_quickcheck_tests.ml
@@ -1,0 +1,293 @@
+open Base
+open Base_quickcheck
+module Array_view = Lsp.Private.Array_view
+module Substring = Lsp.Private.Substring
+
+let select selector ~choices = Int.rem (selector land Stdlib.max_int) choices
+let check label condition = if not condition then failwith label
+
+let check_string label expected actual =
+  if not (String.equal expected actual)
+  then failwith (Printf.sprintf "%s: expected %S, got %S" label expected actual)
+;;
+
+let check_array label expected actual =
+  if not (Array.equal Int.equal expected actual)
+  then failwith (Printf.sprintf "%s: arrays differ" label)
+;;
+
+let substring_index_from text ~pos needle =
+  let rec loop index =
+    if index = String.length text
+    then None
+    else if Char.equal text.[index] needle
+    then Some index
+    else loop (index + 1)
+  in
+  loop pos
+;;
+
+let substring_rindex_from text ~pos needle =
+  let rec loop index =
+    if index < 0
+    then None
+    else if Char.equal text.[index] needle
+    then Some index
+    else loop (index - 1)
+  in
+  loop (pos - 1)
+;;
+
+let count_newlines text ~pos ~len =
+  let stop = pos + len in
+  let rec loop index count =
+    if index = stop
+    then count
+    else loop (index + 1) (if Char.equal text.[index] '\n' then count + 1 else count)
+  in
+  loop pos 0
+;;
+
+module Substring_case = struct
+  type t =
+    { prefix : string
+    ; contents : string
+    ; suffix : string
+    ; other : string
+    ; position_selector : int
+    ; length_selector : int
+    ; needle : char
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let check_substring_case
+      { Substring_case.prefix
+      ; contents
+      ; suffix
+      ; other
+      ; position_selector
+      ; length_selector
+      ; needle
+      }
+  =
+  let substring =
+    Substring.of_slice
+      (prefix ^ contents ^ suffix)
+      ~pos:(String.length prefix)
+      ~len:(String.length contents)
+  in
+  let contents_length = String.length contents in
+  let position = select position_selector ~choices:(contents_length + 1) in
+  let amount = select length_selector ~choices:(contents_length + 3) in
+  check "substring length" (Substring.length substring = contents_length);
+  check_string "substring contents" contents (Substring.to_string substring);
+  let other_substring = Substring.of_string other in
+  check
+    "substring comparison"
+    (Stdlib.compare (Substring.compare substring other_substring) 0
+     = Stdlib.compare (String.compare contents other) 0);
+  let taken = Int.min position contents_length in
+  check_string
+    "take"
+    (String.sub contents ~pos:0 ~len:taken)
+    (Substring.take substring position |> Substring.to_string);
+  check_string
+    "drop"
+    (String.sub contents ~pos:taken ~len:(contents_length - taken))
+    (Substring.drop substring position |> Substring.to_string);
+  let left, right = Substring.split_at substring position in
+  check_string
+    "split_at left"
+    (String.sub contents ~pos:0 ~len:position)
+    (Substring.to_string left);
+  check_string
+    "split_at right"
+    (String.sub contents ~pos:position ~len:(contents_length - position))
+    (Substring.to_string right);
+  let left, right = Substring.rsplit_at substring position in
+  let split = contents_length - position in
+  check_string
+    "rsplit_at left"
+    (String.sub contents ~pos:0 ~len:split)
+    (Substring.to_string left);
+  check_string
+    "rsplit_at right"
+    (String.sub contents ~pos:split ~len:position)
+    (Substring.to_string right);
+  let buffer = Buffer.create contents_length in
+  Substring.add_buffer substring buffer;
+  check_string "add_buffer" contents (Buffer.contents buffer);
+  let destination = Bytes.make (contents_length + 2) '!' in
+  Substring.blit substring ~dst:destination ~dst_pos:1;
+  check_string "blit" ("!" ^ contents ^ "!") (Bytes.to_string destination);
+  let pieces = [| Substring.of_string prefix; substring; Substring.of_string suffix |] in
+  check_string
+    "concat"
+    (prefix ^ contents ^ suffix)
+    (Substring.concat (Array_view.make pieces ~pos:0));
+  if contents_length > 0
+  then (
+    let index = select position_selector ~choices:contents_length in
+    check "get_exn" (Char.equal contents.[index] (Substring.get_exn substring index));
+    check
+      "index_from"
+      (Option.equal
+         Int.equal
+         (substring_index_from contents ~pos:index needle)
+         (Substring.index_from substring ~pos:index needle)));
+  check
+    "rindex_from"
+    (Option.equal
+       Int.equal
+       (substring_rindex_from contents ~pos:position needle)
+       (Substring.rindex_from substring ~pos:position needle));
+  check
+    "rindex"
+    (Option.equal
+       Int.equal
+       (substring_rindex_from contents ~pos:contents_length needle)
+       (Substring.rindex substring needle));
+  let right_move = Substring.move_right substring ~pos:position ~len:amount in
+  let right_consumed = Int.min amount (contents_length - position) in
+  check "move_right consumed" (right_move.consumed = right_consumed);
+  check
+    "move_right newlines"
+    (right_move.newlines = count_newlines contents ~pos:position ~len:right_consumed);
+  let left_move = Substring.move_left substring ~pos:position ~len:amount in
+  let left_consumed = Int.min amount position in
+  check "move_left consumed" (left_move.consumed = left_consumed);
+  check
+    "move_left newlines"
+    (left_move.newlines
+     = count_newlines contents ~pos:(position - left_consumed) ~len:left_consumed)
+;;
+
+module Array_view_case = struct
+  type t =
+    { prefix : int list
+    ; contents : int list
+    ; suffix : int list
+    ; other : int list
+    ; position_selector : int
+    ; length_selector : int
+    ; replacement : int
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let common_suffix_length left right =
+  let rec loop count =
+    if count = Array.length left || count = Array.length right
+    then count
+    else if
+      Int.equal
+        left.(Array.length left - count - 1)
+        right.(Array.length right - count - 1)
+    then loop (count + 1)
+    else count
+  in
+  loop 0
+;;
+
+let check_array_view_case
+      { Array_view_case.prefix
+      ; contents
+      ; suffix
+      ; other
+      ; position_selector
+      ; length_selector
+      ; replacement
+      }
+  =
+  let prefix = Array.of_list prefix in
+  let expected = Array.of_list contents in
+  let suffix = Array.of_list suffix in
+  let backing = Array.concat [ prefix; expected; suffix ] in
+  let view =
+    Array_view.make backing ~pos:(Array.length prefix) ~len:(Array.length expected)
+  in
+  check "array view length" (Array_view.length view = Array.length expected);
+  check
+    "array view emptiness"
+    (Bool.equal (Array_view.is_empty view) (Array.is_empty expected));
+  check_array "array view copy" expected (Array_view.copy view);
+  check
+    "array view fold"
+    (List.equal
+       Int.equal
+       (Array.to_list expected)
+       (Array_view.fold_left view ~init:[] ~f:(fun result value -> value :: result)
+        |> List.rev));
+  let visited = ref [] in
+  Array_view.iteri view ~f:(fun index value -> visited := (index, value) :: !visited);
+  check
+    "array view iteri"
+    (List.equal
+       (fun (left_index, left_value) (right_index, right_value) ->
+          Int.equal left_index right_index && Int.equal left_value right_value)
+       (List.mapi contents ~f:(fun index value -> index, value))
+       (List.rev !visited));
+  Array.iteri expected ~f:(fun index value ->
+    check "array view get" (Int.equal value (Array_view.get view index));
+    check
+      "array view backing position"
+      (Array_view.backing_array_pos view index = Array.length prefix + index));
+  let position = select position_selector ~choices:(Array.length expected + 1) in
+  let remaining = Array.length expected - position in
+  let length = select length_selector ~choices:(remaining + 1) in
+  let subview = Array_view.sub view ~pos:position ~len:length in
+  check_array
+    "array view sub"
+    (Array.sub expected ~pos:position ~len:length)
+    (Array_view.copy subview);
+  let other = Array.of_list other in
+  let other_view = Array_view.make other ~pos:0 in
+  check
+    "common suffix length"
+    (Array_view.common_suffix_len view other_view = common_suffix_length expected other);
+  let destination = Array.create ~len:(Array.length expected + 2) 0 in
+  Array_view.blit view destination ~pos:1;
+  check_array "array view blit" (Array.concat [ [| 0 |]; expected; [| 0 |] ]) destination;
+  if not (Array.is_empty expected)
+  then (
+    let index = select position_selector ~choices:(Array.length expected) in
+    let mutable_backing = Array.copy backing in
+    let mutable_view =
+      Array_view.make
+        mutable_backing
+        ~pos:(Array.length prefix)
+        ~len:(Array.length expected)
+    in
+    Array_view.set mutable_view index replacement;
+    let expected = Array.copy expected in
+    expected.(index) <- replacement;
+    check_array "array view set" expected (Array_view.copy mutable_view))
+;;
+
+let assert_invalid_arg f =
+  match f () with
+  | exception Invalid_argument _ -> ()
+  | exception exn -> raise exn
+  | _ -> failwith "expected Invalid_argument"
+;;
+
+let%test_unit "slice bounds are checked relative to the slice" =
+  let substring = Substring.of_slice "prefix" ~pos:2 ~len:3 in
+  assert_invalid_arg (fun () -> Substring.get_exn substring (-1));
+  let backing = Array.init 8 ~f:Fn.id in
+  assert_invalid_arg (fun () -> Array_view.make backing ~pos:0 ~len:(-1));
+  let view = Array_view.make backing ~pos:2 ~len:3 in
+  assert_invalid_arg (fun () -> Array_view.get view (-1));
+  assert_invalid_arg (fun () -> Array_view.set view (-1) 0);
+  assert_invalid_arg (fun () -> Array_view.sub view ~pos:(-1) ~len:1);
+  assert_invalid_arg (fun () -> Array_view.sub view ~pos:2 ~len:2)
+;;
+
+let%test_unit "substring operations agree with strings" =
+  Test.run_exn (module Substring_case) ~f:check_substring_case
+;;
+
+let%test_unit "array view operations agree with arrays" =
+  Test.run_exn (module Array_view_case) ~f:check_array_view_case
+;;

--- a/lsp/test/substring_tests.ml
+++ b/lsp/test/substring_tests.ml
@@ -39,7 +39,7 @@ let%expect_test "split_at" =
 let%expect_test "rindex is relative to a slice" =
   let substring = Substring.of_slice "xxabc" ~pos:2 ~len:3 in
   Substring.rindex substring 'b' |> Option.iter (printf "%d\n");
-  [%expect {| 3 |}]
+  [%expect {| 1 |}]
 ;;
 
 let%expect_test "negative indices do not escape a substring" =
@@ -47,7 +47,7 @@ let%expect_test "negative indices do not escape a substring" =
   (match Substring.get_exn substring (-1) with
    | character -> printf "character: %C\n" character
    | exception Invalid_argument message -> printf "invalid: %s\n" message);
-  [%expect {| character: 'x' |}]
+  [%expect {| invalid: Substring.get: out of bounds |}]
 ;;
 
 let%expect_test "index_from" =


### PR DESCRIPTION
`Array_view` and `Substring` currently allow some negative or view-relative indices to escape into their backing storage. Validate construction, indexing, and subview bounds relative to the slice, and make substring reverse-search results slice-relative.

Add property tests that compare substring and array-view operations against plain string and array models, including explicit regressions for out-of-bounds reads and mutations.
