### PR TITLE
fix(server): defer dynamic registration until initialized

### DIFF
--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -236,6 +236,33 @@ let set_diagnostics detached diagnostics doc =
          Diagnostics.send diagnostics (`One uri)))
 ;;
 
+let register_dune_and_cram_text_document_sync server (capabilities : ClientCapabilities.t)
+  =
+  match capabilities.textDocument with
+  | Some
+      { TextDocumentClientCapabilities.synchronization =
+          Some { TextDocumentSyncClientCapabilities.dynamicRegistration = Some true; _ }
+      ; _
+      } ->
+    let documentSelector =
+      [ "cram"; "dune"; "dune-project"; "dune-workspace" ]
+      |> List.map ~f:(fun language ->
+        `TextDocumentFilter (TextDocumentFilter.create ~language ()))
+    in
+    let registerOptions =
+      TextDocumentRegistrationOptions.create ~documentSelector ()
+      |> TextDocumentRegistrationOptions.yojson_of_t
+    in
+    let make method_ =
+      let id = "ocamllsp-cram-dune-files/" ^ method_ in
+      Registration.create ~id ~method_ ~registerOptions ()
+    in
+    let registrations = [ make "textDocument/didOpen"; make "textDocument/didClose" ] in
+    let params = RegistrationParams.create ~registrations in
+    Server.request server (Server_request.ClientRegisterCapability params)
+  | _ -> Fiber.return ()
+;;
+
 let on_initialize server (ip : InitializeParams.t) =
   let state : State.t = Server.state server in
   let workspaces = Workspaces.create ip in
@@ -298,38 +325,7 @@ let on_initialize server (ip : InitializeParams.t) =
     | None -> state
     | Some trace -> { state with trace }
   in
-  let resp =
-    match ip.capabilities.textDocument with
-    | Some
-        { TextDocumentClientCapabilities.synchronization =
-            Some { TextDocumentSyncClientCapabilities.dynamicRegistration = Some true; _ }
-        ; _
-        } ->
-      Reply.later (fun send ->
-        let* () = send initialize_info in
-        let register =
-          RegistrationParams.create
-            ~registrations:
-              (let make method_ =
-                 let id = "ocamllsp-cram-dune-files/" ^ method_ in
-                 (* TODO not nice to copy paste *)
-                 let registerOptions =
-                   let documentSelector =
-                     [ "cram"; "dune"; "dune-project"; "dune-workspace" ]
-                     |> List.map ~f:(fun language ->
-                       `TextDocumentFilter (TextDocumentFilter.create ~language ()))
-                   in
-                   TextDocumentRegistrationOptions.create ~documentSelector ()
-                   |> TextDocumentRegistrationOptions.yojson_of_t
-                 in
-                 Registration.create ~id ~method_ ~registerOptions ()
-               in
-               [ make "textDocument/didOpen"; make "textDocument/didClose" ])
-        in
-        Server.request server (Server_request.ClientRegisterCapability register))
-    | _ -> Reply.now initialize_info
-  in
-  resp, state
+  Reply.now initialize_info, state
 ;;
 
 module Formatter = struct
@@ -857,12 +853,17 @@ let on_notification server (notification : Client_notification.t) : State.t Fibe
     in
     Dune.update_workspaces (State.dune state) (State.workspaces state);
     Fiber.return state
+  | Initialized ->
+    let+ () =
+      task_if_running state.detached ~f:(fun () ->
+        register_dune_and_cram_text_document_sync server (State.client_capabilities state))
+    in
+    state
   | DidChangeWatchedFiles _
   | DidCreateFiles _
   | DidDeleteFiles _
   | DidRenameFiles _
   | WillSaveTextDocument _
-  | Initialized
   | WorkDoneProgressCancel _
   | WorkDoneProgress _
   | NotebookDocumentDidOpen _

--- a/ocaml-lsp-server/test/e2e-new/registration_order.ml
+++ b/ocaml-lsp-server/test/e2e-new/registration_order.ml
@@ -8,8 +8,9 @@ let capabilities =
   ClientCapabilities.create ~textDocument ()
 ;;
 
-let%expect_test "dynamic registration arrives before initialized" =
+let%expect_test "dynamic registration waits for initialized" =
   let registration_received = Fiber.Ivar.create () in
+  let sending_initialized = ref false in
   let on_request
         (type resp state)
         (client : state Client.t)
@@ -18,6 +19,8 @@ let%expect_test "dynamic registration arrives before initialized" =
     =
     match request with
     | ClientRegisterCapability params ->
+      if not !sending_initialized
+      then failwith "received client/registerCapability before sending initialized";
       let* () = Fiber.Ivar.fill registration_received params in
       Fiber.return (Lsp_fiber.Rpc.Reply.now (), Client.state client)
     | _ -> assert false
@@ -34,18 +37,20 @@ let%expect_test "dynamic registration arrives before initialized" =
    let reproduce () =
      let* (_ : InitializeResult.t) = Client.initialized client in
      print_endline "received initialize response";
-     let* registration = Fiber.Ivar.read registration_received in
-     print_endline "received client/registerCapability before sending initialized:";
-     RegistrationParams.yojson_of_t registration |> Test.print_result;
      print_endline "sending initialized";
+     sending_initialized := true;
      let* () = Client.notification client Initialized in
+     let* registration = Fiber.Ivar.read registration_received in
+     print_endline "received client/registerCapability after sending initialized:";
+     RegistrationParams.yojson_of_t registration |> Test.print_result;
      Test.shutdown_client client
    in
    Fiber.fork_and_join_unit run_client reproduce);
   [%expect
     {|
     received initialize response
-    received client/registerCapability before sending initialized:
+    sending initialized
+    received client/registerCapability after sending initialized:
     {
       "registrations": [
         {
@@ -74,6 +79,5 @@ let%expect_test "dynamic registration arrives before initialized" =
         }
       ]
     }
-    sending initialized
     |}]
 ;;


### PR DESCRIPTION
Follows the test-only reproduction in #1874 by moving the Dune and Cram text-document registrations to the `initialized` notification path.

The initialize request now returns normally without issuing a client request. After `initialized`, the server schedules the existing `didOpen`/`didClose` registrations on its detached task pool. The regression snapshot now records `initialized` being sent before the unchanged registration payload arrives.
