### PR TITLE
refactor(semantic-tokens): simplify token buffer allocation

### DIFF
--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -238,7 +238,7 @@ end = struct
   let yojson_of_t t = Json.Conv.yojson_of_list yojson_of_token (List.rev t.tokens)
 
   let encode (t : t) : int array =
-    let data = Array.init (t.count * 5) ~f:(fun (_ : int) -> 0) in
+    let data = Array.create ~len:(t.count * 5) 0 in
     let rec aux ix = function
       | [] -> ()
       | [ { start; length; token_type; token_modifiers } ] ->


### PR DESCRIPTION
Use `Array.create` instead of `Array.init` to allocate the zero-filled semantic-token result buffer.

This is extracted from #1860 so that the capability-negotiation change remains focused.
