### PR TITLE
feat(code-actions): open nearest dune file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Features
+
+- Add a code action to open the closest Dune file for the current document.
+  (#1817, fixes #1491, @rgrinberg)
+
 ## Fixes
 
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -115,6 +115,7 @@ let compute server (params : CodeActionParams.t) =
       window.showDocument
     in
     let open_related = Action_open_related.for_uri capabilities doc in
+    let open_dune = Action_open_dune.for_uri capabilities uri in
     let* merlin_jumps =
       match state.configuration.data.merlin_jump_code_actions with
       | Some { enable = true } -> Action_jump.code_actions doc params capabilities
@@ -122,11 +123,12 @@ let compute server (params : CodeActionParams.t) =
     in
     (match Document.syntax doc with
      | Ocamllex | Menhir | Cram | Dune ->
-       Fiber.return (Reply.now (actions (dune_actions @ open_related)), state)
+       Fiber.return (Reply.now (actions (dune_actions @ open_related @ open_dune)), state)
      | Ocaml | Reason | Mlx ->
        let reply () =
          let+ code_action_results = compute_ocaml_code_actions params state doc in
-         List.concat [ code_action_results; dune_actions; open_related; merlin_jumps ]
+         List.concat
+           [ code_action_results; dune_actions; open_related; open_dune; merlin_jumps ]
          |> actions
        in
        let later f =

--- a/ocaml-lsp-server/src/code_actions/action_open_dune.ml
+++ b/ocaml-lsp-server/src/code_actions/action_open_dune.ml
@@ -1,0 +1,66 @@
+open Import
+open Fiber.O
+
+let command_name = "ocamllsp/open-dune-file"
+let kind = CodeActionKind.Other "open-dune"
+let title = "Open dune file"
+
+let invalid_params message =
+  Jsonrpc.Response.Error.raise
+    (Jsonrpc.Response.Error.make ~code:InvalidParams ~message ())
+;;
+
+let command_run server (params : ExecuteCommandParams.t) =
+  let uri =
+    match params.arguments with
+    | Some [ json ] -> DocumentUri.t_of_yojson json
+    | None | Some _ -> invalid_params "takes a single URI as input"
+  in
+  let+ { ShowDocumentResult.success } =
+    let req = ShowDocumentParams.create ~uri ~takeFocus:true () in
+    Server.request server (Server_request.ShowDocumentRequest req)
+  in
+  if not success then Format.eprintf "failed to open %s@." (Uri.to_string uri);
+  `Null
+;;
+
+let file_exists path = Sys.file_exists path && not (Sys.is_directory path)
+
+let is_project_root dir =
+  List.exists [ "dune-project"; "dune-workspace" ] ~f:(fun name ->
+    file_exists (Filename.concat dir name))
+;;
+
+let rec find_closest_dune dir =
+  let dune = Filename.concat dir "dune" in
+  if file_exists dune
+  then Some dune
+  else if is_project_root dir
+  then None
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else find_closest_dune parent)
+;;
+
+let for_uri (capabilities : ShowDocumentClientCapabilities.t option) uri =
+  match
+    match capabilities with
+    | Some { support } -> support
+    | None -> false
+  with
+  | false -> []
+  | true ->
+    let source = Uri.to_path uri in
+    (match find_closest_dune (Filename.dirname source) with
+     | None -> []
+     | Some path when String.equal source path -> []
+     | Some path ->
+       let command =
+         let arguments =
+           let uri = DocumentUri.of_path path in
+           [ DocumentUri.yojson_of_t uri ]
+         in
+         Command.create ~title ~command:command_name ~arguments ()
+       in
+       [ CodeAction.create ~title ~kind ~command () ])
+;;

--- a/ocaml-lsp-server/src/code_actions/action_open_dune.mli
+++ b/ocaml-lsp-server/src/code_actions/action_open_dune.mli
@@ -1,0 +1,6 @@
+open Import
+
+val command_name : string
+val kind : CodeActionKind.t
+val command_run : _ Server.t -> ExecuteCommandParams.t -> Json.t Fiber.t
+val for_uri : ShowDocumentClientCapabilities.t option -> Uri.t -> CodeAction.t list

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -35,6 +35,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
         ; Action_combine_cases.kind
         ; Action_inferred_intf.kind
         ; CodeActionKind.Other "switch"
+        ; Action_open_dune.kind
         ; CodeActionKind.QuickFix
         ; CodeActionKind.RefactorExtract
         ]
@@ -118,6 +119,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
         then
           view_metrics_command_name
           :: Action_open_related.command_name
+          :: Action_open_dune.command_name
           :: Action_jump.command_name
           :: Document_text_command.command_name
           :: Merlin_config_command.command_name
@@ -635,6 +637,8 @@ let on_request
     else if String.equal command.command Action_open_related.command_name
     then
       later (fun _state server -> Action_open_related.command_run server command) server
+    else if String.equal command.command Action_open_dune.command_name
+    then later (fun _state server -> Action_open_dune.command_run server command) server
     else if String.equal command.command Action_jump.command_name
     then later (fun _state server -> Action_jump.command_run server command) server
     else

--- a/ocaml-lsp-server/test/e2e-new/action_open_dune.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_open_dune.ml
@@ -1,0 +1,129 @@
+open Test.Import
+open Lsp_helpers
+
+let kind = CodeActionKind.Other "open-dune"
+
+let capabilities =
+  let window =
+    let showDocument = ShowDocumentClientCapabilities.create ~support:true in
+    WindowClientCapabilities.create ~showDocument ()
+  in
+  let textDocument =
+    let codeAction =
+      let codeActionLiteralSupport =
+        let codeActionKind = ClientCodeActionKindOptions.create ~valueSet:[] in
+        ClientCodeActionLiteralOptions.create ~codeActionKind
+      in
+      CodeActionClientCapabilities.create ~codeActionLiteralSupport ()
+    in
+    TextDocumentClientCapabilities.create ~codeAction ()
+  in
+  ClientCapabilities.create ~window ~textDocument ()
+;;
+
+let handler opened =
+  let on_request (type r) _ (request : r Lsp.Server_request.t)
+    : (r Lsp_fiber.Rpc.Reply.t * unit) Fiber.t
+    =
+    match request with
+    | ShowDocumentRequest params ->
+      let* () = Fiber.Ivar.fill opened params.uri in
+      let result = ShowDocumentResult.create ~success:true in
+      Fiber.return (Lsp_fiber.Rpc.Reply.now result, ())
+    | _ -> assert false
+  in
+  Client.Handler.make
+    ~on_request:{ Client.Handler.on_request }
+    ~on_notification:(fun _ _ -> Fiber.return ())
+    ()
+;;
+
+let request_actions ?(language_id = "ocaml") client path =
+  let uri = DocumentUri.of_path path in
+  let* () = open_document ~language_id ~client ~uri ~source:"let x = 1\n" in
+  let params =
+    let range =
+      let position = Position.create ~line:0 ~character:0 in
+      Range.create ~start:position ~end_:position
+    in
+    let context = CodeActionContext.create ~diagnostics:[] ~only:[ kind ] () in
+    let textDocument = TextDocumentIdentifier.create ~uri in
+    CodeActionParams.create ~textDocument ~range ~context ()
+  in
+  Client.request client (CodeAction params)
+;;
+
+let find_open_dune_action actions =
+  Option.value actions ~default:[]
+  |> List.find_map ~f:(function
+    | `CodeAction ({ CodeAction.kind = Some action_kind; _ } as action)
+      when Poly.equal kind action_kind -> Some action
+    | `CodeAction _ | `Command _ -> None)
+;;
+
+let%expect_test "open the closest dune file without crossing a project boundary" =
+  let root = Test.temp_dir "ocamllsp-open-dune" in
+  let lib = Filename.concat root "lib" in
+  let deep = Filename.concat lib "deep" in
+  let nested_project = Filename.concat root "nested-project" in
+  let nested_src = Filename.concat nested_project "src" in
+  List.iter [ lib; deep; nested_project; nested_src ] ~f:(fun dir -> Unix.mkdir dir 0o700);
+  Test.write_file (Filename.concat root "dune-project") "(lang dune 2.5)\n";
+  Test.write_file (Filename.concat root "dune") "";
+  let closest_dune = Filename.concat lib "dune" in
+  Test.write_file closest_dune "";
+  Test.write_file (Filename.concat nested_project "dune-project") "(lang dune 2.5)\n";
+  let source = Filename.concat deep "source.ml" in
+  let opened = Fiber.Ivar.create () in
+  let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in
+  (let handler = handler opened in
+   let workspace = WorkspaceFolder.create ~uri:(Uri.of_path root) ~name:"test" in
+   Test.run_initialized
+     ~stderr
+     ~handler
+     ~capabilities
+     ~workspaceFolders:(Some [ workspace ])
+   @@ fun client ->
+   let* actions = request_actions client source in
+   let action = find_open_dune_action actions in
+   let* () =
+     match action with
+     | None ->
+       print_endline "closest action: missing";
+       Fiber.return ()
+     | Some { title; command = None; _ } ->
+       Printf.printf "%s: missing command\n" title;
+       Fiber.return ()
+     | Some { title; command = Some command; _ } ->
+       let params =
+         let arguments = command.arguments in
+         ExecuteCommandParams.create ~command:command.command ?arguments ()
+       in
+       let* _ = Client.request client (ExecuteCommand params) in
+       let+ opened = Fiber.Ivar.read opened in
+       Printf.printf "%s: %b\n" title (String.equal (Uri.to_path opened) closest_dune)
+   in
+   let* actions = request_actions ~language_id:"dune" client closest_dune in
+   Printf.printf
+     "dune file action: %s\n"
+     (match find_open_dune_action actions with
+      | None -> "none"
+      | Some _ -> "unexpected");
+   let* actions =
+     let nested_source = Filename.concat nested_src "source.ml" in
+     request_actions client nested_source
+   in
+   Printf.printf
+     "nested project action: %s\n"
+     (match find_open_dune_action actions with
+      | None -> "none"
+      | Some _ -> "unexpected");
+   Test.exit_client client);
+  Unix.close stderr;
+  [%expect
+    {|
+    Open dune file: true
+    dune file action: none
+    nested project action: none
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
@@ -79,7 +79,7 @@ let%expect_test "inline edit is computed eagerly despite resolve support" =
         "destruct-line (enumerate cases, use existing match)", "inferred_intf",
         "merlin-jump-fun", "merlin-jump-let", "merlin-jump-match",
         "merlin-jump-module", "merlin-jump-module-type", "merlin-jump-next-case",
-        "merlin-jump-prev-case", "put module name in identifiers",
+        "merlin-jump-prev-case", "open-dune", "put module name in identifiers",
         "remove module name from identifiers", "remove type annotation",
         "switch", "type-annotate", "update_intf"
       ]

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -42,6 +42,7 @@
    ((pps ppx_expect)
     action_extract
     action_inline
+    action_open_dune
     action_mark_remove
     code_action_destruct_protocol
     code_action_protocol

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -121,7 +121,7 @@ let%expect_test "start/stop" =
             "destruct-line (enumerate cases, use existing match)",
             "inferred_intf", "merlin-jump-fun", "merlin-jump-let",
             "merlin-jump-match", "merlin-jump-module", "merlin-jump-module-type",
-            "merlin-jump-next-case", "merlin-jump-prev-case",
+            "merlin-jump-next-case", "merlin-jump-prev-case", "open-dune",
             "put module name in identifiers",
             "remove module name from identifiers", "remove type annotation",
             "switch", "type-annotate", "update_intf"
@@ -141,8 +141,9 @@ let%expect_test "start/stop" =
         "executeCommandProvider": {
           "commands": [
             "ocamllsp/view-metrics", "ocamllsp/open-related-source",
-            "ocamllsp/merlin-jump-to-target", "ocamllsp/show-document-text",
-            "ocamllsp/show-merlin-config", "dune/promote"
+            "ocamllsp/open-dune-file", "ocamllsp/merlin-jump-to-target",
+            "ocamllsp/show-document-text", "ocamllsp/show-merlin-config",
+            "dune/promote"
           ]
         },
         "experimental": {


### PR DESCRIPTION
Adds an `open-dune` code action that searches parent directories for the nearest `dune` file and opens it through `window/showDocument`. The search stops at `dune-project` or `dune-workspace` boundaries, and the action is only offered to clients that support `window/showDocument`.

Fixes #1491.
