### PR TITLE
test(e2e): expose closure-shadowed inline absence

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -49,6 +49,7 @@ let _ =
 
 let%expect_test "shadow-3" =
   inline_test
+    ~print_none:true
     {|
 let _ =
   let y = 1 in
@@ -56,7 +57,7 @@ let _ =
   let y = 0 in
   x y + 1
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "shadow-4" =


### PR DESCRIPTION
Use the explicit unavailable-action output for the inline test where a closure captures a subsequently shadowed variable. Stacked on #1842.