### PR TITLE
test(e2e): exit gracefully during teardown

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/helpers.ml
@@ -29,5 +29,5 @@ let test
     let* () = req client in
     let* () = Client.request client Shutdown in
     let* () = Fiber.Ivar.read diagnostics in
-    Client.stop client)
+    Client.notification client Exit)
 ;;

--- a/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/syntax_doc_tests.ml
@@ -35,7 +35,7 @@ let run_test text req =
         (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
     in
     let* () = req client in
-    Test.shutdown_client client)
+    Test.exit_client client)
 ;;
 
 let%expect_test "syntax doc should display" =


### PR DESCRIPTION
Send the protocol `Exit` notification after `Shutdown` instead of closing the client transport in the common initialized-document helper and the syntax-documentation helper.

This avoids racing pending server diagnostics against a closed descriptor, which could intermittently produce `fd closed unflushed` failures during forced test runs.
