### PR TITLE
fix(code-actions): skip open-related for unsupported syntaxes

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_open_related.ml
+++ b/ocaml-lsp-server/src/code_actions/action_open_related.ml
@@ -38,9 +38,9 @@ let for_uri (capabilities : ShowDocumentClientCapabilities.t option) doc =
     | `Merlin doc -> Some doc
     | `Other -> None
   in
-  match available capabilities with
-  | false -> []
-  | true ->
+  match available capabilities, Document.syntax doc with
+  | false, _ | true, (Dune | Cram) -> []
+  | true, (Ocaml | Reason | Ocamllex | Menhir | Mlx) ->
     Document.get_impl_intf_counterparts merlin_doc uri
     |> List.map ~f:(fun uri ->
       let path = Uri.to_path uri in

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -70,22 +70,13 @@ let%expect_test "no code actions for dune documents" =
     Lsp.Client_request.CodeAction
       (CodeActionParams.create ~textDocument ~range ~context ())
   in
-  iter_lsp_response_result
+  iter_lsp_response
     ~path:"dune"
     ~language_id:"dune"
     ~makeRequest
     ~source
-    (function
-    | Error error -> Jsonrpc.Response.Error.yojson_of_t error |> Test.print_result
-    | Ok actions -> print_code_action_result actions);
-  [%expect
-    {|
-    {
-      "data": { "extension": "" },
-      "code": -32600,
-      "message": "unsupported file extension"
-    }
-    |}]
+    print_code_action_result;
+  [%expect {| No code actions |}]
 ;;
 
 let%expect_test "code actions" =


### PR DESCRIPTION
Open-related code actions currently attempt implementation/interface counterpart lookup for Dune and Cram documents, causing an `InvalidRequest` for their unsupported extensions.

Return no open-related actions for those syntaxes instead, and update the regression expectation introduced in #1819.
