### PR TITLE
fix(diagnostics): reset Merlin load paths after Dune builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)
+- Prevent stale missing-module diagnostics after Dune restores build artifacts.
+  (#1872, fixes #1209, @rgrinberg)
 - Advertise semantic-token support only to clients that declare the capability.
   (#1851, @rgrinberg)
 - Advertise semantic-token support only to clients that support the relative

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -364,7 +364,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
     ()
 ;;
 
-let merlin_diagnostics diagnostics merlin =
+let merlin_diagnostics ?(refresh_load_path = false) diagnostics merlin =
   let doc = Document.Merlin.to_doc merlin in
   let uri = Document.uri doc in
   let create_diagnostic = Diagnostic.create ~source:ocamllsp_source in
@@ -374,6 +374,9 @@ let merlin_diagnostics diagnostics merlin =
       Query_protocol.Errors { lexing = true; parsing = true; typing = true }
     in
     Document.Merlin.with_pipeline_exn ~name:"diagnostics" merlin (fun pipeline ->
+      (* Work around ocaml/merlin#2109. A different Merlin state can refresh
+         the shared directory cache and mask this state's stale load path. *)
+      if refresh_load_path then Ocaml_utils.Load_path.reset ();
       match Query_commands.dispatch pipeline command with
       | exception Merlin_extend.Extend_main.Handshake.Error error ->
         let message =

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -36,7 +36,7 @@ val tags_of_message
   -> string
   -> DiagnosticTag.t list option
 
-val merlin_diagnostics : t -> Document.Merlin.t -> unit Fiber.t
+val merlin_diagnostics : ?refresh_load_path:bool -> t -> Document.Merlin.t -> unit Fiber.t
 val set_report_dune_diagnostics : t -> report_dune_diagnostics:bool -> unit Fiber.t
 val set_shorten_merlin_diagnostics : t -> shorten_merlin_diagnostics:bool -> unit Fiber.t
 

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -284,12 +284,16 @@ end = struct
               (fun () ->
                  match p with
                  | Failed | Interrupted | Success ->
+                   let refresh_load_path = Poly.equal p Success in
                    let* () =
                      Document_store.parallel_iter document_store ~f:(fun doc ->
                        match Document.kind doc with
                        | `Other -> Fiber.return ()
                        | `Merlin merlin ->
-                         Diagnostics.merlin_diagnostics diagnostics merlin)
+                         Diagnostics.merlin_diagnostics
+                           ~refresh_load_path
+                           diagnostics
+                           merlin)
                    in
                    Diagnostics.send diagnostics `All
                  | _ -> Fiber.return ())

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -373,8 +373,6 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
     {|
     Dune trace: Connected to Dune RPC
     Dune trace: Dune build finished (verbose details present)
-    Unbound module Bar
-    Unbound value x
     Dune trace: Merlin configuration process started
     Dune trace: Merlin configuration request completed
     Dune trace: Merlin configuration process stopped and exited


### PR DESCRIPTION
Dune watch builds can recreate a CMI after Merlin has cached it as missing. Because Merlin states have independent load-path snapshots but share a directory-content cache, one state can make another state's stale snapshot appear current.

After each successful Dune build, reset every open document's load path inside that document's active Merlin pipeline before recomputing diagnostics. Restricting the reset to successful builds avoids rebuilding load paths during ordinary edit diagnostics and failed builds.

The deterministic reproduction landed separately in #1854. This is a temporary workaround for the underlying Merlin cache-coherence problem covered by ocaml/merlin#2109. Fixes #1209.
