### PR TITLE
fix(completion): restrict in keyword suggestions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 - Keep completion sort keys lexically ordered beyond 9,999 items. (#1883, @rgrinberg)
 - Preserve dotted operators in completion prefixes and resolve requests. (#1890, @rgrinberg)
 - Respect the negotiated position encoding in completion requests and edit ranges. (#1889, @rgrinberg)
+- Only suggest the `in` keyword where it can complete a local binding. (#1888, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -293,9 +293,20 @@ module Complete_by_prefix = struct
            ~sort_text_width)
   ;;
 
-  let complete_keywords ~position_encoding completion_position prefix =
-    match prefix with
-    | "" | "i" | "in" ->
+  let can_complete_in position pipeline =
+    let typer = Mpipeline.typer_result pipeline in
+    let browse = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
+    let position = Mpipeline.get_lexing_pos pipeline position in
+    Mbrowse.deepest_before position [ browse ]
+    |> List.exists ~f:(function
+      | _, Browse_raw.Expression { exp_desc = Texp_let (_, _, body); _ } ->
+        body.exp_loc.loc_ghost
+      | _ -> false)
+  ;;
+
+  let complete_keywords ~position_encoding ~can_complete_in completion_position prefix =
+    match prefix, can_complete_in with
+    | ("" | "i" | "in"), true ->
       let ci_for_in =
         CompletionItem.create
           ~label:"in"
@@ -308,7 +319,7 @@ module Complete_by_prefix = struct
           ()
       in
       [ ci_for_in ]
-    | _ -> []
+    | _, _ -> []
   ;;
 
   let complete
@@ -322,17 +333,20 @@ module Complete_by_prefix = struct
         ~supports_enum_member
         ~resolve
     =
-    let+ (completion : Query_protocol.completions) =
-      Document.Merlin.with_pipeline_exn
-        ~name:"completion-prefix"
-        doc
-        (dispatch_cmd ~prefix position)
+    let+ (completion : Query_protocol.completions), can_complete_in =
+      Document.Merlin.with_pipeline_exn ~name:"completion-prefix" doc (fun pipeline ->
+        let can_complete_in =
+          match prefix with
+          | "" | "i" | "in" -> can_complete_in position pipeline
+          | _ -> false
+        in
+        dispatch_cmd ~prefix position pipeline, can_complete_in)
     in
     let keyword_completionItems =
       (* we complete only keyword 'in' for now *)
       match Document.Merlin.kind doc with
       | Intf -> []
-      | Impl -> complete_keywords ~position_encoding pos prefix
+      | Impl -> complete_keywords ~position_encoding ~can_complete_in pos prefix
     in
     keyword_completionItems
     @ process_dispatch_resp

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -1372,21 +1372,7 @@ let%expect_test "does not complete `in` in a top-level binding" =
     List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "in")
   in
   print_completions ~pre_print:only_in source position;
-  [%expect
-    {|
-    Completions:
-    {
-      "kind": 14,
-      "label": "in",
-      "textEdit": {
-        "newText": "in",
-        "range": {
-          "end": { "character": 12, "line": 0 },
-          "start": { "character": 11, "line": 0 }
-        }
-      }
-    }
-    |}]
+  [%expect {| No completions |}]
 ;;
 
 let%expect_test "does not complete `in` before an existing `in`" =
@@ -1396,21 +1382,7 @@ let%expect_test "does not complete `in` before an existing `in`" =
     List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "in")
   in
   print_completions ~pre_print:only_in source position;
-  [%expect
-    {|
-    Completions:
-    {
-      "kind": 14,
-      "label": "in",
-      "textEdit": {
-        "newText": "in",
-        "range": {
-          "end": { "character": 11, "line": 1 },
-          "start": { "character": 10, "line": 1 }
-        }
-      }
-    }
-    |}]
+  [%expect {| No completions |}]
 ;;
 
 let%expect_test "completion for `in` keyword - no prefix" =
@@ -1579,17 +1551,6 @@ let%expect_test "completion for object methods" =
   [%expect
     {|
     Completions:
-    {
-      "kind": 14,
-      "label": "in",
-      "textEdit": {
-        "newText": "in",
-        "range": {
-          "end": { "character": 34, "line": 0 },
-          "start": { "character": 34, "line": 0 }
-        }
-      }
-    }
     {
       "detail": "'a",
       "kind": 2,


### PR DESCRIPTION
The synthetic `in` completion is currently offered outside incomplete local bindings, including top-level bindings and expressions with an existing `in`. Use Merlin's typed browse information to suggest it only where it can complete a local binding.
