### PR TITLE
fix(jsonrpc-fiber): harden pending request lifecycle

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -322,6 +322,20 @@ struct
     | None -> Id.Table.add t.pending ~key:id ~data:ivar
   ;;
 
+  let unregister_request_ivar t id ivar =
+    (* Receiving a response or cancelling a request can remove its entry before
+       the request fiber's finalizer runs. The ID is no longer pending, so another
+       request may reuse it in between. Only remove the entry if it still belongs
+       to this request; otherwise the old finalizer would unregister the newer
+       request.
+
+       TODO: Give pending registrations explicit ownership tokens so this check
+       does not rely on physical equality. *)
+    match Id.Table.find_opt t.pending id with
+    | Some registered when registered == ivar -> Id.Table.remove t.pending id
+    | Some _ | None -> ()
+  ;;
+
   let read_request_ivar req ivar =
     let+ res = Fiber.Ivar.read ivar in
     match res with
@@ -333,27 +347,50 @@ struct
   let request t (req : Request.t) =
     Fiber.of_thunk (fun () ->
       check_running t;
-      let* () = Chan.send t.chan [ Request req ] in
       let ivar = Fiber.Ivar.create () in
-      register_request_ivar t req.id ivar;
-      read_request_ivar req ivar)
+      Fiber.finalize
+        (fun () ->
+           register_request_ivar t req.id ivar;
+           let* () = Chan.send t.chan [ Request req ] in
+           read_request_ivar req ivar)
+        ~finally:(fun () ->
+          unregister_request_ivar t req.id ivar;
+          Fiber.return ()))
   ;;
 
   let request_with_cancel t (req : Request.t) =
     let ivar = Fiber.Ivar.create () in
-    let cancel = Fiber.Ivar.fill ivar (Error `Cancelled) in
+    let cancel =
+      Fiber.of_thunk (fun () ->
+        let* result = Fiber.Ivar.peek ivar in
+        match result with
+        | Some _ -> Fiber.return ()
+        | None ->
+          unregister_request_ivar t req.id ivar;
+          Fiber.Ivar.fill ivar (Error `Cancelled))
+    in
+    let result () =
+      register_request_ivar t req.id ivar;
+      let* () = Chan.send t.chan [ Request req ] in
+      let+ res = Fiber.Ivar.read ivar in
+      match res with
+      | Ok s -> `Ok s
+      | Error `Cancelled -> `Cancelled
+      | Error `Stopped -> raise (Stopped req)
+    in
     let resp =
       Fiber.of_thunk (fun () ->
         check_running t;
-        let* () =
-          let+ () = Chan.send t.chan [ Request req ] in
-          register_request_ivar t req.id ivar
-        in
-        let+ res = Fiber.Ivar.read ivar in
-        match res with
-        | Ok s -> `Ok s
-        | Error `Cancelled -> `Cancelled
-        | Error `Stopped -> raise (Stopped req))
+        let* cancelled = Fiber.Ivar.peek ivar in
+        match cancelled with
+        | Some (Error `Cancelled) -> Fiber.return `Cancelled
+        | Some (Ok _ | Error `Stopped) -> assert false
+        | None ->
+          Fiber.finalize
+            (fun () -> result ())
+            ~finally:(fun () ->
+              unregister_request_ivar t req.id ivar;
+              Fiber.return ()))
     in
     cancel, resp
   ;;

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -591,7 +591,7 @@ let%expect_test "test from jsonrpc_test.ml" =
     { "id": "testing", "jsonrpc": "2.0", "result": 2 } |}]
 ;;
 
-let%expect_test "a response received before send returns races with cancellation" =
+let%expect_test "a response received before send returns is not dropped" =
   let response_read = Fiber.Ivar.create () in
   let send_returned = Fiber.Ivar.create () in
   let client_input, server_output = pipe () in
@@ -650,8 +650,10 @@ let%expect_test "a response received before send returns races with cancellation
       ]
   in
   Fiber_test.test Dyn.opaque run;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| (Failure Fiber.Ivar.fill) |}]
+  [%expect
+    {|
+    response: immediate
+    <opaque> |}]
 ;;
 
 let%expect_test "request IDs may be retried after send errors" =
@@ -689,7 +691,7 @@ let%expect_test "request IDs may be retried after send errors" =
     <opaque> |}]
 ;;
 
-let%expect_test "duplicate request IDs are sent before rejection" =
+let%expect_test "duplicate request IDs are rejected before sending" =
   let first_sent = Fiber.Ivar.create () in
   let sent = ref [] in
   let incoming, incoming_writer = pipe () in
@@ -736,10 +738,7 @@ let%expect_test "duplicate request IDs are sent before rejection" =
     first: rejected
     duplicate: rejected
     wire packets:
-    [
-      { "id": 1, "method": "duplicate", "jsonrpc": "2.0" },
-      { "id": 1, "method": "duplicate", "jsonrpc": "2.0" }
-    ]
+    [ { "id": 1, "method": "duplicate", "jsonrpc": "2.0" } ]
     <opaque> |}]
 ;;
 
@@ -966,17 +965,17 @@ let%expect_test "cancellation and response ordering follows the request model" =
   in
   run_order ~label:"response first" ~respond_first:true;
   run_order ~label:"cancellation first" ~respond_first:false;
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (Failure Fiber.Ivar.fill)
-  Trailing output
-  ---------------
-  events: response -> cancellation
-  |}]
+  [%expect
+    {|
+    events: response -> cancellation
+    response first outcome: server response
+    <opaque>
+    events: cancellation -> response
+    cancellation first outcome: cancelled
+    <opaque> |}]
 ;;
 
-let%expect_test "cancelling before a request starts still sends it" =
+let%expect_test "cancelling before a request starts does not send it" =
   let incoming, incoming_writer = pipe () in
   let sent = ref [] in
   let session = Jrpc.create ~name:"client" (incoming, of_ref sent) () in
@@ -999,7 +998,7 @@ let%expect_test "cancelling before a request starts still sends it" =
     {|
     cancelled
     wire packets:
-    [ { "id": 1, "method": "cancel", "jsonrpc": "2.0" } ]
+    []
     <opaque> |}]
 ;;
 
@@ -1047,24 +1046,17 @@ let%expect_test "late responses can reach a reused cancelled request ID" =
   in
   Fiber_test.test Dyn.opaque (fun () ->
     Fiber.fork_and_join_unit (fun () -> Jrpc.run session) operations);
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  ("(\"duplicate request id\", {})")
-  Trailing output
-  ---------------
-  wire request: cancelled
-  cancelled request outcome: cancelled
-  /-----------------------------------------------------------------------
-  | Internal error: Uncaught exception.
-  | ("duplicate request id", {})
-  \-----------------------------------------------------------------------
-
-  wire request: replacement
-  |}]
+  [%expect
+    {|
+    wire request: cancelled
+    cancelled request outcome: cancelled
+    wire request: replacement
+    wire response: late response for cancelled request
+    replacement outcome: late response for cancelled request
+    <opaque> |}]
 ;;
 
-let%expect_test "cancelled request IDs remain registered" =
+let%expect_test "cancelled request IDs can be reused" =
   let request_sent = Fiber.Mvar.create () in
   let incoming, incoming_writer = pipe () in
   let output : Jsonrpc.Packet.t Out.t =
@@ -1103,7 +1095,7 @@ let%expect_test "cancelled request IDs remain registered" =
   [%expect
     {|
     first: cancelled
-    second: duplicate ID retained
+    second: cancelled
     <opaque> |}]
 ;;
 


### PR DESCRIPTION
Registers pending requests before sending them so immediate responses cannot be dropped, and reliably unregisters request IDs after completion, cancellation, or send failure.

Pre-start cancellation now avoids sending the request, duplicate IDs are rejected before reaching the wire, and late cancellation no longer attempts to overwrite a completed response. This updates the regression cases added in #1865.
