### PR TITLE
test(e2e): restore Unix test suite

### DIFF
--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -832,7 +832,7 @@ let run t : unit Fiber.t =
 
 let update_workspaces t workspaces =
   match !t with
-  | Closed -> failwith "dune is already closed"
+  | Closed -> ()
   | Active active -> active.workspaces <- workspaces
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -501,6 +501,6 @@ let%expect_test "generated source has an existing workspace-symbol location" =
   [%expect
     {|
     path: _build/default/lib/gen.ml
-    contents: "let generated_workspace_symbol = 42\n"
+    contents: "let generated_workspace_symbol = 42"
     |}]
 ;;


### PR DESCRIPTION
The Unix e2e suite currently has two deterministic failures exposed by #1834 and #1838.

- Treat workspace updates as no-ops while Dune integration is disabled, matching the other disabled Dune operations and keeping the workspace update regression's stderr clean.
- Record the generated workspace source without a trailing newline, matching Dune's `echo` action.
