### PR TITLE
fix(lsp): reject negative content lengths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ## Fixes
 
+- Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)
 - Advertise semantic-token support only to clients that declare the capability.

--- a/lsp/src/io.ml
+++ b/lsp/src/io.ml
@@ -68,10 +68,10 @@ struct
              caseless_equal k content_length_lowercase
              && content_length = init_content_length
            then (
-             let content_length = int_of_string_opt (String.trim v) in
-             match content_length with
-             | None -> Io.raise (Error "Content-Length is invalid")
-             | Some content_length -> loop chan content_length content_type)
+             match int_of_string_opt (String.trim v) with
+             | Some content_length when content_length >= 0 ->
+               loop chan content_length content_type
+             | None | Some _ -> Io.raise (Error "Content-Length is invalid"))
            else if caseless_equal k content_type_lowercase && content_type = None
            then (
              let content_type = String.trim v in

--- a/lsp/test/io_tests.ml
+++ b/lsp/test/io_tests.ml
@@ -118,7 +118,7 @@ let%expect_test "LSP framing rejects invalid lengths and truncated bodies" =
     {|
     missing: content length absent
     nonnumeric: Content-Length is invalid
-    negative: content length absent
+    negative: Content-Length is invalid
     negative body reads: []
     truncated: unable to read json |}]
 ;;


### PR DESCRIPTION
Rejects negative `Content-Length` headers as invalid instead of treating `-1` as the sentinel for a missing header.

This prevents invalid lengths from being misclassified and updates the regression coverage added in #1864.
