### PR TITLE
test(semantic-highlighting): cover function parameters

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -820,6 +820,70 @@ let prefixed = ~!1
     |}]
 ;;
 
+let%expect_test "function parameters" =
+  test_semantic_tokens_full
+  @@ String.trim
+       {|
+let f ~labeled ?(optional = 1) unlabeled ~renamed:local (left, right) =
+  labeled + optional + unlabeled + local + left + right
+
+let g = function
+  | Some value -> value
+  | None -> 0
+
+let h (type item) (value : item) = value
+
+let apply continuation value = continuation value
+
+let capture parameter =
+  let nested () = parameter in
+  nested ()
+
+let shadow parameter =
+  let before = parameter in
+  let parameter = 0 in
+  before + parameter
+
+let alias ((left, right) as pair) = left, right, pair
+
+let constrained parameter : int = parameter
+
+module type S = sig
+  val f : labeled:int -> ?optional:string -> float -> unit
+end
+      |};
+  [%expect
+    {|
+    let <function|definition-0>f</0> ~<variable|-1>labeled</1> ?(optional = <number|-2>1</2>) unlabeled ~renamed:local (left, right) =
+      labeled + optional + unlabeled + local + left + right
+
+    let g = function
+      | Some value -> value
+      | None -> 0
+
+    let h (type item) (value : item) = value
+
+    let apply continuation value = continuation value
+
+    let capture parameter =
+      let nested () = parameter in
+      nested ()
+
+    let shadow parameter =
+      let before = parameter in
+      let parameter = 0 in
+      before + parameter
+
+    let alias ((left, right) as pair) = left, right, pair
+
+    let constrained parameter : int = parameter
+
+    module type S = sig
+      val f : labeled:int -> ?optional:string -> float -> unit
+    end
+    |}]
+;;
+
 let%expect_test "comment in unit" =
   test_semantic_tokens_full
   @@ String.trim


### PR DESCRIPTION
Semantic highlighting lacks regression coverage for OCaml function-parameter syntax and name-resolution behavior.

Add passing expectations for labeled, optional, renamed, destructured, and aliased parameters in definitions and signatures. The snapshot also covers function cases, locally abstract types, constrained functions, parameters used as callees, closure capture, and local shadowing.

The expectations intentionally record the current incomplete highlighting and variable/function classifications. In particular, traversal of the optional default emits a token before its earlier parameter binder, producing an out-of-order token stream; the snapshot renderer therefore leaves the remainder of the source unannotated. The follow-up fixes that traversal and updates expectations for all cases.

Parameter tokens and label modifiers will be introduced in a separate follow-up. Part of #1139.
