### PR TITLE
fix(lsp): add text document content request bindings

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -102,6 +102,9 @@ type _ t =
   | TypeHierarchySupertypes :
       TypeHierarchySupertypesParams.t
       -> TypeHierarchyItem.t list option t
+  | WorkspaceTextDocumentContent :
+      TextDocumentContentParams.t
+      -> TextDocumentContentResult.t t
   | UnknownRequest :
       { meth : string
       ; params : Jsonrpc.Structured.t option
@@ -226,6 +229,7 @@ let yojson_of_result (type a) (req : a t) (result : a) =
     Json.Option.yojson_of_t (Json.To.list TypeHierarchyItem.yojson_of_t) result
   | TypeHierarchySupertypes _, result ->
     Json.Option.yojson_of_t (Json.To.list TypeHierarchyItem.yojson_of_t) result
+  | WorkspaceTextDocumentContent _, result -> TextDocumentContentResult.yojson_of_t result
   | UnknownRequest _, resp -> resp
 ;;
 
@@ -395,6 +399,9 @@ let of_jsonrpc (r : Jsonrpc.Request.t) =
   | "typeHierarchy/subtypes" ->
     let+ params = parse TypeHierarchySubtypesParams.t_of_yojson in
     E (TypeHierarchySubtypes params)
+  | "workspace/textDocumentContent" ->
+    let+ params = parse TextDocumentContentParams.t_of_yojson in
+    E (WorkspaceTextDocumentContent params)
   | meth -> Ok (E (UnknownRequest { meth; params = r.params }))
 ;;
 
@@ -455,6 +462,7 @@ let method_ (type a) (t : a t) =
   | WorkspaceSymbolResolve _ -> "workspaceSymbol/resolve"
   | TypeHierarchySupertypes _ -> "typeHierarchy/supertypes"
   | TypeHierarchySubtypes _ -> "typeHierarchy/subtypes"
+  | WorkspaceTextDocumentContent _ -> "workspace/textDocumentContent"
   | UnknownRequest { meth; _ } -> meth
 ;;
 
@@ -529,6 +537,8 @@ let params =
     | TypeHierarchySubtypes params -> ret (TypeHierarchySubtypesParams.yojson_of_t params)
     | TypeHierarchySupertypes params ->
       ret (TypeHierarchySupertypesParams.yojson_of_t params)
+    | WorkspaceTextDocumentContent params ->
+      ret (TextDocumentContentParams.yojson_of_t params)
     | UnknownRequest { params; _ } -> params
 ;;
 
@@ -642,6 +652,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
     option_of_yojson (Json.Of.list InlineValue.t_of_yojson) json
   | TextDocumentPrepareTypeHierarchy _ ->
     option_of_yojson (Json.Of.list TypeHierarchyItem.t_of_yojson) json
+  | WorkspaceTextDocumentContent _ -> TextDocumentContentResult.t_of_yojson json
   | UnknownRequest _ -> json
 ;;
 
@@ -702,5 +713,6 @@ let text_document (type a) (t : a t) f : TextDocumentIdentifier.t option =
   | WillCreateFiles _ -> None
   | WillDeleteFiles _ -> None
   | WillRenameFiles _ -> None
+  | WorkspaceTextDocumentContent _ -> None
   | UnknownRequest { meth; params } -> f ~meth ~params
 ;;

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -102,6 +102,9 @@ type _ t =
   | TypeHierarchySupertypes :
       TypeHierarchySupertypesParams.t
       -> TypeHierarchyItem.t list option t
+  | WorkspaceTextDocumentContent :
+      TextDocumentContentParams.t
+      -> TextDocumentContentResult.t t
   | UnknownRequest :
       { meth : string
       ; params : Jsonrpc.Structured.t option

--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -16,6 +16,7 @@ type _ t =
   | WorkspaceFoldingRangeRefresh : unit t
   | WorkspaceInlayHintRefresh : unit t
   | WorkspaceInlineValueRefresh : unit t
+  | WorkspaceTextDocumentContentRefresh : TextDocumentContentRefreshParams.t -> unit t
   | UnknownRequest : string * Jsonrpc.Structured.t option -> Json.t t
 
 type packed = E : 'r t -> packed
@@ -36,6 +37,7 @@ let method_ (type a) (t : a t) =
   | WorkspaceFoldingRangeRefresh -> "workspace/foldingRange/refresh"
   | WorkspaceInlayHintRefresh -> "workspace/inlayHint/refresh"
   | WorkspaceInlineValueRefresh -> "workspace/inlineValue/refresh"
+  | WorkspaceTextDocumentContentRefresh _ -> "workspace/textDocumentContent/refresh"
   | UnknownRequest (r, _) -> r
 ;;
 
@@ -58,6 +60,8 @@ let params =
     | WorkspaceInlayHintRefresh
     | WorkspaceInlineValueRefresh
     | WorkspaceDiagnosticRefresh -> None
+    | WorkspaceTextDocumentContentRefresh params ->
+      ret (TextDocumentContentRefreshParams.yojson_of_t params)
     | UnknownRequest (_, params) -> params
 ;;
 
@@ -99,6 +103,9 @@ let of_jsonrpc (r : Jsonrpc.Request.t) : (packed, string) Result.t =
   | "workspace/foldingRange/refresh" -> Ok (E WorkspaceFoldingRangeRefresh)
   | "workspace/inlayHint/refresh" -> Ok (E WorkspaceInlayHintRefresh)
   | "workspace/inlineValue/refresh" -> Ok (E WorkspaceInlineValueRefresh)
+  | "workspace/textDocumentContent/refresh" ->
+    let+ params = parse TextDocumentContentRefreshParams.t_of_yojson in
+    E (WorkspaceTextDocumentContentRefresh params)
   | m -> Ok (E (UnknownRequest (m, r.params)))
 ;;
 
@@ -118,6 +125,7 @@ let yojson_of_result (type a) (t : a t) (r : a) : Json.t =
   | WorkspaceFoldingRangeRefresh, _ -> `Null
   | WorkspaceInlayHintRefresh, _ -> `Null
   | WorkspaceInlineValueRefresh, _ -> `Null
+  | WorkspaceTextDocumentContentRefresh _, () -> `Null
   | UnknownRequest (_, _), json -> json
 ;;
 
@@ -138,5 +146,6 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   | WorkspaceFoldingRangeRefresh -> unit_of_yojson json
   | WorkspaceInlayHintRefresh -> unit_of_yojson json
   | WorkspaceInlineValueRefresh -> unit_of_yojson json
+  | WorkspaceTextDocumentContentRefresh _ -> unit_of_yojson json
   | UnknownRequest (_, _) -> json
 ;;

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -16,6 +16,7 @@ type _ t =
   | WorkspaceFoldingRangeRefresh : unit t
   | WorkspaceInlayHintRefresh : unit t
   | WorkspaceInlineValueRefresh : unit t
+  | WorkspaceTextDocumentContentRefresh : TextDocumentContentRefreshParams.t -> unit t
   | UnknownRequest : string * Jsonrpc.Structured.t option -> Json.t t
 
 type packed = E : 'r t -> packed

--- a/lsp/test/request_tests.ml
+++ b/lsp/test/request_tests.ml
@@ -1,0 +1,78 @@
+open Lsp
+open Types
+
+let print_json json = Yojson.Safe.pretty_to_string json |> Stdlib.print_endline
+
+let request_payload method_ params =
+  let fields = [ "method", `String method_ ] in
+  let fields =
+    match params with
+    | None -> fields
+    | Some params -> fields @ [ "params", (params :> Yojson.Safe.t) ]
+  in
+  `Assoc fields
+;;
+
+let content_uri = DocumentUri.of_string "ocaml-source://example"
+
+let%expect_test "workspace text document content request round trip" =
+  let request =
+    Client_request.WorkspaceTextDocumentContent
+      (TextDocumentContentParams.create ~uri:content_uri)
+  in
+  let jsonrpc = Client_request.to_jsonrpc_request request ~id:(`Int 1) in
+  print_json (request_payload jsonrpc.method_ jsonrpc.params);
+  (match Client_request.of_jsonrpc jsonrpc with
+   | Ok
+       (Client_request.E
+          (Client_request.WorkspaceTextDocumentContent params as parsed_request)) ->
+     Stdlib.Printf.printf "parsed typed request: %s\n" (DocumentUri.to_string params.uri);
+     let result = TextDocumentContentResult.create ~text:"let x = 1\n" in
+     let json = Client_request.yojson_of_result parsed_request result in
+     print_json json;
+     let decoded = Client_request.response_of_json parsed_request json in
+     Stdlib.Printf.printf "decoded result: %S\n" decoded.text
+   | Ok _ -> Stdlib.print_endline "parsed as the wrong request"
+   | Error message -> Stdlib.Printf.printf "parse error: %s\n" message);
+  [%expect
+    {|
+    {
+      "method": "workspace/textDocumentContent",
+      "params": { "uri": "ocaml-source://example" }
+    }
+    parsed typed request: ocaml-source://example
+    { "text": "let x = 1\n" }
+    decoded result: "let x = 1\n"
+    |}]
+;;
+
+let%expect_test "workspace text document content refresh request round trip" =
+  let request =
+    Server_request.WorkspaceTextDocumentContentRefresh
+      (TextDocumentContentRefreshParams.create ~uri:content_uri)
+  in
+  let jsonrpc = Server_request.to_jsonrpc_request request ~id:(`Int 1) in
+  print_json (request_payload jsonrpc.method_ jsonrpc.params);
+  (match Server_request.of_jsonrpc jsonrpc with
+   | Ok
+       (Server_request.E
+          (Server_request.WorkspaceTextDocumentContentRefresh params as parsed_request))
+     ->
+     Stdlib.Printf.printf "parsed typed request: %s\n" (DocumentUri.to_string params.uri);
+     let json = Server_request.yojson_of_result parsed_request () in
+     print_json json;
+     let () = Server_request.response_of_json parsed_request json in
+     Stdlib.print_endline "decoded result"
+   | Ok _ -> Stdlib.print_endline "parsed as the wrong request"
+   | Error message -> Stdlib.Printf.printf "parse error: %s\n" message);
+  [%expect
+    {|
+    {
+      "method": "workspace/textDocumentContent/refresh",
+      "params": { "uri": "ocaml-source://example" }
+    }
+    parsed typed request: ocaml-source://example
+    null
+    decoded result
+    |}]
+;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -788,6 +788,7 @@ let on_request
   | TextDocumentPrepareTypeHierarchy _ -> not_supported ()
   | TypeHierarchySupertypes _ -> not_supported ()
   | TypeHierarchySubtypes _ -> not_supported ()
+  | WorkspaceTextDocumentContent _ -> not_supported ()
 ;;
 
 let on_notification server (notification : Client_notification.t) : State.t Fiber.t =


### PR DESCRIPTION
Adds the missing LSP 3.18 typed request bindings for `workspace/textDocumentContent` and `workspace/textDocumentContent/refresh`. The server continues to leave virtual document content unadvertised and explicitly reports an unsolicited inbound request as unavailable.

The request tests cover method and parameter serialization, typed parser dispatch, and result encoding/decoding.
