### PR TITLE
ci: restore fast Nix test job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix develop .#check --command make nix-tests
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -35,36 +35,17 @@
       }
     },
     "nixpkgs": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
       "locked": {
-        "lastModified": 1784403945,
-        "narHash": "sha256-nTnhhfufoVvghzPM+R9Y/QPA34XFFkT3hcyErzqBMyY=",
-        "owner": "nix-ocaml",
-        "repo": "nix-overlays",
-        "rev": "1cb64a731dc1e715bd2eabdac0b8f1d2559bdb9d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-ocaml",
-        "repo": "nix-overlays",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1784376972,
-        "narHash": "sha256-RV+5/2MexV9xfNcm9rhYr5FE250sHPnH1coGz/pKTqM=",
+        "lastModified": 1784983812,
+        "narHash": "sha256-u6pjLiCCqRC4mXg38G0uDyxnKlsr5wY7lUhtvzNQ3lQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d704def0fc91d80d2ffcf23ae4b08cb055308f0",
+        "rev": "897981fe692a325b05017b1d4f4ad95691b20dfe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d704def0fc91d80d2ffcf23ae4b08cb055308f0",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nix-ocaml/nix-overlays";
+    nixpkgs.url = "github:NixOS/nixpkgs";
     merlin = {
       url = "github:ocaml/merlin";
       flake = false;
@@ -47,8 +47,6 @@
             merlin-lib = osuper.merlin-lib.overrideAttrs (o: { src = merlin; });
           });
       };
-      ocamlVersionOverlay =
-        (ocaml: self: super: { ocamlPackages = super.ocaml-ng.${ocaml}; });
       makeLocalPackages = pkgs:
         let buildDunePackage = pkgs.ocamlPackages.buildDunePackage;
         in rec {
@@ -133,10 +131,32 @@
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgsWithoutOverlays = (import nixpkgs { inherit system; });
+        # The project uses Dune language 3.24, which is newer than the Dune in
+        # the current Nixpkgs snapshot.
+        duneLatest = pkgsWithoutOverlays.dune_3.overrideAttrs (_: {
+          version = "3.24.1";
+          src = pkgsWithoutOverlays.fetchurl {
+            url = "https://github.com/ocaml/dune/releases/download/3.24.1/dune-3.24.1.tbz";
+            hash = "sha256-Co6qYt/LlFgCvK+abyAmylIoMz7jkaG97dPnCj8m6iw=";
+          };
+        });
+        ocamlVersionOverlay = ocaml: _final: prev: {
+          ocamlPackages = prev.ocaml-ng.${ocaml}.overrideScope (_: _: {
+            dune = duneLatest;
+            dune_3 = duneLatest;
+          });
+        };
         makeNixpkgs = ocaml: merlin:
-          pkgsWithoutOverlays.appendOverlays [ (ocamlVersionOverlay ocaml) (overlay merlin) ];
+          pkgsWithoutOverlays.appendOverlays [
+            (ocamlVersionOverlay ocaml)
+            (overlay merlin)
+          ];
         pkgs = makeNixpkgs "ocamlPackages_5_5" inputs.merlin;
         localPackages = makeLocalPackages pkgs;
+        checkPkgs = pkgsWithoutOverlays.appendOverlays [
+          (ocamlVersionOverlay "ocamlPackages_5_5")
+        ];
+        checkPackages = makeLocalPackages checkPkgs;
         devShell = localPackages: nixpkgs:
           nixpkgs.mkShell {
             buildInputs = [ nixpkgs.ocamlPackages.utop ];
@@ -162,12 +182,23 @@
               # present
               pkgsWithoutOverlays.ocaml
               (ocamlformat pkgsWithoutOverlays)
-              pkgsWithoutOverlays.ocamlPackages.dune
+              duneLatest
             ];
           };
 
-          check = pkgs.mkShell {
-            inputsFrom = builtins.attrValues localPackages;
+          check = checkPkgs.mkShell {
+            inputsFrom = builtins.attrValues checkPackages;
+            buildInputs = with checkPkgs.ocamlPackages; [
+              dune_3
+              base_quickcheck
+              ppx_expect
+              ppx_sexp_conv
+              (ocamlformat checkPkgs)
+            ];
+            # Keep Dune RPC Unix socket paths below the platform limit.
+            shellHook = ''
+              export TMPDIR=/tmp
+            '';
           };
         };
       }));


### PR DESCRIPTION
Restore the fast Nix-based test job for pull requests and pushes to `master`.

The flake now uses Nixpkgs directly instead of `nix-ocaml`, selecting stock OCaml 5.5 without Flambda. It packages the upstream Dune 3.24.1 release required by the project and uses matching Dune libraries throughout the OCaml package scope. The check shell also includes the Quickcheck, PPX, and `ocamlformat-rpc` dependencies required by the tests, and keeps temporary paths short enough for Dune RPC Unix sockets.

The workflow uses `actions/checkout@v7` and `cachix/install-nix-action@v31`.

Validated locally with `make nix-tests`, `make nix-fmt`, `nix flake check --no-build`, and `actionlint`.
