### PR TITLE
fix(semantic-tokens): require relative format support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 
 - Advertise semantic-token support only to clients that declare the capability.
   (#1851, @rgrinberg)
+- Advertise semantic-token support only to clients that support the relative
+  token format. (#1853, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -130,14 +130,16 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
     in
     let semanticTokensProvider =
       match client_capabilities.textDocument with
-      | Some { semanticTokens = Some _; _ } ->
+      | Some { semanticTokens = Some { formats; _ }; _ }
+        when List.mem formats Lsp.Types.TokenFormat.Relative ~equal:Poly.equal ->
         let full =
           `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
         in
         Some
           (`SemanticTokensOptions
               (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ()))
-      | None | Some { semanticTokens = None; _ } -> None
+      | None | Some { semanticTokens = None; _ } | Some { semanticTokens = Some _; _ } ->
+        None
     in
     let positionEncoding =
       let open Option.O in

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -67,21 +67,7 @@ let%expect_test "does not advertise an unsupported semantic token format" =
   [%expect
     {|
     semanticTokensProvider:
-    {
-      "full": { "delta": true },
-      "legend": {
-        "tokenModifiers": [
-          "declaration", "definition", "readonly", "static", "deprecated",
-          "abstract", "async", "modification", "documentation", "defaultLibrary"
-        ],
-        "tokenTypes": [
-          "namespace", "type", "class", "enum", "interface", "struct",
-          "typeParameter", "parameter", "variable", "property", "enumMember",
-          "event", "function", "method", "macro", "keyword", "modifier",
-          "comment", "string", "number", "regexp", "operator", "decorator"
-        ]
-      }
-    }
+    null
     |}]
 ;;
 
@@ -351,7 +337,7 @@ let%expect_test "direct requests with unsupported client capabilities" =
     [ 0, 4, 1, 8, 0, 0, 4, 1, 19, 0 ]
     unsupported token format:
     semanticTokensProvider.full:
-    { "delta": true }
+    null
     semantic token response data:
     [ 0, 4, 1, 8, 0, 0, 4, 1, 19, 0 ]
     unsupported full requests:


### PR DESCRIPTION
Advertise semantic-token support only when the client includes the LSP `relative` token format in `textDocument.semanticTokens.formats`.

OCaml-LSP encodes tokens using relative positions, and `relative` is currently the only token format defined by LSP. Direct requests retain their existing behavior.

Part of #1138.
