### PR TITLE
refactor(lsp): add text document workspace edit helper

### DIFF
--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -5,12 +5,15 @@ include struct
   module DidOpenTextDocumentParams = DidOpenTextDocumentParams
   module DocumentUri = DocumentUri
   module LanguageKind = LanguageKind
+  module OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier
   module Range = Range
+  module TextDocumentEdit = TextDocumentEdit
   module TextDocumentItem = TextDocumentItem
   module TextDocumentContentChangeEvent = TextDocumentContentChangeEvent
   module TextDocumentContentChangePartial = TextDocumentContentChangePartial
   module TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument
   module TextEdit = TextEdit
+  module WorkspaceEdit = WorkspaceEdit
 end
 
 type invalid_utf = String_zipper.invalid_utf =
@@ -118,6 +121,15 @@ let apply_text_document_edits t (edits : TextEdit.t list) =
   let text = apply_changes t.zipper t.position_encoding edits in
   let zipper = String_zipper.of_string text in
   { t with text = Some text; zipper }
+;;
+
+let workspace_edit t text_edits =
+  let textDocument =
+    OptionalVersionedTextDocumentIdentifier.create ~uri:t.uri ~version:t.version ()
+  in
+  let edits = List.map text_edits ~f:(fun edit -> `TextEdit edit) in
+  let edit = TextDocumentEdit.create ~textDocument ~edits in
+  WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
 ;;
 
 let absolute_position t pos =

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -33,6 +33,10 @@ val set_version : t -> version:int -> t
     interpreted relative to the original document. *)
 val apply_text_document_edits : t -> TextEdit.t list -> t
 
+(** [workspace_edit t edits] creates a versioned workspace edit that applies
+    [edits] to [t]. *)
+val workspace_edit : t -> TextEdit.t list -> WorkspaceEdit.t
+
 (** [absolute_position t pos] returns the absolute position of [pos] inside
     [text t]. If the position is outside the bounds of the document, the offset
     returned will be the length of the document. [pos] is interpreted with

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -297,6 +297,23 @@ let%expect_test "absolute_position" =
   [%expect {| position: 13/13 |}]
 ;;
 
+let%test_unit "workspace edits identify the document and its version" =
+  let uri = Uri.of_string "file:///foo.ml" in
+  let doc = make_document uri ~text:"old" in
+  let range = tuple_range (0, 0) (0, 3) in
+  let text_edit = TextEdit.create ~range ~newText:"new" in
+  match (Text_document.workspace_edit doc [ text_edit ]).documentChanges with
+  | Some
+      [ `TextDocumentEdit
+          { textDocument = { uri = actual_uri; version = Some 1 }
+          ; edits = [ `TextEdit actual_edit ]
+          }
+      ] ->
+    assert (Uri.equal uri actual_uri);
+    assert (text_edit = actual_edit)
+  | _ -> assert false
+;;
+
 let%expect_test "substring uses the document's position encoding" =
   let text = "zero\n😀abc\nlast" in
   let test position_encoding range =

--- a/ocaml-lsp-server/src/code_actions/action_add_rec.ml
+++ b/ocaml-lsp-server/src/code_actions/action_add_rec.ml
@@ -37,7 +37,7 @@ let has_missing_rec pipeline pos_start =
 
 let code_action_add_rec diagnostics doc loc =
   let textedit : TextEdit.t = { range = Range.of_loc loc; newText = "rec " } in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
   CodeAction.create
     ~diagnostics
     ~title:action_title

--- a/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
+++ b/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
@@ -43,7 +43,7 @@ let pick_rhs rhs_expressions =
 
 let make_text_edit ~range ~newText ~doc =
   let text_edit = TextEdit.create ~range ~newText in
-  Code_action.workspace_edit doc [ text_edit ]
+  Text_document.workspace_edit (Document.text_document doc) [ text_edit ]
 ;;
 
 let code_action doc params =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -7,7 +7,7 @@ let kind = CodeActionKind.Other action_kind
 let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, newText) =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   let command =
     if supportsJumpToNextHole

--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -190,7 +190,7 @@ let run_extract_local pipeline doc (params : CodeActionParams.t) =
   CodeAction.create
     ~title:"Extract local"
     ~kind:CodeActionKind.RefactorExtract
-    ~edit:(Document.edit doc edits)
+    ~edit:(Text_document.workspace_edit (Document.text_document doc) edits)
     ~isPreferred:false
     ()
 ;;
@@ -206,7 +206,7 @@ let run_extract_function pipeline doc (params : CodeActionParams.t) =
   CodeAction.create
     ~title:"Extract function"
     ~kind:CodeActionKind.RefactorExtract
-    ~edit:(Document.edit doc edits)
+    ~edit:(Text_document.workspace_edit (Document.text_document doc) edits)
     ~isPreferred:false
     ()
 ;;

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -5,7 +5,7 @@ let action_kind = "inferred_intf"
 
 let code_action_of_intf doc intf range =
   let textedit : TextEdit.t = { range; newText = intf } in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
   let title = String.capitalize_ascii "Insert inferred interface" in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -368,7 +368,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
     in
     Some action
   | _ :: _, (Some _ | None) ->
-    let edit = Code_action.workspace_edit doc edits in
+    let edit = Text_document.workspace_edit (Document.text_document doc) edits in
     let action =
       CodeAction.create
         ~title:action_title

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -111,7 +111,7 @@ let code_action_mark_value_unused pipeline doc (diagnostic : Diagnostic.t) =
   let+ text_edit =
     enclosing_pos pipeline pos |> List.rev_map ~f:snd |> mark_value_unused_edit var_name
   in
-  let edit = Document.edit doc [ text_edit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ text_edit ] in
   CodeAction.create
     ~diagnostics:[ diagnostic ]
     ~title:"Mark as unused"
@@ -148,7 +148,9 @@ let code_action_remove_range
       (diagnostic : Diagnostic.t)
       range
   =
-  let edit = Document.edit doc [ { range; newText = "" } ] in
+  let edit =
+    Text_document.workspace_edit (Document.text_document doc) [ { range; newText = "" } ]
+  in
   CodeAction.create
     ~diagnostics:[ diagnostic ]
     ~title
@@ -171,7 +173,9 @@ let code_action_remove_value pipeline doc pos (diagnostic : Diagnostic.t) =
     the diagnostic [d] by inserting an underscore at [pos] in [doc]. *)
 let create_mark_action ~title doc pos d =
   let edit =
-    Document.edit doc [ { range = Range.create ~start:pos ~end_:pos; newText = "_" } ]
+    Text_document.workspace_edit
+      (Document.text_document doc)
+      [ { range = Range.create ~start:pos ~end_:pos; newText = "_" } ]
   in
   CodeAction.create
     ~diagnostics:[ d ]
@@ -238,7 +242,7 @@ let action_mark_open doc (d : Diagnostic.t) =
   let edit =
     let pos = { d.range.start with character = d.range.start.character + 4 } in
     let range = Range.create ~start:pos ~end_:pos in
-    Document.edit doc [ { range; newText = "!" } ]
+    Text_document.workspace_edit (Document.text_document doc) [ { range; newText = "!" } ]
   in
   CodeAction.create
     ~diagnostics:[ d ]
@@ -301,8 +305,8 @@ let action_remove_case pipeline doc (d : Diagnostic.t) =
   let* end_ = Position.of_lexical_position case_end in
   let+ preceding_bar = find_preceding doc start bar_regex in
   let edit =
-    Document.edit
-      doc
+    Text_document.workspace_edit
+      (Document.text_document doc)
       [ { range = Range.create ~start:preceding_bar.start ~end_; newText = "" } ]
   in
   CodeAction.create
@@ -327,7 +331,11 @@ let action_remove_constructor pipeline doc (d : Diagnostic.t) =
   let* case_start, case_end = case_range in
   let* start = Position.of_lexical_position case_start in
   let+ end_ = Position.of_lexical_position case_end in
-  let edit = Document.edit doc [ { range = Range.create ~start ~end_; newText = "" } ] in
+  let edit =
+    Text_document.workspace_edit
+      (Document.text_document doc)
+      [ { range = Range.create ~start ~end_; newText = "" } ]
+  in
   CodeAction.create
     ~diagnostics:[ d ]
     ~title:"Remove unused constructor"

--- a/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
+++ b/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
@@ -40,7 +40,7 @@ let code_action_of_type_enclosing doc (loc, constr_loc) =
   let textedit : TextEdit.t =
     { range = Range.of_loc (Loc.union loc constr_loc); newText = src_text }
   in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -33,7 +33,7 @@ let code_action_of_type_enclosing doc (loc, typ) =
   let+ original_text = Code_action.source_text doc loc in
   let newText = Printf.sprintf "(%s : %s)" original_text typ in
   let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
-  let edit = Code_action.workspace_edit doc [ textedit ] in
+  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
   let title = String.capitalize_ascii action_kind in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/action_update_signature.ml
+++ b/ocaml-lsp-server/src/code_actions/action_update_signature.ml
@@ -4,7 +4,7 @@ open Fiber.O
 let action_kind = "update_intf"
 
 let code_action_of_intf doc text_edits =
-  let edit = Code_action.workspace_edit doc text_edits in
+  let edit = Text_document.workspace_edit (Document.text_document doc) text_edits in
   let title = String.capitalize_ascii "update signature(s) to match implementation" in
   CodeAction.create
     ~title

--- a/ocaml-lsp-server/src/code_actions/code_action.ml
+++ b/ocaml-lsp-server/src/code_actions/code_action.ml
@@ -26,12 +26,3 @@ let source_text doc (loc : Loc.t) =
   let (`Offset end_) = Msource.get_offset source (Position.logical end_) in
   String.sub (Msource.text source) ~pos:start ~len:(end_ - start)
 ;;
-
-let workspace_edit doc text_edits =
-  let uri = Document.uri doc in
-  let version = Document.version doc in
-  let textDocument = OptionalVersionedTextDocumentIdentifier.create ~uri ~version () in
-  let edits = List.map text_edits ~f:(fun edit -> `TextEdit edit) in
-  let edit = TextDocumentEdit.create ~textDocument ~edits in
-  WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-;;

--- a/ocaml-lsp-server/src/code_actions/code_action.mli
+++ b/ocaml-lsp-server/src/code_actions/code_action.mli
@@ -24,4 +24,3 @@ val non_batchable
   -> t
 
 val source_text : Document.t -> Loc.t -> string option
-val workspace_edit : Document.t -> TextEdit.t list -> WorkspaceEdit.t

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -403,19 +403,6 @@ module Merlin = struct
   ;;
 end
 
-let edit t text_edits =
-  let version = version t in
-  let textDocument =
-    OptionalVersionedTextDocumentIdentifier.create ~uri:(uri t) ~version ()
-  in
-  let edit =
-    TextDocumentEdit.create
-      ~textDocument
-      ~edits:(List.map text_edits ~f:(fun text_edit -> `TextEdit text_edit))
-  in
-  WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
-;;
-
 let kind = function
   | Merlin merlin -> `Merlin merlin
   | Dune _ | Other _ -> `Other

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -126,7 +126,3 @@ val text_document : t -> Text_document.t
 
     For instance, the counterparts of the file [/file.ml] are [/file.mli]. *)
 val get_impl_intf_counterparts : Merlin.t option -> Uri.t -> Uri.t list
-
-(** [edits t edits] creates a [WorkspaceEdit.t] that applies edits [edits] to
-    the document [t]. *)
-val edit : t -> TextEdit.t list -> WorkspaceEdit.t


### PR DESCRIPTION
Adds `Lsp.Text_document.workspace_edit` for constructing a versioned single-document workspace edit. This replaces the duplicate helpers in `Document` and `Code_action`, and server call sites use the library API directly.

Coverage verifies that the generated edit retains the document URI, version, and text edits.
