### PR TITLE
test(e2e): only check preprocessor fixtures

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/preprocessor_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/preprocessor_helpers.ml
@@ -13,7 +13,7 @@ let setup ~name ~fixture ~dune_file =
   Test.write_file path (Io.String_path.read_file fixture);
   Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.24)\n";
   Test.write_file (Filename.concat dir "dune") dune_file;
-  Test.run_command ~cwd:dir "dune build";
+  Test.run_command ~cwd:dir "dune build @check";
   { path; uri = DocumentUri.of_path path }
 ;;
 


### PR DESCRIPTION
The preprocessor fixtures only need checked modules and Merlin build context for their hover requests. Build their `@check` alias instead of the full default target.

This avoids six unnecessary `ocamlopt` actions while preserving fresh, independent fixture projects and the end-to-end PP/PPX coverage.
