### PR TITLE
fix(server): report unsupported requests as unavailable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ## Fixes
 
+- Report unsupported LSP request methods as unavailable instead of internal
+  server errors. (#1862, @rgrinberg)
 - Advertise semantic-token support only to clients that declare the capability.
   (#1851, @rgrinberg)
 - Advertise semantic-token support only to clients that support the relative

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -11,7 +11,7 @@ let make_error = Jsonrpc.Response.Error.make
 
 let not_supported () =
   Jsonrpc.Response.Error.raise
-    (make_error ~code:InternalError ~message:"Request not supported yet!" ())
+    (make_error ~code:MethodNotFound ~message:"Request not supported yet!" ())
 ;;
 
 let view_metrics_command_name = "ocamllsp/view-metrics"

--- a/ocaml-lsp-server/test/e2e-new/unsupported_requests.ml
+++ b/ocaml-lsp-server/test/e2e-new/unsupported_requests.ml
@@ -1,6 +1,6 @@
 open Test.Import
 
-let%expect_test "unsupported standard requests are reported as internal errors" =
+let%expect_test "unsupported standard requests are reported as unavailable" =
   (Test.run_initialized
    @@ fun client ->
    let textDocument =
@@ -23,6 +23,6 @@ let%expect_test "unsupported standard requests are reported as internal errors" 
    Test.shutdown_client client);
   [%expect
     {|
-    { "code": -32603, "message": "Request not supported yet!" }
+    { "code": -32601, "message": "Request not supported yet!" }
     |}]
 ;;


### PR DESCRIPTION
Follows #1861 by returning JSON-RPC `MethodNotFound` for standard LSP methods that ocamllsp does not advertise or implement.

`MethodNotFound` describes a method that is unavailable, whereas `InternalError` incorrectly makes this expected capability mismatch look like a server failure.
