### PR TITLE
fix(completion): preserve dotted operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@
 - Keep completion sort keys lexically ordered beyond 9,999 items. (#1883, @rgrinberg)
 - Replace incorrect identifier suffixes when applying completions. (#1964, fixes #838, @rgrinberg)
 - Give synthetic completion items stable ordering metadata. (#1882, @rgrinberg)
+- Preserve dotted operators in completion prefixes and resolve requests. (#1890, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)
 - Unregister Dune promotion commands after their diagnostics are cleared. (#1746, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -23,6 +23,19 @@ let completion_kind ~supports_enum_member kind : CompletionItemKind.t option =
   | `Type -> Some TypeParameter
 ;;
 
+let ident_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '\128' .. '\255' | '\'' | '_' -> true
+  | _ -> false
+;;
+
+let path_start_char char =
+  ident_char char
+  ||
+  match char with
+  | '~' | '?' | '`' -> true
+  | _ -> false
+;;
+
 let prefix_of_position ~short_path source position =
   match Msource.text source with
   | "" -> ""
@@ -45,7 +58,11 @@ let prefix_of_position ~short_path source position =
         | ' ' | '\n' | '\r' | '\t' | '\012' -> false
         | _ -> true)
     in
-    if short_path
+    let starts_like_a_path =
+      (not (String.is_empty reconstructed_prefix))
+      && path_start_char reconstructed_prefix.[0]
+    in
+    if short_path && starts_like_a_path
     then (
       match String.split reconstructed_prefix ~on:'.' |> List.last with
       | Some s -> s
@@ -53,7 +70,7 @@ let prefix_of_position ~short_path source position =
     else reconstructed_prefix
 ;;
 
-let suffix_of_position source position =
+let suffix_of_position ~is_char source position =
   match Msource.text source with
   | "" -> ""
   | text ->
@@ -64,12 +81,8 @@ let suffix_of_position source position =
     else (
       let from = index in
       let len =
-        let ident_char = function
-          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '\128' .. '\255' | '\'' | '_' -> true
-          | _ -> false
-        in
         let until =
-          String.lfindi ~pos:from text ~f:(fun _ c -> not (ident_char c))
+          String.lfindi ~pos:from text ~f:(fun _ c -> not (is_char c))
           |> Option.value ~default:len
         in
         until - from
@@ -79,7 +92,7 @@ let suffix_of_position source position =
 
 let reconstruct_ident source position =
   let prefix = prefix_of_position ~short_path:false source position in
-  let suffix = suffix_of_position source position in
+  let suffix = suffix_of_position ~is_char:ident_char source position in
   let ident = prefix ^ suffix in
   Option.some_if (ident <> "") ident
 ;;
@@ -100,7 +113,7 @@ let edit_range doc pos =
   let suffix =
     let text_document = Document.Merlin.to_doc doc |> Document.text_document in
     let offset = Text_document.absolute_position text_document pos in
-    suffix_of_position source (`Offset offset)
+    suffix_of_position ~is_char:ident_char source (`Offset offset)
   in
   { range with end_ = { pos with character = pos.character + String.length suffix } }
 ;;
@@ -498,18 +511,24 @@ let resolve doc (compl : CompletionItem.t) (resolve : Resolve.t) query_doc ~mark
     let position : Position.t = resolve.position in
     let logical_position = Position.logical position in
     let doc =
+      let prefix =
+        prefix_of_position ~short_path:true (Document.Merlin.source doc) logical_position
+      in
+      let suffix =
+        let is_operator =
+          (not (String.is_empty prefix))
+          && String.for_all prefix ~f:Ocaml_operator.is_symbolic_character
+        in
+        let is_char =
+          if is_operator then Ocaml_operator.is_symbolic_character else ident_char
+        in
+        suffix_of_position ~is_char (Document.Merlin.source doc) logical_position
+      in
       let complete =
         let start =
-          let prefix =
-            prefix_of_position
-              ~short_path:true
-              (Document.Merlin.source doc)
-              logical_position
-          in
           { position with character = position.character - String.length prefix }
         in
         let end_ =
-          let suffix = suffix_of_position (Document.Merlin.source doc) logical_position in
           { position with character = position.character + String.length suffix }
         in
         let range = Range.create ~start ~end_ in

--- a/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion_resolve.ml
@@ -226,7 +226,7 @@ let _ = 1 >>. 2
     Fiber.return ()
   in
   Helpers.test source req;
-  [%expect {| { "label": ">>." } |}]
+  [%expect {| { "documentation": "combine docs", "label": ">>." } |}]
 ;;
 
 let%expect_test "completion resolve converts UTF-16 positions for Merlin" =

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -77,7 +77,7 @@ let%expect_test "short path prefix" =
 
 let%expect_test "short path preserves a dotted operator" =
   prefix_test ~short_path:true "let _ = 1 +." (`Logical (1, 12));
-  [%expect ""]
+  [%expect "+."]
 ;;
 
 let%expect_test "prefix may contain a Latin-1 identifier" =


### PR DESCRIPTION
Short completion-prefix reconstruction treats dotted operators like module paths and drops them, while resolve scans only identifier suffixes. Distinguish path-like prefixes from operators and scan operator suffixes so dotted operator completions retain their documentation.
