### PR TITLE
test(jsonrpc): cover packet JSON decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ bench: ##
 
 .PHONY: test-ocaml
 test-ocaml: ## Run the unit tests
-	dune build @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
+	dune build @jsonrpc/runtest @lsp/test/runtest @lsp-fiber/runtest @jsonrpc-fiber/runtest @ocaml-lsp-server/runtest
 
 .PHONY: promote
 promote:

--- a/jsonrpc/test/dune
+++ b/jsonrpc/test/dune
@@ -1,0 +1,11 @@
+(library
+ (name jsonrpc_tests)
+ (inline_tests)
+ (libraries
+  jsonrpc
+  yojson
+  ppx_expect.config
+  ppx_expect.config_types
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/jsonrpc/test/jsonrpc_tests.ml
+++ b/jsonrpc/test/jsonrpc_tests.ml
@@ -1,0 +1,46 @@
+let check_round_trip packet =
+  let json = Jsonrpc.Packet.yojson_of_t packet in
+  let reparsed = Jsonrpc.Packet.t_of_yojson json in
+  if packet <> reparsed
+  then
+    failwith
+      (Printf.sprintf
+         "packet did not round trip:\n%s"
+         (Yojson.Safe.pretty_to_string ~std:false json))
+;;
+
+let%expect_test "JSON-RPC packets round trip through JSON" =
+  let request id method_ =
+    Jsonrpc.Request.create
+      ~id
+      ~method_
+      ~params:(`Assoc [ "argument", `String "😀" ])
+      ()
+  in
+  let notification =
+    Jsonrpc.Notification.create
+      ~method_:"notify"
+      ~params:(`List [ `Int 1; `Bool true ])
+      ()
+  in
+  let response = Jsonrpc.Response.ok (`Int 1) (`Assoc [ "answer", `Int 42 ]) in
+  let error =
+    Jsonrpc.Response.Error.make
+      ~code:InvalidParams
+      ~message:"bad parameters"
+      ~data:(`List [ `String "details" ])
+      ()
+  in
+  [ Jsonrpc.Packet.Request (request (`Int 1) "request/int")
+  ; Request (request (`String "two") "request/string")
+  ; Notification notification
+  ; Response response
+  ; Response (Jsonrpc.Response.error (`String "error") error)
+  ; Batch_call
+      [ `Request (request (`Int 3) "batch/request"); `Notification notification ]
+  ; Batch_response
+      [ response; Jsonrpc.Response.error (`String "batch-error") error ]
+  ]
+  |> List.iter check_round_trip;
+  [%expect {| |}]
+;;

--- a/jsonrpc/test/jsonrpc_tests.ml
+++ b/jsonrpc/test/jsonrpc_tests.ml
@@ -9,6 +9,12 @@ let check_round_trip packet =
          (Yojson.Safe.pretty_to_string ~std:false json))
 ;;
 
+let check_rejected label json =
+  match Jsonrpc.Packet.t_of_yojson json with
+  | _ -> Printf.printf "%s: accepted\n" label
+  | exception Jsonrpc.Json.Of_json _ -> Printf.printf "%s: rejected\n" label
+;;
+
 let%expect_test "JSON-RPC packets round trip through JSON" =
   let request id method_ =
     Jsonrpc.Request.create
@@ -43,4 +49,32 @@ let%expect_test "JSON-RPC packets round trip through JSON" =
   ]
   |> List.iter check_round_trip;
   [%expect {| |}]
+;;
+
+let%expect_test "malformed JSON-RPC packets are rejected" =
+  let request =
+    `Assoc
+      [ "jsonrpc", `String "2.0"; "id", `Int 1; "method", `String "request" ]
+  in
+  let response =
+    `Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1; "result", `Null ]
+  in
+  check_rejected "empty batch" (`List []);
+  check_rejected "mixed batch" (`List [ request; response ]);
+  check_rejected
+    "invalid version"
+    (`Assoc [ "jsonrpc", `String "1.0"; "method", `String "notify" ]);
+  check_rejected
+    "scalar params"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "method", `String "notify"
+       ; "params", `String "not structured"
+       ]);
+  [%expect
+    {|
+    empty batch: rejected
+    mixed batch: rejected
+    invalid version: rejected
+    scalar params: rejected |}]
 ;;

--- a/jsonrpc/test/jsonrpc_tests.ml
+++ b/jsonrpc/test/jsonrpc_tests.ml
@@ -17,11 +17,7 @@ let check_rejected label json =
 
 let%expect_test "JSON-RPC packets round trip through JSON" =
   let request id method_ =
-    Jsonrpc.Request.create
-      ~id
-      ~method_
-      ~params:(`Assoc [ "argument", `String "😀" ])
-      ()
+    Jsonrpc.Request.create ~id ~method_ ~params:(`Assoc [ "argument", `String "😀" ]) ()
   in
   let notification =
     Jsonrpc.Notification.create
@@ -42,23 +38,36 @@ let%expect_test "JSON-RPC packets round trip through JSON" =
   ; Notification notification
   ; Response response
   ; Response (Jsonrpc.Response.error (`String "error") error)
-  ; Batch_call
-      [ `Request (request (`Int 3) "batch/request"); `Notification notification ]
-  ; Batch_response
-      [ response; Jsonrpc.Response.error (`String "batch-error") error ]
+  ; Batch_call [ `Request (request (`Int 3) "batch/request"); `Notification notification ]
+  ; Batch_response [ response; Jsonrpc.Response.error (`String "batch-error") error ]
   ]
   |> List.iter check_round_trip;
   [%expect {| |}]
 ;;
 
+let%expect_test "JSON-RPC response decoding accepts ambiguous results" =
+  check_rejected
+    "both result and error"
+    (`Assoc
+        [ "jsonrpc", `String "2.0"
+        ; "id", `Int 1
+        ; "result", `Null
+        ; "error", `Assoc [ "code", `Int (-32603); "message", `String "failed" ]
+        ]);
+  check_rejected
+    "neither result nor error"
+    (`Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1 ]);
+  [%expect
+    {|
+    both result and error: accepted
+    neither result nor error: rejected |}]
+;;
+
 let%expect_test "malformed JSON-RPC packets are rejected" =
   let request =
-    `Assoc
-      [ "jsonrpc", `String "2.0"; "id", `Int 1; "method", `String "request" ]
+    `Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1; "method", `String "request" ]
   in
-  let response =
-    `Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1; "result", `Null ]
-  in
+  let response = `Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1; "result", `Null ] in
   check_rejected "empty batch" (`List []);
   check_rejected "mixed batch" (`List [ request; response ]);
   check_rejected
@@ -67,10 +76,10 @@ let%expect_test "malformed JSON-RPC packets are rejected" =
   check_rejected
     "scalar params"
     (`Assoc
-       [ "jsonrpc", `String "2.0"
-       ; "method", `String "notify"
-       ; "params", `String "not structured"
-       ]);
+        [ "jsonrpc", `String "2.0"
+        ; "method", `String "notify"
+        ; "params", `String "not structured"
+        ]);
   [%expect
     {|
     empty batch: rejected


### PR DESCRIPTION
Adds direct JSON round-trip and malformed-packet coverage for JSON-RPC requests, notifications, responses, and batches.

The response cases also document that an object containing both `result` and `error` is currently accepted, while an object containing neither is rejected.
