### PR TITLE
refactor(code-actions): share destruct action runner

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -4,7 +4,7 @@ open Fiber.O
 let action_kind = "destruct (enumerate cases)"
 let kind = CodeActionKind.Other action_kind
 
-let code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText) =
+let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, newText) =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
   let edit = Code_action.workspace_edit doc [ textedit ] in
@@ -28,38 +28,40 @@ let code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText) =
     ()
 ;;
 
+let run state doc merlin ~action_kind ~(range : Range.t) ~postprocess =
+  let command =
+    let start = Position.logical range.start in
+    let finish = Position.logical range.end_ in
+    Query_protocol.Case_analysis (start, finish)
+  in
+  let+ res = Document.Merlin.dispatch ~name:"destruct" merlin command in
+  match res with
+  | Ok reply ->
+    let reply = postprocess reply in
+    let supportsJumpToNextHole =
+      State.experimental_client_capabilities state
+      |> Client.Experimental_capabilities.supportsJumpToNextHole
+    in
+    Some (code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
+  | Error
+      { exn =
+          ( Merlin_analysis.Destruct.Wrong_parent _
+          | Query_commands.No_nodes
+          | Merlin_analysis.Destruct.Not_allowed _
+          | Merlin_analysis.Destruct.Useless_refine
+          | Merlin_analysis.Destruct.Ill_typed
+          | Merlin_analysis.Destruct.Nothing_to_do )
+      ; backtrace = _
+      } -> None
+  | Error exn -> Exn_with_backtrace.reraise exn
+;;
+
 let code_action (state : State.t) doc (params : CodeActionParams.t) =
   match Document.kind doc with
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
   | `Merlin merlin ->
-    let command =
-      let start = Position.logical params.range.start in
-      let finish = Position.logical params.range.end_ in
-      Query_protocol.Case_analysis (start, finish)
-    in
-    let* res = Document.Merlin.dispatch ~name:"destruct" merlin command in
-    (match res with
-     | Ok (loc, newText) ->
-       let supportsJumpToNextHole =
-         State.experimental_client_capabilities state
-         |> Client.Experimental_capabilities.supportsJumpToNextHole
-       in
-       let opt =
-         Some (code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText))
-       in
-       Fiber.return opt
-     | Error
-         { exn =
-             ( Merlin_analysis.Destruct.Wrong_parent _
-             | Query_commands.No_nodes
-             | Merlin_analysis.Destruct.Not_allowed _
-             | Merlin_analysis.Destruct.Useless_refine
-             | Merlin_analysis.Destruct.Ill_typed
-             | Merlin_analysis.Destruct.Nothing_to_do )
-         ; backtrace = _
-         } -> Fiber.return None
-     | Error exn -> Exn_with_backtrace.reraise exn)
+    run state doc merlin ~action_kind ~range:params.range ~postprocess:Fun.id
 ;;
 
 let t state = { Code_action.kind; run = `Non_batchable (code_action state) }

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -1,4 +1,16 @@
 open Import
 
 val kind : CodeActionKind.t
+
+(** Run Merlin's case analysis and turn its reply into a code action.
+    [postprocess] may adjust the replacement location and text. *)
+val run
+  :  State.t
+  -> Document.t
+  -> Document.Merlin.t
+  -> action_kind:string
+  -> range:Range.t
+  -> postprocess:(Loc.t * string -> Loc.t * string)
+  -> CodeAction.t option Fiber.t
+
 val t : State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -1,5 +1,4 @@
 open Import
-open Fiber.O
 
 let action_kind = "destruct-line (enumerate cases, use existing match)"
 let kind = CodeActionKind.Other action_kind
@@ -243,39 +242,6 @@ let format_merlin_reply ~(statement : destructable_statement) (new_code : string
        String.concat ~sep:" -> _\n" (String.strip first_line :: other_lines))
 ;;
 
-let code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText) =
-  let range : Range.t = Range.of_loc loc in
-  let textedit : TextEdit.t = { range; newText } in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
-  let title = String.capitalize action_kind in
-  let command =
-    if supportsJumpToNextHole
-    then
-      Some
-        (Client.Custom_commands.next_hole
-           ~in_range:(Range.resize_for_edit textedit)
-           ~notify_if_no_hole:false
-           ())
-    else None
-  in
-  CodeAction.create
-    ~title
-    ~kind:(CodeActionKind.Other action_kind)
-    ~edit
-    ?command
-    ~isPreferred:false
-    ()
-;;
-
-let dispatch_destruct (merlin : Document.Merlin.t) (range : Range.t) =
-  let command =
-    let start = Position.logical range.start in
-    let finish = Position.logical range.end_ in
-    Query_protocol.Case_analysis (start, finish)
-  in
-  Document.Merlin.dispatch ~name:"destruct" merlin command
-;;
-
 let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.t) =
   match Document.kind doc with
   | `Other -> Fiber.return None
@@ -283,27 +249,16 @@ let code_action (state : State.t) (doc : Document.t) (params : CodeActionParams.
     (match Document.Merlin.kind merlin, extract_statement doc params.range with
      | Intf, _ | _, None -> Fiber.return None
      | Impl, Some statement ->
-       let+ res = dispatch_destruct merlin statement.query_range in
-       (match res with
-        | Ok (loc, newText) ->
-          let loc = adjust_reply_location ~statement loc in
-          let newText = format_merlin_reply ~statement newText in
-          let supportsJumpToNextHole =
-            State.experimental_client_capabilities state
-            |> Client.Experimental_capabilities.supportsJumpToNextHole
-          in
-          Some (code_action_of_case_analysis ~supportsJumpToNextHole doc (loc, newText))
-        | Error
-            { exn =
-                ( Merlin_analysis.Destruct.Wrong_parent _
-                | Query_commands.No_nodes
-                | Merlin_analysis.Destruct.Not_allowed _
-                | Merlin_analysis.Destruct.Useless_refine
-                | Merlin_analysis.Destruct.Ill_typed
-                | Merlin_analysis.Destruct.Nothing_to_do )
-            ; backtrace = _
-            } -> None
-        | Error exn -> Exn_with_backtrace.reraise exn))
+       Action_destruct.run
+         state
+         doc
+         merlin
+         ~action_kind
+         ~range:statement.query_range
+         ~postprocess:(fun (loc, newText) ->
+           let loc = adjust_reply_location ~statement loc in
+           let newText = format_merlin_reply ~statement newText in
+           loc, newText))
 ;;
 
 let t state = { Code_action.kind; run = `Non_batchable (code_action state) }


### PR DESCRIPTION
The regular and line-oriented destruct actions dispatch the same Merlin case-analysis request, handle the same expected errors, and construct identical edits and follow-up commands.

Share that execution path through `Action_destruct.run`, with a postprocessing hook for the line-oriented action's location and formatting adjustments. This is a behavior-preserving prerequisite for #1829.
