### PR TITLE
perf(code-actions): share destruct analysis

### DIFF
--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -26,12 +26,13 @@ module Code_action_error_monoid = struct
 end
 
 let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
+  let destruct_dispatch = Document.merlin_exn doc |> Action_destruct.cached_dispatch in
   let enabled_actions =
     List.filter
       ~f:(fun (action : Code_action.t) ->
         Code_action.kind_is_requested params.context.only action.kind)
-      [ Action_destruct_line.t state
-      ; Action_destruct.t state
+      [ Action_destruct_line.t ~dispatch:destruct_dispatch state
+      ; Action_destruct.t ~dispatch:destruct_dispatch state
       ; Action_update_signature.t state
       ; Action_combine_cases.t
       ; Action_inferred_intf.t state

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -28,13 +28,32 @@ let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, 
     ()
 ;;
 
-let run state doc merlin ~action_kind ~(range : Range.t) ~postprocess =
+type dispatch = Range.t -> (Loc.t * string, Exn_with_backtrace.t) result Fiber.t
+
+let dispatch merlin (range : Range.t) =
   let command =
     let start = Position.logical range.start in
     let finish = Position.logical range.end_ in
     Query_protocol.Case_analysis (start, finish)
   in
-  let+ res = Document.Merlin.dispatch ~name:"destruct" merlin command in
+  Document.Merlin.dispatch ~name:"destruct" merlin command
+;;
+
+module Range_key = struct
+  type t = Range.t
+
+  let compare = Lsp.Range.compare
+  let hash = Poly.hash
+  let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_opaque
+end
+
+let cached_dispatch merlin =
+  let cache = Fiber_cache.create (module Range_key) ~f:(dispatch merlin) in
+  Fiber_cache.get cache
+;;
+
+let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postprocess =
+  let+ res = dispatch range in
   match res with
   | Ok reply ->
     let reply = postprocess reply in
@@ -56,12 +75,14 @@ let run state doc merlin ~action_kind ~(range : Range.t) ~postprocess =
   | Error exn -> Exn_with_backtrace.reraise exn
 ;;
 
-let code_action (state : State.t) doc (params : CodeActionParams.t) =
+let code_action (state : State.t) dispatch doc (params : CodeActionParams.t) =
   match Document.kind doc with
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
-  | `Merlin merlin ->
-    run state doc merlin ~action_kind ~range:params.range ~postprocess:Fun.id
+  | `Merlin _ ->
+    run state doc ~dispatch ~action_kind ~range:params.range ~postprocess:Fun.id
 ;;
 
-let t state = { Code_action.kind; run = `Non_batchable (code_action state) }
+let t ~dispatch state =
+  { Code_action.kind; run = `Non_batchable (code_action state dispatch) }
+;;

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -1,16 +1,19 @@
 open Import
 
+type dispatch = Range.t -> (Loc.t * string, Exn_with_backtrace.t) result Fiber.t
+
 val kind : CodeActionKind.t
+val cached_dispatch : Document.Merlin.t -> dispatch
 
 (** Run Merlin's case analysis and turn its reply into a code action.
     [postprocess] may adjust the replacement location and text. *)
 val run
   :  State.t
   -> Document.t
-  -> Document.Merlin.t
+  -> dispatch:dispatch
   -> action_kind:string
   -> range:Range.t
   -> postprocess:(Loc.t * string -> Loc.t * string)
   -> CodeAction.t option Fiber.t
 
-val t : State.t -> Code_action.t
+val t : dispatch:dispatch -> State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -240,7 +240,12 @@ let format_merlin_reply ~(statement : destructable_statement) (new_code : string
        String.concat ~sep:" -> _\n" (String.strip first_line :: other_lines))
 ;;
 
-let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.t) =
+let code_action
+      (state : State.t)
+      dispatch
+      (doc : Document.t)
+      (params : CodeActionParams.t)
+  =
   match Document.kind doc with
   | `Other -> Fiber.return None
   | `Merlin merlin ->
@@ -250,7 +255,7 @@ let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.
        Action_destruct.run
          state
          doc
-         merlin
+         ~dispatch
          ~action_kind
          ~range:statement.query_range
          ~postprocess:(fun (loc, newText) ->
@@ -259,4 +264,6 @@ let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.
            loc, newText))
 ;;
 
-let t state = { Code_action.kind; run = `Non_batchable (code_action state) }
+let t ~dispatch state =
+  { Code_action.kind; run = `Non_batchable (code_action state dispatch) }
+;;

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.mli
@@ -45,4 +45,4 @@ open Import
        | (_::_, _::_) -> _] *)
 
 val kind : CodeActionKind.t
-val t : State.t -> Code_action.t
+val t : dispatch:Action_destruct.dispatch -> State.t -> Code_action.t

--- a/ocaml-lsp-server/src/fiber_cache.ml
+++ b/ocaml-lsp-server/src/fiber_cache.ml
@@ -1,0 +1,14 @@
+open Import
+
+type ('key, 'value) t =
+  { entries : ('key, 'value Lazy_fiber.t) Hashtbl.t
+  ; f : 'key -> 'value Fiber.t
+  }
+
+let create key ~f = { entries = Hashtbl.create key; f }
+
+let get t key =
+  Hashtbl.find_or_add t.entries key ~default:(fun () ->
+    Lazy_fiber.create (fun () -> t.f key))
+  |> Lazy_fiber.force
+;;

--- a/ocaml-lsp-server/src/fiber_cache.mli
+++ b/ocaml-lsp-server/src/fiber_cache.mli
@@ -1,0 +1,9 @@
+open Import
+
+type ('key, 'value) t
+
+(** [create key ~f] memoizes [f] by [key]. Concurrent lookups of the same key
+    share one execution, including any error raised by [f]. *)
+val create : 'key Hashtbl.Key.t -> f:('key -> 'value Fiber.t) -> ('key, 'value) t
+
+val get : ('key, 'value) t -> 'key -> 'value Fiber.t

--- a/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_protocol.ml
@@ -160,7 +160,7 @@ let f (x : t) =
     |}]
 ;;
 
-let%expect_test "destruct actions duplicate case analysis" =
+let%expect_test "destruct actions share case analysis" =
   let source =
     {ocaml|let f (x : bool) =
   match x
@@ -180,9 +180,8 @@ let%expect_test "destruct actions duplicate case analysis" =
     code actions:
     - Destruct-line (enumerate cases, use existing match) (destruct-line (enumerate cases, use existing match))
     - Destruct (enumerate cases) (destruct (enumerate cases))
-    - Create metrics.mli (switch)
     Merlin pipeline trace:
     - destruct (enumerate cases) -> destruct
-    - destruct-line (enumerate cases, use existing match) -> destruct
+    - destruct-line (enumerate cases, use existing match) -> <no pipeline>
     |}]
 ;;


### PR DESCRIPTION
The regular destruct and destruct-line actions can request the same Merlin case analysis when both are offered, opening duplicate pipelines for one code-action request.

Cache case-analysis results by range and share the dispatch between both actions. This updates the regression added in #1785 to require a single pipeline.
