### PR TITLE
ci: disable flaky OUnit2 tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,9 +141,11 @@
           };
         });
         ocamlVersionOverlay = ocaml: _final: prev: {
-          ocamlPackages = prev.ocaml-ng.${ocaml}.overrideScope (_: _: {
+          ocamlPackages = prev.ocaml-ng.${ocaml}.overrideScope (_: osuper: {
             dune = duneLatest;
             dune_3 = duneLatest;
+            # OUnit2's process signal test is flaky under GitHub Actions.
+            ounit2 = osuper.ounit2.overrideAttrs (_: { doCheck = false; });
           });
         };
         makeNixpkgs = ocaml: merlin:


### PR DESCRIPTION
Disable OUnit2's flaky process-signal tests in the OCaml 5.5 package scope so the Nix check shell can be built reliably in GitHub Actions.