### PR TITLE
fix(completion): parse non-ASCII and CRLF prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Preserve unescaped Unicode in URI query components. (#1799, @rgrinberg)
 - Preserve document offsets across incremental text edits. (#1777, @rgrinberg)
 - Respect the client's preferred completion documentation format. (#1885, @rgrinberg)
+- Parse non-ASCII completion prefixes and whitespace in CRLF input. (#1886, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -41,7 +41,9 @@ let prefix_of_position ~short_path source position =
       |> Option.value ~default:""
       (* We remove the whitespace because merlin expects no whitespace and it's
          semantically meaningless *)
-      |> String.filter ~f:(fun x -> not (x = ' ' || x = '\n' || x = '\t'))
+      |> String.filter ~f:(function
+        | ' ' | '\n' | '\r' | '\t' | '\012' -> false
+        | _ -> true)
     in
     if short_path
     then (
@@ -63,7 +65,7 @@ let suffix_of_position source position =
       let from = index in
       let len =
         let ident_char = function
-          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '\'' | '_' -> true
+          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '\128' .. '\255' | '\'' | '_' -> true
           | _ -> false
         in
         let until =

--- a/ocaml-lsp-server/src/prefix_parser.ml
+++ b/ocaml-lsp-server/src/prefix_parser.ml
@@ -4,8 +4,14 @@ include struct
   open Re
 
   (* Regex based parser *)
-  let white_space = set "\n\t "
-  let name_char = Re.alt [ rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_'; char '\'' ]
+  let white_space = set "\n\r\t\012 "
+
+  (* OCaml identifiers may contain Latin-1 letters. At this point the regular
+     expression operates on their UTF-8 bytes; accepting non-ASCII bytes lets
+     Merlin perform the precise identifier validation. *)
+  let name_char =
+    Re.alt [ rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; rg '\128' '\255'; char '_'; char '\'' ]
+  ;;
 
   let name_with_dot =
     Re.seq [ name_char; white_space |> rep; char '.'; white_space |> rep ]

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -117,7 +117,7 @@ let%expect_test "completion replaces a Unicode prefix using UTF-16 positions" =
         "newText": "caféine",
         "range": {
           "end": { "character": 12, "line": 1 },
-          "start": { "character": 12, "line": 1 }
+          "start": { "character": 8, "line": 1 }
         }
       }
     }

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -82,12 +82,12 @@ let%expect_test "short path preserves a dotted operator" =
 
 let%expect_test "prefix may contain a Latin-1 identifier" =
   prefix_test "let caféine = 1\nlet _ = café" (`Logical (2, 13));
-  [%expect ""]
+  [%expect "caf\195\169"]
 ;;
 
 let%expect_test "carriage return in dot chain" =
   prefix_test "let _ = List.\r\n  ma" (`Logical (2, 4));
-  [%expect "ma"]
+  [%expect "List.ma"]
 ;;
 
 let%expect_test "Space in dot chain" =


### PR DESCRIPTION
Completion prefix parsing currently drops non-ASCII OCaml identifiers and fails to reconstruct dotted paths split by CRLF. Accept non-ASCII bytes for Merlin to validate and treat carriage returns and form feeds as whitespace, so completion prefixes and replacement ranges are reconstructed correctly.
