### PR TITLE
test(server): model-check position and range relations

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -67,7 +67,9 @@ possible and does not make any assumptions about IO.
   spawn
   astring
   camlp-streams
+  (base_quickcheck (and (>= v0.17.0) :with-test))
   (ppx_expect (and (>= v0.17.0) :with-test))
+  (ppx_sexp_conv (and (>= v0.17.0) :with-test))
   (ocamlformat (and :with-test (= 0.29.0)))
   (ocamlc-loc (>= 3.7.0))
   (pp (>= 1.1.2))

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,9 @@
               doCheck = false;
               checkInputs = let p = pkgs.ocamlPackages;
               in [
+                p.base_quickcheck
                 p.ppx_expect
+                p.ppx_sexp_conv
                 p.ppx_yojson_conv
                 (ocamlformat pkgs)
               ];

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -39,7 +39,9 @@ depends: [
   "spawn"
   "astring"
   "camlp-streams"
+  "base_quickcheck" {>= "v0.17.0" & with-test}
   "ppx_expect" {>= "v0.17.0" & with-test}
+  "ppx_sexp_conv" {>= "v0.17.0" & with-test}
   "ocamlformat" {with-test & = "0.29.0"}
   "ocamlc-loc" {>= "3.7.0"}
   "pp" {>= "1.1.2"}

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -1,7 +1,10 @@
 open! Import
 include module type of Lsp.Types.Position with type t = Lsp.Types.Position.t
 
+(** [compare_inclusion position range] treats both range boundaries as
+    inclusive. *)
 val compare_inclusion : t -> Lsp.Types.Range.t -> [ `Inside | `Outside of t ]
+
 val ( - ) : t -> t -> t
 val compare : t -> t -> Ordering.t
 val logical : t -> [> `Logical of int * int ]

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -23,7 +23,9 @@ val of_loc : Loc.t -> t
     [edit.newText] only. *)
 val resize_for_edit : TextEdit.t -> t
 
-(** [overlaps r1 r2] is true if [r1] and [r2] overlap. *)
+(** [overlaps r1 r2] is true if [r1] and [r2] overlap, treating their
+    boundaries as inclusive. This allows an empty cursor range to overlap a
+    range that contains it. *)
 val overlaps : t -> t -> bool
 
 val to_string : t -> string

--- a/ocaml-lsp-server/src/testing.ml
+++ b/ocaml-lsp-server/src/testing.ml
@@ -3,4 +3,5 @@
 module Compl = Compl
 module Merlin_kernel = Merlin_kernel
 module Prefix_parser = Prefix_parser
+module Position = Position
 module Range = Range

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -1,5 +1,8 @@
 (library
- (modules ocaml_lsp_tests position_prefix_tests)
+ (modules
+  ocaml_lsp_tests
+  position_prefix_tests
+  range_relations_quickcheck_tests)
  (name ocaml_lsp_tests)
  (enabled_if
   (>= %{ocaml_version} 4.08))
@@ -13,8 +16,10 @@
   ;; This is because of the (implicit_transitive_deps false)
   ;; in dune-project
   base
+  base_quickcheck
   ppx_expect.config
   ppx_expect.config_types
-  ppx_inline_test.config)
+  ppx_inline_test.config
+  ppx_sexp_conv.runtime-lib)
  (preprocess
-  (pps ppx_expect)))
+  (pps ppx_expect base_quickcheck.ppx_quickcheck ppx_sexp_conv)))

--- a/ocaml-lsp-server/test/range_relations_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/range_relations_quickcheck_tests.ml
@@ -1,0 +1,123 @@
+open Base
+open Base_quickcheck
+module Position = Ocaml_lsp_server.Testing.Position
+module Range = Ocaml_lsp_server.Testing.Range
+
+let line_width = 17
+let maximum_offset = 256
+let select selector = Int.rem (selector land Stdlib.max_int) (maximum_offset + 1)
+
+let position offset =
+  Lsp.Types.Position.create
+    ~line:(offset / line_width)
+    ~character:(Int.rem offset line_width)
+;;
+
+let ordered first second = if first <= second then first, second else second, first
+
+let range start_selector end_selector =
+  let start, end_ = ordered (select start_selector) (select end_selector) in
+  Lsp.Types.Range.create ~start:(position start) ~end_:(position end_), start, end_
+;;
+
+let ordering integer =
+  if integer < 0 then Stdune.Lt else if integer = 0 then Stdune.Eq else Stdune.Gt
+;;
+
+let check label condition = if not condition then failwith label
+
+let equal_position (left : Lsp.Types.Position.t) (right : Lsp.Types.Position.t) =
+  left.line = right.line && left.character = right.character
+;;
+
+module Case = struct
+  type t =
+    { point : int
+    ; first_start : int
+    ; first_end : int
+    ; second_start : int
+    ; second_end : int
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let check_case { Case.point; first_start; first_end; second_start; second_end } =
+  let point_offset = select point in
+  let point = position point_offset in
+  let first, first_start, first_end = range first_start first_end in
+  let second, second_start, second_end = range second_start second_end in
+  check
+    "position comparison"
+    (Poly.equal
+       (Position.compare point first.start)
+       (ordering (Int.compare point_offset first_start)));
+  let expected_difference =
+    Lsp.Types.Position.create
+      ~line:(point.line - first.start.line)
+      ~character:(point.character - first.start.character)
+  in
+  check
+    "position subtraction"
+    (equal_position Position.(point - first.start) expected_difference);
+  check
+    "logical position"
+    (Poly.equal (Position.logical point) (`Logical (point.line + 1, point.character)));
+  let expected_range_order =
+    match Int.compare first_start second_start with
+    | 0 -> Int.compare first_end second_end
+    | result -> result
+  in
+  check
+    "range comparison"
+    (Poly.equal (Range.compare first second) (ordering expected_range_order));
+  check
+    "range containment"
+    (Bool.equal
+       (Range.contains first second)
+       (first_start <= second_start && second_end <= first_end));
+  let expected_overlap = first_start <= second_end && second_start <= first_end in
+  check "range overlap" (Bool.equal (Range.overlaps first second) expected_overlap);
+  check
+    "range overlap symmetry"
+    (Bool.equal (Range.overlaps first second) (Range.overlaps second first));
+  let expected_size_order =
+    Poly.compare
+      (first.end_.line - first.start.line, first.end_.character - first.start.character)
+      ( second.end_.line - second.start.line
+      , second.end_.character - second.start.character )
+  in
+  check
+    "range size comparison"
+    (Poly.equal (Range.compare_size first second) (ordering expected_size_order));
+  let expected_inclusion, expected_distance =
+    if point_offset < first_start
+    then
+      ( `Outside
+      , Lsp.Types.Position.create
+          ~line:(first.start.line - point.line)
+          ~character:(Int.abs (first.start.character - point.character)) )
+    else if point_offset > first_end
+    then
+      ( `Outside
+      , Lsp.Types.Position.create
+          ~line:(point.line - first.end_.line |> Int.abs)
+          ~character:(point.character - first.end_.character |> Int.abs) )
+    else `Inside, Lsp.Types.Position.create ~line:0 ~character:0
+  in
+  match Position.compare_inclusion point first, expected_inclusion with
+  | `Inside, `Inside -> ()
+  | `Outside actual, `Outside ->
+    check "position inclusion distance" (equal_position actual expected_distance)
+  | _ -> failwith "position inclusion"
+;;
+
+let regression_cases =
+  [ { Case.point = 1; first_start = 0; first_end = 1; second_start = 1; second_end = 2 }
+  ; { point = 1; first_start = 1; first_end = 1; second_start = 0; second_end = 2 }
+  ; { point = 2; first_start = 0; first_end = 4; second_start = 1; second_end = 3 }
+  ]
+;;
+
+let%test_unit "position and range operations agree with inclusive query intervals" =
+  Test.run_exn (module Case) ~examples:regression_cases ~f:check_case
+;;


### PR DESCRIPTION
Add property tests for the relationships between server positions and ranges, covering comparison, subtraction, logical positions, inclusion, containment, overlap, and size ordering.

Document that inclusion and overlap use inclusive boundaries, including empty cursor ranges at a boundary.
