### PR TITLE
fix(code-actions): compute post-edit ranges correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Compute code-action ranges correctly after multiline and UTF-16 edits.
+  (#1911, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -4,7 +4,13 @@ open Fiber.O
 let action_kind = "destruct (enumerate cases)"
 let kind = CodeActionKind.Other action_kind
 
-let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, newText) =
+let code_action_of_case_analysis
+      ~action_kind
+      ~supportsJumpToNextHole
+      ~position_encoding
+      doc
+      (loc, newText)
+  =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
   let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
@@ -14,7 +20,7 @@ let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, 
     then
       Some
         (Client.Custom_commands.next_hole
-           ~in_range:(Range.resize_for_edit textedit)
+           ~in_range:(Range.resize_for_edit ~position_encoding textedit)
            ~notify_if_no_hole:false
            ())
     else None
@@ -61,7 +67,13 @@ let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postpr
       State.experimental_client_capabilities state
       |> Client.Experimental_capabilities.supportsJumpToNextHole
     in
-    Some (code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
+    Some
+      (code_action_of_case_analysis
+         ~action_kind
+         ~supportsJumpToNextHole
+         ~position_encoding:(State.position_encoding state)
+         doc
+         reply)
   | Error
       { exn =
           ( Merlin_analysis.Destruct.Wrong_parent _

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -299,7 +299,12 @@ module Complete_with_construct = struct
     | Error exn -> Exn_with_backtrace.reraise exn
   ;;
 
-  let process_dispatch_resp ~supportsJumpToNextHole ~fallback_range ~position = function
+  let process_dispatch_resp
+        ~supportsJumpToNextHole
+        ~position_encoding
+        ~fallback_range
+        ~position
+    = function
     | None -> []
     | Some (loc, constructed_exprs) ->
       let range =
@@ -330,7 +335,7 @@ module Complete_with_construct = struct
           then
             Some
               (Client.Custom_commands.next_hole
-                 ~in_range:(Range.resize_for_edit edit)
+                 ~in_range:(Range.resize_for_edit ~position_encoding edit)
                  ~notify_if_no_hole:false
                  ())
           else None
@@ -471,6 +476,7 @@ let complete
                in
                Complete_with_construct.process_dispatch_resp
                  ~supportsJumpToNextHole
+                 ~position_encoding:(State.position_encoding state)
                  ~fallback_range:(edit_range merlin pos)
                  ~position:pos
                  construct_cmd_resp

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -16,19 +16,29 @@ let of_loc (loc : Loc.t) : t =
   of_loc_opt loc |> Option.value ~default:Lsp.Range.first_line
 ;;
 
-let resize_for_edit { TextEdit.range; newText } =
-  let lines = String.split_lines newText in
-  match lines with
-  | [] -> { range with end_ = range.start }
-  | several_lines ->
-    let end_ =
-      let start = range.start in
-      let line = start.line + List.length several_lines - 1 in
-      let character =
-        let last_line_len = List.last_exn several_lines |> String.length in
-        if line = start.line then start.character + last_line_len else last_line_len
+let resize_for_edit ~position_encoding { TextEdit.range; newText } =
+  let rec position_after_text (position : Position.t) offset =
+    if offset = String.length newText
+    then position
+    else (
+      let decoded = Stdlib.String.get_utf_8_uchar newText offset in
+      if not (Stdlib.Uchar.utf_decode_is_valid decoded)
+      then invalid_arg "Range.resize_for_edit: invalid UTF-8";
+      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
+      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
+      let position =
+        if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
+        then { Position.line = position.line + 1; character = 0 }
+        else (
+          let character_width =
+            match position_encoding with
+            | `UTF8 -> byte_length
+            | `UTF16 -> Stdlib.Uchar.utf_16_byte_length uchar / 2
+          in
+          { position with character = position.character + character_width })
       in
-      { Position.line; character }
-    in
-    { range with end_ }
+      position_after_text position (offset + byte_length))
+  in
+  let end_ = position_after_text range.start 0 in
+  { range with end_ }
 ;;

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -8,8 +8,8 @@ val of_loc_opt : Loc.t -> t option
     line in the document *)
 val of_loc : Loc.t -> t
 
-(** [resize_for_edit edit] returns shrunk, unchanged, or extended [edit.range]
-    depending on the size of [edit.newText], e.g., if [edit.newText] contains
-    less characters than [edit.range], the new range is shrunk to fit
-    [edit.newText] only. *)
-val resize_for_edit : TextEdit.t -> t
+(** [resize_for_edit ~position_encoding edit] returns shrunk, unchanged, or
+    extended [edit.range] depending on the size of [edit.newText], e.g., if
+    [edit.newText] contains less characters than [edit.range], the new range is
+    shrunk to fit [edit.newText] only. *)
+val resize_for_edit : position_encoding:[ `UTF16 | `UTF8 ] -> TextEdit.t -> t

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -2,6 +2,7 @@
  (modules
   ocaml_lsp_tests
   position_prefix_tests
+  range_quickcheck_tests
   semantic_tokens_quickcheck_tests)
  (name ocaml_lsp_tests)
  (enabled_if
@@ -17,6 +18,7 @@
   ;; in dune-project
   base
   base_quickcheck
+  editing_test_model
   ppx_expect.config
   ppx_expect.config_types
   ppx_inline_test.config

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -18,18 +18,22 @@ let%expect_test "replacement ranges preserve trailing newlines" =
   let start = Position.create ~line:2 ~character:5 in
   let range = Range.create ~start ~end_:start in
   let edit = TextEdit.create ~range ~newText:"x\n" in
-  let range = Ocaml_lsp_server.Testing.Range.resize_for_edit edit in
+  let range =
+    Ocaml_lsp_server.Testing.Range.resize_for_edit ~position_encoding:`UTF16 edit
+  in
   print_endline (Range.to_string range);
-  [%expect {| ((2, 5), (2, 6)) |}]
+  [%expect {| ((2, 5), (3, 0)) |}]
 ;;
 
 let%expect_test "replacement ranges use UTF-16 character units" =
   let start = Position.create ~line:2 ~character:5 in
   let range = Range.create ~start ~end_:start in
   let edit = TextEdit.create ~range ~newText:"😀" in
-  let range = Ocaml_lsp_server.Testing.Range.resize_for_edit edit in
+  let range =
+    Ocaml_lsp_server.Testing.Range.resize_for_edit ~position_encoding:`UTF16 edit
+  in
   print_endline (Range.to_string range);
-  [%expect {| ((2, 5), (2, 9)) |}]
+  [%expect {| ((2, 5), (2, 7)) |}]
 ;;
 
 let%expect_test "document-symbol selection range relationships" =

--- a/ocaml-lsp-server/test/range_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/range_quickcheck_tests.ml
@@ -1,0 +1,122 @@
+open Base
+open Base_quickcheck
+open Editing_model
+module Server_range = Ocaml_lsp_server.Testing.Range
+module Text_document = Lsp.Text_document
+module TextEdit = Lsp.Types.TextEdit
+module TextDocumentItem = Lsp.Types.TextDocumentItem
+module DidOpenTextDocumentParams = Lsp.Types.DidOpenTextDocumentParams
+module DocumentUri = Lsp.Types.DocumentUri
+
+module Case = struct
+  type t =
+    { prefix : atom list
+    ; removed : atom list
+    ; replacement : atom list
+    ; suffix : atom list
+    ; encoding : encoding
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let make_document text encoding =
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:(DocumentUri.of_path "/quickcheck.ml")
+      ~languageId:(Lsp.Types.LanguageKind.Other "ocaml")
+      ~version:0
+      ~text
+  in
+  Text_document.make
+    ~position_encoding:(lsp_encoding encoding)
+    (DidOpenTextDocumentParams.create ~textDocument)
+;;
+
+let equal_position (left : Position.t) (right : Position.t) =
+  left.line = right.line && left.character = right.character
+;;
+
+let show_position (position : Position.t) =
+  Printf.sprintf "%d:%d" position.line position.character
+;;
+
+let run_case { Case.prefix; removed; replacement; suffix; encoding } =
+  let prefix = string_of_atoms prefix in
+  let removed = string_of_atoms removed in
+  let replacement = string_of_atoms replacement in
+  let suffix = string_of_atoms suffix in
+  let source = prefix ^ removed ^ suffix in
+  let start = cursor_at_byte_offset source encoding (String.length prefix) in
+  let stop =
+    cursor_at_byte_offset source encoding (String.length prefix + String.length removed)
+  in
+  let edit =
+    TextEdit.create
+      ~range:(Range.create ~start:(position start) ~end_:(position stop))
+      ~newText:replacement
+  in
+  let resized =
+    Server_range.resize_for_edit ~position_encoding:(lsp_encoding encoding) edit
+  in
+  let expected_end = position_after_text (position start) replacement encoding in
+  if not (equal_position resized.start (position start))
+  then failf "resized range changed its start";
+  if not (equal_position resized.end_ expected_end)
+  then
+    failf
+      "resized range has the wrong end\n\
+       start: %s\n\
+       replacement: %S\n\
+       expected: %s\n\
+       actual: %s"
+      (show_position (position start))
+      replacement
+      (show_position expected_end)
+      (show_position resized.end_);
+  let document = make_document source encoding in
+  let document = Text_document.apply_text_document_edits document [ edit ] in
+  let actual_text = Text_document.text document in
+  let expected_text = prefix ^ replacement ^ suffix in
+  if not (String.equal expected_text actual_text)
+  then
+    failf "edit application differs\nexpected: %S\nactual: %S" expected_text actual_text;
+  let range_start, range_stop = Text_document.absolute_range document resized in
+  let selected = slice actual_text ~start:range_start ~stop:range_stop in
+  if not (String.equal replacement selected)
+  then
+    failf
+      "resized range does not select the inserted text\n\
+       text: %S\n\
+       replacement: %S\n\
+       selected: %S"
+      actual_text
+      replacement
+      selected
+;;
+
+let regression_cases =
+  [ { Case.prefix = [ A; A ]
+    ; removed = []
+    ; replacement = [ A; A; Newline; B; B; B ]
+    ; suffix = [ Space; A ]
+    ; encoding = UTF8
+    }
+  ; { Case.prefix = [ Four_byte; A ]
+    ; removed = [ B; Newline ]
+    ; replacement = []
+    ; suffix = [ Three_byte ]
+    ; encoding = UTF16
+    }
+  ; { Case.prefix = [ A; Newline; B ]
+    ; removed = [ B ]
+    ; replacement = [ Two_byte; Newline; Four_byte ]
+    ; suffix = [ A; B ]
+    ; encoding = UTF16
+    }
+  ]
+;;
+
+let%expect_test "resized edit ranges select exactly the replacement text" =
+  Base_quickcheck.Test.run_exn (module Case) ~examples:regression_cases ~f:run_case;
+  [%expect {| |}]
+;;


### PR DESCRIPTION
Follow-up to #1748. Compute post-edit range endpoints by walking replacement text in the negotiated position encoding instead of relying on split lines and byte lengths. This preserves trailing newlines and reports UTF-16 code-unit offsets correctly for destruct and completion next-hole commands.

Adds regression examples and property tests against text document edit application.
