### PR TITLE
test(e2e): kill shutdown-only server directly

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/exit_notification.ml
+++ b/ocaml-lsp-server/test/e2e-new/exit_notification.ml
@@ -10,10 +10,10 @@ let print_status (status : Unix.process_status) =
 ;;
 
 module T : sig
-  val run : ?timeout:float -> (unit Client.t -> 'a Fiber.t) -> 'a
+  val run : ?on_spawn:(int -> unit) -> (unit Client.t -> 'a Fiber.t) -> 'a
 end = struct
-  let run ?timeout f =
-    let status, a = Test.run_with_status ?timeout f in
+  let run ?on_spawn f =
+    let status, a = Test.run_with_status ?on_spawn f in
     print_status status;
     a
   ;;
@@ -38,8 +38,8 @@ let send_exit_before_initialize () =
   status
 ;;
 
-let test ?timeout run =
-  T.run ?timeout (fun client ->
+let test ?on_spawn run =
+  T.run ?on_spawn (fun client ->
     let run_client () = Test.start_client ~capabilities:client_capabilities client in
     Fiber.fork_and_join_unit run_client (run client))
 ;;
@@ -66,17 +66,14 @@ let%expect_test
 ;;
 
 let%expect_test "ocamllsp does not exit if only Shutdown notification is sent" =
+  let pid = ref None in
   let run client () =
     let* (_ : InitializeResult.t) = Client.initialized client in
-    Client.request client Shutdown
+    let+ () = Client.request client Shutdown in
+    Unix.kill (Option.value_exn !pid) Sys.sigterm
   in
-  (* This test deliberately waits for the watchdog to kill the server. One
-     second leaves ample time to receive the shutdown response without paying
-     the default three-second wait. *)
-  test ~timeout:1.0 run;
-  [%expect
-    {|
-    ocamllsp killed with signal = -7  |}]
+  test ~on_spawn:(fun process -> pid := Some process) run;
+  [%expect {| ocamllsp killed with signal = -11 |}]
 ;;
 
 let%expect_test

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -74,6 +74,7 @@ module T : sig
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
+    -> ?on_spawn:(int -> unit)
     -> (unit Client.t -> 'a Fiber.t)
     -> Unix.process_status * 'a
 
@@ -105,6 +106,7 @@ end = struct
         ?handler
         ?(stderr = Unix.stderr)
         ?(timeout = 3.0)
+        ?on_spawn
         f
     =
     let stdin_i, stdin_o = Unix.pipe ~cloexec:true () in
@@ -113,6 +115,7 @@ end = struct
       let env = extra_env @ Array.to_list (Unix.environment ()) |> Spawn.Env.of_list in
       Spawn.spawn ~env ~prog:bin ~argv:[ bin ] ~stdin:stdin_i ~stdout:stdout_o ~stderr ()
     in
+    Option.iter on_spawn ~f:(fun on_spawn -> on_spawn pid);
     Unix.close stdin_i;
     Unix.close stdout_o;
     let handler =


### PR DESCRIPTION
The shutdown-only lifecycle test currently waits for the watchdog even after receiving a successful shutdown response. Expose the spawned process ID to the test and kill it immediately after that response.

This still verifies that `Shutdown` alone leaves the server running, while making the test deterministic and reducing its partition from about 1.05s to 0.06s.
