### PR TITLE
test(code-actions): reproduce destruct-line on inline match

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -589,6 +589,37 @@ let f (x:bool) =
     |}]
 ;;
 
+let%expect_test "destruct-line is unavailable on a whole inline match expression" =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match A with
+  | A -> _
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:8 ~end_line:3 ~end_character:10 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect {| No code actions |}]
+;;
+
+let%expect_test "destruct-line is unavailable when a match case is on the same line" =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match A with | A -> _
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect {| No code actions |}]
+;;
+
 let%expect_test "destruct-line returns UTF-16 edit ranges" =
   let source =
     {ocaml|


### PR DESCRIPTION
Adds passing regression coverage for #1595.

The expectations record the current `No code actions` behavior when `destruct-line` is requested over a whole inline match expression or when the first match case is on the same line. This makes the failure explicit for a follow-up fix.
