### PR TITLE
test(e2e): share hover test request helpers

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -5,13 +5,7 @@ let%expect_test "returns type inferred under cursor" =
     {ocaml|let x = 1
 |ocaml}
   in
-  let position = Position.create ~line:0 ~character:4 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  Hover_helpers.test_hover source [ Position.create ~line:0 ~character:4 ];
   [%expect
     {|
     {
@@ -27,13 +21,7 @@ let%expect_test "returns type inferred under cursor" =
 let%expect_test "uses UTF-16 positions around astral Unicode characters" =
   let source = "let s = \"😀\";; let x = 1;; x\n" in
   (* The final [x] starts at UTF-16 code unit 27. Its UTF-8 byte offset is 29. *)
-  let position = Position.create ~line:0 ~character:27 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  Hover_helpers.test_hover source [ Position.create ~line:0 ~character:27 ];
   [%expect {| no hover response |}]
 ;;
 
@@ -42,13 +30,10 @@ let%expect_test "returns type inferred under cursor (markdown formatting)" =
     {ocaml|let x = 1
 |ocaml}
   in
-  let position = Position.create ~line:0 ~character:4 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:0 ~character:4 ];
   [%expect
     {|
     {
@@ -68,13 +53,10 @@ let id x = x
 
 |ocaml}
   in
-  let position = Position.create ~line:1 ~character:4 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:1 ~character:4 ];
   [%expect
     {|
     {
@@ -92,13 +74,10 @@ let id x = x
 
 let%expect_test "returns type inferred under cursor with documentation" =
   let source = Hover_helpers.documented_id_use_source in
-  let position = Position.create ~line:3 ~character:9 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:3 ~character:9 ];
   [%expect
     {|
     {
@@ -119,13 +98,10 @@ let%expect_test
      formatting)"
   =
   let source = Hover_helpers.documented_div_use_source in
-  let position = Position.create ~line:23 ~character:9 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:23 ~character:9 ];
   [%expect
     {|
     {
@@ -149,13 +125,10 @@ let f = 10.
 let sum = f i f
 |ocaml}
   in
-  let position = Position.create ~line:3 ~character:13 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:3 ~character:13 ];
   [%expect
     {|
     {
@@ -175,14 +148,10 @@ and s = string
 type 'a fib = ('a -> unit) -> unit
 |ocaml}
   in
-  let req client =
-    let* hover1 = Hover_helpers.hover client (Position.create ~line:1 ~character:4) in
-    Hover_helpers.print_hover hover1;
-    let* hover2 = Hover_helpers.hover client (Position.create ~line:2 ~character:9) in
-    Hover_helpers.print_hover hover2;
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:1 ~character:4; Position.create ~line:2 ~character:9 ];
   [%expect
     {|
     {
@@ -215,13 +184,7 @@ let%expect_test "regression test for #403" =
 let x : foo = 1
 |ocaml}
   in
-  let position = Position.create ~line:2 ~character:4 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  Hover_helpers.test_hover source [ Position.create ~line:2 ~character:4 ];
   [%expect
     {|
     {
@@ -275,13 +238,7 @@ let%expect_test "object method call" =
 let f (o : <  g : int -> unit >) = o#g 4
 |ocaml}
   in
-  let position = Position.create ~line:1 ~character:38 in
-  let req client =
-    let* resp = Hover_helpers.hover client position in
-    let () = Hover_helpers.print_hover resp in
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  Hover_helpers.test_hover source [ Position.create ~line:1 ~character:38 ];
   [%expect
     {|
     {

--- a/ocaml-lsp-server/test/e2e-new/hover_extended.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover_extended.ml
@@ -250,18 +250,21 @@ let f a b c d e f g h i = 1 + a + b + c + d + e + f + g + h + i
     } |}]
 ;;
 
+let test_hover_extended ?capabilities source positions =
+  Hover_helpers.test
+    ?capabilities
+    ~request:(fun client position -> hover_extended client position (Some 0))
+    ~print:print_hover_extended
+    source
+    positions
+;;
+
 let%expect_test "hoverExtended returns type inferred under cursor" =
   let source =
     {ocaml|let x = 1
 |ocaml}
   in
-  let position = Position.create ~line:0 ~character:4 in
-  let req client =
-    let* resp = hover_extended client position (Some 0) in
-    let () = print_hover_extended resp in
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  test_hover_extended source [ Position.create ~line:0 ~character:4 ];
   [%expect
     {|
     {
@@ -279,13 +282,10 @@ let%expect_test "hoverExtended returns type inferred under cursor with markdown"
     {ocaml|let x = 1
 |ocaml}
   in
-  let position = Position.create ~line:0 ~character:4 in
-  let req client =
-    let* resp = hover_extended client position (Some 0) in
-    let () = print_hover_extended resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  test_hover_extended
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:0 ~character:4 ];
   [%expect
     {|
     {
@@ -299,14 +299,10 @@ let%expect_test "hoverExtended returns type inferred under cursor with markdown"
 ;;
 
 let%expect_test "hoverExtended returns type inferred under cursor with documentation" =
-  let source = Hover_helpers.documented_id_use_source in
-  let position = Position.create ~line:3 ~character:9 in
-  let req client =
-    let* resp = hover_extended client position (Some 0) in
-    let () = print_hover_extended resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  test_hover_extended
+    ~capabilities:Hover_helpers.markdown_capabilities
+    Hover_helpers.documented_id_use_source
+    [ Position.create ~line:3 ~character:9 ];
   [%expect
     {|
     {
@@ -324,14 +320,10 @@ let%expect_test "hoverExtended returns type inferred under cursor with documenta
 
 let%expect_test "hoverExtended returns type inferred under cursor with documentation tags"
   =
-  let source = Hover_helpers.documented_div_use_source in
-  let position = Position.create ~line:23 ~character:10 in
-  let req client =
-    let* resp = hover_extended client position (Some 0) in
-    let () = print_hover_extended resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  test_hover_extended
+    ~capabilities:Hover_helpers.markdown_capabilities
+    Hover_helpers.documented_div_use_source
+    [ Position.create ~line:23 ~character:10 ];
   [%expect
     {|
     {
@@ -355,13 +347,10 @@ let f = 10.
 let sum = f i f
 |ocaml}
   in
-  let position = Position.create ~line:3 ~character:13 in
-  let req client =
-    let* resp = hover_extended client position (Some 0) in
-    let () = print_hover_extended resp in
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  test_hover_extended
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:3 ~character:13 ];
   [%expect
     {|
     {
@@ -381,14 +370,10 @@ and s = string
 type 'a fib = ('a -> unit) -> unit
 |ocaml}
   in
-  let req client =
-    let* hover1 = hover_extended client (Position.create ~line:1 ~character:4) (Some 0) in
-    print_hover_extended hover1;
-    let* hover2 = hover_extended client (Position.create ~line:2 ~character:9) (Some 0) in
-    print_hover_extended hover2;
-    Fiber.return ()
-  in
-  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source req;
+  test_hover_extended
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:1 ~character:4; Position.create ~line:2 ~character:9 ];
   [%expect
     {|
     {
@@ -421,12 +406,7 @@ let%expect_test "hoverExtended regression test for #403" =
 let x : foo = 1
 |ocaml}
   in
-  let req client =
-    let* resp = hover_extended client (Position.create ~line:2 ~character:4) (Some 0) in
-    print_hover_extended resp;
-    Fiber.return ()
-  in
-  Helpers.test source req;
+  test_hover_extended source [ Position.create ~line:2 ~character:4 ];
   [%expect
     {|
     {

--- a/ocaml-lsp-server/test/e2e-new/hover_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover_helpers.ml
@@ -16,6 +16,21 @@ let hover ?(uri = Helpers.uri) client position =
        })
 ;;
 
+let test ?capabilities ~request ~print source positions =
+  let rec run client = function
+    | [] -> Fiber.return ()
+    | position :: positions ->
+      let* response = request client position in
+      print response;
+      run client positions
+  in
+  Helpers.test ?capabilities source (fun client -> run client positions)
+;;
+
+let test_hover ?capabilities source positions =
+  test ?capabilities ~request:hover ~print:print_hover source positions
+;;
+
 let markdown_capabilities =
   let hover =
     HoverClientCapabilities.create


### PR DESCRIPTION
Extract shared request-running helpers for the `hover` and `hoverExtended` tests. The test fixtures and all endpoint-specific snapshots remain in their original tests.
