### PR TITLE
test(dune): characterize RPC lifecycle

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -79,6 +79,10 @@
     definition
     diagnostics
     dune_diagnostics
+    dune_nested_root
+    dune_promotion_disconnect
+    dune_promotion_open
+    dune_workspace_removal
     metrics
     refactor_extract
     registration_order

--- a/ocaml-lsp-server/test/e2e-new/dune_nested_root.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_nested_root.ml
@@ -1,0 +1,54 @@
+open Test.Import
+open Dune_rpc_test
+
+let%expect_test "a nested Dune instance ignores parent documents" =
+  let project = create_project "nr" in
+  let outside_dune = Filename.concat project.temp "dune" in
+  let source = "(library(name outside))\n" in
+  Test.write_file outside_dune source;
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run ~workspace_root:project.temp project events ~f:(fun client _workspace ->
+         let uri = Uri.of_path outside_dune in
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         Test.write_file project.gate "";
+         let* (_ : PublishDiagnosticsParams.t) =
+           Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic
+         in
+         let* () = Test.open_document ~language_id:"dune" ~client ~uri ~source () in
+         let textDocument = TextDocumentIdentifier.create ~uri in
+         let options = FormattingOptions.create ~tabSize:2 ~insertSpaces:true () in
+         let request =
+           Lsp.Client_request.TextDocumentFormatting
+             (DocumentFormattingParams.create ~textDocument ~options ())
+         in
+         let* result = Fiber.collect_errors (fun () -> Client.request client request) in
+         match result with
+         | Error
+             [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ }
+             ] ->
+           print_payload
+             project
+             "textDocument/formatting response:"
+             (Jsonrpc.Response.Error.yojson_of_t error);
+           Fiber.return ()
+         | Error errors -> Fiber.reraise_all errors
+         | Ok edits ->
+           let json =
+             match edits with
+             | None -> `Null
+             | Some edits -> `List (List.map edits ~f:TextEdit.yojson_of_t)
+           in
+           print_payload project "textDocument/formatting response:" json;
+           Fiber.return ()));
+  [%expect
+    {|
+    textDocument/formatting response:
+    {
+      "code": -32600,
+      "message": "No dune instance found. Please run dune in watch mode for <test-dir>/dune"
+    }
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
@@ -1,0 +1,76 @@
+open Test.Import
+open Dune_rpc_test
+
+let%expect_test "promotion registrations when Dune disconnects" =
+  let project = create_project "pd" in
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run project events ~f:(fun _client _workspace ->
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         Test.write_file project.gate "";
+         let* initial = Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic in
+         let* registration = Mailbox.wait events.registrations in
+         stop_dune project;
+         let* cleared =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri initial.uri params && no_dune_diagnostic params)
+         in
+         let* () = Lev_fiber.Timer.sleepf 0.02 in
+         print_payload
+           project
+           "initial textDocument/publishDiagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t initial);
+         print_payload
+           project
+           "initial client/registerCapability:"
+           (RegistrationParams.yojson_of_t registration);
+         print_payload
+           project
+           "textDocument/publishDiagnostics after Dune disconnects:"
+           (PublishDiagnosticsParams.yojson_of_t cleared);
+         print_payloads
+           project
+           "client/unregisterCapability after Dune disconnects:"
+           UnregistrationParams.yojson_of_t
+           (Mailbox.take_pending events.unregistrations);
+         Fiber.return ()));
+  [%expect
+    {|
+    initial textDocument/publishDiagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    initial client/registerCapability:
+    {
+      "registrations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction",
+          "registerOptions": {
+            "codeActionKinds": [ "Promote" ],
+            "documentSelector": [
+              { "language": null, "scheme": null, "pattern": "<document-path>" }
+            ]
+          }
+        }
+      ]
+    }
+    textDocument/publishDiagnostics after Dune disconnects:
+    { "diagnostics": [], "uri": "<document-uri>" }
+    client/unregisterCapability after Dune disconnects:
+    []
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
@@ -1,0 +1,102 @@
+open Test.Import
+open Dune_rpc_test
+
+let%expect_test "promotion removal while its document is open" =
+  let project = create_project "po" in
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run project events ~f:(fun client _workspace ->
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         Test.write_file project.gate "";
+         let uri = Uri.of_path project.expected in
+         let* initial = Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic in
+         let* registration = Mailbox.wait events.registrations in
+         let* () = open_document client ~uri ~text:project.old_source in
+         let* opened_unregistration = Mailbox.wait events.unregistrations in
+         Test.write_file project.expected "let answer = 42";
+         Test.write_file project.trigger "fixed\n";
+         let* cleared =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri initial.uri params && no_dune_diagnostic params)
+         in
+         let* () = Lev_fiber.Timer.sleepf 0.01 in
+         print_payload
+           project
+           "initial textDocument/publishDiagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t initial);
+         print_payload
+           project
+           "initial client/registerCapability:"
+           (RegistrationParams.yojson_of_t registration);
+         print_payload
+           project
+           "client/unregisterCapability after textDocument/didOpen:"
+           (UnregistrationParams.yojson_of_t opened_unregistration);
+         print_payload
+           project
+           "Dune diagnostics after removing the promotion:"
+           (PublishDiagnosticsParams.yojson_of_t (only_dune_diagnostics cleared));
+         print_payloads
+           project
+           "client/unregisterCapability after removing the promotion:"
+           UnregistrationParams.yojson_of_t
+           (Mailbox.take_pending events.unregistrations);
+         Fiber.return ()));
+  [%expect
+    {|
+    initial textDocument/publishDiagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    initial client/registerCapability:
+    {
+      "registrations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction",
+          "registerOptions": {
+            "codeActionKinds": [ "Promote" ],
+            "documentSelector": [
+              { "language": null, "scheme": null, "pattern": "<document-path>" }
+            ]
+          }
+        }
+      ]
+    }
+    client/unregisterCapability after textDocument/didOpen:
+    {
+      "unregisterations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction"
+        }
+      ]
+    }
+    Dune diagnostics after removing the promotion:
+    { "diagnostics": [], "uri": "<document-uri>" }
+    client/unregisterCapability after removing the promotion:
+    [
+      {
+        "unregisterations": [
+          {
+            "id": "ocamllsp-promote/<document-uri>",
+            "method": "textDocument/codeAction"
+          }
+        ]
+      }
+    ]
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -1,0 +1,361 @@
+open Test.Import
+
+module Signal = struct
+  type t =
+    { mutable pending : int
+    ; mutable waiter : unit Fiber.Ivar.t option
+    }
+
+  let create () = { pending = 0; waiter = None }
+
+  let notify t =
+    match t.waiter with
+    | None ->
+      t.pending <- t.pending + 1;
+      Fiber.return ()
+    | Some waiter ->
+      t.waiter <- None;
+      Fiber.Ivar.fill waiter ()
+  ;;
+
+  let wait t =
+    if t.pending > 0
+    then (
+      t.pending <- t.pending - 1;
+      Fiber.return ())
+    else (
+      assert (Option.is_none t.waiter);
+      let waiter = Fiber.Ivar.create () in
+      t.waiter <- Some waiter;
+      Fiber.Ivar.read waiter)
+  ;;
+end
+
+module Mailbox = struct
+  type 'a t =
+    { mutable pending_rev : 'a list
+    ; mutable waiter : 'a Fiber.Ivar.t option
+    }
+
+  let create () = { pending_rev = []; waiter = None }
+
+  let push t value =
+    match t.waiter with
+    | None ->
+      t.pending_rev <- value :: t.pending_rev;
+      Fiber.return ()
+    | Some waiter ->
+      t.waiter <- None;
+      Fiber.Ivar.fill waiter value
+  ;;
+
+  let wait t =
+    match List.rev t.pending_rev with
+    | value :: rest ->
+      t.pending_rev <- List.rev rest;
+      Fiber.return value
+    | [] ->
+      assert (Option.is_none t.waiter);
+      let waiter = Fiber.Ivar.create () in
+      t.waiter <- Some waiter;
+      Fiber.Ivar.read waiter
+  ;;
+
+  let take_pending t =
+    let pending = List.rev t.pending_rev in
+    t.pending_rev <- [];
+    pending
+  ;;
+end
+
+module Events = struct
+  type diagnostic_waiter =
+    (PublishDiagnosticsParams.t -> bool) * PublishDiagnosticsParams.t Fiber.Ivar.t
+
+  type t =
+    { dune_ready : Signal.t
+    ; mutable diagnostics : PublishDiagnosticsParams.t list
+    ; mutable diagnostic_waiter : diagnostic_waiter option
+    }
+
+  let create () =
+    { dune_ready = Signal.create (); diagnostics = []; diagnostic_waiter = None }
+  ;;
+
+  let dune_ready t = t.dune_ready
+
+  let rec take_matching ~f rev_prefix = function
+    | [] -> None
+    | diagnostic :: rest ->
+      if f diagnostic
+      then Some (diagnostic, List.rev_append rev_prefix rest)
+      else take_matching ~f (diagnostic :: rev_prefix) rest
+  ;;
+
+  let wait_for_diagnostics t ~f =
+    match take_matching ~f [] t.diagnostics with
+    | Some (diagnostic, diagnostics) ->
+      t.diagnostics <- diagnostics;
+      Fiber.return diagnostic
+    | None ->
+      assert (Option.is_none t.diagnostic_waiter);
+      let waiter = Fiber.Ivar.create () in
+      t.diagnostic_waiter <- Some (f, waiter);
+      Fiber.Ivar.read waiter
+  ;;
+
+  let publish_diagnostics t diagnostic =
+    match t.diagnostic_waiter with
+    | Some (f, waiter) when f diagnostic ->
+      t.diagnostic_waiter <- None;
+      Fiber.Ivar.fill waiter diagnostic
+    | None | Some _ ->
+      t.diagnostics <- diagnostic :: t.diagnostics;
+      Fiber.return ()
+  ;;
+
+  let take_pending t =
+    let diagnostics = List.rev t.diagnostics in
+    t.diagnostics <- [];
+    diagnostics
+  ;;
+
+  let on_notification t _ (notification : Lsp.Server_notification.t) =
+    match notification with
+    | PublishDiagnostics diagnostic -> publish_diagnostics t diagnostic
+    | LogMessage { message; _ }
+      when Re.execp (Re.compile (Re.str ": connected to dune at ")) message ->
+      Signal.notify t.dune_ready
+    | _ -> Fiber.return ()
+  ;;
+end
+
+module Lifecycle_events = struct
+  type t =
+    { dune : Events.t
+    ; registrations : RegistrationParams.t Mailbox.t
+    ; unregistrations : UnregistrationParams.t Mailbox.t
+    }
+
+  let create () =
+    { dune = Events.create ()
+    ; registrations = Mailbox.create ()
+    ; unregistrations = Mailbox.create ()
+    }
+  ;;
+
+  let handler t =
+    let on_request
+          (type response state)
+          (client : state Client.t)
+          (request : response Lsp.Server_request.t)
+      : (response Lsp_fiber.Rpc.Reply.t * state) Fiber.t
+      =
+      match request with
+      | WorkDoneProgressCreate _ ->
+        Fiber.return (Lsp_fiber.Rpc.Reply.now (), Client.state client)
+      | ClientRegisterCapability params ->
+        let+ () = Mailbox.push t.registrations params in
+        Lsp_fiber.Rpc.Reply.now (), Client.state client
+      | ClientUnregisterCapability params ->
+        let+ () = Mailbox.push t.unregistrations params in
+        Lsp_fiber.Rpc.Reply.now (), Client.state client
+      | _ -> assert false
+    in
+    Client.Handler.make
+      ~on_request:{ Client.Handler.on_request }
+      ~on_notification:(Events.on_notification t.dune)
+      ()
+  ;;
+end
+
+let for_uri uri (params : PublishDiagnosticsParams.t) = Uri.equal uri params.uri
+
+let is_dune_diagnostic (diagnostic : Diagnostic.t) =
+  Option.equal String.equal diagnostic.source (Some "dune")
+;;
+
+let has_dune_diagnostic (params : PublishDiagnosticsParams.t) =
+  List.exists params.diagnostics ~f:is_dune_diagnostic
+;;
+
+let no_dune_diagnostic params = not (has_dune_diagnostic params)
+
+let only_dune_diagnostics (params : PublishDiagnosticsParams.t) =
+  { params with diagnostics = List.filter params.diagnostics ~f:is_dune_diagnostic }
+;;
+
+let terminate_process pid =
+  match Unix.kill pid Sys.sigterm with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.ESRCH, _, _) -> ()
+;;
+
+let stop_process pid =
+  terminate_process pid;
+  ignore (Test.waitpid pid : Unix.process_status)
+;;
+
+let start_dune root runtime_dir =
+  let prog = Bin.which "dune" |> Option.value_exn in
+  let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
+  let env =
+    let is_runtime_dir value =
+      Stdlib.String.starts_with ~prefix:"XDG_RUNTIME_DIR=" value
+    in
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter ~f:(fun value -> not (is_runtime_dir value))
+    |> List.cons ("XDG_RUNTIME_DIR=" ^ runtime_dir)
+    |> Spawn.Env.of_list
+  in
+  let pid =
+    Spawn.spawn
+      ~env
+      ~cwd:(Path root)
+      ~prog
+      ~argv:[ prog; "build"; "--root"; root; "-w"; "@repro" ]
+      ~stdout:output
+      ~stderr:output
+      ()
+  in
+  Unix.close output;
+  pid
+;;
+
+let stop_abruptly client pid =
+  let+ () = Client.stop client in
+  terminate_process pid
+;;
+
+let open_document client ~uri ~text =
+  let textDocument =
+    TextDocumentItem.create ~uri ~languageId:(LanguageKind.Other "ocaml") ~version:0 ~text
+  in
+  Client.notification
+    client
+    (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+;;
+
+type project =
+  { temp : string
+  ; root : string
+  ; runtime_dir : string
+  ; expected : string
+  ; trigger : string
+  ; gate : string
+  ; old_source : string
+  ; mutable dune_pid : int option
+  }
+
+let create_project name =
+  let temp = Test.temp_dir ("lsp-" ^ name ^ "-") in
+  let root = Filename.concat temp "r" in
+  let runtime_dir = Filename.concat temp "x" in
+  Unix.mkdir root 0o700;
+  Unix.mkdir runtime_dir 0o700;
+  Test.write_file (Filename.concat root "dune-project") "(lang dune 3.24)\n";
+  let expected = Filename.concat root "expected.ml" in
+  let trigger = Filename.concat root "trigger" in
+  let gate = Filename.concat temp "gate" in
+  let old_source = "let answer = 0\n" in
+  Test.write_file expected old_source;
+  Test.write_file trigger "0\n";
+  let wait_script = Filename.concat root "wait.sh" in
+  Test.write_file wait_script "#!/bin/sh\nwhile [ ! -e \"$1\" ]; do sleep 0.01; done\n";
+  Unix.chmod wait_script 0o755;
+  Test.write_file
+    (Filename.concat root "dune")
+    (Printf.sprintf
+       {jbuild|
+(rule
+ (alias repro)
+ (deps expected.ml trigger wait.sh)
+ (target actual.ml)
+ (action
+  (progn
+   (run %%{dep:wait.sh} %s)
+   (with-stdout-to %%{target} (echo "let answer = 42"))
+   (diff expected.ml %%{target}))))
+|jbuild}
+       gate);
+  { temp
+  ; root
+  ; runtime_dir
+  ; expected
+  ; trigger
+  ; gate
+  ; old_source
+  ; dune_pid = Some (start_dune root runtime_dir)
+  }
+;;
+
+let sanitize_string project string =
+  let replacements =
+    [ Uri.to_string (Uri.of_path project.expected), "<document-uri>"
+    ; project.expected, "<document-path>"
+    ; Uri.to_string (Uri.of_path project.root), "<workspace-uri>"
+    ; project.root, "<workspace-path>"
+    ; Uri.to_string (Uri.of_path project.temp), "<test-uri>"
+    ; project.temp, "<test-dir>"
+    ]
+  in
+  List.fold_left replacements ~init:string ~f:(fun string (pattern, with_) ->
+    String.substr_replace_all string ~pattern ~with_)
+;;
+
+let rec sanitize_json project : Yojson.Safe.t -> Yojson.Safe.t = function
+  | `String string -> `String (sanitize_string project string)
+  | `Assoc fields ->
+    `Assoc (List.map fields ~f:(fun (name, value) -> name, sanitize_json project value))
+  | `List values -> `List (List.map values ~f:(sanitize_json project))
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `Null) as json -> json
+;;
+
+let print_payload project label json =
+  print_endline label;
+  sanitize_json project json |> Test.print_result
+;;
+
+let print_payloads project label yojson_of_t values =
+  values
+  |> List.map ~f:yojson_of_t
+  |> fun values -> print_payload project label (`List values)
+;;
+
+let stop_dune project =
+  let pid = Option.value_exn project.dune_pid in
+  project.dune_pid <- None;
+  stop_process pid
+;;
+
+let destroy_project project =
+  Option.iter project.dune_pid ~f:stop_process;
+  ignore (Sys.command ("rm -rf -- " ^ Filename.quote project.temp) : int)
+;;
+
+let run ?workspace_root project events ~f =
+  let ocamllsp_stderr = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close ocamllsp_stderr)
+    (fun () ->
+       let window = WindowClientCapabilities.create ~workDoneProgress:true () in
+       let capabilities = ClientCapabilities.create ~window () in
+       let workspace_root = Option.value workspace_root ~default:project.root in
+       let workspace =
+         WorkspaceFolder.create ~uri:(Uri.of_path workspace_root) ~name:"dune-rpc"
+       in
+       let server_pid = ref None in
+       Test.run_initialized
+         ~extra_env:[ "OCAMLLSP_TEST=false"; "XDG_RUNTIME_DIR=" ^ project.runtime_dir ]
+         ~timeout:30.0
+         ~handler:(Lifecycle_events.handler events)
+         ~stderr:ocamllsp_stderr
+         ~capabilities
+         ~workspaceFolders:(Some [ workspace ])
+         ~on_spawn:(fun pid -> server_pid := Some pid)
+       @@ fun client ->
+       Fiber.finalize
+         (fun () -> f client workspace)
+         ~finally:(fun () -> stop_abruptly client (Option.value_exn !server_pid)))
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -1,0 +1,67 @@
+open Test.Import
+
+module Signal : sig
+  type t
+
+  val wait : t -> unit Fiber.t
+end
+
+module Mailbox : sig
+  type 'a t
+
+  val wait : 'a t -> 'a Fiber.t
+  val take_pending : 'a t -> 'a list
+end
+
+module Events : sig
+  type t
+
+  val dune_ready : t -> Signal.t
+
+  val wait_for_diagnostics
+    :  t
+    -> f:(PublishDiagnosticsParams.t -> bool)
+    -> PublishDiagnosticsParams.t Fiber.t
+
+  val take_pending : t -> PublishDiagnosticsParams.t list
+end
+
+module Lifecycle_events : sig
+  type t = private
+    { dune : Events.t
+    ; registrations : RegistrationParams.t Mailbox.t
+    ; unregistrations : UnregistrationParams.t Mailbox.t
+    }
+
+  val create : unit -> t
+end
+
+val for_uri : Uri.t -> PublishDiagnosticsParams.t -> bool
+val has_dune_diagnostic : PublishDiagnosticsParams.t -> bool
+val no_dune_diagnostic : PublishDiagnosticsParams.t -> bool
+val only_dune_diagnostics : PublishDiagnosticsParams.t -> PublishDiagnosticsParams.t
+val open_document : unit Client.t -> uri:Uri.t -> text:string -> unit Fiber.t
+
+type project = private
+  { temp : string
+  ; root : string
+  ; runtime_dir : string
+  ; expected : string
+  ; trigger : string
+  ; gate : string
+  ; old_source : string
+  ; mutable dune_pid : int option
+  }
+
+val create_project : string -> project
+val stop_dune : project -> unit
+val destroy_project : project -> unit
+val print_payload : project -> string -> Yojson.Safe.t -> unit
+val print_payloads : project -> string -> ('a -> Yojson.Safe.t) -> 'a list -> unit
+
+val run
+  :  ?workspace_root:string
+  -> project
+  -> Lifecycle_events.t
+  -> f:(unit Client.t -> WorkspaceFolder.t -> 'a Fiber.t)
+  -> 'a

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -1,0 +1,88 @@
+open Test.Import
+open Dune_rpc_test
+
+let%expect_test "connected Dune does not process workspace removal" =
+  let project = create_project "ws" in
+  let events = Lifecycle_events.create () in
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       run project events ~f:(fun client workspace ->
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         Test.write_file project.gate "";
+         let* initial = Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic in
+         let* registration = Mailbox.wait events.registrations in
+         print_payload
+           project
+           "initial textDocument/publishDiagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t initial);
+         print_payload
+           project
+           "initial client/registerCapability:"
+           (RegistrationParams.yojson_of_t registration);
+         let event =
+           WorkspaceFoldersChangeEvent.create ~added:[] ~removed:[ workspace ]
+         in
+         let params = DidChangeWorkspaceFoldersParams.create ~event in
+         print_payload
+           project
+           "client workspace/didChangeWorkspaceFolders:"
+           (DidChangeWorkspaceFoldersParams.yojson_of_t params);
+         let* () = Client.notification client (ChangeWorkspaceFolders params) in
+         let* () = Lev_fiber.Timer.sleepf 0.1 in
+         print_payloads
+           project
+           "textDocument/publishDiagnostics after workspace removal:"
+           PublishDiagnosticsParams.yojson_of_t
+           (Events.take_pending events.dune);
+         print_payloads
+           project
+           "client/unregisterCapability after workspace removal:"
+           UnregistrationParams.yojson_of_t
+           (Mailbox.take_pending events.unregistrations);
+         Fiber.return ()));
+  [%expect
+    {|
+    initial textDocument/publishDiagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    initial client/registerCapability:
+    {
+      "registrations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction",
+          "registerOptions": {
+            "codeActionKinds": [ "Promote" ],
+            "documentSelector": [
+              { "language": null, "scheme": null, "pattern": "<document-path>" }
+            ]
+          }
+        }
+      ]
+    }
+    client workspace/didChangeWorkspaceFolders:
+    {
+      "event": {
+        "added": [],
+        "removed": [ { "name": "dune-rpc", "uri": "<workspace-uri>" } ]
+      }
+    }
+    textDocument/publishDiagnostics after workspace removal:
+    []
+    client/unregisterCapability after workspace removal:
+    []
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -156,6 +156,7 @@ module T : sig
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
+    -> ?on_spawn:(int -> unit)
     -> (unit Client.t -> 'a Fiber.t)
     -> 'a
 
@@ -169,6 +170,7 @@ module T : sig
     -> ?capabilities:ClientCapabilities.t
     -> ?workspaceFolders:WorkspaceFolder.t list option
     -> ?trace:TraceValue.t
+    -> ?on_spawn:(int -> unit)
     -> (unit Client.t -> 'a Fiber.t)
     -> 'a
 end = struct
@@ -246,8 +248,8 @@ end = struct
     |> Lev_fiber.Error.ok_exn
   ;;
 
-  let run ?extra_env ?handler ?stderr ?timeout f =
-    snd @@ run_with_status ?extra_env ?handler ?stderr ?timeout f
+  let run ?extra_env ?handler ?stderr ?timeout ?on_spawn f =
+    snd @@ run_with_status ?extra_env ?handler ?stderr ?timeout ?on_spawn f
   ;;
 
   let run_initialized
@@ -258,9 +260,10 @@ end = struct
         ?(capabilities = ClientCapabilities.create ())
         ?workspaceFolders
         ?trace
+        ?on_spawn
         f
     =
-    run ?extra_env ?handler ?stderr ?timeout
+    run ?extra_env ?handler ?stderr ?timeout ?on_spawn
     @@ fun client ->
     let run_client () = start_client ~capabilities ?workspaceFolders ?trace client in
     let run_test () =


### PR DESCRIPTION
This test-only change characterizes the current Dune RPC behavior using real `dune build -w` processes:

- Connects ocamllsp to Dune through an isolated RPC registry and waits for the client handshake.
- Snapshots workspace removal while Dune is connected: removal currently times out, diagnostics remain, and promotion cleanup is missing.
- Exercises promotion capability registration when a failing `diff` rule offers a promotion.
- Exercises capability unregistration when the promoted document is opened.
- Removes the underlying diagnostic and snapshots the redundant unregister currently sent while the document remains open.
- Stops Dune and snapshots that Dune diagnostics are cleared while the promotion capability remains registered.
- Checks that a parent workspace discovers a nested Dune instance.
- Checks that the nested Dune instance does not claim or format a parent `dune` document.
- Snapshots the normalized diagnostics, registration, unregistration, workspace-change, and error payloads rather than summary counters.
- Runs each real-Dune scenario in its own inline-test partition.
- Adds an e2e spawn hook so tests can terminate the server deterministically without depending on the lifecycle behavior being characterized.

There are no production-code changes in this PR.


