### PR TITLE
fix(code-actions): offer destruct-line on inline matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@
   (#1860, @rgrinberg)
 - Advertise and encode only semantic token modifiers supported by the client.
   (#1978, @rgrinberg)
+- Offer the `destruct-line` code action on inline match expressions with
+  incomplete cases. (#1829, fixes #1595, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
 - Report a missing project build-system executable as a diagnostic without

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -1,5 +1,107 @@
 open Import
 
+module Search = struct
+  module Lexer = Ocaml_preprocess.Lexer_raw
+  module Parser = Ocaml_preprocess.Parser_raw
+
+  type t =
+    { match_start : int
+    ; case_start : int option
+    }
+
+  type token =
+    { kind : Parser.token
+    ; start : int
+    ; end_ : int
+    }
+
+  let lexer code =
+    let lexbuf = Lexing.from_string code in
+    let lexer = Lexer.make (Lexer.keywords []) in
+    let rec finish = function
+      | Lexer.Return token -> Some token
+      | Refill refill -> finish (refill ())
+      | Fail _ -> None
+    in
+    Staged.stage (fun () ->
+      match finish (Lexer.token_without_comments lexer lexbuf) with
+      | None | Some EOF -> None
+      | Some kind ->
+        Some { kind; start = Lexing.lexeme_start lexbuf; end_ = Lexing.lexeme_end lexbuf })
+  ;;
+
+  let find_case code ~start next =
+    (* The stack tracks the innermost open constructs: [`Match] for a nested
+     [match]/[try] and [`Brace] for a record-update brace. A [with] closes the
+     innermost [`Match]; a [with] above a [`Brace] belongs to the record
+     update; and a [with] with an empty stack belongs to the [match] we started
+     from, whose first case (if any) immediately follows. *)
+    (* The search is bounded to a few lines after the [match] to avoid lexing the
+     rest of the file when the [match] has no cases yet. *)
+    let max_lines = 100 in
+    let lines = ref 0 in
+    let prev_end = ref start in
+    let budget_ok token =
+      let len = token.start - !prev_end in
+      if len > 0
+      then (
+        let skipped = String.sub code ~pos:!prev_end ~len in
+        String.iter skipped ~f:(fun c -> if Char.equal c '\n' then incr lines));
+      prev_end := token.end_;
+      !lines <= max_lines
+    in
+    let rec loop stack =
+      match next () with
+      | None -> None
+      | Some token when not (budget_ok token) -> None
+      | Some { kind = MATCH | TRY; _ } -> loop (`Match :: stack)
+      | Some { kind = LBRACE; _ } -> loop (`Brace :: stack)
+      | Some { kind = RBRACE; _ } ->
+        (match stack with
+         | `Brace :: rest -> loop rest
+         | _ -> loop stack)
+      | Some { kind = WITH; _ } ->
+        (match stack with
+         | `Match :: rest -> loop rest
+         | `Brace :: _ -> loop stack
+         | [] ->
+           (match next () with
+            | Some ({ kind = BAR; start; _ } as token) when budget_ok token -> Some start
+            | None | Some _ -> None))
+      | Some _ -> loop stack
+    in
+    loop []
+  ;;
+
+  let find code ~position =
+    let line_end =
+      String.substr_index code ~pattern:"\n" |> Option.value ~default:(String.length code)
+    in
+    let next = Staged.unstage (lexer code) in
+    match next () with
+    | None -> None
+    | Some first ->
+      let rec loop token =
+        if token.start >= line_end
+        then None
+        else (
+          match token.kind with
+          | MATCH
+            when token.start = first.start
+                 || (token.start <= position && position <= token.end_) ->
+            Some
+              { match_start = token.start
+              ; case_start = find_case code ~start:token.end_ next
+              }
+          | MATCH | _ ->
+            (match next () with
+             | None -> None
+             | Some token -> loop token))
+      in
+      loop first
+  ;;
+end
+
 let action_kind = "destruct-line (enumerate cases, use existing match)"
 let kind = CodeActionKind.Other action_kind
 
@@ -165,21 +267,45 @@ let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) : 
   { loc with loc_start; loc_end }
 ;;
 
+let statement_of_code ~prefix_len code range =
+  let code = String.make prefix_len ' ' ^ String.drop_prefix code prefix_len in
+  match get_statement_kind code range with
+  | None -> None
+  | Some kind ->
+    let query_range = get_query_range code kind range in
+    let reply_range = get_reply_range code kind query_range in
+    Some { code; kind; query_range; reply_range }
+;;
+
+let statement_at_offset doc source offset =
+  let (`Logical (line, character)) = Msource.get_logical source (`Offset offset) in
+  let position = Position.create ~line:(line - 1) ~character in
+  let range = Range.create ~start:position ~end_:position in
+  statement_of_code ~prefix_len:character (get_line doc range) range
+;;
+
 (** Tries to find a statement we know how to handle on the line where the range
-    starts. *)
+    starts. Inline matches are focused by masking their prefix, preserving all
+    character offsets used by the existing line-oriented processing. *)
 let extract_statement (doc : Document.t) (ca_range : Range.t)
   : destructable_statement option
   =
-  if not (Lsp.Range.is_single_line ca_range)
-  then None
-  else (
-    let code = get_line doc ca_range in
-    match get_statement_kind code ca_range with
-    | None -> None
-    | Some kind ->
-      let query_range = get_query_range code kind ca_range in
-      let reply_range = get_reply_range code kind query_range in
-      Some { code; kind; query_range; reply_range })
+  let multiline = not (Lsp.Range.is_single_line ca_range) in
+  let line_range : Range.t =
+    if multiline then { start = ca_range.start; end_ = ca_range.start } else ca_range
+  in
+  let code = get_line doc line_range in
+  let source = Document.source doc in
+  let (`Offset line_start) =
+    Msource.get_offset source (`Logical (line_range.start.line + 1, 0))
+  in
+  let search_code = String.drop_prefix (Document.text doc) line_start in
+  match Search.find search_code ~position:line_range.start.character with
+  | None -> if multiline then None else statement_of_code ~prefix_len:0 code line_range
+  | Some { case_start = Some case_start; _ } ->
+    statement_at_offset doc source (line_start + case_start)
+  | Some { match_start; case_start = None } ->
+    statement_of_code ~prefix_len:match_start code line_range
 ;;
 
 (** Strips " -> _ " off the rhs and " | " off the lhs of a case-line if present. *)
@@ -267,3 +393,7 @@ let code_action
 let t ~dispatch state =
   { Code_action.kind; run = `Non_batchable (code_action state dispatch) }
 ;;
+
+module Testing = struct
+  module Search = Search
+end

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.mli
@@ -1,11 +1,12 @@
 open Import
 
 (** This code action allows the user to invoke Merlin-destruct to enumerate
-    cases from various lines of a partial match statement. If the line is of any
-    of these forms: [match x] [match x with] [| x -> y] then the pre-processing
-    will extract [x] and invoke Merlin-destruct on it. Some post-processing is
-    applied to Merlin's response to make it more useful for adding subsequent
-    code: extraneous tokens are stripped and cases are split across lines. For
+    cases from various lines of a partial match statement. If a line contains
+    one of these forms: [match x] [match x with] [| x -> y] then the
+    pre-processing will extract [x] and invoke Merlin-destruct on it. Existing
+    cases are reused when the action is requested on [match]. Merlin's response
+    is post-processed to make it more useful for adding subsequent code:
+    extraneous tokens are stripped and cases are split across lines. For
     example, supposing [x] is a [bool], then the line [match x with] expands to
     [match x with
      | false -> _
@@ -46,3 +47,16 @@ open Import
 
 val kind : CodeActionKind.t
 val t : dispatch:Action_destruct.dispatch -> State.t -> Code_action.t
+
+module Testing : sig
+  module Search : sig
+    type t =
+      { match_start : int
+      ; case_start : int option
+      }
+
+    (** Locate a [match] on the first line and its first case, if any. The [match]
+    must either be the first token or contain [position]. *)
+    val find : string -> position:int -> t option
+  end
+end

--- a/ocaml-lsp-server/src/testing.ml
+++ b/ocaml-lsp-server/src/testing.ml
@@ -2,6 +2,7 @@
 
 module Bin = Bin
 module Compl = Compl
+module Action_destruct_line = Action_destruct_line
 module Document_symbol = Document_symbol
 module Merlin_kernel = Merlin_kernel
 module Prefix_parser = Prefix_parser

--- a/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
@@ -1,0 +1,224 @@
+open Base
+open Base_quickcheck
+module Search = Ocaml_lsp_server.Testing.Action_destruct_line.Testing.Search
+
+let bounded value bound = Int.rem (value land Stdlib.max_int) bound
+
+let whitespace ~allow_empty selector =
+  let length = bounded selector 5 + if allow_empty then 0 else 1 in
+  let char = if selector land 1 = 0 then ' ' else '\t' in
+  Stdlib.String.make length char
+;;
+
+let identifier selector = Stdlib.String.make (bounded selector 8 + 1) 'x'
+
+let check_equal label expected actual =
+  if not (Option.equal Int.equal expected actual)
+  then
+    failwith
+      (Printf.sprintf
+         "%s: expected %s"
+         label
+         (Option.value_map expected ~default:"none" ~f:Int.to_string))
+;;
+
+let find_match source ~position =
+  Search.find source ~position
+  |> Option.map ~f:(fun (result : Search.t) -> result.match_start)
+;;
+
+let find_case source ~position =
+  Search.find source ~position
+  |> Option.bind ~f:(fun (result : Search.t) -> result.case_start)
+;;
+
+type context =
+  | Line_start
+  | Inline
+[@@deriving quickcheck, sexp_of]
+
+module Match_case = struct
+  type t =
+    { context : context
+    ; indentation : int
+    ; identifier_length : int
+    ; cursor : int
+    ; suffix : int
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let check_match { Match_case.context; indentation; identifier_length; cursor; suffix } =
+  let indentation = whitespace ~allow_empty:true indentation in
+  let prefix =
+    match context with
+    | Line_start -> indentation
+    | Inline -> indentation ^ "let " ^ identifier identifier_length ^ " = "
+  in
+  let match_start = String.length prefix in
+  let source = prefix ^ "match" ^ whitespace ~allow_empty:false suffix ^ "value" in
+  let position =
+    match context with
+    | Line_start -> 0
+    | Inline -> match_start + bounded cursor (String.length "match" + 1)
+  in
+  check_equal "match location" (Some match_start) (find_match source ~position);
+  match context with
+  | Line_start -> ()
+  | Inline ->
+    check_equal "position outside inline match" None (find_match source ~position:0)
+;;
+
+let%test_unit "find_match preserves offsets in line-leading and inline matches" =
+  Base_quickcheck.Test.run_exn (module Match_case) ~f:check_match
+;;
+
+type expression =
+  | Simple
+  | Record_update
+  | Nested_match
+  | Nested_try
+  | Nested_match_with_record
+  | Nested_try_with_record
+  | Array_literal
+  | Raw_string
+  | String_literal
+  | Comment
+[@@deriving quickcheck, sexp_of]
+
+module Existing_case = struct
+  type t =
+    { indentation : int
+    ; identifier_length : int
+    ; before_with : int
+    ; after_with : int
+    ; expression : expression
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let check_existing_case
+      { Existing_case.indentation
+      ; identifier_length
+      ; before_with
+      ; after_with
+      ; expression
+      }
+  =
+  let prefix =
+    whitespace ~allow_empty:true indentation
+    ^ "let "
+    ^ identifier identifier_length
+    ^ " = "
+  in
+  let expression =
+    match expression with
+    | Simple -> "A"
+    | Record_update -> "{ r with value = A }.value"
+    | Nested_match -> "(match A with | A -> B)"
+    | Nested_try -> "(try A with | _ -> A)"
+    | Nested_match_with_record -> "(match { r with a = b } with | A -> B)"
+    | Nested_try_with_record -> "(try { r with a = b } with | _ -> c)"
+    | Array_literal -> "[| 1; 2 |]"
+    | Raw_string -> "{| with | |}"
+    | String_literal -> "f \"with |\""
+    | Comment -> "f (* with | *)"
+  in
+  let before_with = whitespace ~allow_empty:false before_with in
+  let after_with = whitespace ~allow_empty:true after_with in
+  let before_case = prefix ^ "match " ^ expression ^ before_with ^ "with" ^ after_with in
+  let source = before_case ^ "| A -> _" in
+  let match_start = String.length prefix in
+  check_equal
+    "case location"
+    (Some (String.length before_case))
+    (find_case source ~position:match_start)
+;;
+
+let%test_unit "find_case handles prefixes, whitespace, and nested syntax" =
+  Base_quickcheck.Test.run_exn (module Existing_case) ~f:check_existing_case
+;;
+
+let%test_unit "keywords embedded in identifiers are ignored" =
+  check_equal "match identifier" None (find_match "let matcher = 0" ~position:4);
+  check_equal
+    "match identifier with apostrophe"
+    None
+    (find_match "let match' = 0" ~position:4);
+  check_equal
+    "with identifier"
+    None
+    (find_case "match value somewith | A -> _" ~position:0)
+;;
+
+let%test_unit "a line-leading match shadows a match under the cursor" =
+  check_equal
+    "first match wins"
+    (Some 0)
+    (find_match "match A with | A -> match B with | B -> _" ~position:22)
+;;
+
+let%test_unit "destruct-line search ignores try lines" =
+  check_equal "try line" None (find_match "try A with | _ -> B" ~position:0)
+;;
+
+let%test_unit "a match without cases reports no case" =
+  check_equal "no case" None (find_case "match A with" ~position:0)
+;;
+
+let%test_unit "a first case without a bar is not recognized" =
+  check_equal "bar-less first case" None (find_case "match A with A -> _" ~position:0)
+;;
+
+let%test_unit "find_case crosses line breaks" =
+  check_equal
+    "case on the next line"
+    (Some 13)
+    (find_case "match A with\n| A -> _" ~position:0);
+  check_equal
+    "case after an inline match"
+    (Some 21)
+    (find_case "let x = match A with\n| A -> _" ~position:8)
+;;
+
+let%test_unit "find_case crosses comments and line breaks" =
+  let before_case = "match A with\n(* existing case *)\n  " in
+  check_equal
+    "case after comment"
+    (Some (String.length before_case))
+    (find_case (before_case ^ "| A -> _") ~position:0)
+;;
+
+let%test_unit "matches without cases do not consume a later match" =
+  check_equal
+    "later match"
+    None
+    (find_case "match A with\nlet y = match B with | B -> _" ~position:0)
+;;
+
+let%test_unit "record updates inside nested matches do not hide the outer case" =
+  check_equal
+    "case after nested match with record update"
+    (Some 50)
+    (find_case "match (match { r with a = b } with | A -> B) with | C -> _" ~position:0);
+  check_equal
+    "case after nested try with record update"
+    (Some 48)
+    (find_case "match (try { r with a = b } with | _ -> c) with | D -> _" ~position:0)
+;;
+
+let%test_unit "find_case stops scanning after a line budget" =
+  let source = "match A with\n" ^ String.make 5000 '\n' ^ "| A -> _" in
+  check_equal "case beyond the budget" None (find_case source ~position:0);
+  check_equal
+    "case within the budget"
+    (Some 13)
+    (find_case "match A with\n| A -> _" ~position:0)
+;;
+
+let%test_unit "record updates without a case are ignored" =
+  check_equal
+    "record update"
+    None
+    (find_case "match { r with value = A } with" ~position:0)
+;;

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -1,5 +1,6 @@
 (library
  (modules
+  destruct_line_quickcheck_tests
   ocaml_lsp_tests
   position_prefix_tests
   semantic_tokens_quickcheck_tests)

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -163,7 +163,7 @@ let f (x:bool) =
     |}]
 ;;
 
-let%expect_test "destruct-line is unavailable on a whole inline match expression" =
+let%expect_test "destruct-line is available on a whole inline match expression" =
   let source =
     {ocaml|
 type t = A | B | C
@@ -176,10 +176,34 @@ let x = match A with
     source
     range
     ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
-  [%expect {| No code actions |}]
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n  | B -> _\n  | C -> _",
+                "range": {
+                  "end": { "character": 10, "line": 3 },
+                  "start": { "character": 10, "line": 3 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
 ;;
 
-let%expect_test "destruct-line is unavailable when a match case is on the same line" =
+let%expect_test "destruct-line is available when a match case is on the same line" =
   let source =
     {ocaml|
 type t = A | B | C
@@ -191,7 +215,227 @@ let x = match A with | A -> _
     source
     range
     ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n                     | B -> _\n                     | C -> _",
+                "range": {
+                  "end": { "character": 29, "line": 2 },
+                  "start": { "character": 29, "line": 2 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
+;;
+
+let%expect_test "destruct-line expands an inline match without cases" =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match A with
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "match A with\n        | A -> _\n        | B -> _\n        | C -> _",
+                "range": {
+                  "end": { "character": 20, "line": 2 },
+                  "start": { "character": 8, "line": 2 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
+;;
+
+let%expect_test
+    "destruct-line is not offered when the selection starts before an inline match"
+  =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match A with
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:0 ~end_line:2 ~end_character:20 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
   [%expect {| No code actions |}]
+;;
+
+let%expect_test
+    "destruct-line is not offered when a multiline selection starts before an inline \
+     match"
+  =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match A with
+  | A -> _
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:0 ~end_line:3 ~end_character:10 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect {| No code actions |}]
+;;
+
+let%expect_test "destruct-line finds a case after a record update" =
+  let source =
+    {ocaml|
+type t = A | B | C
+type r = { value : t }
+let f r = match { r with value = A }.value with | A -> _
+|ocaml}
+  in
+  let range = range ~start_line:3 ~start_character:10 ~end_line:3 ~end_character:15 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n                                                | B -> _\n                                                | C -> _",
+                "range": {
+                  "end": { "character": 56, "line": 3 },
+                  "start": { "character": 56, "line": 3 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
+;;
+
+let%expect_test "destruct-line finds the outer case of a nested match" =
+  let source =
+    {ocaml|
+type t = A | B | C
+let x = match (match A with | A -> B | B -> C | C -> A) with | A -> _
+|ocaml}
+  in
+  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n                                                             | B -> _\n                                                             | C -> _",
+                "range": {
+                  "end": { "character": 69, "line": 2 },
+                  "start": { "character": 69, "line": 2 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
+;;
+
+let%expect_test
+    "destruct-line finds the outer case of a nested match containing a record update"
+  =
+  let source =
+    {ocaml|
+type t = A | B | C
+type r = { value : t }
+let f r = match (match { r with value = A } with | A -> B | B -> C | C -> A) with | C -> _
+|ocaml}
+  in
+  let range = range ~start_line:3 ~start_character:10 ~end_line:3 ~end_character:15 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n                                                                                  | A -> _\n                                                                                  | B -> _",
+                "range": {
+                  "end": { "character": 90, "line": 3 },
+                  "start": { "character": 90, "line": 3 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
 ;;
 
 let%expect_test "destruct-line returns UTF-16 edit ranges" =


### PR DESCRIPTION
Fixes #1595 by recognizing `match` expressions embedded in larger lines and accepting ranges that cover the whole match expression.

The implementation isolates match/case discovery in a small pure module backed by Merlin's OCaml lexer, while leaving the existing statement processing unchanged. When a match already has cases, the action asks Merlin for missing cases through the first case belonging to that match.

Quickcheck coverage varies prefixes, cursor positions, whitespace, comments, strings, record updates, and nested matches. End-to-end expectations verify complete edits for multiline matches, same-line cases, matches without cases, record-update scrutinees, and nested matches.
