### PR TITLE
fix(jsonrpc): register response error exception printer

### DIFF
--- a/jsonrpc-fiber/src/import.ml
+++ b/jsonrpc-fiber/src/import.ml
@@ -75,11 +75,3 @@ module Log = struct
 end
 
 let sprintf = Printf.sprintf
-
-let () =
-  Printexc.register_printer (function
-    | Jsonrpc.Response.Error.E t ->
-      let json = Jsonrpc.Response.Error.yojson_of_t t in
-      Some ("jsonrpc response error " ^ Json.to_pretty_string (json :> Json.t))
-    | _ -> None)
-;;

--- a/jsonrpc/src/jsonrpc.ml
+++ b/jsonrpc/src/jsonrpc.ml
@@ -146,6 +146,23 @@ module Response = struct
         | Other code -> code
       ;;
 
+      let to_string = function
+        | ParseError -> "ParseError"
+        | InvalidRequest -> "InvalidRequest"
+        | MethodNotFound -> "MethodNotFound"
+        | InvalidParams -> "InvalidParams"
+        | InternalError -> "InternalError"
+        | ServerErrorStart -> "ServerErrorStart"
+        | ServerErrorEnd -> "ServerErrorEnd"
+        | ServerNotInitialized -> "ServerNotInitialized"
+        | UnknownErrorCode -> "UnknownErrorCode"
+        | RequestFailed -> "RequestFailed"
+        | ServerCancelled -> "ServerCancelled"
+        | ContentModified -> "ContentModified"
+        | RequestCancelled -> "RequestCancelled"
+        | Other _ -> "Other"
+      ;;
+
       let t_of_yojson json =
         match json with
         | `Int i -> of_int i
@@ -182,6 +199,19 @@ module Response = struct
     ;;
 
     exception E of t
+
+    let () =
+      Printexc.register_printer (function
+        | E ({ code; _ } as error) ->
+          let json = Yojson.Safe.pretty_to_string ~std:false (yojson_of_t error) in
+          Some
+            (Printf.sprintf
+               "jsonrpc response error %s (%d): %s"
+               (Code.to_string code)
+               (Code.to_int code)
+               json)
+        | _ -> None)
+    ;;
 
     let raise t = raise (E t)
     let make ?data ~code ~message () = { data; code; message }

--- a/jsonrpc/src/jsonrpc.mli
+++ b/jsonrpc/src/jsonrpc.mli
@@ -78,6 +78,9 @@ module Response : sig
         | ContentModified
         | RequestCancelled
         | Other of int
+
+      (** Returns the constructor name. [Other _] is represented as ["Other"]. *)
+      val to_string : t -> string
     end
 
     type t =


### PR DESCRIPTION
Register the `Response.Error.E` printer in the base `jsonrpc` library so errors include the symbolic and numeric code alongside readable JSON. Remove the now-redundant registration from `jsonrpc-fiber`.

Fixes #1084.
