### PR TITLE
fix(completion): replace backtick-only polymorphic variant prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+- Replace a lone polymorphic-variant backtick when applying completions.
+  (#1823, fixes #1427, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)
 - Ensure `textDocument/documentSymbol` returns a `selectionRange` contained
   within its `range`, so clients no longer reject the document outline.

--- a/ocaml-lsp-server/src/prefix_parser.ml
+++ b/ocaml-lsp-server/src/prefix_parser.ml
@@ -16,10 +16,13 @@ include struct
   let infix = set (operator ^ "#")
 
   let name_or_label =
+    let name = alt [ name_char; name_with_dot ] in
     compile
       (seq
-         [ alt [ set "~?``"; str "let%"; str "and%" ] |> opt
-         ; alt [ name_char; name_with_dot ] |> rep1
+         [ alt
+             [ seq [ char '`'; name |> rep ]
+             ; seq [ alt [ set "~?"; str "let%"; str "and%" ] |> opt; name |> rep1 ]
+             ]
          ; stop
          ])
   ;;

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -926,7 +926,7 @@ let x : t = `|ocaml}
         "newText": "`T1",
         "range": {
           "end": { "character": 13, "line": 2 },
-          "start": { "character": 13, "line": 2 }
+          "start": { "character": 12, "line": 2 }
         }
       }
     }
@@ -939,7 +939,7 @@ let x : t = `|ocaml}
         "newText": "`T2",
         "range": {
           "end": { "character": 13, "line": 2 },
-          "start": { "character": 13, "line": 2 }
+          "start": { "character": 12, "line": 2 }
         }
       }
     }


### PR DESCRIPTION
Completion immediately after a polymorphic-variant backtick treats the prefix as empty, producing a zero-width text edit as captured in #1820.

Recognize a lone backtick as a completion prefix so the edit replaces the typed character, and update the regression expectation to the corrected range.

Fixes #1427.
