### PR TITLE
refactor(lsp): expose position helpers

### DIFF
--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -1,4 +1,5 @@
 module Progress = Progress
+module Position = Position
 module Client_notification = Client_notification
 module Client_request = Client_request
 module Extension = Extension

--- a/lsp/src/position.ml
+++ b/lsp/src/position.ml
@@ -8,3 +8,6 @@ let compare t { line; character } =
   | 0 -> Int.compare t.character character
   | n -> n
 ;;
+
+let min x y = if compare x y <= 0 then x else y
+let max x y = if compare x y >= 0 then x else y

--- a/lsp/src/position.mli
+++ b/lsp/src/position.mli
@@ -1,0 +1,8 @@
+open! Import
+include module type of Types.Position with type t = Types.Position.t
+
+val zero : t
+val is_zero : t -> bool
+val compare : t -> t -> int
+val min : t -> t -> t
+val max : t -> t -> t

--- a/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
@@ -59,8 +59,8 @@ module TySet = Set.Make (struct
       let c = Option.compare DocumentUri.compare doc_a doc_b in
       if Int.equal 0 c
       then (
-        let c = Position.compare pos_a pos_b in
-        if Ordering.is_eq c then compare ty_a ty_b else c |> Ordering.to_int)
+        let c = Lsp.Position.compare pos_a pos_b in
+        if Int.equal 0 c then Poly.compare ty_a ty_b |> Ordering.to_int else c)
       else c
     ;;
   end)

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -95,9 +95,7 @@ let make_enclosing_command position index =
 let get_first_enclosing_index range_end enclosings =
   List.find_mapi enclosings ~f:(fun i (loc, _, _) ->
     let range = Range.of_loc loc in
-    match Position.compare range_end range.end_ with
-    | Ordering.Lt | Ordering.Eq -> Some i
-    | Ordering.Gt -> None)
+    if Lsp.Position.compare range_end range.end_ <= 0 then Some i else None)
 ;;
 
 let dispatch_command pipeline command first_index index =

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -16,9 +16,7 @@ let normalize_selection_range ~(range : Range.t) = function
   | None -> range
   | Some (selection_range : Range.t) ->
     let selection_is_valid =
-      match Position.compare selection_range.start selection_range.end_ with
-      | Lt | Eq -> true
-      | Gt -> false
+      Lsp.Position.compare selection_range.start selection_range.end_ <= 0
     in
     if selection_is_valid && Range.contains range selection_range
     then selection_range

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -340,7 +340,7 @@ let type_enclosing_hover
         match state.hover_extended.history with
         | None -> 0
         | Some (h_uri, h_position, h_verbosity) ->
-          if Uri.equal uri h_uri && Ordering.is_eq (Position.compare position h_position)
+          if Uri.equal uri h_uri && Lsp.Position.compare position h_position = 0
           then succ h_verbosity
           else 0
       in

--- a/ocaml-lsp-server/src/position.ml
+++ b/ocaml-lsp-server/src/position.ml
@@ -5,8 +5,6 @@ let to_dyn { line; character } =
   Dyn.record [ "line", Dyn.int line; "character", Dyn.int character ]
 ;;
 
-let start = { line = 0; character = 0 }
-
 let is_dummy (lp : Lexing.position) =
   lp.pos_lnum = Lexing.dummy_pos.pos_lnum && lp.pos_cnum = Lexing.dummy_pos.pos_cnum
 ;;
@@ -38,30 +36,12 @@ let ( - ) ({ line; character } : t) (t : t) : t =
 
 let abs ({ line; character } : t) : t = { line = abs line; character = abs character }
 
-let compare ({ line; character } : t) (t : t) : Ordering.t =
-  match Int.compare line t.line with
-  | Eq -> Int.compare character t.character
-  | r -> r
-;;
-
-let max x y =
-  match compare x y with
-  | Lt -> y
-  | Eq | Gt -> x
-;;
-
-let min x y =
-  match compare x y with
-  | Lt | Eq -> x
-  | Gt -> y
-;;
-
 let compare_inclusion (t : t) (r : Lsp.Types.Range.t) =
-  match compare t r.start, compare t r.end_ with
-  | Lt, Lt -> `Outside (abs (r.start - t))
-  | Gt, Gt -> `Outside (abs (r.end_ - t))
-  | Eq, Lt | Gt, Eq | Eq, Eq | Gt, Lt -> `Inside
-  | Eq, Gt | Lt, Eq | Lt, Gt -> assert false
+  if Lsp.Position.compare t r.start < 0
+  then `Outside (abs (r.start - t))
+  else if Lsp.Position.compare t r.end_ > 0
+  then `Outside (abs (r.end_ - t))
+  else `Inside
 ;;
 
 let logical position =

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -6,10 +6,6 @@ include module type of Lsp.Types.Position with type t = Lsp.Types.Position.t
 val compare_inclusion : t -> Lsp.Types.Range.t -> [ `Inside | `Outside of t ]
 
 val ( - ) : t -> t -> t
-val compare : t -> t -> Ordering.t
-val max : t -> t -> t
-val min : t -> t -> t
 val logical : t -> [> `Logical of int * int ]
 val of_lexical_position : Lexing.position -> t option
-val start : t
 val to_dyn : t -> Dyn.t

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -2,9 +2,12 @@ open Import
 include Lsp.Types.Range
 
 let compare (x : t) (y : t) =
-  match Position.compare x.start y.start with
-  | (Lt | Gt) as r -> r
-  | Ordering.Eq -> Position.compare x.end_ y.end_
+  let result =
+    match Lsp.Position.compare x.start y.start with
+    | 0 -> Lsp.Position.compare x.end_ y.end_
+    | result -> result
+  in
+  Ordering.of_int result
 ;;
 
 let to_dyn { start; end_ } =
@@ -12,18 +15,13 @@ let to_dyn { start; end_ } =
 ;;
 
 let contains (x : t) (y : t) =
-  let open Ordering in
-  match Position.compare x.start y.start, Position.compare x.end_ y.end_ with
-  | (Lt | Eq), (Gt | Eq) -> true
-  | _ -> false
+  Lsp.Position.compare x.start y.start <= 0 && Lsp.Position.compare y.end_ x.end_ <= 0
 ;;
 
 let intersection (x : t) (y : t) =
-  let start = Position.max x.start y.start in
-  let end_ = Position.min x.end_ y.end_ in
-  match Position.compare start end_ with
-  | Lt -> Some { start; end_ }
-  | Eq | Gt -> None
+  let start = Lsp.Position.max x.start y.start in
+  let end_ = Lsp.Position.min x.end_ y.end_ in
+  if Lsp.Position.compare start end_ < 0 then Some { start; end_ } else None
 ;;
 
 (* Compares ranges by their lengths*)
@@ -34,8 +32,8 @@ let compare_size (x : t) (y : t) =
 ;;
 
 let first_line =
-  let start = { Position.line = 0; character = 0 } in
-  let end_ = { Position.line = 1; character = 0 } in
+  let start = Lsp.Position.zero in
+  let end_ = { Lsp.Types.Position.line = 1; character = 0 } in
   { start; end_ }
 ;;
 
@@ -68,10 +66,7 @@ let resize_for_edit { TextEdit.range; newText } =
 ;;
 
 let overlaps x y =
-  let open Ordering in
-  match Position.compare x.start y.end_, Position.compare x.end_ y.start with
-  | (Lt | Eq), (Gt | Eq) | (Gt | Eq), (Lt | Eq) -> true
-  | _ -> false
+  Lsp.Position.compare x.start y.end_ <= 0 && Lsp.Position.compare y.start x.end_ <= 0
 ;;
 
 let to_string t =

--- a/ocaml-lsp-server/src/typed_hole.ml
+++ b/ocaml-lsp-server/src/typed_hole.ml
@@ -11,9 +11,9 @@ let find_prev ~range ~position holes =
   Base.List.fold_until
     ~init:None
     ~f:(fun prev hole ->
-      match Position.compare hole.end_ position with
-      | Lt -> Continue (Some hole)
-      | Gt | Eq -> Stop prev)
+      if Lsp.Position.compare hole.end_ position < 0
+      then Continue (Some hole)
+      else Stop prev)
     ~finish:Fun.id
     holes
   |> function
@@ -23,12 +23,7 @@ let find_prev ~range ~position holes =
 
 let find_next ~range ~position holes =
   let holes = in_range range holes in
-  List.find
-    ~f:(fun hole ->
-      match Position.compare hole.start position with
-      | Gt -> true
-      | Lt | Eq -> false)
-    holes
+  List.find ~f:(fun hole -> Lsp.Position.compare hole.start position > 0) holes
   |> function
   | None -> Base.List.hd holes
   | hole -> hole

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -729,11 +729,7 @@ let g childs = List.map f childs
   let request client =
     let open Fiber.O in
     let+ response = Util.call_document_symbol client in
-    let le a b =
-      match Position.compare a b with
-      | Gt -> false
-      | Lt | Eq -> true
-    in
+    let le a b = Lsp.Position.compare a b <= 0 in
     let rec check (symbol : DocumentSymbol.t) =
       let range = symbol.range
       and selection = symbol.selectionRange in

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -301,15 +301,15 @@ let offset_of_position src (pos : Position.t) =
 let apply_edits src edits =
   let edits =
     List.sort edits ~compare:(fun (e : TextEdit.t) (e' : TextEdit.t) ->
-      Position.compare e.range.start e'.range.start)
+      Lsp.Position.compare e.range.start e'.range.start |> Ordering.of_int)
   in
   (* check that edits are non-overlapping *)
   let rec overlaps : TextEdit.t list -> _ = function
     | [] | [ _ ] -> false
     | e :: e' :: es ->
-      (match Position.compare e.range.end_ e'.range.start with
-       | Gt -> true
-       | Lt | Eq -> overlaps (e' :: es))
+      if Lsp.Position.compare e.range.end_ e'.range.start > 0
+      then true
+      else overlaps (e' :: es)
   in
   if overlaps edits then failwith "overlapping edits";
   let _, edits =

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -1,5 +1,10 @@
 open Lsp.Types
 
+let%test_unit "convert an LSP position to a Merlin logical position" =
+  let position = Position.create ~line:2 ~character:3 in
+  assert (Ocaml_lsp_server.Testing.Position.logical position = `Logical (3, 3))
+;;
+
 let%expect_test "replacement ranges preserve trailing newlines" =
   let start = Position.create ~line:2 ~character:5 in
   let range = Range.create ~start ~end_:start in

--- a/ocaml-lsp-server/test/range_relations_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/range_relations_quickcheck_tests.ml
@@ -49,7 +49,7 @@ let check_case { Case.point; first_start; first_end; second_start; second_end } 
   check
     "position comparison"
     (Poly.equal
-       (Position.compare point first.start)
+       (ordering (Lsp.Position.compare point first.start))
        (ordering (Int.compare point_offset first_start)));
   let expected_difference =
     Lsp.Types.Position.create


### PR DESCRIPTION
The `lsp` library already owns the generic position implementation, but it was not part of the public `Lsp` module, leaving `ocaml-lsp-server` to duplicate comparison and min/max operations.

Expose `Lsp.Position` with an explicit interface and make the server delegate its generic position operations to it. OCaml/Merlin-specific position conversion remains in `ocaml-lsp-server`.
