### PR TITLE
refactor(lsp): add text document substring helper

### DIFF
--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -131,3 +131,11 @@ let absolute_range t (range : Range.t) =
   let stop = String_zipper.offset zipper in
   start, stop
 ;;
+
+let substring t range =
+  let start, end_ = absolute_range t range in
+  let text = text t in
+  if start < 0 || start > end_ || end_ > String.length text
+  then None
+  else Some (String.sub text ~pos:start ~len:(end_ - start))
+;;

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -42,3 +42,8 @@ val absolute_position : t -> Position.t -> int
 (* [absolute_range t range] same as [(absolute_position t range.start ,
    absolute_position t range.end_)] but possibly faster *)
 val absolute_range : t -> Range.t -> int * int
+
+(** [substring t range] returns the text within [range], interpreted using the
+    document's position encoding. Returns [None] when the range's start follows
+    its end. *)
+val substring : t -> Range.t -> string option

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -297,6 +297,25 @@ let%expect_test "absolute_position" =
   [%expect {| position: 13/13 |}]
 ;;
 
+let%expect_test "substring uses the document's position encoding" =
+  let text = "zero\n😀abc\nlast" in
+  let test position_encoding range =
+    let doc = make_document ~position_encoding (Uri.of_path "foo.ml") ~text in
+    match Text_document.substring doc range with
+    | None -> print_endline "<none>"
+    | Some substring -> print_endline substring
+  in
+  test `UTF8 (tuple_range (1, 0) (1, 5));
+  test `UTF16 (tuple_range (1, 0) (1, 3));
+  test `UTF8 (tuple_range (1, 5) (1, 0));
+  [%expect
+    {|
+    😀a
+    😀a
+    <none>
+    |}]
+;;
+
 let%expect_test "replace second line first line is \\n" =
   let range = tuple_range (1, 2) (1, 2) in
   let doc = make_document (Uri.of_path "foo.ml") ~text:"\nfoo\nbar\nbaz\n" in

--- a/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
+++ b/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
@@ -56,7 +56,7 @@ let code_action doc params =
        let result =
          let open Option.O in
          let* range = select_complete_lines params.CodeActionParams.range in
-         let* code = Document.substring doc range in
+         let* code = Text_document.substring (Document.text_document doc) range in
          let code = String.strip ~drop:(fun c -> Char.equal c '\n') code in
          let* lhs_patterns, rhs_expressions = split_cases code in
          let+ i = Base.String.index code '|' in

--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -143,7 +143,7 @@ let extract_local doc typedtree range =
   let* extract_range = Range.of_loc_opt to_extract.exp_loc in
   let* edit_pos = tightest_enclosing_binder_position typedtree range in
   let new_name = "var_name" in
-  let* local_text = Document.substring doc extract_range in
+  let* local_text = Text_document.substring (Document.text_document doc) extract_range in
   let newText = sprintf "let %s = %s in\n" new_name local_text in
   let insert_range = { Range.start = edit_pos; end_ = edit_pos } in
   Some
@@ -169,7 +169,7 @@ let extract_function doc typedtree range =
     let s = String.concat ~sep:" " args in
     if String.is_empty s then "()" else s
   in
-  let* func_text = Document.substring doc extract_range in
+  let* func_text = Text_document.substring (Document.text_document doc) extract_range in
   let new_function = sprintf "let %s %s = %s\n\n" new_name args_str func_text in
   let new_call = sprintf "%s %s" new_name args_str in
   let insert_range = { Range.start = edit_pos; end_ = edit_pos } in

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -106,7 +106,7 @@ let rec mark_value_unused_edit name contexts =
 
 let code_action_mark_value_unused pipeline doc (diagnostic : Diagnostic.t) =
   let open Option.O in
-  let* var_name = Document.substring doc diagnostic.range in
+  let* var_name = Text_document.substring (Document.text_document doc) diagnostic.range in
   let pos = diagnostic.range.start in
   let+ text_edit =
     enclosing_pos pipeline pos |> List.rev_map ~f:snd |> mark_value_unused_edit var_name
@@ -160,7 +160,7 @@ let code_action_remove_range
 
 (* Create a code action that removes the value mentioned in [diagnostic]. *)
 let code_action_remove_value pipeline doc pos (diagnostic : Diagnostic.t) =
-  let* var_name = Document.substring doc diagnostic.range in
+  let* var_name = Text_document.substring (Document.text_document doc) diagnostic.range in
   enclosing_pos pipeline pos
   |> List.map ~f:snd
   |> enclosing_value_binding_range var_name

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -485,11 +485,3 @@ let get_impl_intf_counterparts m uri =
   in
   List.map ~f:Uri.of_path files_to_switch_to
 ;;
-
-let substring doc range =
-  let start, end_ = Text_document.absolute_range (text_document doc) range in
-  let text = text doc in
-  if start < 0 || start > end_ || end_ > String.length text
-  then None
-  else Some (String.sub text ~pos:start ~len:(end_ - start))
-;;

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -130,9 +130,3 @@ val get_impl_intf_counterparts : Merlin.t option -> Uri.t -> Uri.t list
 (** [edits t edits] creates a [WorkspaceEdit.t] that applies edits [edits] to
     the document [t]. *)
 val edit : t -> TextEdit.t list -> WorkspaceEdit.t
-
-(** [substring t range] returns the substring of the document [t] that
-    corresponds to the range [range].
-
-    Returns [None] when there is no corresponding substring. *)
-val substring : t -> Range.t -> string option


### PR DESCRIPTION
Moves the generic range-to-text logic from `ocaml-lsp-server` into `Lsp.Text_document.substring`. Server call sites now use the library helper directly.

Coverage verifies UTF-8 and UTF-16 position handling and reversed ranges.
