### PR TITLE
test(server): reproduce unsupported requests as internal errors

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -93,6 +93,7 @@
     phrase
     type_expression
     typed_holes
+    unsupported_requests
     locate
     locate_types
     type_search

--- a/ocaml-lsp-server/test/e2e-new/unsupported_requests.ml
+++ b/ocaml-lsp-server/test/e2e-new/unsupported_requests.ml
@@ -1,0 +1,28 @@
+open Test.Import
+
+let%expect_test "unsupported standard requests are reported as internal errors" =
+  (Test.run_initialized
+   @@ fun client ->
+   let textDocument =
+     TextDocumentIdentifier.create ~uri:(DocumentUri.of_path "unsupported.ml")
+   in
+   let position = Position.create ~line:0 ~character:0 in
+   let params = LinkedEditingRangeParams.create ~textDocument ~position () in
+   let* response =
+     Fiber.collect_errors (fun () -> Client.request client (LinkedEditingRange params))
+   in
+   let* () =
+     match response with
+     | Error
+         [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+       Jsonrpc.Response.Error.yojson_of_t error |> Test.print_result;
+       Fiber.return ()
+     | Error errors -> Fiber.reraise_all errors
+     | Ok _ -> failwith "unsupported request unexpectedly succeeded"
+   in
+   Test.shutdown_client client);
+  [%expect
+    {|
+    { "code": -32603, "message": "Request not supported yet!" }
+    |}]
+;;


### PR DESCRIPTION
Adds an end-to-end regression test showing that a known but unadvertised standard LSP request (`textDocument/linkedEditingRange`) is currently answered with JSON-RPC `InternalError` (`-32603`).

This is intentionally a test-only PR. A follow-up change will report unsupported methods as unavailable instead of making them look like server failures.
