### PR TITLE
test(lsp): model-check document editing

### DIFF
--- a/lsp/test/dune
+++ b/lsp/test/dune
@@ -1,5 +1,15 @@
 (library
+ (name editing_test_model)
+ (wrapped false)
+ (modules editing_model)
+ (libraries lsp base base_quickcheck ppx_sexp_conv.runtime-lib)
+ (preprocess
+  (pps base_quickcheck.ppx_quickcheck ppx_sexp_conv)))
+
+(library
  (name lsp_tests)
+ (modules
+  (:standard \ editing_model))
  (enabled_if
   (>= %{ocaml_version} 4.08))
  (inline_tests)
@@ -12,6 +22,7 @@
   ;; in dune-project
   base
   base_quickcheck
+  editing_test_model
   ppx_expect.config
   ppx_expect.config_types
   ppx_inline_test.config

--- a/lsp/test/editing_model.ml
+++ b/lsp/test/editing_model.ml
@@ -1,0 +1,131 @@
+open Base
+module Position = Lsp.Types.Position
+module Range = Lsp.Types.Range
+
+type atom =
+  | A
+  | B
+  | Space
+  | Tab
+  | Nul
+  | Newline
+  | Two_byte
+  | Three_byte
+  | Four_byte
+[@@deriving quickcheck, sexp_of]
+
+type encoding =
+  | UTF8
+  | UTF16
+[@@deriving quickcheck, sexp_of]
+
+let string_of_atom = function
+  | A -> "a"
+  | B -> "b"
+  | Space -> " "
+  | Tab -> "\t"
+  | Nul -> "\000"
+  | Newline -> "\n"
+  | Two_byte -> "é"
+  | Three_byte -> "€"
+  | Four_byte -> "😀"
+;;
+
+let string_of_atoms atoms = List.map atoms ~f:string_of_atom |> String.concat ~sep:""
+
+let lsp_encoding = function
+  | UTF8 -> `UTF8
+  | UTF16 -> `UTF16
+;;
+
+type cursor =
+  { byte_offset : int
+  ; line : int
+  ; character : int
+  }
+[@@deriving sexp_of]
+
+let position { line; character; byte_offset = _ } = Position.create ~line ~character
+
+let cursors text encoding =
+  let text_length = String.length text in
+  let rec loop byte_offset line character acc =
+    let acc = { byte_offset; line; character } :: acc in
+    if byte_offset = text_length
+    then List.rev acc
+    else (
+      let decoded = Stdlib.String.get_utf_8_uchar text byte_offset in
+      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
+      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
+      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
+      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
+      then loop (byte_offset + byte_length) (line + 1) 0 acc
+      else (
+        let code_units =
+          match encoding with
+          | UTF8 -> byte_length
+          | UTF16 -> Stdlib.Uchar.utf_16_byte_length uchar / 2
+        in
+        loop (byte_offset + byte_length) line (character + code_units) acc))
+  in
+  loop 0 0 0 []
+;;
+
+(* Mapping arbitrary selectors to the current text keeps generated operation
+   sequences valid even though earlier operations may have changed the document. *)
+let index selector ~length = Stdlib.Int.rem (selector land Stdlib.max_int) length
+
+let select_cursor text encoding selector =
+  let cursors = cursors text encoding |> Array.of_list in
+  cursors.(index selector ~length:(Array.length cursors))
+;;
+
+let cursor_at_byte_offset text encoding byte_offset =
+  List.find_exn (cursors text encoding) ~f:(fun cursor ->
+    cursor.byte_offset = byte_offset)
+;;
+
+let ordered_cursors text encoding first second =
+  let first = select_cursor text encoding first in
+  let second = select_cursor text encoding second in
+  if first.byte_offset <= second.byte_offset then first, second else second, first
+;;
+
+let replace text ~start ~stop replacement =
+  let length = String.length text in
+  Stdlib.String.sub text 0 start
+  ^ replacement
+  ^ Stdlib.String.sub text stop (length - stop)
+;;
+
+let slice text ~start ~stop = Stdlib.String.sub text start (stop - start)
+
+let line_starts text =
+  let rec loop offset acc =
+    if offset = String.length text
+    then List.rev acc
+    else if Char.equal text.[offset] '\n'
+    then loop (offset + 1) ((offset + 1) :: acc)
+    else loop (offset + 1) acc
+  in
+  loop 0 [ 0 ]
+;;
+
+let count_newlines_before text stop =
+  let rec loop offset count =
+    if offset = stop
+    then count
+    else loop (offset + 1) (if Char.equal text.[offset] '\n' then count + 1 else count)
+  in
+  loop 0 0
+;;
+
+let position_after_text (start : Position.t) text encoding =
+  let final = List.last_exn (cursors text encoding) in
+  Position.create
+    ~line:(start.Position.line + final.line)
+    ~character:
+      (if final.line = 0 then start.character + final.character else final.character)
+;;
+
+let failf fmt = Printf.ksprintf failwith fmt

--- a/lsp/test/string_zipper_quickcheck_tests.ml
+++ b/lsp/test/string_zipper_quickcheck_tests.ml
@@ -1,29 +1,10 @@
 open Base
 open Stdune
 open Base_quickcheck
-module Position = Lsp.Types.Position
-module Range = Lsp.Types.Range
+open Editing_model
 module String_zipper = Lsp.Private.String_zipper
 module Substring = Lsp.Private.Substring
 
-type atom =
-  | A
-  | Space
-  | Tab
-  | Nul
-  | Newline
-  | Two_byte
-  | Three_byte
-  | Four_byte
-[@@deriving quickcheck, sexp_of]
-
-type encoding =
-  | UTF8
-  | UTF16
-[@@deriving quickcheck, sexp_of]
-
-(* Integer selectors are mapped to valid positions in the current model. This lets
-   Quickcheck generate operation lists without knowing each intermediate state. *)
 type operation =
   | Insert of atom list
   | Goto_line of int
@@ -42,96 +23,6 @@ module Case = struct
     }
   [@@deriving quickcheck, sexp_of]
 end
-
-let string_of_atom = function
-  | A -> "a"
-  | Space -> " "
-  | Tab -> "\t"
-  | Nul -> "\000"
-  | Newline -> "\n"
-  | Two_byte -> "é"
-  | Three_byte -> "€"
-  | Four_byte -> "😀"
-;;
-
-let string_of_atoms atoms = List.map atoms ~f:string_of_atom |> String.concat ~sep:""
-
-let lsp_encoding = function
-  | UTF8 -> `UTF8
-  | UTF16 -> `UTF16
-;;
-
-type cursor =
-  { byte_offset : int
-  ; line : int
-  ; character : int
-  }
-
-let position { line; character; byte_offset = _ } = Position.create ~line ~character
-
-let cursors text encoding =
-  let text_length = String.length text in
-  let rec loop byte_offset line character acc =
-    let acc = { byte_offset; line; character } :: acc in
-    if byte_offset = text_length
-    then List.rev acc
-    else (
-      let decoded = Stdlib.String.get_utf_8_uchar text byte_offset in
-      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
-      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
-      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
-      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
-      then loop (byte_offset + byte_length) (line + 1) 0 acc
-      else (
-        let code_units =
-          match encoding with
-          | UTF8 -> byte_length
-          | UTF16 -> Stdlib.Uchar.utf_16_byte_length uchar / 2
-        in
-        loop (byte_offset + byte_length) line (character + code_units) acc))
-  in
-  loop 0 0 0 []
-;;
-
-let index selector ~length = Stdlib.Int.rem (selector land Stdlib.max_int) length
-
-let select_cursor text encoding selector =
-  let cursors = cursors text encoding |> Array.of_list in
-  cursors.(index selector ~length:(Array.length cursors))
-;;
-
-let ordered_cursors text encoding first second =
-  let first = select_cursor text encoding first in
-  let second = select_cursor text encoding second in
-  if first.byte_offset <= second.byte_offset then first, second else second, first
-;;
-
-let replace text ~start ~stop replacement =
-  let length = String.length text in
-  Stdlib.String.sub text 0 start
-  ^ replacement
-  ^ Stdlib.String.sub text stop (length - stop)
-;;
-
-let line_starts text =
-  let rec loop offset acc =
-    if offset = String.length text
-    then List.rev acc
-    else if Char.equal text.[offset] '\n'
-    then loop (offset + 1) ((offset + 1) :: acc)
-    else loop (offset + 1) acc
-  in
-  loop 0 [ 0 ]
-;;
-
-let count_newlines_before text stop =
-  let rec loop offset count =
-    if offset = stop
-    then count
-    else loop (offset + 1) (if Char.equal text.[offset] '\n' then count + 1 else count)
-  in
-  loop 0 0
-;;
 
 type model =
   { text : string
@@ -156,7 +47,7 @@ let fail state message =
        (String_zipper.to_string_debug zipper))
 ;;
 
-(* Check the observable result and the representation invariants after every operation. *)
+(* Check the observable result and representation invariants after every operation. *)
 let check state =
   let { model = { text; offset }; zipper } = state in
   let actual_text = String_zipper.to_string zipper in
@@ -173,6 +64,14 @@ let check state =
     String_zipper.Private.reflect zipper
   in
   let current_length = Substring.length current in
+  let represented_length =
+    List.fold_left left ~init:current_length ~f:(fun total substring ->
+      total + Substring.length substring)
+    |> fun length ->
+    List.fold_left right ~init:length ~f:(fun total substring ->
+      total + Substring.length substring)
+  in
+  if represented_length <> String.length text then fail state "length differs";
   if rel_pos < 0 || rel_pos > current_length
   then fail state "relative position is invalid";
   let expected_abs_pos =
@@ -259,10 +158,7 @@ let apply_operation state = function
     let buffer = Buffer.create 0 in
     String_zipper.add_buffer_between buffer start.zipper stop.zipper;
     let expected =
-      Stdlib.String.sub
-        state.model.text
-        first.byte_offset
-        (second.byte_offset - first.byte_offset)
+      slice state.model.text ~start:first.byte_offset ~stop:second.byte_offset
     in
     if not (String.equal expected (Buffer.contents buffer))
     then fail state "buffer contents differ";
@@ -287,15 +183,29 @@ let run_case { Case.initial; operations } =
   |> ignore
 ;;
 
-(* These paths previously corrupted [abs_pos]. Keep them even if the generated
-   distribution changes. *)
+(* Keep known failure shapes even if the generated distribution changes. *)
 let regression_cases : Case.t list =
-  [ { initial = [ A ]; operations = [ Goto_end; Insert [ A ] ] }
-  ; { initial = [ A; Newline; A ]
+  [ { initial = [ A ]; operations = [ Goto_end; Insert [ B ] ] }
+  ; { initial = [ A; Newline; B ]
     ; operations = [ Goto_line 1; Insert [ A ]; Goto_end; Goto_line 0 ]
     }
   ; { initial = [ A ]; operations = [ Drop_until (UTF8, 0, 0) ] }
   ; { initial = [ A; A; A ]; operations = [ Drop_until (UTF16, 1, 2) ] }
+  ; { initial = [ A; A; Newline; B; B ]
+    ; operations =
+        [ Goto_position (UTF8, 1)
+        ; Insert [ Four_byte; Newline; Three_byte ]
+        ; Goto_end
+        ; Goto_position (UTF16, 3)
+        ]
+    }
+  ; { initial = [ A; Four_byte; B; Newline; Three_byte; A ]
+    ; operations =
+        [ Apply_change (UTF16, 1, 5, [ Two_byte; Newline; Four_byte ])
+        ; Squash
+        ; Add_buffer_between (UTF8, 0, 3)
+        ]
+    }
   ]
 ;;
 

--- a/lsp/test/text_document_quickcheck_tests.ml
+++ b/lsp/test/text_document_quickcheck_tests.ml
@@ -1,0 +1,205 @@
+open Base
+open Base_quickcheck
+open Editing_model
+module Text_document = Lsp.Text_document
+module TextDocumentContentChangeEvent = Lsp.Types.TextDocumentContentChangeEvent
+
+module TextDocumentContentChangeWholeDocument =
+  Lsp.Types.TextDocumentContentChangeWholeDocument
+
+module TextDocumentContentChangePartial = Lsp.Types.TextDocumentContentChangePartial
+module TextDocumentItem = Lsp.Types.TextDocumentItem
+module DidOpenTextDocumentParams = Lsp.Types.DidOpenTextDocumentParams
+module DocumentUri = Lsp.Types.DocumentUri
+
+type change =
+  | Full_document of atom list
+  | Ranged of int * int * atom list
+[@@deriving quickcheck, sexp_of]
+
+type version_update =
+  | Keep_version
+  | Set_change_version of int
+[@@deriving quickcheck, sexp_of]
+
+type operation =
+  | Apply_changes of version_update * change list
+  | Read_text
+  | Query_position of int
+  | Query_range of int * int
+  | Set_version of int
+[@@deriving quickcheck, sexp_of]
+
+module Case = struct
+  type t =
+    { initial : atom list
+    ; encoding : encoding
+    ; operations : operation list
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+type state =
+  { text : string
+  ; version : int
+  ; encoding : encoding
+  ; document : Text_document.t
+  }
+
+let normalized_version value = value land Stdlib.max_int
+
+let make_document text encoding =
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:(DocumentUri.of_path "/quickcheck.ml")
+      ~languageId:(Lsp.Types.LanguageKind.Other "ocaml")
+      ~version:0
+      ~text
+  in
+  Text_document.make
+    ~position_encoding:(lsp_encoding encoding)
+    (DidOpenTextDocumentParams.create ~textDocument)
+;;
+
+let fail state message =
+  failf
+    "%s\nmodel: text=%S version=%d\ndocument: text=%S version=%d"
+    message
+    state.text
+    state.version
+    (Text_document.text state.document)
+    (Text_document.version state.document)
+;;
+
+let check_metadata state =
+  if Text_document.version state.document <> state.version
+  then fail state "document version differs";
+  if
+    not
+      (Poly.equal
+         (Text_document.position_encoding state.document)
+         (lsp_encoding state.encoding))
+  then fail state "position encoding differs"
+;;
+
+let check_text state =
+  let actual = Text_document.text state.document in
+  if not (String.equal state.text actual) then fail state "document text differs"
+;;
+
+let resolve_change text encoding = function
+  | Full_document atoms ->
+    let replacement = string_of_atoms atoms in
+    ( replacement
+    , `TextDocumentContentChangeWholeDocument
+        (TextDocumentContentChangeWholeDocument.create ~text:replacement) )
+  | Ranged (first_selector, second_selector, atoms) ->
+    let first, second = ordered_cursors text encoding first_selector second_selector in
+    let replacement = string_of_atoms atoms in
+    let range = Range.create ~start:(position first) ~end_:(position second) in
+    let text =
+      replace text ~start:first.byte_offset ~stop:second.byte_offset replacement
+    in
+    ( text
+    , `TextDocumentContentChangePartial
+        (TextDocumentContentChangePartial.create ~range ~text:replacement ()) )
+;;
+
+let apply_changes state version_update changes =
+  let text, changes =
+    List.fold_map changes ~init:state.text ~f:(fun text change ->
+      let text, change = resolve_change text state.encoding change in
+      text, change)
+  in
+  let version =
+    match version_update with
+    | Keep_version -> None
+    | Set_change_version version -> Some (normalized_version version)
+  in
+  let document = Text_document.apply_content_changes ?version state.document changes in
+  let version = Option.value version ~default:state.version in
+  { state with text; version; document }
+;;
+
+let apply_operation state = function
+  | Apply_changes (version, changes) -> apply_changes state version changes
+  | Read_text ->
+    let first = Text_document.text state.document in
+    let second = Text_document.text state.document in
+    if not (String.equal state.text first) then fail state "document text differs";
+    if not (String.equal first second) then fail state "repeated reads differ";
+    state
+  | Query_position selector ->
+    let cursor = select_cursor state.text state.encoding selector in
+    let actual = Text_document.absolute_position state.document (position cursor) in
+    if actual <> cursor.byte_offset then fail state "absolute position differs";
+    state
+  | Query_range (first_selector, second_selector) ->
+    let first, second =
+      ordered_cursors state.text state.encoding first_selector second_selector
+    in
+    let range = Range.create ~start:(position first) ~end_:(position second) in
+    let actual_start, actual_stop = Text_document.absolute_range state.document range in
+    if actual_start <> first.byte_offset || actual_stop <> second.byte_offset
+    then fail state "absolute range differs";
+    state
+  | Set_version version ->
+    let version = normalized_version version in
+    { state with version; document = Text_document.set_version state.document ~version }
+;;
+
+let run_case { Case.initial; encoding; operations } =
+  let text = string_of_atoms initial in
+  let state = { text; version = 0; encoding; document = make_document text encoding } in
+  check_metadata state;
+  check_text state;
+  let final =
+    List.fold_left operations ~init:state ~f:(fun state operation ->
+      let state = apply_operation state operation in
+      check_metadata state;
+      state)
+  in
+  check_text final
+;;
+
+let regression_cases =
+  [ { Case.initial = [ A; A; Newline; B; B ]
+    ; encoding = UTF8
+    ; operations =
+        [ Apply_changes
+            ( Set_change_version 1
+            , [ Ranged (1, 4, [ Four_byte; Newline; A ]); Ranged (2, 3, [ B; B ]) ] )
+        ; Query_position 4
+        ; Query_range (0, 5)
+        ; Read_text
+        ]
+    }
+  ; { Case.initial = [ Four_byte; A; Newline; Three_byte ]
+    ; encoding = UTF16
+    ; operations =
+        [ Apply_changes
+            ( Keep_version
+            , [ Full_document [ A; Four_byte; Newline; B ]
+              ; Ranged (1, 3, [ Two_byte; Newline ])
+              ] )
+        ; Read_text
+        ; Set_version 17
+        ; Query_position 2
+        ]
+    }
+  ; { Case.initial = []
+    ; encoding = UTF8
+    ; operations =
+        [ Apply_changes
+            ( Set_change_version 2
+            , [ Ranged (0, 0, [ A ]); Ranged (1, 1, [ Newline; Four_byte ]) ] )
+        ; Read_text
+        ]
+    }
+  ]
+;;
+
+let%expect_test "content-change sequences agree with a string model" =
+  Base_quickcheck.Test.run_exn (module Case) ~examples:regression_cases ~f:run_case;
+  [%expect {| |}]
+;;

--- a/lsp/test/text_edit_quickcheck_tests.ml
+++ b/lsp/test/text_edit_quickcheck_tests.ml
@@ -1,0 +1,195 @@
+open Base
+open Base_quickcheck
+open Editing_model
+module Text_document = Lsp.Text_document
+module TextEdit = Lsp.Types.TextEdit
+module TextDocumentItem = Lsp.Types.TextDocumentItem
+module DidOpenTextDocumentParams = Lsp.Types.DidOpenTextDocumentParams
+module DocumentUri = Lsp.Types.DocumentUri
+
+type raw_edit =
+  { first : int
+  ; second : int
+  ; replacement : atom list
+  }
+[@@deriving quickcheck, sexp_of]
+
+module Edit_case = struct
+  type t =
+    { initial : atom list
+    ; encoding : encoding
+    ; edits : raw_edit list
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+module Diff_case = struct
+  type t =
+    { from : atom list
+    ; to_ : atom list
+    ; encoding : encoding
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+type edit =
+  { index : int
+  ; start : cursor
+  ; stop : cursor
+  ; replacement : string
+  }
+
+let make_document text encoding =
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:(DocumentUri.of_path "/quickcheck.ml")
+      ~languageId:(Lsp.Types.LanguageKind.Other "ocaml")
+      ~version:0
+      ~text
+  in
+  Text_document.make
+    ~position_encoding:(lsp_encoding encoding)
+    (DidOpenTextDocumentParams.create ~textDocument)
+;;
+
+let compare_edit left right =
+  match Int.compare left.start.byte_offset right.start.byte_offset with
+  | 0 -> Int.compare left.index right.index
+  | ordering -> ordering
+;;
+
+let normalize_edits text encoding edits =
+  let candidates =
+    List.mapi edits ~f:(fun index { first; second; replacement } ->
+      let start, stop = ordered_cursors text encoding first second in
+      { index; start; stop; replacement = string_of_atoms replacement })
+    |> List.sort ~compare:compare_edit
+  in
+  let _, accepted =
+    List.fold candidates ~init:(None, []) ~f:(fun (previous, accepted) candidate ->
+      let accept =
+        match previous with
+        | None -> true
+        | Some previous ->
+          let starts_after_previous =
+            candidate.start.byte_offset > previous.start.byte_offset
+            && candidate.start.byte_offset >= previous.stop.byte_offset
+          in
+          let insertions_at_same_position =
+            candidate.start.byte_offset = previous.start.byte_offset
+            && candidate.start.byte_offset = candidate.stop.byte_offset
+            && previous.start.byte_offset = previous.stop.byte_offset
+          in
+          starts_after_previous || insertions_at_same_position
+      in
+      if accept then Some candidate, candidate :: accepted else previous, accepted)
+  in
+  List.rev accepted
+;;
+
+let text_edit edit =
+  let range = Range.create ~start:(position edit.start) ~end_:(position edit.stop) in
+  TextEdit.create ~range ~newText:edit.replacement
+;;
+
+let apply_model text edits =
+  let buffer = Buffer.create (String.length text) in
+  let offset = ref 0 in
+  List.iter edits ~f:(fun edit ->
+    Buffer.add_substring buffer text ~pos:!offset ~len:(edit.start.byte_offset - !offset);
+    Buffer.add_string buffer edit.replacement;
+    offset := edit.stop.byte_offset);
+  Buffer.add_substring buffer text ~pos:!offset ~len:(String.length text - !offset);
+  Buffer.contents buffer
+;;
+
+let apply_document text encoding edits =
+  let document = make_document text encoding in
+  Text_document.apply_text_document_edits document (List.map edits ~f:text_edit)
+  |> Text_document.text
+;;
+
+let duplicate_starts edits =
+  let rec loop = function
+    | [] | [ _ ] -> false
+    | first :: (second :: _ as rest) ->
+      first.start.byte_offset = second.start.byte_offset || loop rest
+  in
+  loop edits
+;;
+
+let run_edit_case { Edit_case.initial; encoding; edits } =
+  let text = string_of_atoms initial in
+  let edits = normalize_edits text encoding edits in
+  let expected = apply_model text edits in
+  let actual = apply_document text encoding edits in
+  if not (String.equal expected actual)
+  then
+    failf "text edits differ\nsource: %S\nexpected: %S\nactual: %S" text expected actual;
+  if not (duplicate_starts edits)
+  then (
+    let reversed = apply_document text encoding (List.rev edits) in
+    if not (String.equal expected reversed)
+    then
+      failf
+        "distinct text edits depend on input order\nsource: %S\nexpected: %S\nactual: %S"
+        text
+        expected
+        reversed)
+;;
+
+let run_diff_case { Diff_case.from; to_; encoding } =
+  let from = string_of_atoms from in
+  let to_ = string_of_atoms to_ in
+  let edits = Lsp.Diff.edit ~from ~to_ in
+  let document = make_document from encoding in
+  let actual =
+    Text_document.apply_text_document_edits document edits |> Text_document.text
+  in
+  if not (String.equal to_ actual)
+  then failf "diff round trip failed\nfrom: %S\nto: %S\nactual: %S" from to_ actual
+;;
+
+let edit_examples =
+  [ { Edit_case.initial = [ A; A; Newline; B; B ]
+    ; encoding = UTF8
+    ; edits =
+        [ { first = 1; second = 1; replacement = [ Four_byte; Newline ] }
+        ; { first = 4; second = 5; replacement = [] }
+        ]
+    }
+  ; { Edit_case.initial = [ Four_byte; A; Newline; Three_byte; B ]
+    ; encoding = UTF16
+    ; edits =
+        [ { first = 1; second = 2; replacement = [ Two_byte ] }
+        ; { first = 4; second = 4; replacement = [ A ] }
+        ]
+    }
+  ; { Edit_case.initial = [ A; B ]
+    ; encoding = UTF8
+    ; edits =
+        [ { first = 1; second = 1; replacement = [ A ] }
+        ; { first = 1; second = 1; replacement = [ B ] }
+        ]
+    }
+  ]
+;;
+
+let diff_examples =
+  [ { Diff_case.from = []; to_ = [ Four_byte; Newline ]; encoding = UTF8 }
+  ; { Diff_case.from = [ A; Newline; Four_byte ]
+    ; to_ = [ Three_byte; Newline; B; Newline ]
+    ; encoding = UTF16
+    }
+  ]
+;;
+
+let%expect_test "simultaneous text edits agree with a string model" =
+  Base_quickcheck.Test.run_exn (module Edit_case) ~examples:edit_examples ~f:run_edit_case;
+  [%expect {| |}]
+;;
+
+let%expect_test "diff edits reconstruct the target text" =
+  Base_quickcheck.Test.run_exn (module Diff_case) ~examples:diff_examples ~f:run_diff_case;
+  [%expect {| |}]
+;;


### PR DESCRIPTION
Share an independent UTF-8/UTF-16 string model across Quickcheck suites for the string zipper, sequential content changes, simultaneous text edits, and diff round trips.

The generated cases compare each operation with plain-string editing semantics and retain focused regressions alongside the randomized coverage.
