### PR TITLE
test(semantic-highlighting): cover built-in types

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -1100,6 +1100,30 @@ end
     |}]
 ;;
 
+let%expect_test "built-in types" =
+  test_semantic_tokens_full
+  @@ String.trim
+       {|
+type uses_builtin = int * string * bool
+
+type int = Shadowed
+
+type uses_shadowed = int
+
+type uses_qualified_builtin = Stdlib.int
+      |};
+  [%expect
+    {|
+    type <type|definition-0>uses_builtin</0> = <type|-1>int</1> * <type|-2>string</2> * <type|-3>bool</3>
+
+    type <enum|definition-4>int</4> = <enumMember|definition-5>Shadowed</5>
+
+    type <type|definition-6>uses_shadowed</6> = <type|-7>int</7>
+
+    type <type|definition-8>uses_qualified_builtin</8> = <namespace|-9>Stdlib</9>.<type|-10>int</10>
+    |}]
+;;
+
 let%expect_test "comment in unit" =
   test_semantic_tokens_full
   @@ String.trim


### PR DESCRIPTION
Semantic highlighting lacks focused regression coverage for distinguishing OCaml predeclared types from user-defined types with the same spelling.

Add passing expectations for several predeclared types, a local `int` declaration and its use, and a qualified `Stdlib.int` reference. The snapshot intentionally records the current uniform type classification.

The `defaultLibrary` modifier and typed shadowing resolution will be introduced in a separate follow-up. Part of #1139.
