### PR TITLE
fix(semantic-tokens): respect delta request support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   token format. (#1853, @rgrinberg)
 - Advertise semantic-token support only to clients that support full-document
   requests. (#1856, @rgrinberg)
+- Advertise semantic-token delta support only to clients that request it.
+  (#1859, @rgrinberg)
 - Replace a lone polymorphic-variant backtick when applying completions.
   (#1823, fixes #1427, @rgrinberg)
 - Advertise all code-action kinds that the server may return. (#1803, @rgrinberg)

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -132,23 +132,24 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
       let open Option.O in
       let* text_document = client_capabilities.textDocument in
       let* semantic_tokens = text_document.semanticTokens in
-      match
+      let supports_relative =
         List.mem semantic_tokens.formats Lsp.Types.TokenFormat.Relative ~equal:Poly.equal
-      with
-      | false -> None
-      | true ->
-        (match semantic_tokens.requests.full with
-         | None | Some (`Bool false) -> None
-         | Some (`Bool true) | Some (`ClientSemanticTokensRequestFullDelta _) ->
-           let full =
-             `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ())
-           in
-           Some
-             (`SemanticTokensOptions
-                 (SemanticTokensOptions.create
-                    ~legend:Semantic_highlighting.legend
-                    ~full
-                    ())))
+      in
+      let* full_request = semantic_tokens.requests.full in
+      let* full =
+        match supports_relative, full_request with
+        | false, _ | true, `Bool false -> None
+        | true, `Bool true -> Some (`Bool true)
+        | true, `ClientSemanticTokensRequestFullDelta { delta } ->
+          Some
+            (match delta with
+             | None | Some false -> `Bool true
+             | Some true ->
+               `SemanticTokensFullDelta (SemanticTokensFullDelta.create ~delta:true ()))
+      in
+      Some
+        (`SemanticTokensOptions
+            (SemanticTokensOptions.create ~legend:Semantic_highlighting.legend ~full ()))
     in
     let positionEncoding =
       let open Option.O in

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -107,7 +107,7 @@ let%expect_test "does not advertise unsupported semantic token deltas" =
   [%expect
     {|
     semanticTokensProvider.full:
-    { "delta": true }
+    true
     |}]
 ;;
 
@@ -130,10 +130,10 @@ let%expect_test "advertises supported semantic token request variants" =
     {|
     full = true:
     semanticTokensProvider.full:
-    { "delta": true }
+    true
     full object without delta support:
     semanticTokensProvider.full:
-    { "delta": true }
+    true
     full object with delta support:
     semanticTokensProvider.full:
     { "delta": true }


### PR DESCRIPTION
Advertise semantic-token delta support only when the client sets `textDocument.semanticTokens.requests.full.delta` to `true`.

Clients that support full requests without deltas now receive `full: true`; clients that explicitly support deltas continue to receive `{ "delta": true }`. The capability negotiation is also flattened into a single match over the supported format and full-request variant.

Part of #1138.
