### PR TITLE
test(e2e): expose optional-argument inline absence

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -147,12 +147,13 @@ let _ =
 
 let%expect_test "" =
   inline_test
+    ~print_none:true
     {|
 let _ =
   let $x = Some 0 in
   (fun ?(x = 2) -> x) ?x
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "" =


### PR DESCRIPTION
Use the explicit unavailable-action output for the incompatible optional-argument forwarding case. Stacked on #1844.