### PR TITLE
fix(dune): keep RPC polling responsive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Keep Dune RPC registry polling responsive while connected instances are
+  running. (#1919, @rgrinberg)
 - Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`
   rather than `<sys/statfs.h>`. (#2070, fixes #1069, @dayangac)
 - Keep construct-completion text edits on the request line when Merlin recovery

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -751,7 +751,8 @@ let poll active last_error =
                (* this is guaranteed not to raise since we don't connect to more
                   than one dune instance per workspace *)
                Map.add_exn acc ~key:(Registry.Dune.root source) ~data:instance);
-        Fiber.parallel_iter connected ~f:(run_instance active)
+        Fiber.parallel_iter connected ~f:(fun instance ->
+          Fiber.Pool.task active.pool ~f:(fun () -> run_instance active instance))
     in
     `No_error
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -28,13 +28,17 @@ let%expect_test "connected Dune does not process workspace removal" =
            project
            "client workspace/didChangeWorkspaceFolders:"
            (DidChangeWorkspaceFoldersParams.yojson_of_t params);
+         let diagnostics_after_removal =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri initial.uri params && no_dune_diagnostic params)
+         in
          let* () = Client.notification client (ChangeWorkspaceFolders params) in
-         let* () = Lev_fiber.Timer.sleepf 0.1 in
+         let* cleared = diagnostics_after_removal in
          print_payloads
            project
            "textDocument/publishDiagnostics after workspace removal:"
            PublishDiagnosticsParams.yojson_of_t
-           (Events.take_pending events.dune);
+           (cleared :: Events.take_pending events.dune);
          print_payloads
            project
            "client/unregisterCapability after workspace removal:"
@@ -81,7 +85,7 @@ let%expect_test "connected Dune does not process workspace removal" =
       }
     }
     textDocument/publishDiagnostics after workspace removal:
-    []
+    [ { "diagnostics": [], "uri": "<document-uri>" } ]
     client/unregisterCapability after workspace removal:
     []
     |}]


### PR DESCRIPTION
Registry polling currently waits for `Instance.run`, which lasts for the lifetime of the Dune connection. After the first connection, the poll loop therefore stops observing workspace changes.

Schedule connected instance runners in the existing active fiber pool so polling can continue. The workspace-removal snapshot now shows the Dune diagnostic being cleared while preserving the separately characterized missing promotion cleanup.

