### PR TITLE
test(e2e): expose module-shadowed inline absence

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -62,6 +62,7 @@ let _ =
 
 let%expect_test "shadow-4" =
   inline_test
+    ~print_none:true
     {|
 module M = struct
   let y = 1
@@ -73,7 +74,7 @@ let _ =
   end in
   x
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "shadow-5" =


### PR DESCRIPTION
Use the explicit unavailable-action output for the inline test where the referenced module is shadowed. Stacked on #1843.