### PR TITLE
refactor(lsp): add Range.is_single_line

### DIFF
--- a/lsp/src/range.ml
+++ b/lsp/src/range.ml
@@ -7,6 +7,8 @@ let compare x y =
   | ordering -> ordering
 ;;
 
+let is_single_line t = t.start.line = t.end_.line
+
 let contains outer inner =
   Position.compare outer.start inner.start <= 0
   && Position.compare inner.end_ outer.end_ <= 0

--- a/lsp/src/range.mli
+++ b/lsp/src/range.mli
@@ -4,6 +4,9 @@ include module type of Types.Range with type t = Types.Range.t
 (** Compare ranges by start position, then by end position. *)
 val compare : t -> t -> int
 
+(** Whether the range starts and ends on the same line. *)
+val is_single_line : t -> bool
+
 (** [contains outer inner] is true when both boundaries of [inner] are within
     [outer]. *)
 val contains : t -> t -> bool

--- a/lsp/test/range_relations_quickcheck_tests.ml
+++ b/lsp/test/range_relations_quickcheck_tests.ml
@@ -66,6 +66,11 @@ let check_case { Case.point; first_start; first_end; second_start; second_end } 
   in
   check "range comparison" (Int.equal (Range.compare first second) expected_range_order);
   check
+    "single-line range"
+    (Bool.equal
+       (Range.is_single_line first)
+       (first_start / line_width = first_end / line_width));
+  check
     "range containment"
     (Bool.equal
        (Range.contains first second)

--- a/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
+++ b/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
@@ -4,7 +4,7 @@ let action_kind = "combine-cases"
 let kind = CodeActionKind.Other action_kind
 
 let select_complete_lines (range : Range.t) =
-  if range.start.line = range.end_.line
+  if Lsp.Range.is_single_line range
   then None
   else (
     let start = { range.start with character = 0 } in

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -170,7 +170,7 @@ let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) : 
 let extract_statement (doc : Document.t) (ca_range : Range.t)
   : destructable_statement option
   =
-  if ca_range.start.line <> ca_range.end_.line
+  if not (Lsp.Range.is_single_line ca_range)
   then None
   else (
     let code = get_line doc ca_range in

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -14,7 +14,7 @@ let folding_range { Range.start; end_ } =
 let fold_over_parsetree (parsetree : Mreader.parsetree) =
   let ranges = ref [] in
   let push (range : Range.t) =
-    if range.start.line < range.end_.line (* don't fold a single line *)
+    if not (Lsp.Range.is_single_line range) (* don't fold a single line *)
     then ranges := range :: !ranges
   in
   let iterator =

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -536,7 +536,7 @@ let highlight
         let range = Range.of_loc loc in
         (* filter out multi-line ranges, since those are very noisy and happen
            a lot with certain PPXs *)
-        match range.start.line = range.end_.line with
+        match Lsp.Range.is_single_line range with
         | true ->
           (* using the default kind as we are lacking info to make a
              difference between assignment and usage. *)


### PR DESCRIPTION
Add `Lsp.Range.is_single_line` and use it in code actions, folding ranges, and document highlights instead of repeating line-boundary comparisons.
