### PR TITLE
fix(dune): handle zero-work progress updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ## Fixes
 
+- Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)

--- a/ocaml-lsp-server/src/progress.ml
+++ b/ocaml-lsp-server/src/progress.ml
@@ -79,8 +79,11 @@ let build_progress t (progress : Drpc.Progress.t) =
          (* The percentage is useless as it isn't monotinically increasing as
             the spec requires, but it's the best we can do. *)
          let percentage =
-           let fraction = float_of_int progress.complete /. float_of_int total in
-           int_of_float (fraction *. 100.)
+           if total = 0
+           then 0
+           else (
+             let fraction = float_of_int progress.complete /. float_of_int total in
+             int_of_float (fraction *. 100.))
          in
          report_progress
            (ProgressParams.create


### PR DESCRIPTION
Dune may report an in-progress build with no completed or remaining
work. Report 0% instead of converting NaN to an integer.