### PR TITLE
fix(semantic-tokens): require client support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 
 ## Fixes
 
+- Advertise semantic-token support only to clients that declare the capability.
+  (#1851, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -129,11 +129,15 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       ExecuteCommandOptions.create ~commands ()
     in
     let semanticTokensProvider =
-      let full =
-        `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
-      in
-      `SemanticTokensOptions
-        (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ())
+      match client_capabilities.textDocument with
+      | Some { semanticTokens = Some _; _ } ->
+        let full =
+          `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
+        in
+        Some
+          (`SemanticTokensOptions
+              (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ()))
+      | None | Some { semanticTokens = None; _ } -> None
     in
     let positionEncoding =
       let open Option.O in
@@ -162,7 +166,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       ~documentSymbolProvider:(`Bool true)
       ~workspaceSymbolProvider:(`Bool true)
       ~foldingRangeProvider:(`Bool true)
-      ~semanticTokensProvider
+      ?semanticTokensProvider
       ~experimental
       ~renameProvider
       ~inlayHintProvider:(`Bool true)

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -31,21 +31,7 @@ let%expect_test "does not advertise semantic tokens without client support" =
   [%expect
     {|
     semanticTokensProvider:
-    {
-      "full": { "delta": true },
-      "legend": {
-        "tokenModifiers": [
-          "declaration", "definition", "readonly", "static", "deprecated",
-          "abstract", "async", "modification", "documentation", "defaultLibrary"
-        ],
-        "tokenTypes": [
-          "namespace", "type", "class", "enum", "interface", "struct",
-          "typeParameter", "parameter", "variable", "property", "enumMember",
-          "event", "function", "method", "macro", "keyword", "modifier",
-          "comment", "string", "number", "regexp", "operator", "decorator"
-        ]
-      }
-    }
+    null
     |}]
 ;;
 
@@ -147,8 +133,9 @@ let%expect_test "does not advertise unsupported full semantic token requests" =
 
 let print_semantic_tokens_full_provider initialized =
   print_endline "semanticTokensProvider.full:";
-  semantic_tokens_provider_json initialized
-  |> Yojson.Safe.Util.member "full"
+  (match semantic_tokens_provider_json initialized with
+   | `Null -> `Null
+   | provider -> Yojson.Safe.Util.member "full" provider)
   |> Test.print_result
 ;;
 
@@ -359,7 +346,7 @@ let%expect_test "direct requests with unsupported client capabilities" =
     {|
     missing semantic token capability:
     semanticTokensProvider.full:
-    { "delta": true }
+    null
     semantic token response data:
     [ 0, 4, 1, 8, 0, 0, 4, 1, 19, 0 ]
     unsupported token format:

--- a/ocaml-lsp-server/test/e2e-new/start_stop.ml
+++ b/ocaml-lsp-server/test/e2e-new/start_stop.ml
@@ -170,22 +170,6 @@ let%expect_test "start/stop" =
         "referencesProvider": true,
         "renameProvider": { "prepareProvider": true },
         "selectionRangeProvider": true,
-        "semanticTokensProvider": {
-          "full": { "delta": true },
-          "legend": {
-            "tokenModifiers": [
-              "declaration", "definition", "readonly", "static", "deprecated",
-              "abstract", "async", "modification", "documentation",
-              "defaultLibrary"
-            ],
-            "tokenTypes": [
-              "namespace", "type", "class", "enum", "interface", "struct",
-              "typeParameter", "parameter", "variable", "property", "enumMember",
-              "event", "function", "method", "macro", "keyword", "modifier",
-              "comment", "string", "number", "regexp", "operator", "decorator"
-            ]
-          }
-        },
         "signatureHelpProvider": {
           "triggerCharacters": [ " ", "~", "?", ":", "(" ]
         },


### PR DESCRIPTION
Only advertise `semanticTokensProvider` when the client declares semantic-token support during initialization.

This is the first capability-negotiation fix for #1138. Direct semantic-token requests continue to return the existing response; this change only corrects the server capability advertisement.
