### PR TITLE
fix(completion): respect documentation format preference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Preserve URI paths whose first segment resembles a non-letter Windows drive. (#1800, @rgrinberg)
 - Preserve unescaped Unicode in URI query components. (#1799, @rgrinberg)
 - Preserve document offsets across incremental text edits. (#1777, @rgrinberg)
+- Respect the client's preferred completion documentation format. (#1885, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -319,10 +319,8 @@ include struct
       | None -> false
       | Some td ->
         (match field td with
-         | None -> false
-         | Some format ->
-           let set = Option.value format ~default:[ MarkupKind.Markdown ] in
-           List.mem set MarkupKind.Markdown ~equal:Poly.equal)
+         | Some (Some (MarkupKind.Markdown :: _)) -> true
+         | None | Some None | Some (Some _) -> false)
     ;;
   end
 

--- a/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
@@ -114,7 +114,7 @@ let%expect_test "completion resolve after its document changes" =
     Same item resolved after document update to version 1:
     {
       "detail": "int",
-      "documentation": { "kind": "markdown", "value": "new docs" },
+      "documentation": "new docs",
       "kind": 12,
       "label": "old_value",
       "sortText": "0000",
@@ -151,10 +151,7 @@ let%expect_test "completion documentation when no format is advertised" =
   [%expect
     {|
     {
-      "documentation": {
-        "kind": "markdown",
-        "value": "`map2 f [a1; ...; an] [b1; ...; bn]` is `[f a1 b1; ...; f an bn]`.\n\n***@raise*** `Invalid_argument`\nif the two lists are determined to have different lengths."
-      },
+      "documentation": "[map2 f [a1; ...; an] [b1; ...; bn]] is\n   [[f a1 b1; ...; f an bn]].\n   @raise Invalid_argument if the two lists are determined\n   to have different lengths.",
       "label": "map2"
     }
     |}]
@@ -187,10 +184,7 @@ let%expect_test "completion documentation respects the client's preferred format
   [%expect
     {|
     {
-      "documentation": {
-        "kind": "markdown",
-        "value": "`map2 f [a1; ...; an] [b1; ...; bn]` is `[f a1 b1; ...; f an bn]`.\n\n***@raise*** `Invalid_argument`\nif the two lists are determined to have different lengths."
-      },
+      "documentation": "[map2 f [a1; ...; an] [b1; ...; bn]] is\n   [[f a1 b1; ...; f an bn]].\n   @raise Invalid_argument if the two lists are determined\n   to have different lengths.",
       "label": "map2"
     }
     |}]


### PR DESCRIPTION
Completion resolve should honor the client's ordered documentation format preference. Return Markdown only when it is the first preferred format; otherwise return plain-text documentation.
