### PR TITLE
fix(server): report missing build tool as a diagnostic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
   (#1859, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
+- Report a missing project build-system executable as a diagnostic without
+  discarding the opened document. (#1814, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
 - Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
   within its `range`, so clients no longer reject the document outline.

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -122,12 +122,7 @@ module Process = struct
       | Some bin -> bin, [ "ocaml-merlin" ]
     in
     match Bin.which bin with
-    | None ->
-      Jsonrpc.Response.Error.raise
-        (Jsonrpc.Response.Error.make
-           ~code:InternalError
-           ~message:(Printf.sprintf "%s binary not found" bin)
-           ())
+    | None -> Fiber.return (Error (Printf.sprintf "%s binary not found" bin))
     | Some prog ->
       let command = String.concat ~sep:" " (prog :: args) in
       let stdin_r, stdin_w = Unix.pipe () in
@@ -179,7 +174,7 @@ module Process = struct
           ~verbose:(fun () ->
             sprintf "Command: %s; pid: %d; cwd: %s" command (Pid.to_int pid) dir)
       in
-      process
+      Ok process
   ;;
 end
 
@@ -255,13 +250,16 @@ end
 
 let get_process t ~dir =
   match Hashtbl.find t.running dir with
-  | Some p -> Fiber.return p
+  | Some p -> Fiber.return (Ok p)
   | None ->
     let* process = Process.start ~trace:t.trace ~dir in
-    let entry = Entry.create t process in
-    Hashtbl.add_exn t.running ~key:dir ~data:entry;
-    let+ () = Fiber.Pool.task t.pool ~f:(fun () -> Process.waitpid process) in
-    entry
+    (match process with
+     | Error _ as error -> Fiber.return error
+     | Ok process ->
+       let entry = Entry.create t process in
+       Hashtbl.add_exn t.running ~key:dir ~data:entry;
+       let+ () = Fiber.Pool.task t.pool ~f:(fun () -> Process.waitpid process) in
+       Ok entry)
 ;;
 
 type context =
@@ -444,24 +442,31 @@ let config (t : t) : Mconfig.t Fiber.t =
       let+ () = destroy t in
       Mconfig.get_external_config t.path t.initial
     | Some (ctx, config_path) ->
-      let* entry = get_process t.db ~dir:ctx.process_dir in
-      let* () =
-        match t.entry with
-        | None ->
-          use_entry entry;
-          Fiber.return ()
-        | Some entry' ->
-          if Entry.equal entry entry'
-          then Fiber.return ()
-          else
-            let+ () = destroy t in
-            use_entry entry
+      let* dot, failures =
+        let* entry = get_process t.db ~dir:ctx.process_dir in
+        match entry with
+        | Error failure ->
+          let+ () = destroy t in
+          empty, [ failure ]
+        | Ok entry ->
+          let* () =
+            match t.entry with
+            | None ->
+              use_entry entry;
+              Fiber.return ()
+            | Some entry' ->
+              if Entry.equal entry entry'
+              then Fiber.return ()
+              else
+                let+ () = destroy t in
+                use_entry entry
+          in
+          get_config entry.process ~workdir:ctx.workdir t.path
       in
-      let+ dot, failures = get_config entry.process ~workdir:ctx.workdir t.path in
       let merlin =
         Mconfig.merge_merlin_config dot t.initial.merlin ~failures ~config_path
       in
-      Mconfig.normalize { t.initial with merlin })
+      Fiber.return (Mconfig.normalize { t.initial with merlin }))
 ;;
 
 module DB = struct

--- a/ocaml-lsp-server/test/e2e-new/document_flow.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_flow.ml
@@ -86,7 +86,7 @@ let%expect_test "it should allow double opening the same document" =
     |}]
 ;;
 
-let%expect_test "missing dune leaves an opened document unavailable (#1417)" =
+let%expect_test "missing dune is reported as a diagnostic (#1417)" =
   let dir = Test.temp_dir "ocamllsp-missing-dune-" in
   let source = "let answer = 42\n" in
   let path = Filename.concat dir "main.ml" in
@@ -95,7 +95,18 @@ let%expect_test "missing dune leaves an opened document unavailable (#1417)" =
   Test.write_file path source;
   let uri = DocumentUri.of_path path in
   let workspace = WorkspaceFolder.create ~uri:(DocumentUri.of_path dir) ~name:"test" in
-  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
+  let diagnostics = Fiber.Ivar.create () in
+  let handler =
+    Client.Handler.make
+      ~on_notification:(fun _ -> function
+         | PublishDiagnostics params ->
+           let* filled = Fiber.Ivar.peek diagnostics in
+           (match filled with
+            | Some _ -> Fiber.return ()
+            | None -> Fiber.Ivar.fill diagnostics params)
+         | _ -> Fiber.return ())
+      ()
+  in
   let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in
   (Test.run_initialized
      ~extra_env:[ "PATH=" ]
@@ -115,6 +126,9 @@ let%expect_test "missing dune leaves an opened document unavailable (#1417)" =
        client
        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
    in
+   let* diagnostics = Fiber.Ivar.read diagnostics in
+   List.iter diagnostics.diagnostics ~f:(fun diagnostic ->
+     Diagnostic.yojson_of_t diagnostic |> Test.print_result);
    let textDocument = TextDocumentIdentifier.create ~uri in
    let position = Position.create ~line:0 ~character:4 in
    let* result =
@@ -146,5 +160,17 @@ let%expect_test "missing dune leaves an opened document unavailable (#1417)" =
    let* () = Client.request client Shutdown in
    Client.stop client);
   Unix.close stderr;
-  [%expect {| no document found with uri: <document-uri> |}]
+  [%expect
+    {|
+    {
+      "message": "dune binary not found",
+      "range": {
+        "end": { "character": 0, "line": 1 },
+        "start": { "character": 0, "line": 0 }
+      },
+      "severity": 1,
+      "source": "ocamllsp"
+    }
+    hover succeeded
+    |}]
 ;;


### PR DESCRIPTION
A missing project build-system executable currently aborts `didOpen`, causing later requests to return the misleading `no document found` error instead of exposing the configuration problem.

Treat the missing executable as a Merlin configuration failure. This reports it as a diagnostic while keeping the document open with fallback configuration, so features such as hover can continue working.

Fixes #1417.
