### PR TITLE
test: bound child process cleanup

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -209,7 +209,7 @@ let stop_dune pid gate =
   (match Unix.kill pid Sys.sigterm with
    | () -> ()
    | exception Unix.Unix_error (Unix.ESRCH, _, _) -> ());
-  ignore (Unix.waitpid [] pid : int * Unix.process_status)
+  ignore (Test.waitpid pid : Unix.process_status)
 ;;
 
 let%expect_test "Dune success refreshes load paths in every Merlin state" =

--- a/ocaml-lsp-server/test/e2e-new/exit_notification.ml
+++ b/ocaml-lsp-server/test/e2e-new/exit_notification.ml
@@ -33,7 +33,7 @@ let send_exit_before_initialize () =
   let oc = Unix.out_channel_of_descr stdin_o in
   output_string oc packet;
   close_out oc;
-  let _, status = Unix.waitpid [] pid in
+  let status = Test.waitpid pid in
   Unix.close stdout_i;
   status
 ;;

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -124,6 +124,23 @@ let exit_client client =
 
 let bin = Bin.which "ocamllsp" |> Option.value_exn
 
+let waitpid ?(timeout = 5.0) pid =
+  let deadline = Unix.gettimeofday () +. timeout in
+  let rec wait () =
+    match Unix.waitpid [ Unix.WNOHANG ] pid with
+    | 0, _ when Unix.gettimeofday () < deadline ->
+      Unix.sleepf 0.01;
+      wait ()
+    | 0, _ ->
+      (match Unix.kill pid Sys.sigkill with
+       | () -> ()
+       | exception Unix.Unix_error (Unix.ESRCH, _, _) -> ());
+      Unix.waitpid [] pid |> snd
+    | _, status -> status
+  in
+  wait ()
+;;
+
 module T : sig
   val run_with_status
     :  ?extra_env:string list


### PR DESCRIPTION
A child process that fails to exit can currently block an e2e partition—and therefore the complete test job—indefinitely.

Add a bounded `Test.waitpid` helper that returns immediately for normal exits, but sends `SIGKILL` and reaps the child after a five-second deadline. Use it for the existing Dune watcher cleanup and the raw pre-initialization exit test.

