### PR TITLE
test(e2e): expose optional-argument inline absence

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -147,12 +147,13 @@ let _ =
 
 let%expect_test "" =
   inline_test
+    ~print_none:true
     {|
 let _ =
   let $x = Some 0 in
   (fun ?(x = 2) -> x) ?x
 |};
-  [%expect {| |}]
+  [%expect {| None |}]
 ;;
 
 let%expect_test "" =


### PR DESCRIPTION
Print the unavailable inline-action result for incompatible optional-argument forwarding. This replaces #1845, which was merged into an already-merged stack branch and therefore did not reach master.