### PR TITLE
fix(semantic-tokens): require full request support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   (#1851, @rgrinberg)
 - Advertise semantic-token support only to clients that support the relative
   token format. (#1853, @rgrinberg)
+- Advertise semantic-token support only to clients that support full-document
+  requests. (#1856, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -129,17 +129,26 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       ExecuteCommandOptions.create ~commands ()
     in
     let semanticTokensProvider =
-      match client_capabilities.textDocument with
-      | Some { semanticTokens = Some { formats; _ }; _ }
-        when List.mem formats Lsp.Types.TokenFormat.Relative ~equal:Poly.equal ->
-        let full =
-          `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
-        in
-        Some
-          (`SemanticTokensOptions
-              (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ()))
-      | None | Some { semanticTokens = None; _ } | Some { semanticTokens = Some _; _ } ->
-        None
+      let open Option.O in
+      let* text_document = client_capabilities.textDocument in
+      let* semantic_tokens = text_document.semanticTokens in
+      match
+        List.mem semantic_tokens.formats Lsp.Types.TokenFormat.Relative ~equal:Poly.equal
+      with
+      | false -> None
+      | true ->
+        (match semantic_tokens.requests.full with
+         | None | Some (`Bool false) -> None
+         | Some (`Bool true) | Some (`ClientSemanticTokensRequestFullDelta _) ->
+           let full =
+             `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
+           in
+           Some
+             (`SemanticTokensOptions
+                 (SemanticTokensOptions.create
+                    ~legend:Semantic_highlighting.legend
+                    ~full
+                    ())))
     in
     let positionEncoding =
       let open Option.O in

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -82,38 +82,10 @@ let%expect_test "does not advertise unsupported full semantic token requests" =
     {|
     omitted full support:
     semanticTokensProvider:
-    {
-      "full": { "delta": true },
-      "legend": {
-        "tokenModifiers": [
-          "declaration", "definition", "readonly", "static", "deprecated",
-          "abstract", "async", "modification", "documentation", "defaultLibrary"
-        ],
-        "tokenTypes": [
-          "namespace", "type", "class", "enum", "interface", "struct",
-          "typeParameter", "parameter", "variable", "property", "enumMember",
-          "event", "function", "method", "macro", "keyword", "modifier",
-          "comment", "string", "number", "regexp", "operator", "decorator"
-        ]
-      }
-    }
+    null
     full = false:
     semanticTokensProvider:
-    {
-      "full": { "delta": true },
-      "legend": {
-        "tokenModifiers": [
-          "declaration", "definition", "readonly", "static", "deprecated",
-          "abstract", "async", "modification", "documentation", "defaultLibrary"
-        ],
-        "tokenTypes": [
-          "namespace", "type", "class", "enum", "interface", "struct",
-          "typeParameter", "parameter", "variable", "property", "enumMember",
-          "event", "function", "method", "macro", "keyword", "modifier",
-          "comment", "string", "number", "regexp", "operator", "decorator"
-        ]
-      }
-    }
+    null
     |}]
 ;;
 
@@ -342,7 +314,7 @@ let%expect_test "direct requests with unsupported client capabilities" =
     [ 0, 4, 1, 8, 0, 0, 4, 1, 19, 0 ]
     unsupported full requests:
     semanticTokensProvider.full:
-    { "delta": true }
+    null
     semantic token response data:
     [ 0, 4, 1, 8, 0, 0, 4, 1, 19, 0 ]
     |}]


### PR DESCRIPTION
Advertise the semantic-token provider only when the client supports `textDocument/semanticTokens/full` requests.

OCaml-LSP currently implements full-document semantic tokens, but not range requests. When `requests.full` is omitted or false, there is no request form supported by both sides. Direct requests retain their existing behavior.

Part of #1138.
