### PR TITLE
test(completion): expose completion protocol and encoding bugs

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -15,58 +15,112 @@ let iter_completions
   Lsp_helpers.iter_lsp_response ?prep ?path ~language_id:"ocaml" ~makeRequest
 ;;
 
+let print_completion_response
+      ?(limit = 10)
+      ?(pre_print = fun x -> x)
+      (completions :
+        [ `CompletionList of CompletionList.t | `List of CompletionItem.t list ] option)
+  =
+  match completions with
+  | None -> print_endline "No completion Items"
+  | Some completions ->
+    let items =
+      match completions with
+      | `CompletionList comp -> comp.items
+      | `List comp -> comp
+    in
+    items
+    |> pre_print
+    |> (function
+     | [] -> print_endline "No completions"
+     | items ->
+       print_endline "Completions:";
+       let originalLength = List.length items in
+       items
+       |> List.take (min limit originalLength)
+       |> List.iter ~f:(fun item ->
+         item
+         |> CompletionItem.yojson_of_t
+         |> Yojson.Safe.pretty_to_string ~std:false
+         |> print_endline);
+       if originalLength > limit then print_endline ".............")
+;;
+
 let print_completions
       ?(prep = fun _ -> Fiber.return ())
       ?(path = "foo.ml")
-      ?(limit = 10)
-      ?(pre_print = fun x -> x)
+      ?limit
+      ?pre_print
       source
       position
   =
-  iter_completions ~prep ~path ~source ~position (function
-    | None -> print_endline "No completion Items"
-    | Some completions ->
-      let items =
-        match completions with
-        | `CompletionList comp -> comp.items
-        | `List comp -> comp
-      in
-      items
-      |> pre_print
-      |> (function
-       | [] -> print_endline "No completions"
-       | items ->
-         print_endline "Completions:";
-         let originalLength = List.length items in
-         items
-         |> List.take (min limit originalLength)
-         |> List.iter ~f:(fun item ->
-           item
-           |> CompletionItem.yojson_of_t
-           |> Yojson.Safe.pretty_to_string ~std:false
-           |> print_endline);
-         if originalLength > limit then print_endline "............."))
+  iter_completions
+    ~prep
+    ~path
+    ~source
+    ~position
+    (print_completion_response ?limit ?pre_print)
 ;;
 
-let%expect_test "completion uses UTF-16 positions for Unicode prefixes" =
-  let source = "let café = 1\nlet _ = café" in
-  let position = Position.create ~line:1 ~character:12 in
-  print_completions ~limit:1 source position;
+let request_completions client position =
+  Client.request
+    client
+    (TextDocumentCompletion
+       (CompletionParams.create
+          ~textDocument:(TextDocumentIdentifier.create ~uri:Helpers.uri)
+          ~position
+          ()))
+;;
+
+let%expect_test "completion converts UTF-16 positions before querying Merlin" =
+  let source = "let café = List.ma" in
+  let position = Position.create ~line:0 ~character:18 in
+  let only_map =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "map")
+  in
+  print_completions ~pre_print:only_map source position;
   [%expect
     {|
     Completions:
     {
-      "kind": 14,
-      "label": "in",
+      "detail": "('a -> 'b) -> 'a list -> 'b list",
+      "kind": 12,
+      "label": "map",
+      "sortText": "0000",
       "textEdit": {
-        "newText": "in",
+        "newText": "map",
+        "range": {
+          "end": { "character": 18, "line": 0 },
+          "start": { "character": 17, "line": 0 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "completion replaces a Unicode prefix using UTF-16 positions" =
+  let source = "let caféine = 1\nlet _ = café" in
+  let position = Position.create ~line:1 ~character:12 in
+  let only_cafeine =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "caféine")
+  in
+  print_completions ~pre_print:only_cafeine source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "int",
+      "kind": 12,
+      "label": "caféine",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "caféine",
         "range": {
           "end": { "character": 12, "line": 1 },
           "start": { "character": 12, "line": 1 }
         }
       }
     }
-    .............
     |}]
 ;;
 
@@ -773,21 +827,21 @@ let u = f `Str
   print_completions source position;
   [%expect
     {|
-  Completions:
-  {
-    "detail": "`String",
-    "kind": 20,
-    "label": "`String",
-    "sortText": "0000",
-    "textEdit": {
-      "newText": "`String",
-      "range": {
-        "end": { "character": 14, "line": 3 },
-        "start": { "character": 10, "line": 3 }
+    Completions:
+    {
+      "detail": "`String",
+      "kind": 20,
+      "label": "`String",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "`String",
+        "range": {
+          "end": { "character": 14, "line": 3 },
+          "start": { "character": 10, "line": 3 }
+        }
       }
     }
-  }
-  |}]
+    |}]
 ;;
 
 let%expect_test "works for polymorphic variants - function application context - 2" =
@@ -802,21 +856,21 @@ let u = f `In
   print_completions source position;
   [%expect
     {|
-  Completions:
-  {
-    "detail": "`Int of int",
-    "kind": 20,
-    "label": "`Int",
-    "sortText": "0000",
-    "textEdit": {
-      "newText": "`Int",
-      "range": {
-        "end": { "character": 13, "line": 3 },
-        "start": { "character": 10, "line": 3 }
+    Completions:
+    {
+      "detail": "`Int of int",
+      "kind": 20,
+      "label": "`Int",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "`Int",
+        "range": {
+          "end": { "character": 13, "line": 3 },
+          "start": { "character": 10, "line": 3 }
+        }
       }
     }
-  }
-  |}]
+    |}]
 ;;
 
 let%expect_test "works for polymorphic variants" =
@@ -831,21 +885,21 @@ let x : t = `I
   print_completions source position;
   [%expect
     {|
-  Completions:
-  {
-    "detail": "`Int",
-    "kind": 20,
-    "label": "`Int",
-    "sortText": "0000",
-    "textEdit": {
-      "newText": "`Int",
-      "range": {
-        "end": { "character": 15, "line": 3 },
-        "start": { "character": 13, "line": 3 }
+    Completions:
+    {
+      "detail": "`Int",
+      "kind": 20,
+      "label": "`Int",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "`Int",
+        "range": {
+          "end": { "character": 15, "line": 3 },
+          "start": { "character": 13, "line": 3 }
+        }
       }
     }
-  }
-  |}]
+    |}]
 ;;
 
 let%expect_test "completion for holes" =
@@ -873,6 +927,16 @@ let%expect_test "completion for holes" =
     }
   }
   |}]
+;;
+
+let%expect_test "construct completion converts Merlin ranges to UTF-16" =
+  let source = "let café : int = _" in
+  let position = Position.create ~line:0 ~character:18 in
+  let only_zero =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "0")
+  in
+  print_completions ~pre_print:only_zero source position;
+  [%expect {| No completions |}]
 ;;
 
 let%expect_test "completes identifier at top level" =
@@ -1107,6 +1171,75 @@ let%expect_test "completes a module name" =
   |}]
 ;;
 
+let%expect_test "named types are not reported as type parameters" =
+  let source = "type special_type = int\nlet (_ : spec) = 1" in
+  let position = Position.create ~line:1 ~character:13 in
+  let only_special_type =
+    List.filter ~f:(fun (item : CompletionItem.t) ->
+      String.equal item.label "special_type")
+  in
+  print_completions ~pre_print:only_special_type source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "type special_type = int",
+      "kind": 25,
+      "label": "special_type",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "special_type",
+        "range": {
+          "end": { "character": 13, "line": 1 },
+          "start": { "character": 9, "line": 1 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "deprecated completions use tags when supported" =
+  let capabilities =
+    let tagSupport =
+      CompletionItemTagOptions.create ~valueSet:[ CompletionItemTag.Deprecated ]
+    in
+    let completionItem = ClientCompletionItemOptions.create ~tagSupport () in
+    let completion = CompletionClientCapabilities.create ~completionItem () in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let source =
+    "module M : sig val old_value : int [@@deprecated] end = struct let old_value = 1 \n\
+     end\n\
+     let _ = M.old_"
+  in
+  let position = Position.create ~line:2 ~character:14 in
+  let only_old_value =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "old_value")
+  in
+  Helpers.test ~capabilities source (fun client ->
+    let* response = request_completions client position in
+    print_completion_response ~pre_print:only_old_value response;
+    Fiber.return ());
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "int",
+      "kind": 12,
+      "label": "old_value",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "old_value",
+        "range": {
+          "end": { "character": 14, "line": 2 },
+          "start": { "character": 10, "line": 2 }
+        }
+      }
+    }
+    |}]
+;;
+
 let%expect_test "completion doesn't autocomplete record fields" =
   let source =
     {ocaml|
@@ -1225,7 +1358,8 @@ let foo param1 =
         }
       }
     }
-    ............. |}]
+    .............
+    |}]
 ;;
 
 let%expect_test "completion for `in` keyword - prefix i" =
@@ -1277,7 +1411,8 @@ let foo param1 =
         }
       }
     }
-    ............. |}]
+    .............
+    |}]
 ;;
 
 let%expect_test "completion for `in` keyword - prefix in" =
@@ -1329,7 +1464,8 @@ let foo param1 =
         }
       }
     }
-    ............. |}]
+    .............
+    |}]
 ;;
 
 (* Test case was taken from issue #1358 *)
@@ -1363,7 +1499,8 @@ let%expect_test "completion for object methods" =
           "start": { "character": 34, "line": 0 }
         }
       }
-    } |}]
+    }
+    |}]
 ;;
 
 let%expect_test "completion for object methods" =

--- a/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
@@ -129,6 +129,42 @@ let%expect_test "completion resolve after its document changes" =
     |}]
 ;;
 
+let%expect_test "completion documentation respects the client's preferred format" =
+  let capabilities =
+    let resolveSupport =
+      ClientCompletionItemResolveOptions.create ~properties:[ "documentation" ]
+    in
+    let completionItem =
+      ClientCompletionItemOptions.create
+        ~documentationFormat:[ MarkupKind.PlainText; MarkupKind.Markdown ]
+        ~resolveSupport
+        ()
+    in
+    let completion = CompletionClientCapabilities.create ~completionItem () in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let source = "List.ma" in
+  let req client =
+    let* response =
+      completion_item_resolve client "map2" (Position.create ~line:0 ~character:7)
+    in
+    print_completion_item response;
+    Fiber.return ()
+  in
+  Helpers.test ~capabilities source req;
+  [%expect
+    {|
+    {
+      "documentation": {
+        "kind": "markdown",
+        "value": "`map2 f [a1; ...; an] [b1; ...; bn]` is `[f a1 b1; ...; f an bn]`.\n\n***@raise*** `Invalid_argument`\nif the two lists are determined to have different lengths."
+      },
+      "label": "map2"
+    }
+    |}]
+;;
+
 let%expect_test "can get documentation at arbitrary position" =
   let source =
     {ocaml|List.fld((=) 0) [1; 2; 3]
@@ -149,6 +185,37 @@ let%expect_test "can get documentation at arbitrary position" =
       "label": "find_all"
     }
     |}]
+;;
+
+let%expect_test "can resolve a dotted operator from the middle of its name" =
+  let source =
+    {ocaml|(** combine docs *)
+let ( >>. ) x y = x + y
+let _ = 1 >>. 2
+|ocaml}
+  in
+  let req client =
+    let* response =
+      completion_item_resolve client ">>." (Position.create ~line:2 ~character:11)
+    in
+    print_completion_item response;
+    Fiber.return ()
+  in
+  Helpers.test source req;
+  [%expect {| { "label": ">>." } |}]
+;;
+
+let%expect_test "completion resolve converts UTF-16 positions for Merlin" =
+  let source = "let café = List.ma" in
+  let req client =
+    let* response =
+      completion_item_resolve client "map2" (Position.create ~line:0 ~character:18)
+    in
+    print_completion_item response;
+    Fiber.return ()
+  in
+  Helpers.test source req;
+  [%expect {| { "label": "map2" } |}]
 ;;
 
 let%expect_test "can get documentation at arbitrary position (before dot)" =

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -75,6 +75,21 @@ let%expect_test "short path prefix" =
   [%expect "ma"]
 ;;
 
+let%expect_test "short path preserves a dotted operator" =
+  prefix_test ~short_path:true "let _ = 1 +." (`Logical (1, 12));
+  [%expect ""]
+;;
+
+let%expect_test "prefix may contain a Latin-1 identifier" =
+  prefix_test "let caféine = 1\nlet _ = café" (`Logical (2, 13));
+  [%expect ""]
+;;
+
+let%expect_test "carriage return in dot chain" =
+  prefix_test "let _ = List.\r\n  ma" (`Logical (2, 4));
+  [%expect "ma"]
+;;
+
 let%expect_test "Space in dot chain" =
   prefix_test "[1;2] |> Other. Thing.Core .List . ma\n" (`Logical (1, 37));
   [%expect "Other.Thing.Core.List.ma"]


### PR DESCRIPTION
Adds regression coverage for completion protocol and encoding edge cases before fixing them:

- UTF-16 completion queries and edit ranges, including construct completion;
- completion kinds and deprecated-tag capability handling;
- documentation-format preference and resolution of operators and Unicode positions;
- prefix parsing for dotted operators, Latin-1 identifiers, and CRLF input.