### PR TITLE
fix(server): translate positions for negotiated UTF-16 encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
   (#1823, fixes #1427, @rgrinberg)
 - Report a missing project build-system executable as a diagnostic without
   discarding the opened document. (#1814, @rgrinberg)
+- Translate positions using the UTF-16 encoding negotiated with the client. (#1813, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
 - Respect hierarchical code-action kind filters from clients. (#1802, @rgrinberg)
 - Ensure `textDocument/documentSymbol` returns a `selectionRange` contained

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -188,3 +188,43 @@ let substring t range =
   then None
   else Some (String.sub text ~pos:start ~len:(end_ - start))
 ;;
+
+let position_of_lexical_position_in_text
+      ~position_encoding
+      ~text
+      (position : Lexing.position)
+  =
+  if
+    position.pos_lnum = Lexing.dummy_pos.pos_lnum
+    && position.pos_cnum = Lexing.dummy_pos.pos_cnum
+  then None
+  else (
+    let line = max 0 (position.pos_lnum - 1) in
+    let byte_length = max 0 (position.pos_cnum - position.pos_bol) in
+    let character =
+      match position_encoding with
+      | `UTF8 -> byte_length
+      | `UTF16 ->
+        if
+          position.pos_bol < 0
+          || position.pos_bol > position.pos_cnum
+          || position.pos_cnum > String.length text
+        then byte_length
+        else
+          Uutf.String.fold_utf_8
+            ~pos:position.pos_bol
+            ~len:byte_length
+            (fun length _ -> function
+               | `Uchar uchar -> length + (Uchar.utf_16_byte_length uchar / 2)
+               | `Malformed input -> raise (Invalid_utf (Malformed input)))
+            0
+            text
+    in
+    Some (Position.create ~line ~character))
+;;
+
+let position_of_lexical_position t =
+  position_of_lexical_position_in_text
+    ~position_encoding:t.position_encoding
+    ~text:(text t)
+;;

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -57,3 +57,14 @@ val range_of_utf8_offsets : t -> start_offset:int -> end_offset:int -> Range.t
     document's position encoding. Returns [None] when the range's start follows
     its end. *)
 val substring : t -> Range.t -> string option
+
+(** Convert an OCaml lexer position, whose character offset is measured in UTF-8
+    bytes, to the requested position encoding. *)
+val position_of_lexical_position_in_text
+  :  position_encoding:encoding
+  -> text:string
+  -> Lexing.position
+  -> Position.t option
+
+(** Convert an OCaml lexer position to the encoding negotiated for this document. *)
+val position_of_lexical_position : t -> Lexing.position -> Position.t option

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -26,6 +26,15 @@ module Code_action_error_monoid = struct
 end
 
 let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
+  let params =
+    let range = Document.merlin_range doc params.range in
+    let diagnostics =
+      List.map params.context.diagnostics ~f:(fun (diagnostic : Diagnostic.t) ->
+        { diagnostic with range = Document.merlin_range doc diagnostic.range })
+    in
+    let context = { params.context with diagnostics } in
+    { params with range; context }
+  in
   let destruct_dispatch = Document.merlin_exn doc |> Action_destruct.cached_dispatch in
   let enabled_actions =
     List.filter

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -46,10 +46,10 @@ let command_run server (params : ExecuteCommandParams.t) =
 ;;
 
 (* Dispatch the jump request to Merlin and get the result *)
-let process_jump_request ~merlin ~position ~target =
+let process_jump_request ~doc ~merlin ~position ~target =
   let+ results =
     Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-      let pposition = Position.logical position in
+      let pposition = (Document.merlin_position doc position :> Msource.position) in
       let query = Query_protocol.Jump (target, pposition) in
       Query_commands.dispatch pipeline query)
   in
@@ -72,10 +72,12 @@ let code_actions
     let+ actions =
       (* TODO: Merlin Jump command that returns all available jump locations for a source code buffer. *)
       Fiber.parallel_map targets ~f:(fun target ->
-        let+ res = process_jump_request ~merlin ~position:params.range.start ~target in
+        let+ res =
+          process_jump_request ~doc ~merlin ~position:params.range.start ~target
+        in
         let open Option.O in
         let* lexing_pos = res in
-        let+ position = Position.of_lexical_position lexing_pos in
+        let+ position = Document.position_of_lexical_position doc lexing_pos in
         let uri = Document.uri doc in
         let range = { Range.start = position; end_ = position } in
         let title = sprintf "%s jump" (String.capitalize (rename_target target)) in

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
@@ -4,7 +4,7 @@ let code_action
       (mode : [ `Qualify | `Unqualify ])
       (action_kind : string)
       pipeline
-      _
+      doc
       (params : CodeActionParams.t)
   =
   let res =
@@ -19,12 +19,12 @@ let code_action
   | changes ->
     let code_action =
       let edit : WorkspaceEdit.t =
-        let edits =
+        let changes =
           List.map changes ~f:(fun (newText, loc) ->
-            { TextEdit.newText; range = Range.of_loc loc })
+            let range = Range.of_loc loc |> Document.range_of_merlin_range doc in
+            { TextEdit.newText; range })
         in
-        let uri = params.textDocument.uri in
-        WorkspaceEdit.create ~changes:[ uri, edits ] ()
+        WorkspaceEdit.create ~changes:[ params.textDocument.uri, changes ] ()
       in
       let kind = CodeActionKind.Other action_kind in
       let title = String.capitalize action_kind in

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -76,12 +76,12 @@ let make_construct_command position with_values depth =
   Query_protocol.Construct (position, with_values, depth)
 ;;
 
-let dispatch_construct position with_values depth pipeline =
-  let position = Position.logical position in
+let dispatch_construct position with_values depth doc pipeline =
+  let position = (Document.merlin_position doc position :> Msource.position) in
   let command = make_construct_command position with_values depth in
   try
     let pos, result = Query_commands.dispatch pipeline command in
-    yojson_of_t { position = Range.of_loc pos; result }
+    yojson_of_t { position = Document.range_of_loc doc pos; result }
   with
   | Merlin_analysis.Construct.Not_a_hole -> `Null
 ;;
@@ -93,6 +93,6 @@ let on_request ~params state =
       Request_params.t_of_yojson params
     in
     let uri = text_document.uri in
-    Util.with_impl_pipeline state uri ~default:`Null
+    Util.with_impl_pipeline_doc state uri ~default:`Null
     @@ dispatch_construct position with_values depth)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_destruct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_destruct.ml
@@ -43,13 +43,14 @@ let yojson_of_t { range; content } =
 
 let make_destruct_command start stop = Query_protocol.Case_analysis (start, stop)
 
-let dispatch_destruct range pipeline =
+let dispatch_destruct range doc pipeline =
+  let range = Document.merlin_range doc range in
   let start = range.Range.start |> Position.logical
   and stop = range.Range.end_ |> Position.logical in
   let command = make_destruct_command start stop in
   try
     let loc, content = Query_commands.dispatch pipeline command in
-    yojson_of_t { content; range = Range.of_loc loc }
+    yojson_of_t { content; range = Document.range_of_loc doc loc }
   with
   | Merlin_analysis.Destruct.Wrong_parent _
   | Query_commands.No_nodes
@@ -64,5 +65,5 @@ let on_request ~params state =
     let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
     let Request_params.{ text_document; range } = Request_params.t_of_yojson params in
     let uri = text_document.uri in
-    Util.with_impl_pipeline state uri ~default:`Null @@ dispatch_destruct range)
+    Util.with_impl_pipeline_doc state uri ~default:`Null @@ dispatch_destruct range)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_get_documentation.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_get_documentation.ml
@@ -84,7 +84,10 @@ end
 
 let dispatch ~merlin ~position ~identifier ~contentFormat =
   Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-    let position = Position.logical position in
+    let position =
+      (Document.merlin_position (Document.Merlin.to_doc merlin) position
+        :> Msource.position)
+    in
     let query = Query_protocol.Document (identifier, position) in
     let result = Query_commands.dispatch pipeline query in
     match result with

--- a/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
@@ -154,43 +154,57 @@ let rec yojson_of_t ?set ({ data; children } as pl) =
        ])
 ;;
 
-let map_payload type_ result =
+let map_payload state doc type_ result =
   { ty = type_
   ; result =
       (match result with
        | `Found (file, pos) ->
-         let uri = Option.map ~f:DocumentUri.of_string file
-         and pos = pos |> Position.of_lexical_position |> Option.value_exn in
-         `Found (uri, pos)
+         let uri = Option.map ~f:DocumentUri.of_string file in
+         let target_doc = Option.bind uri ~f:(Document_store.get_opt state.State.store) in
+         let pos =
+           match target_doc, uri with
+           | Some target_doc, _ -> Document.position_of_lexical_position target_doc pos
+           | None, Some uri ->
+             (match
+                Exn_with_backtrace.try_with (fun () ->
+                  let path = Uri.to_path uri in
+                  In_channel.with_open_text path In_channel.input_all |> Msource.make)
+              with
+              | Ok source ->
+                Document.position_of_lexical_position_in_source doc source pos
+              | Error _ -> Position.of_lexical_position pos)
+           | None, None -> Document.position_of_lexical_position doc pos
+         in
+         `Found (uri, Option.value_exn pos)
        | (`Not_in_env _ | `Builtin _) as s -> s
        | `Not_found (file, ty) -> `Not_found (DocumentUri.of_string file, ty)
        | `File_not_found file -> `File_not_found (DocumentUri.of_string file))
   }
 ;;
 
-let map_node = function
+let map_node state doc = function
   | P.Tree.Arrow -> Arrow
   | P.Tree.Tuple -> Tuple
   | P.Tree.Object -> Object
   | P.Tree.Poly_variant -> Poly_variant
   | P.Tree.Other s -> Other s
-  | P.Tree.Type_ref { type_; result } -> Type_ref (map_payload type_ result)
+  | P.Tree.Type_ref { type_; result } -> Type_ref (map_payload state doc type_ result)
 ;;
 
-let rec map_tree_result result =
-  let children = List.map ~f:map_tree_result result.P.Tree.children in
-  let data = map_node result.data in
+let rec map_tree_result state doc result =
+  let children = List.map ~f:(map_tree_result state doc) result.P.Tree.children in
+  let data = map_node state doc result.data in
   { data; children }
 ;;
 
 let make_locate_types_command position = Query_protocol.Locate_types position
 
-let dispatch_locate_types position pipeline =
-  let position = Position.logical position in
+let dispatch_locate_types state position doc pipeline =
+  let position = (Document.merlin_position doc position :> Msource.position) in
   let command = make_locate_types_command position in
   match Query_commands.dispatch pipeline command with
   | P.Success result ->
-    let result = map_tree_result result in
+    let result = map_tree_result state doc result in
     yojson_of_t result
   | P.Invalid_context ->
     let open Jsonrpc.Response.Error in
@@ -202,5 +216,6 @@ let on_request ~params state =
     let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
     let Request_params.{ text_document; position } = Request_params.t_of_yojson params in
     let uri = text_document.uri in
-    Util.with_pipeline state uri ~default:`Null @@ dispatch_locate_types position)
+    Util.with_pipeline_doc state uri ~default:`Null
+    @@ dispatch_locate_types state position)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_merlin_jump.ml
@@ -69,7 +69,10 @@ end
 
 let dispatch ~merlin ~position ~target =
   Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-    let pposition = Position.logical position in
+    let pposition =
+      (Document.merlin_position (Document.Merlin.to_doc merlin) position
+        :> Msource.position)
+    in
     let query = Query_protocol.Jump (target, pposition) in
     Query_commands.dispatch pipeline query)
 ;;
@@ -93,7 +96,9 @@ let on_request ~params state =
           |> Fiber.map ~f:(function
             | `Error _ -> None
             | `Found pos ->
-              (match Position.of_lexical_position pos with
+              (match
+                 Document.position_of_lexical_position (Document.Merlin.to_doc merlin) pos
+               with
                | None -> None
                | Some position -> Some (target, position))))
       in

--- a/ocaml-lsp-server/src/custom_requests/req_phrase.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_phrase.ml
@@ -53,11 +53,11 @@ type t = Position.t
 let t_of_yojson x = Position.t_of_yojson x
 let make_phrase_command position target = Query_protocol.Phrase (target, position)
 
-let dispatch_phrase position target pipeline =
-  let position = Position.logical position in
+let dispatch_phrase position target doc pipeline =
+  let position = (Document.merlin_position doc position :> Msource.position) in
   let command = make_phrase_command position target in
   let result = Query_commands.dispatch pipeline command in
-  match Position.of_lexical_position result with
+  match Document.position_of_lexical_position doc result with
   | None -> `Null
   | Some pos -> Position.yojson_of_t pos
 ;;
@@ -68,5 +68,5 @@ let on_request ~params state =
       (Option.value ~default:(`Assoc []) params :> Yojson.Safe.t)
       |> Request_params.t_of_yojson
     in
-    Util.with_pipeline state uri ~default:`Null @@ dispatch_phrase position target)
+    Util.with_pipeline_doc state uri ~default:`Null @@ dispatch_phrase position target)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
@@ -48,7 +48,8 @@ let yojson_of_t { position; content; selection_range } =
     ]
 ;;
 
-let dispatch ~range ~extract_name pipeline =
+let dispatch ~range ~extract_name doc pipeline =
+  let range = Document.merlin_range doc range in
   let start = Position.logical range.Range.start in
   let end_ = Position.logical range.Range.end_ in
   let command = Query_protocol.Refactor_extract_region (start, end_, extract_name) in
@@ -57,9 +58,9 @@ let dispatch ~range ~extract_name pipeline =
       Query_commands.dispatch pipeline command
     in
     yojson_of_t
-      { position = Range.of_loc loc
+      { position = Document.range_of_loc doc loc
       ; content
-      ; selection_range = Range.of_loc selection_range
+      ; selection_range = Document.range_of_loc doc selection_range
       }
   with
   | Merlin_analysis.Refactor_extract_region.Nothing_to_do -> `Null
@@ -72,5 +73,5 @@ let on_request ~params state =
       Request_params.t_of_yojson params
     in
     let uri = text_document.uri in
-    Util.with_impl_pipeline state uri ~default:`Null @@ dispatch ~range ~extract_name)
+    Util.with_impl_pipeline_doc state uri ~default:`Null @@ dispatch ~range ~extract_name)
 ;;

--- a/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
@@ -40,8 +40,8 @@ let make_type_expr_command position expression =
   Query_protocol.Type_expr (expression, position)
 ;;
 
-let dispatch_type_expr position expression pipeline =
-  let position = Position.logical position in
+let dispatch_type_expr position expression doc pipeline =
+  let position = (Document.merlin_position doc position :> Msource.position) in
   let command = make_type_expr_command position expression in
   let result = Query_commands.dispatch pipeline command in
   Some result
@@ -55,7 +55,11 @@ let on_request ~params state =
       |> Request_params.t_of_yojson
     in
     let* typ =
-      Util.with_pipeline state uri ~default:None (dispatch_type_expr position expression)
+      Util.with_pipeline_doc
+        state
+        uri
+        ~default:None
+        (dispatch_type_expr position expression)
     in
     match typ with
     | Some typ ->

--- a/ocaml-lsp-server/src/custom_requests/req_type_search.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_search.ml
@@ -49,7 +49,7 @@ end
 module TypeSearch = struct
   type t = string Query_protocol.type_search_result list
 
-  let yojson_of_t (t : t) doc_format =
+  let yojson_of_t (t : t) doc doc_format =
     let format =
       match doc_format with
       | Some format -> format
@@ -59,7 +59,7 @@ module TypeSearch = struct
       `Assoc
         [ "name", `String res.name
         ; "typ", `String res.typ
-        ; "loc", Range.yojson_of_t (Range.of_loc res.loc)
+        ; "loc", Range.yojson_of_t (Document.range_of_loc doc res.loc)
         ; ( "doc"
           , match res.doc with
             | Some value ->
@@ -87,10 +87,11 @@ end
 
 let dispatch merlin position limit query with_doc doc_format =
   Document.Merlin.with_pipeline_exn merlin (fun pipeline ->
-    let position = Position.logical position in
+    let doc = Document.Merlin.to_doc merlin in
+    let position = (Document.merlin_position doc position :> Msource.position) in
     let query = Query_protocol.Type_search (query, position, limit, with_doc) in
     let results = Query_commands.dispatch pipeline query in
-    TypeSearch.yojson_of_t results doc_format)
+    TypeSearch.yojson_of_t results doc doc_format)
 ;;
 
 let on_request ~params state =

--- a/ocaml-lsp-server/src/custom_requests/util.ml
+++ b/ocaml-lsp-server/src/custom_requests/util.ml
@@ -17,11 +17,24 @@ let with_pipeline state uri ~default f =
     Document.Merlin.with_pipeline_exn merlin f)
 ;;
 
+let with_pipeline_doc state uri ~default f =
+  with_merlin state uri ~default (fun merlin ->
+    Document.Merlin.with_pipeline_exn merlin (f (Document.Merlin.to_doc merlin)))
+;;
+
 let with_impl_pipeline state uri ~default f =
   with_merlin state uri ~default (fun merlin ->
     match Document.Merlin.kind merlin with
     | Document.Kind.Intf -> Fiber.return default
     | Document.Kind.Impl -> Document.Merlin.with_pipeline_exn merlin f)
+;;
+
+let with_impl_pipeline_doc state uri ~default f =
+  with_merlin state uri ~default (fun merlin ->
+    match Document.Merlin.kind merlin with
+    | Document.Kind.Intf -> Fiber.return default
+    | Document.Kind.Impl ->
+      Document.Merlin.with_pipeline_exn merlin (f (Document.Merlin.to_doc merlin)))
 ;;
 
 let raise_invalid_params ?data ~message () =

--- a/ocaml-lsp-server/src/custom_requests/util.mli
+++ b/ocaml-lsp-server/src/custom_requests/util.mli
@@ -9,11 +9,25 @@ val with_merlin
 
 val with_pipeline : State.t -> Uri.t -> default:'a -> (Mpipeline.t -> 'a) -> 'a Fiber.t
 
+val with_pipeline_doc
+  :  State.t
+  -> Uri.t
+  -> default:'a
+  -> (Document.t -> Mpipeline.t -> 'a)
+  -> 'a Fiber.t
+
 val with_impl_pipeline
   :  State.t
   -> Uri.t
   -> default:'a
   -> (Mpipeline.t -> 'a)
+  -> 'a Fiber.t
+
+val with_impl_pipeline_doc
+  :  State.t
+  -> Uri.t
+  -> default:'a
+  -> (Document.t -> Mpipeline.t -> 'a)
   -> 'a Fiber.t
 
 val raise_invalid_params : ?data:Json.t -> message:string -> unit -> 'a

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -320,7 +320,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
   let uri = Document.uri doc in
   let loc = Loc.loc_of_report error in
   let source = Document.Merlin.source merlin in
-  let original_range = Range.of_loc loc |> clamp_range_to_source source in
+  let original_range = Document.range_of_loc doc loc |> clamp_range_to_source source in
   let range =
     if diagnostics.shorten_merlin_diagnostics
     then first_n_lines_of_range original_range 1
@@ -344,7 +344,9 @@ let error_to_diagnostics ~diagnostics ~merlin error =
          , Some
              (List.map error.sub ~f:(fun (sub : Loc.msg) ->
                 let location =
-                  let range = Range.of_loc sub.loc |> clamp_range_to_source source in
+                  let range =
+                    Document.range_of_loc doc sub.loc |> clamp_range_to_source source
+                  in
                   Location.create ~range ~uri
                 in
                 let message = make_message Loc.print_sub_msg sub in
@@ -401,7 +403,7 @@ let merlin_diagnostics diagnostics merlin =
         let holes_as_err_diags =
           Query_commands.dispatch pipeline Holes
           |> List.rev_map ~f:(fun (loc, typ) ->
-            let range = Range.of_loc loc |> clamp_range_to_source source in
+            let range = Document.range_of_loc doc loc |> clamp_range_to_source source in
             let severity = DiagnosticSeverity.Error in
             let message =
               "This typed hole should be replaced with an expression of type " ^ typ

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -236,6 +236,70 @@ let text t = Text_document.text (text_document t)
 let source t = Msource.make (text t)
 let version t = Text_document.version (text_document t)
 
+let merlin_position t position =
+  let text_document = text_document t in
+  let offset = Text_document.absolute_position text_document position in
+  let filename = Uri.to_path (uri t) in
+  let lexical_position = Msource.get_lexing_pos ~filename (source t) (`Offset offset) in
+  let character =
+    match Text_document.position_of_lexical_position text_document lexical_position with
+    | Some clamped
+      when clamped.line = position.line && clamped.character < position.character ->
+      (* Preserve the previous behavior for invalid positions beyond the end of a line. *)
+      position.character
+    | Some _ | None -> lexical_position.pos_cnum - lexical_position.pos_bol
+  in
+  `Logical (lexical_position.pos_lnum, character)
+;;
+
+let position_of_lexical_position_in_source t source position =
+  let text_document = text_document t in
+  Text_document.position_of_lexical_position_in_text
+    ~position_encoding:(Text_document.position_encoding text_document)
+    ~text:(Msource.text source)
+    position
+;;
+
+let position_of_lexical_position t position =
+  position_of_lexical_position_in_source t (source t) position
+;;
+
+let range_of_loc_opt_in_source t source (loc : Loc.t) =
+  let open Option.O in
+  let* start = position_of_lexical_position_in_source t source loc.loc_start in
+  let+ end_ = position_of_lexical_position_in_source t source loc.loc_end in
+  Range.create ~start ~end_
+;;
+
+let range_of_loc_opt t loc = range_of_loc_opt_in_source t (source t) loc
+
+let range_of_loc_in_source t source loc =
+  range_of_loc_opt_in_source t source loc |> Option.value ~default:Lsp.Range.first_line
+;;
+
+let range_of_loc t loc = range_of_loc_in_source t (source t) loc
+
+let merlin_lsp_position t position =
+  let (`Logical (line, character)) = merlin_position t position in
+  Position.create ~line:(line - 1) ~character
+;;
+
+let merlin_range t ({ start; end_ } : Range.t) =
+  Range.create ~start:(merlin_lsp_position t start) ~end_:(merlin_lsp_position t end_)
+;;
+
+let range_of_merlin_range t ({ start; end_ } : Range.t) =
+  let source = source t in
+  let filename = Uri.to_path (uri t) in
+  let position ({ line; character } : Position.t) =
+    Msource.get_lexing_pos ~filename source (`Logical (line + 1, character))
+    |> position_of_lexical_position_in_source t source
+  in
+  match position start, position end_ with
+  | Some start, Some end_ -> Range.create ~start ~end_
+  | None, _ | _, None -> Lsp.Range.first_line
+;;
+
 let make_merlin wheel merlin_db pipeline tdoc syntax =
   let* timer = Lev_fiber.Timer.Wheel.task wheel in
   let uri = Text_document.documentUri tdoc in

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -121,6 +121,25 @@ val update_text : ?version:int -> t -> TextDocumentContentChangeEvent.t list -> 
 val close : t -> unit Fiber.t
 val text_document : t -> Text_document.t
 
+(** Convert between positions in the negotiated LSP encoding and Merlin's
+    UTF-8 byte-based positions. *)
+val merlin_position : t -> Position.t -> [ `Logical of int * int ]
+
+val merlin_range : t -> Range.t -> Range.t
+
+val position_of_lexical_position_in_source
+  :  t
+  -> Msource.t
+  -> Lexing.position
+  -> Position.t option
+
+val position_of_lexical_position : t -> Lexing.position -> Position.t option
+val range_of_loc_opt_in_source : t -> Msource.t -> Loc.t -> Range.t option
+val range_of_loc_opt : t -> Loc.t -> Range.t option
+val range_of_loc_in_source : t -> Msource.t -> Loc.t -> Range.t
+val range_of_loc : t -> Loc.t -> Range.t
+val range_of_merlin_range : t -> Range.t -> Range.t
+
 (** [get_impl_intf_counterparts uri] returns the implementation/interface
     counterparts for the URI [uri].
 

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -23,7 +23,7 @@ let normalize_selection_range ~(range : Range.t) = function
     else Option.value (Lsp.Range.intersection range selection_range) ~default:range
 ;;
 
-let rec items_to_symbols ~supports_deprecated_tag items =
+let rec items_to_symbols doc ~supports_deprecated_tag items =
   List.rev_map
     ~f:
       (fun
@@ -35,12 +35,12 @@ let rec items_to_symbols ~supports_deprecated_tag items =
         ; deprecated
         ; _
         } ->
-      let range = Range.of_loc location in
+      let range = Document.range_of_loc doc location in
       (* The LSP spec requires [selectionRange] to be contained in [range].
          Preserve valid selections, clip non-empty overlaps, and fall back to
          [range] for ghost, invalid, touching, or disjoint selections. *)
       let selectionRange =
-        normalize_selection_range ~range (Range.of_loc_opt selection)
+        normalize_selection_range ~range (Document.range_of_loc_opt doc selection)
       in
       let { Deprecation.deprecated; tags } =
         Deprecation.create
@@ -56,7 +56,7 @@ let rec items_to_symbols ~supports_deprecated_tag items =
         ~selectionRange
         ?deprecated
         ?tags
-        ~children:(items_to_symbols ~supports_deprecated_tag children)
+        ~children:(items_to_symbols doc ~supports_deprecated_tag children)
         ())
     items
 ;;
@@ -106,7 +106,7 @@ let run (client_capabilities : ClientCapabilities.t) doc uri =
               tag_support.valueSet
               ~tag:Lsp.Types.SymbolTag.Deprecated))
     in
-    let symbols = items_to_symbols ~supports_deprecated_tag outline in
+    let symbols = items_to_symbols doc ~supports_deprecated_tag outline in
     (match
        Option.value
          ~default:false

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -124,6 +124,7 @@ module Poll =
 type config =
   { diagnostics : Diagnostics.t
   ; document_store : Document_store.t
+  ; position_encoding : [ `UTF8 | `UTF16 ]
   ; include_promotions : bool
   ; progress : Progress.t
   ; log : type_:MessageType.t -> message:string -> unit Fiber.t
@@ -181,7 +182,7 @@ end = struct
 
   let source t = t.source
 
-  let lsp_of_dune diagnostics ~include_promotions diagnostic =
+  let lsp_of_dune config diagnostic =
     let module D = Drpc.Diagnostic in
     let range_of_loc loc =
       let loc =
@@ -189,7 +190,22 @@ end = struct
         let loc_end = Drpc.Loc.stop loc in
         { Loc.loc_start; loc_end; loc_ghost = false }
       in
-      Range.of_loc loc
+      let uri = Uri.of_path loc.loc_start.pos_fname in
+      match Document_store.get_opt config.document_store uri with
+      | Some doc -> Document.range_of_loc doc loc
+      | None ->
+        (match Fs_io.read_file (Uri.to_path uri) with
+         | Error _ -> Range.of_loc loc
+         | Ok text ->
+           let position position =
+             Text_document.position_of_lexical_position_in_text
+               ~position_encoding:config.position_encoding
+               ~text
+               position
+           in
+           (match position loc.loc_start, position loc.loc_end with
+            | Some start, Some end_ -> Range.create ~start ~end_
+            | None, _ | _, None -> Lsp.Range.first_line))
     in
     let range =
       match D.loc diagnostic with
@@ -222,9 +238,9 @@ end = struct
              DiagnosticRelatedInformation.create ~location ~message))
     in
     let message = make_message (D.message diagnostic) in
-    let tags = Diagnostics.tags_of_message diagnostics ~src:`Dune message in
+    let tags = Diagnostics.tags_of_message config.diagnostics ~src:`Dune message in
     let data =
-      match include_promotions with
+      match config.include_promotions with
       | false -> None
       | true ->
         (match D.promotion diagnostic with
@@ -356,14 +372,7 @@ end = struct
               in
               Diagnostics.set
                 diagnostics
-                (`Dune
-                    ( running.diagnostics_id
-                    , id
-                    , uri
-                    , lsp_of_dune
-                        diagnostics
-                        ~include_promotions:config.include_promotions
-                        d ));
+                (`Dune (running.diagnostics_id, id, uri, lsp_of_dune config d));
               promotions, requests :: add, remove)
       in
       promotions, List.concat add, List.concat remove
@@ -488,7 +497,15 @@ end = struct
       }
     in
     t.state <- Running running;
-    let { progress; diagnostics; include_promotions = _; log = _; document_store } =
+    let { progress
+        ; diagnostics
+        ; include_promotions = _
+        ; log = _
+        ; trace = _
+        ; document_store
+        ; position_encoding = _
+        }
+      =
       config
     in
     let* () =
@@ -779,6 +796,7 @@ let create
       diagnostics
       progress
       document_store
+      ~position_encoding
       ~log
       ~trace
   =
@@ -797,7 +815,14 @@ let create
          | _ -> false)
       | _ -> false
     in
-    { document_store; diagnostics; progress; include_promotions; log; trace }
+    { document_store
+    ; diagnostics
+    ; progress
+    ; position_encoding
+    ; include_promotions
+    ; log
+    ; trace
+    }
   in
   let registry =
     Registry.create (Registry.Config.create (Xdg.create ~env:Sys.getenv_opt ()))
@@ -818,13 +843,22 @@ let create
       diagnostics
       progress
       document_store
+      ~position_encoding
       ~log
       ~trace
   =
   if inside_test
   then ref Closed
   else
-    create workspaces client_capabilities diagnostics progress document_store ~log ~trace
+    create
+      workspaces
+      client_capabilities
+      diagnostics
+      progress
+      document_store
+      ~position_encoding
+      ~log
+      ~trace
 ;;
 
 let run_loop t =

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -17,6 +17,7 @@ val create
   -> Diagnostics.t
   -> Progress.t
   -> Document_store.t
+  -> position_encoding:[ `UTF8 | `UTF16 ]
   -> log:(type_:MessageType.t -> message:string -> unit Fiber.t)
   -> trace:(message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t)
   -> t

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -11,7 +11,13 @@ let folding_range { Range.start; end_ } =
     ()
 ;;
 
-let fold_over_parsetree (parsetree : Mreader.parsetree) =
+let fold_over_parsetree doc (parsetree : Mreader.parsetree) =
+  let module Range = struct
+    include Range
+
+    let of_loc = Document.range_of_loc doc
+  end
+  in
   let ranges = ref [] in
   let push (range : Range.t) =
     if not (Lsp.Range.is_single_line range) (* don't fold a single line *)
@@ -298,7 +304,7 @@ let compute (state : State.t) (params : FoldingRangeParams.t) =
       let+ ranges =
         Document.Merlin.with_pipeline_exn ~name:"folding range" m (fun pipeline ->
           let parsetree = Mpipeline.reader_parsetree pipeline in
-          fold_over_parsetree parsetree)
+          fold_over_parsetree (Document.Merlin.to_doc m) parsetree)
       in
       Some ranges)
 ;;

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -351,7 +351,7 @@ let type_enclosing_hover
     Document.Merlin.type_enclosing
       ~name:"hover-enclosing"
       merlin
-      (Position.logical position)
+      (Document.merlin_position doc position :> Msource.position)
       verbosity
       ~with_syntax_doc
   in
@@ -390,7 +390,7 @@ let type_enclosing_hover
       in
       format_type_enclosing ~syntax ~markdown ~typ ~doc:documentation ~syntax_doc
     in
-    let range = Range.of_loc loc in
+    let range = Document.range_of_loc doc loc in
     let hover = Hover.create ~contents ~range () in
     Fiber.return (Some hover)
 ;;
@@ -411,7 +411,7 @@ let handle server { HoverParams.textDocument = { uri }; position; _ } mode =
           (Document.merlin_exn doc)
           (fun pipeline -> Mpipeline.reader_parsetree pipeline)
       in
-      (match hover_at_cursor parsetree (Position.logical position) with
+      (match hover_at_cursor parsetree (Document.merlin_position doc position) with
        | None -> Fiber.return None
        | Some `Type_enclosing ->
          let with_syntax_doc =
@@ -425,12 +425,14 @@ let handle server { HoverParams.textDocument = { uri }; position; _ } mode =
            Document.Merlin.dispatch_exn
              ~name:"expand-ppx"
              (Document.merlin_exn doc)
-             (Query_protocol.Expand_ppx (Position.logical position))
+             (Query_protocol.Expand_ppx
+                (Document.merlin_position doc position :> Msource.position))
          in
          (match ppxed_source with
           | `Found { Query_protocol.code; attr_start; attr_end } ->
             let range =
-              Range.of_loc
+              Document.range_of_loc
+                doc
                 { loc_start = attr_start; loc_end = attr_end; loc_ghost = false }
             in
             let contents = format_ppx_expansion ~ppx ~expansion:code in

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -18,6 +18,7 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
   | `Merlin doc ->
+    let lsp_doc = Document.Merlin.to_doc doc in
     let+ hints =
       let hint_let_bindings =
         Option.map state.configuration.data.inlay_hints ~f:(fun c -> c.hint_let_bindings)
@@ -34,8 +35,8 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
         |> Option.value ~default:false
       in
       Document.Merlin.with_pipeline_exn ~name:"inlay-hints" doc (fun pipeline ->
-        let start = range.start |> Position.logical
-        and stop = range.end_ |> Position.logical in
+        let start = (Document.merlin_position lsp_doc range.start :> Msource.position)
+        and stop = (Document.merlin_position lsp_doc range.end_ :> Msource.position) in
         let command =
           Query_protocol.Inlay_hints
             ( start
@@ -49,7 +50,7 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
         List.filter_map
           ~f:(fun (pos, label) ->
             let open Option.O in
-            let+ position = Position.of_lexical_position pos in
+            let+ position = Document.position_of_lexical_position lsp_doc pos in
             let label = `String (outline_type label) in
             InlayHint.create
               ~kind:Type

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -293,6 +293,13 @@ let on_initialize server (ip : InitializeParams.t) =
               Server.Batch.notification batch (PublishDiagnostics d));
             Server.Batch.submit batch))
   in
+  let initialize_info = initialize_info ip.capabilities in
+  let position_encoding =
+    match initialize_info.capabilities.positionEncoding with
+    | None | Some UTF16 -> `UTF16
+    | Some UTF8 -> `UTF8
+    | Some UTF32 | Some (Other _) -> assert false
+  in
   let+ dune =
     let progress =
       Progress.create
@@ -309,21 +316,13 @@ let on_initialize server (ip : InitializeParams.t) =
         diagnostics
         progress
         state.store
+        ~position_encoding
         ~log:(State.log_msg server)
         ~trace:(State.log_trace server)
     in
     Fiber.return dune
   in
-  let initialize_info = initialize_info ip.capabilities in
-  let state =
-    let position_encoding =
-      match initialize_info.capabilities.positionEncoding with
-      | None | Some UTF16 -> `UTF16
-      | Some UTF8 -> `UTF8
-      | Some UTF32 | Some (Other _) -> assert false
-    in
-    State.initialize state ~position_encoding ip workspaces dune diagnostics
-  in
+  let state = State.initialize state ~position_encoding ip workspaces dune diagnostics in
   let state =
     match ip.trace with
     | None -> state

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -63,7 +63,7 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
     let store = state.store in
     Document_store.get store uri
   in
-  let pos = Position.logical position in
+  let pos = (Document.merlin_position doc position :> Msource.position) in
   let prefix =
     (* The value of [short_path] doesn't make a difference to the final result
        because labels cannot include dots. However, a true value is slightly

--- a/ocaml-lsp-server/src/typed_hole.ml
+++ b/ocaml-lsp-server/src/typed_hole.ml
@@ -35,7 +35,8 @@ let find ~range ~position ~direction holes =
 ;;
 
 let all ?(pipeline_name = "typed-holes") merlin =
+  let doc = Document.Merlin.to_doc merlin in
   Holes
   |> Document.Merlin.dispatch_exn ~name:pipeline_name merlin
-  |> Fiber.map ~f:(List.map ~f:(fun (loc, _ty) -> Range.of_loc loc))
+  |> Fiber.map ~f:(List.map ~f:(fun (loc, _ty) -> Document.range_of_loc doc loc))
 ;;

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -92,6 +92,29 @@ let%expect_test "has related diagnostics" =
     |}]
 ;;
 
+let%expect_test "uses UTF-16 ranges around astral Unicode characters" =
+  let source = "let _ = (* 😀 *) missing\n" in
+  test source;
+  [%expect
+    {|
+    textDocument/publishDiagnostics
+    {
+      "diagnostics": [
+        {
+          "message": "Unbound value missing",
+          "range": {
+            "end": { "character": 24, "line": 0 },
+            "start": { "character": 17, "line": 0 }
+          },
+          "severity": 1,
+          "source": "ocamllsp"
+        }
+      ],
+      "uri": "file:///test.ml"
+    }
+    |}]
+;;
+
 let%expect_test "unused values have diagnostic tags" =
   let source =
     {ocaml|let () =


### PR DESCRIPTION
LSP positions use the encoding negotiated during initialization—UTF-16 by default—while Merlin and OCaml lexer locations use UTF-8 byte columns. Treating these columns as interchangeable shifts requests and returned ranges after multibyte characters, as captured by the hover regression in #1733.

Add document-aware conversion helpers in both directions and route Merlin queries, diagnostics, symbols, edits, semantic tokens, custom requests, and Dune locations through them. Valid positions are translated through source offsets while preserving the previous behavior for invalid positions beyond the end of a line.
