### PR TITLE
test(e2e): make missing inline actions explicit

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -1,4 +1,6 @@
-let inline_test = Code_actions.code_action_test ~title:"Inline into uses"
+let inline_test ?print_none source =
+  Code_actions.code_action_test ?print_none ~title:"Inline into uses" source
+;;
 
 let%expect_test "" =
   inline_test
@@ -16,6 +18,7 @@ let _ =
 
 let%expect_test "shadow-1" =
   inline_test
+    ~print_none:true
     {|
 let _ =
   let y = 1 in
@@ -23,7 +26,7 @@ let _ =
   let y = 0 in
   x + 1
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "shadow-2" =

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -1854,9 +1854,11 @@ let apply_code_action ?diagnostics title source range =
   |> Test.apply_edits source
 ;;
 
-let code_action_test ~title source =
+let code_action_test ?(print_none = false) ~title source =
   let src, range = parse_selection source in
-  Option.iter (apply_code_action title src range) ~f:print_string
+  match apply_code_action title src range with
+  | None -> if print_none then print_endline "None"
+  | Some result -> print_string result
 ;;
 
 let setup_inferred_intf_workspace () =

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -27,5 +27,6 @@ val apply_code_action
   -> string option
 
 (** [code_action_test title source] runs the code action with title [title] and
-    prints the resulting source. *)
-val code_action_test : title:string -> string -> unit
+    prints the resulting source. When [print_none] is set, it explicitly prints
+    when the action is unavailable. *)
+val code_action_test : ?print_none:bool -> title:string -> string -> unit


### PR DESCRIPTION
Let code-action expect tests explicitly print an unavailable result, then use it for the first shadowing case. The snapshot now records the subject instead of succeeding with empty output.