### PR TITLE
feat(server): trace dune events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Report Dune RPC, build progress, and Merlin configuration process activity
+  through LSP trace notifications. (#1899, @rgrinberg)
 - Add a code action to open the closest Dune file for the current document.
   (#1817, fixes #1491, @rgrinberg)
 - Distinguish operators from functions in semantic highlighting. (#1831, @rgrinberg)

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -127,6 +127,7 @@ type config =
   ; include_promotions : bool
   ; progress : Progress.t
   ; log : type_:MessageType.t -> message:string -> unit Fiber.t
+  ; trace : message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t
   }
 
 module Instance : sig
@@ -243,7 +244,26 @@ end = struct
       ()
   ;;
 
-  let progress_loop client diagnostics document_store progress =
+  let trace_progress trace source (progress : Drpc.Progress.t) =
+    let message () =
+      match progress with
+      | Success -> "Dune build finished"
+      | Failed -> "Dune build failed"
+      | Interrupted -> "Dune build interrupted"
+      | Waiting -> "Dune build waiting for changes"
+      | In_progress { complete; remaining } ->
+        sprintf "Dune build progress: %d/%d" complete (complete + remaining)
+    in
+    let verbose () =
+      sprintf
+        "Dune root: %s; pid: %d"
+        (Registry.Dune.root source)
+        (Registry.Dune.pid source)
+    in
+    trace ~message ~verbose
+  ;;
+
+  let progress_loop client diagnostics document_store progress trace source =
     (* We get all the progress updates even if the user can't see them to
        refresh the merlin config at the end of every build. Not very clean, but
        the assumption is that most good lsp clients will have progress reporting
@@ -257,6 +277,7 @@ end = struct
         match res with
         | None -> Fiber.return None
         | Some p ->
+          let* () = trace_progress trace source p in
           let+ () =
             Fiber.fork_and_join_unit
               (fun () -> Progress.build_progress progress p)
@@ -430,17 +451,20 @@ end = struct
       t.state <- Finished;
       Error ()
     | Ok session ->
-      let* () =
-        let message =
-          sprintf
-            "Connected to dune %s (%s)"
-            (Registry.Dune.root source)
-            (match Registry.Dune.where source with
-             | `Unix s -> s
-             | `Ip (`Host h, `Port p) -> sprintf "%s:%d" h p)
-        in
-        config.log ~type_:Info ~message
+      let message =
+        sprintf
+          "Connected to dune %s (%s)"
+          (Registry.Dune.root source)
+          (match Registry.Dune.where source with
+           | `Unix s -> s
+           | `Ip (`Host h, `Port p) -> sprintf "%s:%d" h p)
       in
+      let* () =
+        config.trace
+          ~message:(fun () -> "Connected to Dune RPC")
+          ~verbose:(fun () -> message)
+      in
+      let* () = config.log ~type_:Info ~message in
       t.state <- Connected (session, where);
       Fiber.return (Ok ())
   ;;
@@ -500,7 +524,15 @@ end = struct
                in
                config.log ~type_:Info ~message
              in
-             let progress = progress_loop client diagnostics document_store progress in
+             let progress =
+               progress_loop
+                 client
+                 diagnostics
+                 document_store
+                 progress
+                 config.trace
+                 source
+             in
              let diagnostics =
                let dune_root = DocumentUri.of_path (Registry.Dune.root source) in
                diagnostic_loop ~dune_root client config running diagnostics
@@ -766,6 +798,7 @@ let create
       progress
       document_store
       ~log
+      ~trace
   =
   let config =
     let include_promotions =
@@ -782,7 +815,7 @@ let create
          | _ -> false)
       | _ -> false
     in
-    { document_store; diagnostics; progress; include_promotions; log }
+    { document_store; diagnostics; progress; include_promotions; log; trace }
   in
   let registry = Registry.create (Registry.Config.create (Xdg.create ~env ())) in
   ref
@@ -802,10 +835,12 @@ let create
       progress
       document_store
       ~log
+      ~trace
   =
   if inside_test
   then ref Closed
-  else create workspaces client_capabilities diagnostics progress document_store ~log
+  else
+    create workspaces client_capabilities diagnostics progress document_store ~log ~trace
 ;;
 
 let run_loop t =

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -18,6 +18,7 @@ val create
   -> Progress.t
   -> Document_store.t
   -> log:(type_:MessageType.t -> message:string -> unit Fiber.t)
+  -> trace:(message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t)
   -> t
 
 val update_workspaces : t -> Workspaces.t -> unit

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -372,6 +372,7 @@ include struct
   module LanguageKind = LanguageKind
   module Location = Location
   module LogMessageParams = LogMessageParams
+  module LogTraceParams = LogTraceParams
   module MarkupContent = MarkupContent
   module MarkupKind = MarkupKind
   module MessageType = MessageType

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -32,11 +32,15 @@ module Misc = Ocaml_utils.Misc
 
 let empty = Mconfig_dot.empty_config
 
+type trace = message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t
+
 module Process = struct
   type nonrec t =
     { pid : Pid.t
     ; prog : string
+    ; command : string
     ; initial_cwd : string
+    ; trace : trace
     ; stdin : Lev_fiber.Io.output Lev_fiber.Io.t
     ; stdout : Lev_fiber.Io.input Lev_fiber.Io.t
     ; session : Lev_fiber_csexp.Session.t
@@ -63,7 +67,21 @@ module Process = struct
      | WSTOPPED _ -> ());
     Lev_fiber.Io.close t.stdin;
     Lev_fiber.Io.close t.stdout;
-    Fiber.return ()
+    t.trace
+      ~message:(fun () -> "Merlin configuration process exited")
+      ~verbose:(fun () ->
+        let status =
+          match status with
+          | Unix.WEXITED code -> sprintf "exited with code %d" code
+          | WSIGNALED signal -> sprintf "terminated by signal %d" signal
+          | WSTOPPED signal -> sprintf "stopped by signal %d" signal
+        in
+        sprintf
+          "Command: %s; pid: %d; cwd: %s; status: %s"
+          t.command
+          (Pid.to_int t.pid)
+          t.initial_cwd
+          status)
   ;;
 
   let await_exit t wheel =
@@ -83,13 +101,19 @@ module Process = struct
   ;;
 
   let send_signal t signal =
-    if not t.exited
-    then (
-      try Unix.kill (Pid.to_int t.pid) signal with
-      | Unix.Unix_error (Unix.ESRCH, _, _) -> ())
+    if t.exited
+    then Fiber.return ()
+    else (
+      match Unix.kill (Pid.to_int t.pid) signal with
+      | exception Unix.Unix_error (Unix.ESRCH, _, _) -> Fiber.return ()
+      | () ->
+        t.trace
+          ~message:(fun () -> "Signal sent to Merlin configuration process")
+          ~verbose:(fun () ->
+            sprintf "Command: %s; pid: %d; signal: %d" t.command (Pid.to_int t.pid) signal))
   ;;
 
-  let start ~dir =
+  let start ~trace ~dir =
     let bin, args =
       (* the convention is that $OCAMLLSP_PROJECT_BUILD_SYSTEM executable has
          `ocaml-merlin` subcommand to start a merlin configuration server *)
@@ -105,6 +129,7 @@ module Process = struct
            ~message:(Printf.sprintf "%s binary not found" bin)
            ())
     | Some prog ->
+      let command = String.concat ~sep:" " (prog :: args) in
       let stdin_r, stdin_w = Unix.pipe () in
       let stdout_r, stdout_w = Unix.pipe () in
       Unix.set_close_on_exec stdin_w;
@@ -133,17 +158,28 @@ module Process = struct
         Lev_fiber.Io.create fd what
       in
       let* stdin = make stdin_w Output in
-      let+ stdout = make stdout_r Input in
+      let* stdout = make stdout_r Input in
       let session = Lev_fiber_csexp.Session.create ~socket:false stdout stdin in
-      { prog
-      ; pid
-      ; initial_cwd = dir
-      ; stdin
-      ; stdout
-      ; session
-      ; exited = false
-      ; shutdown_timer = None
-      }
+      let process =
+        { prog
+        ; command
+        ; pid
+        ; initial_cwd = dir
+        ; trace
+        ; stdin
+        ; stdout
+        ; session
+        ; exited = false
+        ; shutdown_timer = None
+        }
+      in
+      let+ () =
+        trace
+          ~message:(fun () -> "Merlin configuration process started")
+          ~verbose:(fun () ->
+            sprintf "Command: %s; pid: %d; cwd: %s" command (Pid.to_int pid) dir)
+      in
+      process
   ;;
 end
 
@@ -172,6 +208,7 @@ let prefer_dot_merlin = ref false
 type db =
   { running : (string, entry) Table.t
   ; pool : Fiber.Pool.t
+  ; trace : trace
   }
 
 and entry =
@@ -194,6 +231,16 @@ module Entry = struct
     else (
       t.stopping <- true;
       Table.remove t.db.running t.process.initial_cwd;
+      let* () =
+        t.process.trace
+          ~message:(fun () -> "Stopping Merlin configuration process")
+          ~verbose:(fun () ->
+            sprintf
+              "Command: %s; pid: %d; cwd: %s"
+              t.process.command
+              (Pid.to_int t.process.pid)
+              t.process.initial_cwd)
+      in
       Dot_protocol_io.Commands.halt t.process.session)
   ;;
 
@@ -208,7 +255,7 @@ let get_process t ~dir =
   match Table.find t.running dir with
   | Some p -> Fiber.return p
   | None ->
-    let* process = Process.start ~dir in
+    let* process = Process.start ~trace:t.trace ~dir in
     let entry = Entry.create t process in
     Table.add_exn t.running ~key:dir ~data:entry;
     let+ () = Fiber.Pool.task t.pool ~f:(fun () -> Process.waitpid process) in
@@ -222,8 +269,31 @@ type context =
 
 let get_config (p : Process.t) ~workdir path_abs =
   let query path (p : Process.t) =
+    let* () =
+      p.trace
+        ~message:(fun () -> "Merlin configuration request sent")
+        ~verbose:(fun () ->
+          sprintf "Command: %s; pid: %d; file: %s" p.command (Pid.to_int p.pid) path)
+    in
     let* () = Dot_protocol_io.Commands.send_file p.session path in
-    Dot_protocol_io.read p.session
+    let* response = Dot_protocol_io.read p.session in
+    let+ () =
+      p.trace
+        ~message:(fun () -> "Merlin configuration response received")
+        ~verbose:(fun () ->
+          let status =
+            match response with
+            | Ok directives -> sprintf "success; directives: %d" (List.length directives)
+            | Error _ -> "error"
+          in
+          sprintf
+            "Command: %s; pid: %d; file: %s; status: %s"
+            p.command
+            (Pid.to_int p.pid)
+            path
+            status)
+    in
+    response
   in
   (* Both [p.initial_cwd] and [path_abs] have gone through
      [canonicalize_filename] *)
@@ -397,8 +467,8 @@ module DB = struct
 
   let get t uri = create t uri
 
-  let create () =
-    { running = Table.create (module Base.String); pool = Fiber.Pool.create () }
+  let create ~trace =
+    { running = Table.create (module Base.String); pool = Fiber.Pool.create (); trace }
   ;;
 
   let run t = Fiber.Pool.run t.pool
@@ -416,8 +486,8 @@ module DB = struct
       let* wheel = Lev_fiber.Timer.Wheel.create ~delay:0.5 in
       let signal_after_timeout signal =
         Fiber.parallel_iter running ~f:(fun entry ->
-          let+ exited = Process.await_exit entry.process wheel in
-          if not exited then Process.send_signal entry.process signal)
+          let* exited = Process.await_exit entry.process wheel in
+          if exited then Fiber.return () else Process.send_signal entry.process signal)
       in
       let shutdown () =
         let* () = Fiber.parallel_iter running ~f:Entry.stop in

--- a/ocaml-lsp-server/src/merlin_config.mli
+++ b/ocaml-lsp-server/src/merlin_config.mli
@@ -12,7 +12,10 @@ module DB : sig
   type config := t
   type t
 
-  val create : unit -> t
+  val create
+    :  trace:(message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t)
+    -> t
+
   val stop : t -> unit Fiber.t
   val run : t -> unit Fiber.t
   val get : t -> Uri.t -> config

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -306,9 +306,9 @@ let on_initialize server (ip : InitializeParams.t) =
         progress
         state.store
         ~log:(State.log_msg server)
+        ~trace:(State.log_trace server)
     in
-    let+ () = Fiber.Pool.task state.detached ~f:(fun () -> Dune.run dune) in
-    dune
+    Fiber.return dune
   in
   let initialize_info = initialize_info ip.capabilities in
   let state =
@@ -325,7 +325,12 @@ let on_initialize server (ip : InitializeParams.t) =
     | None -> state
     | Some trace -> { state with trace }
   in
-  Reply.now initialize_info, state
+  let response =
+    Reply.later (fun send ->
+      let* () = send initialize_info in
+      task_if_running state.detached ~f:(fun () -> Dune.run dune))
+  in
+  response, state
 ;;
 
 module Formatter = struct
@@ -905,7 +910,9 @@ let start stream =
             ~configuration
             ~detached
             ~symbols_thread
-            ~wheel));
+            ~wheel
+            ~trace:(fun ~message ~verbose ->
+              State.log_trace (Fdecl.get server) ~message ~verbose)));
     Fdecl.get server
   in
   let state = Server.state server in

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -27,10 +27,18 @@ type t =
   ; hover_extended : hover_extended
   }
 
-let create ~store ~merlin ~detached ~configuration ~ocamlformat_rpc ~symbols_thread ~wheel
+let create
+      ~store
+      ~merlin
+      ~detached
+      ~configuration
+      ~ocamlformat_rpc
+      ~symbols_thread
+      ~wheel
+      ~trace
   =
   { init = Uninitialized
-  ; merlin_config = Merlin_config.DB.create ()
+  ; merlin_config = Merlin_config.DB.create ~trace
   ; store
   ; merlin = Document.Single_pipeline.create merlin
   ; detached
@@ -129,4 +137,19 @@ let log_msg server ~type_ ~message =
   task_if_running state.detached ~f:(fun () ->
     let log = LogMessageParams.create ~type_ ~message in
     Server.notification server (Server_notification.LogMessage log))
+;;
+
+let log_trace server ~message ~verbose =
+  let state = Server.state server in
+  let send verbose =
+    task_if_running state.detached ~f:(fun () ->
+      let message = message () in
+      let verbose = Option.map verbose ~f:(fun verbose -> verbose ()) in
+      let trace = LogTraceParams.create ~message ?verbose () in
+      Server.notification server (Server_notification.LogTrace trace))
+  in
+  match state.trace with
+  | Off -> Fiber.return ()
+  | Messages -> send None
+  | Compact | Verbose -> send (Some verbose)
 ;;

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -41,6 +41,7 @@ val create
   -> ocamlformat_rpc:Ocamlformat_rpc.t
   -> symbols_thread:Lev_fiber.Thread.t Lazy_fiber.t
   -> wheel:Lev_fiber.Timer.Wheel.t
+  -> trace:(message:(unit -> string) -> verbose:(unit -> string) -> unit Fiber.t)
   -> t
 
 val position_encoding : t -> [ `UTF16 | `UTF8 ]
@@ -72,3 +73,9 @@ val experimental_client_capabilities : t -> Client.Experimental_capabilities.t
 
 val diagnostics : t -> Diagnostics.t
 val log_msg : t Server.t -> type_:MessageType.t -> message:string -> unit Fiber.t
+
+val log_trace
+  :  t Server.t
+  -> message:(unit -> string)
+  -> verbose:(unit -> string)
+  -> unit Fiber.t

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -37,14 +37,28 @@ module Events = struct
 
   type t =
     { dune_connected : Signal.t
+    ; dune_connection_traced : Signal.t
     ; build_finished : Signal.t
+    ; build_finished_traced : Signal.t
+    ; merlin_config_started : Signal.t
+    ; merlin_config_request : Signal.t
+    ; merlin_config_response : Signal.t
+    ; merlin_config_stopping : Signal.t
+    ; merlin_config_exited : Signal.t
     ; mutable diagnostics : PublishDiagnosticsParams.t list
     ; mutable diagnostic_waiter : diagnostic_waiter option
     }
 
   let create () =
     { dune_connected = Signal.create ()
+    ; dune_connection_traced = Signal.create ()
     ; build_finished = Signal.create ()
+    ; build_finished_traced = Signal.create ()
+    ; merlin_config_started = Signal.create ()
+    ; merlin_config_request = Signal.create ()
+    ; merlin_config_response = Signal.create ()
+    ; merlin_config_stopping = Signal.create ()
+    ; merlin_config_exited = Signal.create ()
     ; diagnostics = []
     ; diagnostic_waiter = None
     }
@@ -86,6 +100,34 @@ module Events = struct
     | LogMessage { message; _ }
       when Stdlib.String.starts_with ~prefix:"Connected to dune " message ->
       Signal.notify t.dune_connected
+    | LogTrace { message = "Connected to Dune RPC"; verbose = None } ->
+      Signal.notify t.dune_connection_traced
+    | LogTrace { message = "Connected to Dune RPC"; verbose = Some _ } ->
+      failwith "messages-level Dune connection trace included verbose details"
+    | LogTrace { message = "Dune build finished"; verbose = Some verbose }
+      when Stdlib.String.starts_with ~prefix:"Dune root: " verbose ->
+      Signal.notify t.build_finished_traced
+    | LogTrace { message = "Dune build finished"; verbose = None } ->
+      failwith "verbose Dune build trace omitted details"
+    | LogTrace { message = "Merlin configuration process started"; verbose = Some _ } ->
+      Signal.notify t.merlin_config_started
+    | LogTrace { message = "Merlin configuration request sent"; verbose = Some _ } ->
+      Signal.notify t.merlin_config_request
+    | LogTrace { message = "Merlin configuration response received"; verbose = Some _ } ->
+      Signal.notify t.merlin_config_response
+    | LogTrace { message = "Stopping Merlin configuration process"; verbose = Some _ } ->
+      Signal.notify t.merlin_config_stopping
+    | LogTrace { message = "Merlin configuration process exited"; verbose = Some _ } ->
+      Signal.notify t.merlin_config_exited
+    | LogTrace
+        { message =
+            ( "Merlin configuration process started"
+            | "Merlin configuration request sent"
+            | "Merlin configuration response received"
+            | "Stopping Merlin configuration process"
+            | "Merlin configuration process exited" )
+        ; verbose = None
+        } -> failwith "verbose Merlin configuration process trace omitted details"
     | WorkDoneProgress { token = `String token; value = Lsp.Progress.End _ }
       when Stdlib.String.starts_with ~prefix:"dune-build-" token ->
       Signal.notify t.build_finished
@@ -100,6 +142,13 @@ let open_document client ~uri ~text =
   Client.notification
     client
     (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+;;
+
+let close_document client ~uri =
+  let textDocument = TextDocumentIdentifier.create ~uri in
+  Client.notification
+    client
+    (TextDocumentDidClose (DidCloseTextDocumentParams.create ~textDocument))
 ;;
 
 let change_document client ~uri ~text =
@@ -248,9 +297,19 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
          ~stderr:ocamllsp_stderr
          ~capabilities
          ~workspaceFolders:(Some [ workspace ])
+         ~trace:Messages
        @@ fun client ->
+       let* () = Client.notification client Initialized in
        (* The blocked initial build makes Dune RPC connection deterministic. *)
        let* () = Signal.wait events.dune_connected in
+       let* () = Signal.wait events.dune_connection_traced in
+       print_endline "Dune trace: Connected to Dune RPC";
+       let* () =
+         Client.notification client (SetTrace (SetTraceParams.create ~value:Verbose))
+       in
+       let* (_ : Lsp.Extension.DebugEcho.Result.t) =
+         Client.request client (DebugEcho { message = "trace barrier" })
+       in
        let one_uri = Uri.of_path one in
        let two_uri = Uri.of_path two in
        let* () = open_document client ~uri:one_uri ~text:initial_source in
@@ -278,15 +337,35 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
           states, then use its Success notification to refresh both documents. *)
        let two_after_build = Events.wait_for_diagnostics events ~f:(for_uri two_uri) in
        let build_finished = Signal.wait events.build_finished in
+       let build_finished_traced = Signal.wait events.build_finished_traced in
        Test.write_file gate "";
        let* two_after_build = two_after_build in
        let* () = build_finished in
+       let* () = build_finished_traced in
+       print_endline "Dune trace: Dune build finished (verbose details present)";
        List.iter two_after_build.diagnostics ~f:(fun diagnostic ->
          print_endline (diagnostic_message diagnostic));
+       let* () = Signal.wait events.merlin_config_started in
+       print_endline "Dune trace: Merlin configuration process started";
+       let* () = Signal.wait events.merlin_config_request in
+       let* () = Signal.wait events.merlin_config_response in
+       print_endline "Dune trace: Merlin configuration request completed";
+       let stopping = Signal.wait events.merlin_config_stopping in
+       let exited = Signal.wait events.merlin_config_exited in
+       let* () = close_document client ~uri:one_uri in
+       let* () = close_document client ~uri:two_uri in
+       let* () = stopping in
+       let* () = exited in
+       print_endline "Dune trace: Merlin configuration process stopped and exited";
        Test.shutdown_client client);
   [%expect
     {|
+    Dune trace: Connected to Dune RPC
+    Dune trace: Dune build finished (verbose details present)
     Unbound module Bar
     Unbound value x
+    Dune trace: Merlin configuration process started
+    Dune trace: Merlin configuration request completed
+    Dune trace: Merlin configuration process stopped and exited
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -54,8 +54,13 @@ end
 
 open Import
 
-let start_client ?(capabilities = ClientCapabilities.create ()) ?workspaceFolders client =
-  Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ())
+let start_client
+      ?(capabilities = ClientCapabilities.create ())
+      ?workspaceFolders
+      ?trace
+      client
+  =
+  Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ?trace ())
 ;;
 
 let shutdown_client client =
@@ -95,6 +100,7 @@ module T : sig
     -> ?timeout:float
     -> ?capabilities:ClientCapabilities.t
     -> ?workspaceFolders:WorkspaceFolder.t list option
+    -> ?trace:TraceValue.t
     -> (unit Client.t -> 'a Fiber.t)
     -> 'a
 end = struct
@@ -186,11 +192,12 @@ end = struct
         ?timeout
         ?(capabilities = ClientCapabilities.create ())
         ?workspaceFolders
+        ?trace
         f
     =
     run ?extra_env ?handler ?stderr ?timeout
     @@ fun client ->
-    let run_client () = start_client ~capabilities ?workspaceFolders client in
+    let run_client () = start_client ~capabilities ?workspaceFolders ?trace client in
     let run_test () =
       let* (_ : InitializeResult.t) = Client.initialized client in
       f client


### PR DESCRIPTION
Start making the existing LSP trace setting observable by emitting `$/logTrace` notifications for Dune RPC connections, build events, and communication with the `dune ocaml-merlin` configuration process. Process tracing covers startup, configuration requests and responses, graceful stopping, escalation signals, and final exit status.

The trace helper applies the negotiated level centrally: `off` emits and computes nothing, `messages` omits verbose details, and `verbose` (plus the legacy `compact` value) includes them. Message construction is lazy so disabled tracing has no formatting cost. Dune startup is scheduled only after the initialize response has been sent, preventing trace notifications during initialization.

The Dune diagnostics end-to-end test records connection, successful-build, and Merlin configuration process traces. It checks that the initial `messages` level omits details, then switches to `verbose` with `$/setTrace` before exercising configuration requests and the process lifecycle.
