### PR TITLE
fix(jsonrpc): reject ambiguous response objects

### DIFF
--- a/jsonrpc/src/jsonrpc.ml
+++ b/jsonrpc/src/jsonrpc.ml
@@ -248,11 +248,14 @@ module Response = struct
       if jsonrpc <> Constant.jsonrpcv
       then Json.error "Invalid response" json
       else (
-        match Json.field fields Constant.result (fun x -> x) with
-        | Some res -> { id; result = Ok res }
-        | None ->
-          let result = Error (Json.field_exn fields Constant.error Error.t_of_yojson) in
-          { id; result })
+        match
+          ( Json.field fields Constant.result (fun x -> x)
+          , Json.field fields Constant.error Error.t_of_yojson )
+        with
+        | Some result, None -> { id; result = Ok result }
+        | None, Some error -> { id; result = Error error }
+        | Some _, Some _ -> Json.error "response contains both result and error" json
+        | None, None -> Json.error "response contains neither result nor error" json)
     | _ -> Json.error "Jsonrpc.Result.t" json
   ;;
 
@@ -293,15 +296,7 @@ module Packet = struct
        | Some method_ ->
          let params = Json.field fields Constant.params Structured.t_of_yojson in
          Request { Request.method_; params; id }
-       | None ->
-         Response
-           (match Json.field fields Constant.result (fun x -> x) with
-            | Some result -> { Response.id; result = Ok result }
-            | None ->
-              let error =
-                Json.field_exn fields Constant.error Response.Error.t_of_yojson
-              in
-              { id; result = Error error }))
+       | None -> Response (Response.t_of_yojson (`Assoc fields)))
   ;;
 
   let t_of_yojson_single json =

--- a/jsonrpc/test/jsonrpc_tests.ml
+++ b/jsonrpc/test/jsonrpc_tests.ml
@@ -45,7 +45,7 @@ let%expect_test "JSON-RPC packets round trip through JSON" =
   [%expect {| |}]
 ;;
 
-let%expect_test "JSON-RPC response decoding accepts ambiguous results" =
+let%expect_test "JSON-RPC response decoding rejects ambiguous results" =
   check_rejected
     "both result and error"
     (`Assoc
@@ -59,7 +59,7 @@ let%expect_test "JSON-RPC response decoding accepts ambiguous results" =
     (`Assoc [ "jsonrpc", `String "2.0"; "id", `Int 1 ]);
   [%expect
     {|
-    both result and error: accepted
+    both result and error: rejected
     neither result nor error: rejected |}]
 ;;
 


### PR DESCRIPTION
Rejects JSON-RPC response objects unless they contain exactly one of `result` or `error`.

This makes packet decoding consistently enforce the response shape covered by #1863 instead of silently preferring `result` when both fields are present.
