### PR TITLE
fix(completion): preserve lexical sort order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 - Parse non-ASCII completion prefixes and whitespace in CRLF input. (#1886, @rgrinberg)
 - Use constructor completion kinds when clients do not support enum members. (#1887, @rgrinberg)
 - Use completion deprecation tags when supported by the client. (#1903, @rgrinberg)
+- Keep completion sort keys lexically ordered beyond 9,999 items. (#1883, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -93,10 +93,16 @@ let range_prefix (lsp_position : Position.t) prefix : Range.t =
   { Range.start; end_ = lsp_position }
 ;;
 
-let sortText_of_index idx = Printf.sprintf "%04d" idx
+let sortText_width item_count =
+  max 4 (String.length (Int.to_string (max 0 (item_count - 1))))
+;;
+
+let sortText_of_index ~width idx = Printf.sprintf "%0*d" width idx
 
 module For_tests = struct
-  let sortText_of_index = sortText_of_index
+  let sortText_of_index ~item_count idx =
+    sortText_of_index ~width:(sortText_width item_count) idx
+  ;;
 end
 
 module Complete_by_prefix = struct
@@ -108,6 +114,7 @@ module Complete_by_prefix = struct
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
+        ~sort_text_width
     =
     let kind = completion_kind ~supports_enum_member entry.kind in
     let deprecated, tags =
@@ -128,7 +135,7 @@ module Complete_by_prefix = struct
       ?tags
         (* Without this field the client is not forced to respect the order
            provided by merlin. *)
-      ~sortText:(sortText_of_index idx)
+      ~sortText:(sortText_of_index ~width:sort_text_width idx)
       ?data:compl_params
       ~textEdit
       ()
@@ -188,6 +195,7 @@ module Complete_by_prefix = struct
            CompletionParams.create ~textDocument ~position:pos ()
            |> CompletionParams.yojson_of_t)
     in
+    let sort_text_width = sortText_width (List.length completion_entries) in
     List.mapi
       completion_entries
       ~f:
@@ -196,7 +204,8 @@ module Complete_by_prefix = struct
            ~supports_deprecated_tag
            ~supports_enum_member
            ~range
-           ~compl_params)
+           ~compl_params
+           ~sort_text_width)
   ;;
 
   let complete_keywords completion_position prefix =
@@ -268,6 +277,7 @@ module Complete_with_construct = struct
     | None -> []
     | Some (loc, constructed_exprs) ->
       let range = Range.of_loc loc in
+      let sort_text_width = sortText_width (List.length constructed_exprs) in
       let deparen_constr_expr expr =
         if
           (not (String.equal expr "()"))
@@ -297,7 +307,7 @@ module Complete_with_construct = struct
           ~textEdit:(`TextEdit edit)
           ~filterText:("_" ^ expr)
           ~kind:CompletionItemKind.Text
-          ~sortText:(sortText_of_index idx)
+          ~sortText:(sortText_of_index ~width:sort_text_width idx)
           ?command
           ()
       in
@@ -396,8 +406,9 @@ let complete
                ~resolve
            else (
              let reindex_sortText completion_items =
+               let width = sortText_width (List.length completion_items) in
                List.mapi completion_items ~f:(fun idx (ci : CompletionItem.t) ->
-                 let sortText = Some (sortText_of_index idx) in
+                 let sortText = Some (sortText_of_index ~width idx) in
                  { ci with sortText })
              in
              let preselect_first =

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -46,5 +46,5 @@ val prefix_of_position : short_path:bool -> Msource.t -> [< Msource.position ] -
 val reconstruct_ident : Msource.t -> [< Msource.position ] -> string option
 
 module For_tests : sig
-  val sortText_of_index : int -> string
+  val sortText_of_index : item_count:int -> int -> string
 end

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -116,15 +116,17 @@ let%expect_test "let+$% thing" =
 ;;
 
 let%expect_test "completion sort text preserves order above 9999 items" =
+  let item_count = 10_002 in
   [ 9998; 9999; 10_000; 10_001 ]
-  |> List.map (fun index -> index, Testing.Compl.For_tests.sortText_of_index index)
+  |> List.map (fun index ->
+    index, Testing.Compl.For_tests.sortText_of_index ~item_count index)
   |> List.sort (fun (_, left) (_, right) -> String.compare left right)
   |> List.iter (fun (index, _) -> Printf.printf "%d\n" index);
   [%expect
     {|
-    10000
-    10001
     9998
     9999
+    10000
+    10001
     |}]
 ;;


### PR DESCRIPTION
Completion sort keys use four-digit zero padding, so lists above 10,000 items no longer preserve numeric order in clients that compare `sortText` strings lexically, including VS Code. Derive the padding width from the candidate count, retaining four-digit keys for ordinary lists and widening the whole list when needed.
