### PR TITLE
test(e2e): remove document sync teardown delay

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/document_sync.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_sync.ml
@@ -56,7 +56,6 @@ let run_document_test f =
   Test.run_initialized ~handler
   @@ fun client ->
   let* () = f client in
-  let* () = Lev_fiber.Timer.sleepf 0.1 in
   Test.exit_client client
 ;;
 


### PR DESCRIPTION
Each document-sync test ends with a request that confirms earlier notifications have been processed. Remove the additional 100 ms sleep before graceful shutdown.

This cuts the partition from about 0.92s to 0.13s without changing coverage or test isolation.
