### PR TITLE
feature(lsp): add text document position conversions

### DIFF
--- a/lsp/src/string_zipper.ml
+++ b/lsp/src/string_zipper.ml
@@ -325,6 +325,99 @@ let add_buffer_between b start stop =
   loop bufs remaining
 ;;
 
+let rec move_right t remaining =
+  if remaining = 0
+  then t
+  else (
+    let { Substring.newlines; consumed } =
+      Substring.move_right t.current ~pos:t.rel_pos ~len:remaining
+    in
+    let t = { t with rel_pos = t.rel_pos + consumed; line = t.line + newlines } in
+    let remaining = remaining - consumed in
+    if remaining = 0
+    then t
+    else (
+      match t.right with
+      | [] -> t
+      | current :: right ->
+        move_right
+          { abs_pos = t.abs_pos + Substring.length t.current
+          ; left = t.current :: t.left
+          ; current
+          ; line = t.line
+          ; right
+          ; rel_pos = 0
+          }
+          remaining))
+;;
+
+let rec move_left t remaining =
+  if remaining = 0 || is_begin t
+  then t
+  else (
+    let { Substring.newlines; consumed } =
+      Substring.move_left t.current ~pos:t.rel_pos ~len:remaining
+    in
+    let t = { t with rel_pos = t.rel_pos - consumed; line = t.line - newlines } in
+    let remaining = remaining - consumed in
+    if remaining = 0
+    then t
+    else (
+      match t.left with
+      | [] -> t
+      | current :: left ->
+        let current_length = Substring.length current in
+        move_left
+          { abs_pos = t.abs_pos - current_length
+          ; left
+          ; current
+          ; line = t.line
+          ; right = t.current :: t.right
+          ; rel_pos = current_length
+          }
+          remaining))
+;;
+
+let goto_offset t target =
+  let current = offset t in
+  if target <= 0
+  then move_left t current
+  else if target >= current
+  then move_right t (target - current)
+  else move_left t (current - target)
+;;
+
+let utf16_code_units_between start stop =
+  let buffer = Buffer.create (offset stop - offset start) in
+  add_buffer_between buffer start stop;
+  Uutf.String.fold_utf_8
+    (fun code_units _ -> function
+       | `Uchar uchar -> code_units + (Uchar.utf_16_byte_length uchar / 2)
+       | `Malformed input -> raise (Invalid_utf (Malformed input)))
+    0
+    (Buffer.contents buffer)
+;;
+
+let position_at_cursor t encoding =
+  let start = beginning_of_line t in
+  let character =
+    match encoding with
+    | `UTF8 -> offset t - offset start
+    | `UTF16 -> utf16_code_units_between start t
+  in
+  Position.create ~line:t.line ~character
+;;
+
+let position t ~offset encoding = position_at_cursor (goto_offset t offset) encoding
+
+let range t ~start_offset_inclusive ~end_offset_exclusive encoding =
+  let t = goto_offset t start_offset_inclusive in
+  let start = position_at_cursor t encoding in
+  let t = goto_offset t end_offset_exclusive in
+  let end_ = position_at_cursor t encoding in
+  Range.create ~start ~end_
+;;
+
 let rec goto_end t = if is_end t then t else find_next_nl t |> advance_char |> goto_end
 
 let goto_position t (position : Position.t) encoding =

--- a/lsp/src/string_zipper.mli
+++ b/lsp/src/string_zipper.mli
@@ -20,6 +20,14 @@ val goto_end : t -> t
 val drop_until : t -> t -> t
 val apply_change : t -> Types.Range.t -> [ `UTF16 | `UTF8 ] -> replacement:string -> t
 val offset : t -> int
+val position : t -> offset:int -> [ `UTF16 | `UTF8 ] -> Position.t
+
+val range
+  :  t
+  -> start_offset_inclusive:int
+  -> end_offset_exclusive:int
+  -> [ `UTF16 | `UTF8 ]
+  -> Types.Range.t
 
 module Private : sig
   type zipper := t

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -132,11 +132,11 @@ let workspace_edit t text_edits =
   WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
 ;;
 
-let absolute_position t pos =
+let offset t pos =
   String_zipper.goto_position t.zipper pos t.position_encoding |> String_zipper.offset
 ;;
 
-let absolute_range t (range : Range.t) =
+let offsets t (range : Range.t) =
   let zipper = String_zipper.goto_position t.zipper range.start t.position_encoding in
   let start = String_zipper.offset zipper in
   let zipper = String_zipper.goto_position zipper range.end_ t.position_encoding in
@@ -180,6 +180,19 @@ let range_of_utf8_offsets t ~start_offset ~end_offset =
   let end_ = position_of_utf8_offset t end_offset in
   Range.create ~start ~end_
 ;;
+
+let position t ~offset = String_zipper.position t.zipper ~offset t.position_encoding
+
+let range t ~start_offset_inclusive ~end_offset_exclusive =
+  String_zipper.range
+    t.zipper
+    ~start_offset_inclusive
+    ~end_offset_exclusive
+    t.position_encoding
+;;
+
+let absolute_position = offset
+let absolute_range = offsets
 
 let substring t range =
   let start, end_ = absolute_range t range in

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -37,14 +37,30 @@ val apply_text_document_edits : t -> TextEdit.t list -> t
     [edits] to [t]. *)
 val workspace_edit : t -> TextEdit.t list -> WorkspaceEdit.t
 
-(** [absolute_position t pos] returns the absolute position of [pos] inside
-    [text t]. If the position is outside the bounds of the document, the offset
-    returned will be the length of the document. [pos] is interpreted with
-    [position_encoding t] *)
+(** [offset t position] returns the UTF-8 byte offset of [position] in [text t].
+    If [position] is outside the document, the result is clamped to the end of
+    the corresponding line or document. [position] is interpreted using
+    [position_encoding t]. *)
+val offset : t -> Position.t -> int
+
+(** [offsets t range] is equivalent to
+    [(offset t range.start, offset t range.end_)] but may be faster. *)
+val offsets : t -> Range.t -> int * int
+
+(** [position t ~offset] returns the position at the UTF-8 byte [offset] in
+    [text t], using [position_encoding t]. Offsets outside the document are
+    clamped to its bounds. *)
+val position : t -> offset:int -> Position.t
+
+(** [range t ~start_offset_inclusive ~end_offset_exclusive] converts a range of
+    UTF-8 byte offsets to positions using [position_encoding t]. Offsets outside
+    the document are clamped to its bounds. *)
+val range : t -> start_offset_inclusive:int -> end_offset_exclusive:int -> Range.t
+
+(** Compatibility alias for {!offset}. *)
 val absolute_position : t -> Position.t -> int
 
-(* [absolute_range t range] same as [(absolute_position t range.start ,
-   absolute_position t range.end_)] but possibly faster *)
+(** Compatibility alias for {!offsets}. *)
 val absolute_range : t -> Range.t -> int * int
 
 (** [range_of_utf8_offsets t ~start_offset ~end_offset] converts the half-open

--- a/lsp/test/text_document_quickcheck_tests.ml
+++ b/lsp/test/text_document_quickcheck_tests.ml
@@ -131,24 +131,37 @@ let apply_operation state = function
     state
   | Query_position selector ->
     let cursor = select_cursor state.text state.encoding selector in
-    let actual = Text_document.absolute_position state.document (position cursor) in
-    if actual <> cursor.byte_offset then fail state "absolute position differs";
+    let expected = position cursor in
+    let actual_offset = Text_document.offset state.document expected in
+    if actual_offset <> cursor.byte_offset then fail state "position offset differs";
+    let actual_position =
+      Text_document.position state.document ~offset:cursor.byte_offset
+    in
+    if not (Poly.equal actual_position expected) then fail state "offset position differs";
     state
   | Query_range (first_selector, second_selector) ->
     let first, second =
       ordered_cursors state.text state.encoding first_selector second_selector
     in
-    let range = Range.create ~start:(position first) ~end_:(position second) in
-    let actual_start, actual_stop = Text_document.absolute_range state.document range in
+    let expected = Range.create ~start:(position first) ~end_:(position second) in
+    let actual_start, actual_stop = Text_document.offsets state.document expected in
     if actual_start <> first.byte_offset || actual_stop <> second.byte_offset
-    then fail state "absolute range differs";
+    then fail state "range offsets differ";
     let round_trip =
       Text_document.range_of_utf8_offsets
         state.document
         ~start_offset:first.byte_offset
         ~end_offset:second.byte_offset
     in
-    if not (Poly.equal round_trip range) then fail state "UTF-8 offset range differs";
+    if not (Poly.equal round_trip expected)
+    then fail state "UTF-8 offset range differs";
+    let actual =
+      Text_document.range
+        state.document
+        ~start_offset_inclusive:first.byte_offset
+        ~end_offset_exclusive:second.byte_offset
+    in
+    if not (Poly.equal actual expected) then fail state "offsets range differs";
     state
   | Set_version version ->
     let version = normalized_version version in

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -372,6 +372,48 @@ let%expect_test "range_of_utf8_offsets rejects invalid offsets" =
     |}]
 ;;
 
+let print_position ({ Position.line; character } : Position.t) =
+  printf "%d:%d" line character
+;;
+
+let%expect_test "offset and position conversions" =
+  let text = "a😀b\né€c" in
+  let offsets = [ -1; 0; 1; 5; 6; 7; 9; 12; 13; 100 ] in
+  List.iter [ `UTF8; `UTF16 ] ~f:(fun position_encoding ->
+    let doc = make_document ~position_encoding (Uri.of_path "foo.ml") ~text in
+    printf
+      "%s: "
+      (match position_encoding with
+       | `UTF8 -> "UTF-8"
+       | `UTF16 -> "UTF-16");
+    List.iter offsets ~f:(fun offset ->
+      Text_document.position doc ~offset |> print_position;
+      printf " ");
+    print_newline ());
+  [%expect
+    {|
+    UTF-8: 0:0 0:0 0:1 0:5 0:6 1:0 1:2 1:5 1:6 1:6
+    UTF-16: 0:0 0:0 0:1 0:3 0:4 1:0 1:1 1:2 1:3 1:3 |}]
+;;
+
+let%expect_test "offsets and range conversions" =
+  let text = "a😀b\né€c" in
+  List.iter [ `UTF8; `UTF16 ] ~f:(fun position_encoding ->
+    let doc = make_document ~position_encoding (Uri.of_path "foo.ml") ~text in
+    let range =
+      Text_document.range doc ~start_offset_inclusive:1 ~end_offset_exclusive:12
+    in
+    let start, stop = Text_document.offsets doc range in
+    print_position range.start;
+    printf "-";
+    print_position range.end_;
+    printf " = %d-%d\n" start stop);
+  [%expect
+    {|
+    0:1-1:5 = 1-12
+    0:1-1:2 = 1-12 |}]
+;;
+
 let%expect_test "replace second line first line is \\n" =
   let range = tuple_range (1, 2) (1, 2) in
   let doc = make_document (Uri.of_path "foo.ml") ~text:"\nfoo\nbar\nbaz\n" in


### PR DESCRIPTION
Add encoding-aware conversions between LSP positions/ranges and UTF-8 byte offsets without exposing `Text_document`'s zipper. The existing `absolute_position` and `absolute_range` names remain as compatibility aliases.

Use the new API to remove the byte-offset/lexer-position round trip from the unused-code-action lookup, and cover both directions with UTF-8, UTF-16, and model-based editing tests.

Fixes #1090.
