### PR TITLE
fix(completion): order synthetic completion items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Use constructor completion kinds when clients do not support enum members. (#1887, @rgrinberg)
 - Use completion deprecation tags when supported by the client. (#1903, @rgrinberg)
 - Keep completion sort keys lexically ordered beyond 9,999 items. (#1883, @rgrinberg)
+- Give synthetic completion items stable ordering metadata. (#1882, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -105,6 +105,13 @@ module For_tests = struct
   ;;
 end
 
+let reindex_sortText completion_items =
+  let width = sortText_width (List.length completion_items) in
+  List.mapi completion_items ~f:(fun idx (ci : CompletionItem.t) ->
+    let sortText = Some (sortText_of_index ~width idx) in
+    { ci with sortText })
+;;
+
 module Complete_by_prefix = struct
   let completionItem_of_completion_entry
         idx
@@ -258,6 +265,7 @@ module Complete_by_prefix = struct
         doc
         pos
         completion
+    |> reindex_sortText
   ;;
 end
 
@@ -405,12 +413,6 @@ let complete
                ~supports_enum_member
                ~resolve
            else (
-             let reindex_sortText completion_items =
-               let width = sortText_width (List.length completion_items) in
-               List.mapi completion_items ~f:(fun idx (ci : CompletionItem.t) ->
-                 let sortText = Some (sortText_of_index ~width idx) in
-                 { ci with sortText })
-             in
              let preselect_first =
                match
                  let open Option.O in

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -1362,6 +1362,7 @@ let%expect_test "does not complete `in` in a top-level binding" =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1386,6 +1387,7 @@ let%expect_test "does not complete `in` before an existing `in`" =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1411,6 +1413,7 @@ let foo param1 =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1423,7 +1426,7 @@ let foo param1 =
       "detail": "'a -> 'b",
       "kind": 12,
       "label": "param1",
-      "sortText": "0000",
+      "sortText": "0001",
       "textEdit": {
         "newText": "param1",
         "range": {
@@ -1436,7 +1439,7 @@ let foo param1 =
       "detail": "'a ref -> 'a",
       "kind": 12,
       "label": "!",
-      "sortText": "0001",
+      "sortText": "0002",
       "textEdit": {
         "newText": "!",
         "range": {
@@ -1464,6 +1467,7 @@ let foo param1 =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1476,7 +1480,7 @@ let foo param1 =
       "detail": "'a -> unit",
       "kind": 12,
       "label": "ignore",
-      "sortText": "0000",
+      "sortText": "0001",
       "textEdit": {
         "newText": "ignore",
         "range": {
@@ -1489,7 +1493,7 @@ let foo param1 =
       "detail": "in_channel -> int",
       "kind": 12,
       "label": "in_channel_length",
-      "sortText": "0001",
+      "sortText": "0002",
       "textEdit": {
         "newText": "in_channel_length",
         "range": {
@@ -1517,6 +1521,7 @@ let foo param1 =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1529,7 +1534,7 @@ let foo param1 =
       "detail": "in_channel -> int",
       "kind": 12,
       "label": "in_channel_length",
-      "sortText": "0000",
+      "sortText": "0001",
       "textEdit": {
         "newText": "in_channel_length",
         "range": {
@@ -1542,7 +1547,7 @@ let foo param1 =
       "detail": "int ref -> unit",
       "kind": 12,
       "label": "incr",
-      "sortText": "0001",
+      "sortText": "0002",
       "textEdit": {
         "newText": "incr",
         "range": {
@@ -1566,6 +1571,7 @@ let%expect_test "completion for object methods" =
     {
       "kind": 14,
       "label": "in",
+      "sortText": "0000",
       "textEdit": {
         "newText": "in",
         "range": {
@@ -1578,7 +1584,7 @@ let%expect_test "completion for object methods" =
       "detail": "'a",
       "kind": 2,
       "label": "a_method",
-      "sortText": "0000",
+      "sortText": "0001",
       "textEdit": {
         "newText": "a_method",
         "range": {


### PR DESCRIPTION
Synthetic completion items such as the `in` keyword did not participate in the final completion ordering. Reindex the combined completion list so every item receives stable, monotonic `sortText` metadata.
