### PR TITLE
test(e2e): expose module-shadowed inline absence

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -147,12 +147,13 @@ let _ =
 
 let%expect_test "" =
   inline_test
+    ~print_none:true
     {|
 let _ =
   let $x = Some 0 in
   (fun ?(x = 2) -> x) ?x
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "" =

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -62,6 +62,7 @@ let _ =
 
 let%expect_test "shadow-4" =
   inline_test
+    ~print_none:true
     {|
 module M = struct
   let y = 1
@@ -73,7 +74,7 @@ let _ =
   end in
   x
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "shadow-5" =


### PR DESCRIPTION
Print the unavailable inline-action result for the module-shadowing case. This replaces #1844, which was merged into an already-merged stack branch and therefore did not reach master.