### PR TITLE
fix(merlin): close configuration process input after halt

### DIFF
--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -241,7 +241,9 @@ module Entry = struct
               (Pid.to_int t.process.pid)
               t.process.initial_cwd)
       in
-      Dot_protocol_io.Commands.halt t.process.session)
+      let+ () = Dot_protocol_io.Commands.halt t.process.session in
+      (* Do not leave a process that handled [Halt] blocked waiting for more input. *)
+      Lev_fiber.Io.close t.process.stdin)
   ;;
 
   let destroy (t : t) =

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -219,14 +219,26 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
   let runtime_dir = Filename.concat temp "runtime" in
   let gate = Filename.concat temp "gate" in
   let trigger = Filename.concat root "trigger" in
+  let bin_dir = Filename.concat temp "bin" in
+  let dune_shim = Filename.concat bin_dir "dune" in
   Unix.mkdir root 0o700;
   Unix.mkdir lib 0o700;
   Unix.mkdir runtime_dir 0o700;
+  Unix.mkdir bin_dir 0o700;
   Test.write_file (Filename.concat root "dune-project") "(lang dune 3.24)\n(name repro)\n";
   Test.write_file trigger "0\n";
   let wait_script = Filename.concat root "wait.sh" in
   Test.write_file wait_script "#!/bin/sh\nwhile [ ! -e \"$1\" ]; do sleep 0.05; done\n";
   Unix.chmod wait_script 0o755;
+  (* Keep the shim alive after the real [dune ocaml-merlin] handles [Halt].
+     Closing the protocol input must make the shim observe EOF and exit. *)
+  let dune = Bin.which "dune" |> Option.value_exn in
+  Test.write_file
+    dune_shim
+    (Printf.sprintf
+       "#!/bin/sh\ntrap '' TERM\n%s \"$@\"\nwhile IFS= read -r _; do :; done\n"
+       (Filename.quote dune));
+  Unix.chmod dune_shim 0o755;
   Test.write_file
     (Filename.concat root "dune")
     (Printf.sprintf
@@ -290,7 +302,11 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
          WorkspaceFolder.create ~uri:(Uri.of_path root) ~name:"stale-load-path"
        in
        Test.run_initialized
-         ~extra_env:[ "OCAMLLSP_TEST=false"; "XDG_RUNTIME_DIR=" ^ runtime_dir ]
+         ~extra_env:
+           [ "OCAMLLSP_TEST=false"
+           ; "XDG_RUNTIME_DIR=" ^ runtime_dir
+           ; "PATH=" ^ bin_dir ^ ":" ^ Option.value_exn (Sys.getenv_opt "PATH")
+           ]
          ~timeout:30.0
          ~handler
          ~stderr:ocamllsp_stderr


### PR DESCRIPTION
Follow-up to #1770. After sending `Halt` to `dune ocaml-merlin`, the server kept the process input open. A configuration process waiting for another protocol message could therefore remain alive, leaving the Dune diagnostics test blocked until its watchdog killed `ocamllsp` and `Lev_fiber` reported a deadlock.

Close the process input after flushing `Halt`. The regression test wraps `dune ocaml-merlin` in a shim that remains alive and ignores `SIGTERM` until it observes protocol EOF.
