### PR TITLE
refactor(server): remove Base and stdlib aliases

### DIFF
--- a/ocaml-lsp-server/src/bin.ml
+++ b/ocaml-lsp-server/src/bin.ml
@@ -5,7 +5,7 @@ let path_separator = if Sys.win32 then ';' else ':'
 let path =
   lazy
     (Option.value ~default:"" (Sys.getenv_opt "PATH")
-     |> String.split_on_char ~sep:path_separator
+     |> String.split ~on:path_separator
      |> List.filter ~f:(fun path -> not (String.is_empty path)))
 ;;
 

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -56,7 +56,7 @@ let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
   let batchable, non_batchable =
     List.partition_map enabled_actions ~f:(fun ca ->
       match ca.run with
-      | `Batchable f -> Base.Either.First f
+      | `Batchable f -> Either.First f
       | `Non_batchable f -> Second f)
   in
   let* batch_results =

--- a/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
+++ b/ocaml-lsp-server/src/code_actions/action_combine_cases.ml
@@ -34,7 +34,7 @@ let pick_rhs rhs_expressions =
   let distinct_nonempty =
     List.map rhs_expressions ~f:String.strip
     |> List.filter ~f:(fun s -> (not (String.is_empty s)) && not (String.equal s "_"))
-    |> Base.List.dedup_and_sort ~compare:Base.String.compare
+    |> List.dedup_and_sort ~compare:String.compare
   in
   match distinct_nonempty with
   | [ expr ] -> expr
@@ -59,7 +59,7 @@ let code_action doc params =
          let* code = Text_document.substring (Document.text_document doc) range in
          let code = String.strip ~drop:(fun c -> Char.equal c '\n') code in
          let* lhs_patterns, rhs_expressions = split_cases code in
-         let+ i = Base.String.index code '|' in
+         let+ i = String.index code '|' in
          let indent = String.sub code ~pos:0 ~len:i in
          let lhs = String.concat ~sep:" | " lhs_patterns in
          let rhs = pick_rhs rhs_expressions in

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -8,7 +8,7 @@ let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, 
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
   let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
-  let title = String.capitalize_ascii action_kind in
+  let title = String.capitalize action_kind in
   let command =
     if supportsJumpToNextHole
     then

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -211,15 +211,13 @@ let format_match_cases lines ~indent =
 let separate_match_line new_code =
   let end_of_match = String.substr_index_exn new_code ~pattern:"with" in
   let match_line = String.prefix new_code (end_of_match + 4) in
-  let rest = Base.String.drop_prefix new_code (end_of_match + 4) in
+  let rest = String.drop_prefix new_code (end_of_match + 4) in
   match_line, rest
 ;;
 
 let format_merlin_reply ~(statement : destructable_statement) (new_code : string) =
   let indent =
-    match
-      String.lfindi statement.code ~f:(fun _ c -> not (Base.Char.is_whitespace c))
-    with
+    match String.lfindi statement.code ~f:(fun _ c -> not (Char.is_whitespace c)) with
     | None -> ""
     | Some i -> String.sub statement.code ~pos:0 ~len:i
   in

--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -100,7 +100,7 @@ let tightest_enclosing_binder_position typedtree range =
   | Found e -> Some e
 ;;
 
-module LongidentSet = Set.Make (struct
+module LongidentSet = Stdlib.Set.Make (struct
     type t = Longident.t
 
     let compare = compare

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -6,7 +6,7 @@ let action_kind = "inferred_intf"
 let code_action_of_intf doc intf range =
   let textedit : TextEdit.t = { range; newText = intf } in
   let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
-  let title = String.capitalize_ascii "Insert inferred interface" in
+  let title = String.capitalize "Insert inferred interface" in
   CodeAction.create
     ~title
     ~kind:(CodeActionKind.Other action_kind)

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -222,7 +222,7 @@ let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
       (match arg.pexp_desc with
        | Pexp_tuple args ->
          let args = List.map ~f:snd args in
-         List.fold_left2 ~f:beta_reduce_arg ~init:body pats args
+         List.fold2_exn pats args ~init:body ~f:beta_reduce_arg
        | _ -> with_let ())
     | _ -> with_let ()
   in
@@ -238,11 +238,8 @@ let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
     when List.length params = List.length args && all_unlabeled_params params ->
     (match extract_param_pats params with
      | Some pats ->
-       List.fold_left2
-         ~f:(fun body pat (_, arg) -> beta_reduce_arg body pat arg)
-         ~init:body
-         pats
-         args
+       List.fold2_exn pats args ~init:body ~f:(fun body pat (_, arg) ->
+         beta_reduce_arg body pat arg)
      | None -> app)
   | _ -> app
 ;;

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -74,7 +74,7 @@ let code_actions
         let+ position = Position.of_lexical_position lexing_pos in
         let uri = Document.uri doc in
         let range = { Range.start = position; end_ = position } in
-        let title = sprintf "%s jump" (String.capitalize_ascii (rename_target target)) in
+        let title = sprintf "%s jump" (String.capitalize (rename_target target)) in
         let command =
           let arguments = [ DocumentUri.yojson_of_t uri; Range.yojson_of_t range ] in
           Command.create ~title ~command:command_name ~arguments ()

--- a/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
+++ b/ocaml-lsp-server/src/code_actions/action_refactor_open.ml
@@ -27,7 +27,7 @@ let code_action
         WorkspaceEdit.create ~changes:[ uri, edits ] ()
       in
       let kind = CodeActionKind.Other action_kind in
-      let title = String.capitalize_ascii action_kind in
+      let title = String.capitalize action_kind in
       CodeAction.create ~title ~kind ~edit ~isPreferred:false ()
     in
     Some code_action

--- a/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
+++ b/ocaml-lsp-server/src/code_actions/action_remove_type_annotation.ml
@@ -41,7 +41,7 @@ let code_action_of_type_enclosing doc (loc, constr_loc) =
     { range = Range.of_loc (Loc.union loc constr_loc); newText = src_text }
   in
   let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
-  let title = String.capitalize_ascii action_kind in
+  let title = String.capitalize action_kind in
   CodeAction.create
     ~title
     ~kind:(CodeActionKind.Other action_kind)

--- a/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
+++ b/ocaml-lsp-server/src/code_actions/action_type_annotate.ml
@@ -34,7 +34,7 @@ let code_action_of_type_enclosing doc (loc, typ) =
   let newText = Printf.sprintf "(%s : %s)" original_text typ in
   let textedit : TextEdit.t = { range = Range.of_loc loc; newText } in
   let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
-  let title = String.capitalize_ascii action_kind in
+  let title = String.capitalize action_kind in
   CodeAction.create
     ~title
     ~kind:(CodeActionKind.Other action_kind)

--- a/ocaml-lsp-server/src/code_actions/action_update_signature.ml
+++ b/ocaml-lsp-server/src/code_actions/action_update_signature.ml
@@ -5,7 +5,7 @@ let action_kind = "update_intf"
 
 let code_action_of_intf doc text_edits =
   let edit = Text_document.workspace_edit (Document.text_document doc) text_edits in
-  let title = String.capitalize_ascii "update signature(s) to match implementation" in
+  let title = String.capitalize "update signature(s) to match implementation" in
   CodeAction.create
     ~title
     ~kind:(CodeActionKind.Other action_kind)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -47,7 +47,7 @@ let prefix_of_position ~short_path source position =
     in
     if short_path
     then (
-      match String.split_on_char reconstructed_prefix ~sep:'.' |> List.last with
+      match String.split reconstructed_prefix ~on:'.' |> List.last with
       | Some s -> s
       | None -> reconstructed_prefix)
     else reconstructed_prefix
@@ -170,7 +170,7 @@ module Complete_by_prefix = struct
         @ List.map labels ~f:(fun (name, typ) ->
           let name =
             if String.is_prefix prefix ~prefix:"~" && String.is_prefix name ~prefix:"?"
-            then "~" ^ String.drop_prefix_if_exists name ~prefix:"?"
+            then "~" ^ String.chop_prefix_if_exists name ~prefix:"?"
             else name
           in
           { Query_protocol.Compl.name

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -42,7 +42,7 @@ module Request_params = struct
     |> member "withValues"
     |> to_string_option
     |> Option.bind ~f:(fun value ->
-      match String.lowercase (String.trim value) with
+      match String.lowercase (String.strip value) with
       | "none" -> Some `None
       | "local" -> Some `Local
       | _ -> None)

--- a/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_locate_types.ml
@@ -52,7 +52,7 @@ type t =
   ; children : t list
   }
 
-module TySet = Set.Make (struct
+module TySet = Stdlib.Set.Make (struct
     type t = string * DocumentUri.t option * Position.t
 
     let compare (ty_a, doc_a, pos_a) (ty_b, doc_b, pos_b) =
@@ -60,7 +60,7 @@ module TySet = Set.Make (struct
       if Int.equal 0 c
       then (
         let c = Lsp.Position.compare pos_a pos_b in
-        if Int.equal 0 c then Poly.compare ty_a ty_b |> Ordering.to_int else c)
+        if Int.equal 0 c then Poly.compare ty_a ty_b else c)
       else c
     ;;
   end)

--- a/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_expression.ml
@@ -62,6 +62,6 @@ let on_request ~params state =
       let* result = Ocamlformat_rpc.format_type ~typ state.ocamlformat_rpc in
       (match result with
        | Error _ -> Fiber.return (`String typ)
-       | Ok typ -> Fiber.return (`String (String.trim ~drop:(Char.equal '\n') typ)))
+       | Ok typ -> Fiber.return (`String (String.strip ~drop:(Char.equal '\n') typ)))
     | None -> Fiber.return `Null)
 ;;

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -21,7 +21,7 @@ module Dune = struct
       }
 
     let compare x y =
-      match Int.compare (Pid.to_int x.pid) (Pid.to_int y.pid) with
+      match Int.compare (Pid.to_int x.pid) (Pid.to_int y.pid) |> Ordering.of_int with
       | Eq -> Id.compare x.id y.id
       | r -> r
     ;;
@@ -75,10 +75,10 @@ let equal_message =
 ;;
 
 type t =
-  { dune : (Dune.t, (Drpc.Diagnostic.Id.t, Uri.t * Diagnostic.t) Table.t) Table.t
-  ; merlin : (Uri.t, Diagnostic.t list) Table.t
+  { dune : (Dune.t, (Drpc.Diagnostic.Id.t, Uri.t * Diagnostic.t) Hashtbl.t) Hashtbl.t
+  ; merlin : (Uri.t, Diagnostic.t list) Hashtbl.t
   ; send : PublishDiagnosticsParams.t list -> unit Fiber.t
-  ; mutable dirty_uris : (Uri.t, Uri.comparator_witness) Base.Set.t
+  ; mutable dirty_uris : (Uri.t, Uri.comparator_witness) Set.t
   ; related_information : bool
   ; tags : DiagnosticTag.t list
   ; mutable report_dune_diagnostics : bool
@@ -100,9 +100,9 @@ let create
          | None -> []
          | Some { valueSet } -> valueSet) )
   in
-  { dune = Table.create (module Dune)
-  ; merlin = Table.create (module Uri)
-  ; dirty_uris = Base.Set.empty (module Uri)
+  { dune = Hashtbl.create (module Dune)
+  ; merlin = Hashtbl.create (module Uri)
+  ; dirty_uris = Set.empty (module Uri)
   ; send
   ; related_information
   ; tags
@@ -112,7 +112,7 @@ let create
 ;;
 
 let send =
-  let module Range_map = Map.Make (struct
+  let module Range_map = Stdlib.MoreLabels.Map.Make (struct
       include Range
 
       let compare = Lsp.Range.compare
@@ -121,7 +121,7 @@ let send =
   (* TODO deduplicate related errors as well *)
   let add_dune_diagnostic pending uri (diagnostic : Diagnostic.t) =
     let value =
-      match Table.find pending uri with
+      match Hashtbl.find pending uri with
       | None -> Range_map.singleton diagnostic.range [ diagnostic ]
       | Some map ->
         Range_map.update map ~key:diagnostic.range ~f:(fun diagnostics ->
@@ -144,7 +144,7 @@ let send =
                then diagnostics
                else diagnostic :: diagnostics))
     in
-    Table.set pending ~key:uri ~data:value
+    Hashtbl.set pending ~key:uri ~data:value
   in
   let range_map_of_unduplicated_diagnostics diagnostics =
     List.rev_map diagnostics ~f:(fun (d : Diagnostic.t) -> d.range, d)
@@ -158,17 +158,17 @@ let send =
       let dirty_uris =
         match which with
         | `All -> t.dirty_uris
-        | `One uri -> Base.Set.singleton (module Uri) uri
+        | `One uri -> Set.singleton (module Uri) uri
       in
-      let pending = Table.create (module Uri) in
-      Base.Set.iter dirty_uris ~f:(fun uri ->
-        let diagnostics = Table.Multi.find t.merlin uri in
-        Table.set
+      let pending = Hashtbl.create (module Uri) in
+      Set.iter dirty_uris ~f:(fun uri ->
+        let diagnostics = Hashtbl.find_multi t.merlin uri in
+        Hashtbl.set
           pending
           ~key:uri
           ~data:(range_map_of_unduplicated_diagnostics diagnostics));
       let set_dune_source =
-        let annotate_dune_pid = Table.length t.dune > 1 in
+        let annotate_dune_pid = Hashtbl.length t.dune > 1 in
         if annotate_dune_pid
         then
           fun pid (d : Diagnostic.t) ->
@@ -178,17 +178,17 @@ let send =
       in
       if t.report_dune_diagnostics
       then
-        Table.fold ~init:() t.dune ~f:(fun ~key:dune ~data:per_dune () ->
-          Table.iter per_dune ~f:(fun (uri, diagnostic) ->
-            if Base.Set.mem dirty_uris uri
+        Hashtbl.fold ~init:() t.dune ~f:(fun ~key:dune ~data:per_dune () ->
+          Hashtbl.iter per_dune ~f:(fun (uri, diagnostic) ->
+            if Set.mem dirty_uris uri
             then (
               let diagnostic = set_dune_source dune.pid diagnostic in
               add_dune_diagnostic pending uri diagnostic)));
       t.dirty_uris
       <- (match which with
-          | `All -> Base.Set.empty (module Uri)
-          | `One uri -> Base.Set.remove t.dirty_uris uri);
-      Table.fold pending ~init:[] ~f:(fun ~key:uri ~data:diagnostics acc ->
+          | `All -> Set.empty (module Uri)
+          | `One uri -> Set.remove t.dirty_uris uri);
+      Hashtbl.fold pending ~init:[] ~f:(fun ~key:uri ~data:diagnostics acc ->
         let diagnostics = Range_map.to_list diagnostics |> List.concat_map ~f:snd in
         (* we don't include a version because some of the diagnostics might
            come from dune which reads from the file system and not from the
@@ -203,35 +203,35 @@ let set t what =
     | `Dune (_, _, uri, _) -> uri
     | `Merlin (uri, _) -> uri
   in
-  t.dirty_uris <- Base.Set.add t.dirty_uris uri;
+  t.dirty_uris <- Set.add t.dirty_uris uri;
   match what with
-  | `Merlin (uri, diagnostics) -> Table.set t.merlin ~key:uri ~data:diagnostics
+  | `Merlin (uri, diagnostics) -> Hashtbl.set t.merlin ~key:uri ~data:diagnostics
   | `Dune (dune, id, uri, diagnostics) ->
     let dune_table =
-      Table.find_or_add t.dune dune ~default:(fun _ -> Table.create (module Id))
+      Hashtbl.find_or_add t.dune dune ~default:(fun _ -> Hashtbl.create (module Id))
     in
-    Table.set dune_table ~key:id ~data:(uri, diagnostics)
+    Hashtbl.set dune_table ~key:id ~data:(uri, diagnostics)
 ;;
 
 let remove t = function
   | `Dune (dune, diagnostic) ->
-    Table.find t.dune dune
+    Hashtbl.find t.dune dune
     |> Option.iter ~f:(fun dune ->
-      Table.find dune diagnostic
+      Hashtbl.find dune diagnostic
       |> Option.iter ~f:(fun (uri, _) ->
-        Table.remove dune diagnostic;
-        t.dirty_uris <- Base.Set.add t.dirty_uris uri))
+        Hashtbl.remove dune diagnostic;
+        t.dirty_uris <- Set.add t.dirty_uris uri))
   | `Merlin uri ->
-    t.dirty_uris <- Base.Set.add t.dirty_uris uri;
-    Table.remove t.merlin uri
+    t.dirty_uris <- Set.add t.dirty_uris uri;
+    Hashtbl.remove t.merlin uri
 ;;
 
 let disconnect t dune =
-  Table.find t.dune dune
+  Hashtbl.find t.dune dune
   |> Option.iter ~f:(fun dune_diagnostics ->
-    Table.iter dune_diagnostics ~f:(fun (uri, _) ->
-      t.dirty_uris <- Base.Set.add t.dirty_uris uri);
-    Table.remove t.dune dune)
+    Hashtbl.iter dune_diagnostics ~f:(fun (uri, _) ->
+      t.dirty_uris <- Set.add t.dirty_uris uri);
+    Hashtbl.remove t.dune dune)
 ;;
 
 let tags_of_message =
@@ -251,7 +251,7 @@ let tags_of_message =
 let extract_related_errors uri raw_message =
   match Ocamlc_loc.parse_raw raw_message with
   | `Message message :: related ->
-    let string_of_message message = String.trim message in
+    let string_of_message message = String.strip message in
     let related =
       let rec loop acc = function
         | `Loc loc :: `Message m :: xs -> loop ((loc, m) :: acc) xs
@@ -321,7 +321,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
     | Warning -> DiagnosticSeverity.Warning
     | _ -> DiagnosticSeverity.Error
   in
-  let make_message ppf m = String.trim (Format.asprintf "%a@." ppf m) in
+  let make_message ppf m = String.strip (Format.asprintf "%a@." ppf m) in
   let message = make_message Loc.print_main error in
   let message, related_information =
     match diagnostics.related_information with
@@ -407,7 +407,7 @@ let merlin_diagnostics diagnostics merlin =
         (* Can we use [List.merge] instead? *)
         List.rev_append holes_as_err_diags merlin_diagnostics
         |> List.sort ~compare:(fun (d1 : Diagnostic.t) (d2 : Diagnostic.t) ->
-          Lsp.Range.compare d1.range d2.range |> Ordering.of_int))
+          Lsp.Range.compare d1.range d2.range))
   in
   set diagnostics (`Merlin (uri, all_diagnostics))
 ;;
@@ -417,9 +417,9 @@ let set_report_dune_diagnostics t ~report_dune_diagnostics =
   then Fiber.return ()
   else (
     t.report_dune_diagnostics <- report_dune_diagnostics;
-    Table.iter t.dune ~f:(fun per_dune ->
-      Table.iter per_dune ~f:(fun (uri, _diagnostic) ->
-        t.dirty_uris <- Base.Set.add t.dirty_uris uri));
+    Hashtbl.iter t.dune ~f:(fun per_dune ->
+      Hashtbl.iter per_dune ~f:(fun (uri, _diagnostic) ->
+        t.dirty_uris <- Set.add t.dirty_uris uri));
     send t `All)
 ;;
 
@@ -428,8 +428,8 @@ let set_shorten_merlin_diagnostics t ~shorten_merlin_diagnostics =
   then Fiber.return ()
   else (
     t.shorten_merlin_diagnostics <- shorten_merlin_diagnostics;
-    Table.iter t.dune ~f:(fun per_dune ->
-      Table.iter per_dune ~f:(fun (uri, _diagnostic) ->
-        t.dirty_uris <- Base.Set.add t.dirty_uris uri));
+    Hashtbl.iter t.dune ~f:(fun per_dune ->
+      Hashtbl.iter per_dune ~f:(fun (uri, _diagnostic) ->
+        t.dirty_uris <- Set.add t.dirty_uris uri));
     send t `All)
 ;;

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -37,7 +37,7 @@ type doc =
   }
 
 type t =
-  { db : (Uri.t, doc ref) Table.t
+  { db : (Uri.t, doc ref) Hashtbl.t
   ; server : server
   ; (* The pool is needed to run subscribe/unsubscribe requests. To prevent
        deadlocks with synchronous responses to lsp. In the future, these
@@ -45,7 +45,7 @@ type t =
     pool : Fiber.Pool.t
   }
 
-let make s pool = { db = Table.create (module Uri); server = Server s; pool }
+let make s pool = { db = Hashtbl.create (module Uri); server = Server s; pool }
 let code_action_id uri = "ocamllsp-promote/" ^ Uri.to_string uri
 let method_ = "textDocument/codeAction"
 
@@ -96,9 +96,9 @@ let register_request t uris =
 let open_document t doc =
   let* () = Fiber.return () in
   let key = Document.uri doc in
-  match Table.find t.db key with
+  match Hashtbl.find t.db key with
   | None ->
-    Table.set
+    Hashtbl.set
       t.db
       ~key
       ~data:(ref { document = Some doc; promotions = 0; semantic_tokens_cache = None });
@@ -113,7 +113,7 @@ let open_document t doc =
     if unregister then unregister_request t [ key ] else Fiber.return ()
 ;;
 
-let get_opt t uri = Table.find t.db uri |> Option.bind ~f:(fun d -> !d.document)
+let get_opt t uri = Hashtbl.find t.db uri |> Option.bind ~f:(fun d -> !d.document)
 
 let no_document_found uri = function
   | Some s -> s
@@ -125,7 +125,7 @@ let no_document_found uri = function
          ())
 ;;
 
-let get' t uri = Table.find t.db uri |> no_document_found uri
+let get' t uri = Hashtbl.find t.db uri |> no_document_found uri
 let get t uri = !(get' t uri).document |> no_document_found uri
 
 let change_document t uri ~f =
@@ -143,13 +143,13 @@ let maybe_close_doc (doc : doc) =
 
 let close_document t uri =
   Fiber.of_thunk (fun () ->
-    match Table.find t.db uri with
+    match Hashtbl.find t.db uri with
     | None -> Fiber.return ()
     | Some doc ->
       let close_doc () = maybe_close_doc !doc in
       if !doc.promotions = 0
       then (
-        Table.remove t.db uri;
+        Hashtbl.remove t.db uri;
         close_doc ())
       else (
         doc := { !doc with document = None };
@@ -159,12 +159,12 @@ let close_document t uri =
 let unregister_promotions t uris =
   let* () = Fiber.return () in
   List.filter uris ~f:(fun uri ->
-    match Table.find t.db uri with
+    match Hashtbl.find t.db uri with
     | None -> false
     | Some doc ->
       doc := { !doc with promotions = !doc.promotions - 1 };
       let unsubscribe = !doc.promotions = 0 in
-      if unsubscribe && !doc.document = None then Table.remove t.db uri;
+      if unsubscribe && !doc.document = None then Hashtbl.remove t.db uri;
       unsubscribe)
   |> unregister_request t
 ;;
@@ -172,10 +172,10 @@ let unregister_promotions t uris =
 let register_promotions t uris =
   let* () = Fiber.return () in
   List.filter uris ~f:(fun uri ->
-    match Table.find t.db uri with
+    match Hashtbl.find t.db uri with
     | None ->
       let doc = ref { document = None; promotions = 1; semantic_tokens_cache = None } in
-      Table.set t.db ~key:uri ~data:doc;
+      Hashtbl.set t.db ~key:uri ~data:doc;
       true
     | Some doc ->
       doc := { !doc with promotions = !doc.promotions + 1 };
@@ -198,7 +198,7 @@ let get_semantic_tokens_cache : t -> Uri.t -> semantic_tokens_cache option =
 ;;
 
 let parallel_iter t ~f =
-  let all = Table.fold ~init:[] t.db ~f:(fun ~key:_ ~data:doc acc -> doc :: acc) in
+  let all = Hashtbl.fold ~init:[] t.db ~f:(fun ~key:_ ~data:doc acc -> doc :: acc) in
   Fiber.parallel_iter all ~f:(fun doc ->
     match !doc.document with
     | None -> Fiber.return ()
@@ -206,7 +206,7 @@ let parallel_iter t ~f =
 ;;
 
 let fold t ~init ~f =
-  Table.fold t.db ~init ~f:(fun ~key:_ ~data:doc acc ->
+  Hashtbl.fold t.db ~init ~f:(fun ~key:_ ~data:doc acc ->
     match !doc.document with
     | None -> acc
     | Some x -> f x acc)
@@ -214,7 +214,7 @@ let fold t ~init ~f =
 
 let close_all t =
   Fiber.of_thunk (fun () ->
-    let docs = Table.fold t.db ~init:[] ~f:(fun ~key:_ ~data:doc acc -> !doc :: acc) in
-    Table.clear t.db;
+    let docs = Hashtbl.fold t.db ~init:[] ~f:(fun ~key:_ ~data:doc acc -> !doc :: acc) in
+    Hashtbl.clear t.db;
     Fiber.parallel_iter docs ~f:maybe_close_doc)
 ;;

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -139,7 +139,7 @@ module Instance : sig
   val connect : t -> (unit, unit) result Fiber.t
   val source : t -> Registry.Dune.t
   val create : Registry.Dune.t -> config -> t
-  val promotions : t -> Drpc.Diagnostic.Promotion.t String.Map.t
+  val promotions : t -> Drpc.Diagnostic.Promotion.t Map.M(String).t
   val client : t -> Client.t option
 end = struct
   module Id = Id.Make ()
@@ -152,7 +152,7 @@ end = struct
     ; mutable client : Client.t option
     ; mutable promotions :
         (* TODO we need to clean these up in the finalizer *)
-        Drpc.Diagnostic.Promotion.t String.Map.t
+        Drpc.Diagnostic.Promotion.t Map.M(String).t
     }
 
   type state =
@@ -175,7 +175,7 @@ end = struct
 
   let promotions t =
     match t.state with
-    | Connected _ | Idle | Finished -> String.Map.empty
+    | Connected _ | Idle | Finished -> Map.empty (module String)
     | Running r -> r.promotions
   ;;
 
@@ -202,7 +202,7 @@ end = struct
         | D.Error -> DiagnosticSeverity.Error
         | Warning -> DiagnosticSeverity.Warning)
     in
-    let make_message message = String.trim (Format.asprintf "%a@." Pp.to_fmt message) in
+    let make_message message = String.strip (Format.asprintf "%a@." Pp.to_fmt message) in
     let relatedInformation =
       match D.related diagnostic with
       | [] -> None
@@ -320,8 +320,8 @@ end = struct
                   ~init:(promotions, [])
                   ~f:(fun (ps, acc) promotion ->
                     let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match String.Map.find ps source with
-                    | Some _ -> String.Map.remove ps source, promotion :: acc
+                    match Map.find ps source with
+                    | Some _ -> Map.remove ps source, promotion :: acc
                     | None ->
                       Log.log ~section:"warning" (fun () ->
                         Log.msg
@@ -340,12 +340,12 @@ end = struct
                   ~init:(promotions, [])
                   ~f:(fun (ps, acc) promotion ->
                     let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match String.Map.find ps source with
+                    match Map.find ps source with
                     | Some _ ->
                       (* TODO it should not be possible to offer more than one
                          promotion for a file in dune *)
                       assert false
-                    | None -> String.Map.add_exn ps source promotion, promotion :: acc)
+                    | None -> Map.add_exn ps ~key:source ~data:promotion, promotion :: acc)
               in
               let uri : Uri.t =
                 match Drpc.Diagnostic.loc d with
@@ -481,7 +481,7 @@ end = struct
     let running =
       { chan
       ; finish
-      ; promotions = String.Map.empty
+      ; promotions = Map.empty (module String)
       ; client = None
       ; diagnostics_id = Diagnostics.Dune.gen (Pid.of_int (Registry.Dune.pid source))
       ; id = Id.gen ()
@@ -565,14 +565,14 @@ end = struct
   ;;
 end
 
-module Dune_map = Map.Make (struct
+module Dune_map = Stdlib.MoreLabels.Map.Make (struct
     include Registry.Dune
 
     let compare x y = Ordering.to_int (compare x y)
   end)
 
 type active =
-  { mutable instances : Instance.t String.Map.t (* keyed by root *)
+  { mutable instances : Instance.t Map.M(String).t (* keyed by root *)
   ; mutable workspaces : Workspaces.t
   ; registry : Registry.t
   ; config : config
@@ -600,7 +600,7 @@ let uri_dune_overlap =
       else component acc path i (i - 1)
     and component acc path end_ i =
       if i < 0
-      then String.take path (end_ + 1) :: acc
+      then String.prefix path (end_ + 1) :: acc
       else if is_dir_sep (String.unsafe_get path i)
       then start (String.sub path ~pos:(i + 1) ~len:(end_ - i) :: acc) path (i - 1)
       else component acc path end_ (i - 1)
@@ -631,10 +631,11 @@ let uri_dune_overlap =
 let make_finalizer active (instance : Instance.t) =
   Lazy_fiber.create (fun () ->
     active.instances
-    <- String.Map.remove active.instances (Registry.Dune.root (Instance.source instance));
+    <- Map.remove active.instances (Registry.Dune.root (Instance.source instance));
     let to_unregister =
       Instance.promotions instance
-      |> String.Map.to_list_map ~f:(fun _ promotion ->
+      |> Map.data
+      |> List.map ~f:(fun promotion ->
         let path = Drpc.Diagnostic.Promotion.in_source promotion in
         Uri.of_path path)
     in
@@ -689,18 +690,18 @@ let poll active last_error =
     `Exn exn
   | Ok _refresh ->
     let remaining, to_kill =
-      String.Map.partition active.instances ~f:(fun (running : Instance.t) ->
+      Map.partition_tf active.instances ~f:(fun (running : Instance.t) ->
         let source = Instance.source running in
         List.exists workspace_folders ~f:(fun (wsf : WorkspaceFolder.t) ->
           uri_dune_overlap wsf.uri source))
     in
-    let to_kill = String.Map.values to_kill in
+    let to_kill = Map.data to_kill in
     active.instances <- remaining;
     let* connected =
       let to_create =
         (* won't work very well with large workspaces and many instances of
            dune *)
-        let is_running dune = String.Map.mem active.instances (Registry.Dune.root dune) in
+        let is_running dune = Map.mem active.instances (Registry.Dune.root dune) in
         Registry.current active.registry
         |> List.fold_left ~init:[] ~f:(fun acc dune ->
           if
@@ -714,8 +715,9 @@ let poll active last_error =
         let source = Instance.source instance in
         let root = Registry.Dune.root source in
         root, instance)
-      |> String.Map.of_list_multi
-      |> String.Map.values
+      |> List.rev
+      |> Map.of_alist_multi (module String)
+      |> Map.data
       |> Fiber.parallel_map ~f:(fun instances ->
         (* TODO put timeouts on all this stuff *)
         let rec loop = function
@@ -768,7 +770,7 @@ let poll active last_error =
                let source = Instance.source instance in
                (* this is guaranteed not to raise since we don't connect to more
                   than one dune instance per workspace *)
-               String.Map.add_exn acc (Registry.Dune.root source) instance);
+               Map.add_exn acc ~key:(Registry.Dune.root source) ~data:instance);
         Fiber.parallel_iter connected ~f:(run_instance active)
     in
     `No_error
@@ -788,11 +790,8 @@ let stop (t : t) =
       t := Closed;
       Fiber.fork_and_join_unit
         (fun () -> Fiber.Pool.stop active.pool)
-        (fun () ->
-           String.Map.values active.instances |> Fiber.parallel_iter ~f:Instance.stop))
+        (fun () -> Map.data active.instances |> Fiber.parallel_iter ~f:Instance.stop))
 ;;
-
-let env = Sys.getenv_opt
 
 let create
       workspaces
@@ -820,11 +819,13 @@ let create
     in
     { document_store; diagnostics; progress; include_promotions; log; trace }
   in
-  let registry = Registry.create (Registry.Config.create (Xdg.create ~env ())) in
+  let registry =
+    Registry.create (Registry.Config.create (Xdg.create ~env:Sys.getenv_opt ()))
+  in
   ref
     (Active
        { pool = Fiber.Pool.create ()
-       ; instances = String.Map.empty
+       ; instances = Map.empty (module String)
        ; config
        ; registry
        ; workspaces
@@ -912,7 +913,7 @@ module Promote = struct
           | Some [ arg ] -> Input.t_of_yojson arg
           | _ -> assert false
         in
-        (match String.Map.find active.instances promote.dune with
+        (match Map.find active.instances promote.dune with
          | None ->
            let message = sprintf "dune %S already disconected" promote.dune in
            Jsonrpc.Response.Error.raise
@@ -947,10 +948,10 @@ let code_actions (t : t) (uri : Uri.t) =
   | Closed -> []
   | Active active ->
     let path = Uri.to_path uri in
-    String.Map.fold active.instances ~init:[] ~f:(fun dune acc ->
+    Map.fold active.instances ~init:[] ~f:(fun ~key:_ ~data:dune acc ->
       match
         let promotions = Instance.promotions dune in
-        String.Map.find promotions path
+        Map.find promotions path
       with
       | None -> acc
       | Some promotion ->
@@ -983,6 +984,6 @@ let for_doc t doc =
   | Closed -> []
   | Active t ->
     let uri = Document.Dune.uri doc in
-    String.Map.fold ~init:[] t.instances ~f:(fun instance acc ->
+    Map.fold t.instances ~init:[] ~f:(fun ~key:_ ~data:instance acc ->
       if uri_dune_overlap uri (Instance.source instance) then instance :: acc else acc)
 ;;

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -365,7 +365,7 @@ let type_enclosing_hover
       match result with
       | Ok v ->
         (* OCamlformat adds an unnecessary newline at the end of the type *)
-        Fiber.return (String.trim v)
+        Fiber.return (String.strip v)
       | Error `No_process -> Fiber.return typ
       | Error (`Msg message) ->
         (* We log OCamlformat errors and display the unformatted type *)

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -1,14 +1,34 @@
 (* The modules are listed alphabetically. Try to keep the order. *)
 
-module Poly = struct
-  let equal = ( = )
-  let compare x y = Ordering.of_int (compare x y)
-  let hash x = Hashtbl.hash x
+include struct
+  open Base
+  module Array = Array
+  module Char = Char
+  module Comparator = Comparator
+  module Either = Either
+  module Float = Float
+  module Fn = Fn
+  module Hashtbl = Hashtbl
+  module Int = Int
+  module List = List
+  module Map = Map
+  module Option = Option
+  module Poly = Poly
+  module Queue = Queue
+  module Result = Result
+  module Set = Set
+  module Staged = Staged
+  module String = String
 end
 
 let sprintf = Printf.sprintf
 
-module Map = Stdlib.MoreLabels.Map
+module Poly = struct
+  include Base.Poly
+
+  let hash = Base.Hashtbl.hash
+end
+
 module Exn_with_backtrace = Stdune.Exn_with_backtrace
 
 module Id = struct
@@ -19,87 +39,21 @@ module Id = struct
 
     let gen () =
       let id = !next in
-      incr next;
+      Int.incr next;
       id
     ;;
 
     let to_int t = t
-    let compare x y = Ordering.of_int (Stdlib.Int.compare x y)
+    let compare x y = Ordering.of_int (Int.compare x y)
   end
 end
 
 module Monoid = Stdune.Monoid
 
-module Int = struct
-  type t = int
-
-  let compare x y = Ordering.of_int (Stdlib.Int.compare x y)
-  let equal = Stdlib.Int.equal
-  let of_string = int_of_string_opt
-  let to_string = string_of_int
-end
-
-module Table = struct
-  include Base.Hashtbl
-
-  module Multi = struct
-    let find = find_multi
-  end
-end
-
-include struct
-  open Base
-  module Queue = Queue
-
-  module Array = struct
-    include Base.Array
-
-    let common_prefix_len ~equal (a : 'a array) (b : 'a array) : int =
-      let i = ref 0 in
-      let min_len = min (Array.length a) (Array.length b) in
-      while !i < min_len && equal (Array.get a !i) (Array.get b !i) do
-        Int.incr i
-      done;
-      !i
-    ;;
-  end
-end
-
-module List = struct
-  include Base.List
-
-  let compare xs ys ~compare =
-    Base.List.compare (fun x y -> Ordering.to_int (compare x y)) xs ys
-  ;;
-
-  let sort xs ~compare = sort xs ~compare:(fun x y -> Ordering.to_int (compare x y))
-  let fold_left2 xs ys ~init ~f = Stdlib.List.fold_left2 f init xs ys
-  let mem t x ~equal = mem t x ~equal
-  let map t ~f = map t ~f
-  let concat_map t ~f = concat_map t ~f
-  let filter_map t ~f = filter_map t ~f
-  let fold_left t ~init ~f = fold_left t ~init ~f
-  let findi xs ~f = findi xs ~f
-
-  let sort_uniq xs ~compare =
-    Stdlib.List.sort_uniq (fun x y -> Ordering.to_int (compare x y)) xs
-  ;;
-
-  let for_all xs ~f = for_all xs ~f
-  let find_mapi xs ~f = find_mapi xs ~f
-  let sub xs ~pos ~len = sub xs ~pos ~len
-  let hd_exn t = hd_exn t
-  let nth_exn t n = nth_exn t n
-  let hd t = hd t
-  let filter t ~f = filter t ~f
-  let tl t = tl t
-  let drop xs i = drop xs i
-end
-
 module Result = struct
   module O = struct
-    let ( let+ ) x f = Result.map f x
-    let ( let* ) x f = Result.bind x f
+    let ( let+ ) x f = Stdlib.Result.map f x
+    let ( let* ) x f = Stdlib.Result.bind x f
   end
 
   include Base.Result
@@ -107,8 +61,8 @@ end
 
 module Option = struct
   module O = struct
-    let ( let+ ) x f = Option.map f x
-    let ( let* ) x f = Option.bind x f
+    let ( let+ ) x f = Stdlib.Option.map f x
+    let ( let* ) x f = Stdlib.Option.bind x f
   end
 
   module List = struct
@@ -148,92 +102,6 @@ module Env_vars = struct
   ;;
 end
 
-module String = struct
-  type t = string
-
-  module Map = struct
-    include MoreLabels.Map.Make (Stdlib.String)
-
-    let find t key = find_opt key t
-    let mem t key = mem key t
-    let set t key data = add t ~key ~data
-    let remove t key = remove key t
-    let values t = to_list t |> List.map ~f:snd
-    let to_list_map t ~f = to_list t |> List.map ~f:(fun (k, v) -> f k v)
-    let partition t ~f = partition t ~f:(fun _key v -> f v)
-    let fold t ~init ~f = fold t ~init ~f:(fun ~key:_ ~data acc -> f data acc)
-
-    let of_list_multi xs =
-      List.fold_left xs ~init:empty ~f:(fun acc (key, v) ->
-        update acc ~key ~f:(function
-          | None -> Some [ v ]
-          | Some xs -> Some (v :: xs)))
-    ;;
-
-    let add_exn t key data =
-      match find t key with
-      | None -> set t key data
-      | Some _ -> failwith (sprintf "%s already set" key)
-    ;;
-  end
-
-  let extract_words s ~is_word_char =
-    let open StringLabels in
-    let rec skip_blanks i =
-      if i = length s
-      then []
-      else if is_word_char s.[i]
-      then parse_word i (i + 1)
-      else skip_blanks (i + 1)
-    and parse_word i j =
-      if j = length s
-      then [ sub s ~pos:i ~len:(j - i) ]
-      else if is_word_char s.[j]
-      then parse_word i (j + 1)
-      else sub s ~pos:i ~len:(j - i) :: skip_blanks (j + 1)
-    in
-    skip_blanks 0
-  ;;
-
-  let to_dyn = Dyn.string
-
-  include struct
-    open Base.String
-
-    let unsafe_get = unsafe_get
-    let get = get
-    let split_lines = split_lines
-    let sub = sub
-    let equal = equal
-    let rsplit2 = rsplit2
-    let concat = concat
-    let length = length
-    let strip = strip
-    let trim = strip
-    let drop = drop_prefix
-    let hash = hash
-    let drop_prefix = chop_prefix
-    let is_prefix = is_prefix
-    let map = map
-    let lowercase = lowercase
-    let capitalize_ascii = capitalize
-    let capitalize = capitalize
-    let split_on_char t ~sep = split t ~on:sep
-    let is_empty = is_empty
-    let split = split
-    let chop_prefix_if_exists = chop_prefix_if_exists
-    let chop_suffix_if_exists = chop_suffix_if_exists
-    let drop_prefix_if_exists = chop_prefix_if_exists
-    let take = prefix
-    let substr_index_exn = substr_index_exn
-    let substr_index = substr_index
-    let prefix = prefix
-    let lfindi = lfindi
-    let filter = filter
-    let is_suffix = is_suffix
-  end
-end
-
 (* All modules from [Lsp] should be in the struct below. The modules are listed
    alphabetically. Try to keep the order. *)
 include struct
@@ -252,7 +120,7 @@ include struct
     end
 
     include Uri
-    include Base.Comparator.Make (Uri)
+    include Comparator.Make (Uri)
     module Map = Stdlib.Map.Make (Uri)
   end
 end

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -4,9 +4,8 @@ open Fiber.O
 let outline_type typ =
   typ
   |> Format.asprintf "@[<h>: %s@]"
-  |> String.extract_words ~is_word_char:(function
-    | ' ' | '\t' | '\n' -> false
-    | _ -> true)
+  |> String.split_on_chars ~on:[ ' '; '\t'; '\n' ]
+  |> List.filter ~f:(Fn.non String.is_empty)
   |> String.concat ~sep:" "
 ;;
 

--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -206,7 +206,7 @@ module Dot_protocol_io =
 let prefer_dot_merlin = ref false
 
 type db =
-  { running : (string, entry) Table.t
+  { running : (string, entry) Hashtbl.t
   ; pool : Fiber.Pool.t
   ; trace : trace
   }
@@ -230,7 +230,7 @@ module Entry = struct
     then Fiber.return ()
     else (
       t.stopping <- true;
-      Table.remove t.db.running t.process.initial_cwd;
+      Hashtbl.remove t.db.running t.process.initial_cwd;
       let* () =
         t.process.trace
           ~message:(fun () -> "Stopping Merlin configuration process")
@@ -252,12 +252,12 @@ module Entry = struct
 end
 
 let get_process t ~dir =
-  match Table.find t.running dir with
+  match Hashtbl.find t.running dir with
   | Some p -> Fiber.return p
   | None ->
     let* process = Process.start ~trace:t.trace ~dir in
     let entry = Entry.create t process in
-    Table.add_exn t.running ~key:dir ~data:entry;
+    Hashtbl.add_exn t.running ~key:dir ~data:entry;
     let+ () = Fiber.Pool.task t.pool ~f:(fun () -> Process.waitpid process) in
     entry
 ;;
@@ -298,13 +298,13 @@ let get_config (p : Process.t) ~workdir path_abs =
   (* Both [p.initial_cwd] and [path_abs] have gone through
      [canonicalize_filename] *)
   let path_rel =
-    String.drop_prefix ~prefix:p.initial_cwd path_abs
+    String.chop_prefix ~prefix:p.initial_cwd path_abs
     |> Option.map ~f:(fun path ->
       (* We need to remove the leading path separator after chopping. There
          is one case where no separator is left: when [initial_cwd] was the
          root of the filesystem *)
       if String.length path > 0 && path.[0] = Filename.dir_sep.[0]
-      then String.drop path 1
+      then String.drop_prefix path 1
       else path)
   in
   let path =
@@ -468,14 +468,14 @@ module DB = struct
   let get t uri = create t uri
 
   let create ~trace =
-    { running = Table.create (module Base.String); pool = Fiber.Pool.create (); trace }
+    { running = Hashtbl.create (module String); pool = Fiber.Pool.create (); trace }
   ;;
 
   let run t = Fiber.Pool.run t.pool
 
   let stop t =
     let running =
-      Table.fold t.running ~init:[] ~f:(fun ~key:_ ~data acc -> data :: acc)
+      Hashtbl.fold t.running ~init:[] ~f:(fun ~key:_ ~data acc -> data :: acc)
     in
     match running with
     | [] -> Fiber.Pool.stop t.pool

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -49,7 +49,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
             ; Action_refactor_open.qualify
             ; Action_inline.t
             ]
-        |> List.sort_uniq ~compare:Poly.compare
+        |> List.dedup_and_sort ~compare:Poly.compare
       in
       `CodeActionOptions (CodeActionOptions.create ~codeActionKinds ())
     | _ -> `Bool true

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -195,10 +195,10 @@ let compute_modified_margin binary cancel offset formatter =
           config
           |> String.split_lines
           |> List.find_map ~f:(fun line ->
-            match String.drop_prefix line ~prefix:"margin=" with
+            match String.chop_prefix line ~prefix:"margin=" with
             | None -> None
             | Some margin ->
-              String.split margin ~on:' ' |> List.hd |> Option.bind ~f:Int.of_string)
+              String.split margin ~on:' ' |> List.hd |> Option.bind ~f:Int.of_string_opt)
           |> Option.value ~default
         | Error _ -> default
       in
@@ -207,7 +207,7 @@ let compute_modified_margin binary cancel offset formatter =
   | Reason _ ->
     let margin =
       Sys.getenv_opt "REFMT_PRINT_WIDTH"
-      |> Option.bind ~f:Int.of_string
+      |> Option.bind ~f:Int.of_string_opt
       |> Option.value ~default
     in
     let margin = margin - offset in
@@ -231,14 +231,14 @@ let format_snippet ~start ~stop ~padding formatter binary cancel contents =
   let prefix, to_format, suffix =
     ( String.sub contents ~pos:0 ~len:start
     , String.sub contents ~pos:start ~len:(stop - start)
-    , String.drop contents stop )
+    , String.drop_prefix contents stop )
   in
   let args = args formatter in
   let args =
     (* if we're formatting the start of a [let ... in] construct,
         don't emit [;;] before the [in]! *)
     let next =
-      String.trim suffix ~drop:(function
+      String.strip suffix ~drop:(function
         | ' ' | '\n' | '\r' | '\t' -> true
         | _ -> false)
     in
@@ -249,7 +249,7 @@ let format_snippet ~start ~stop ~padding formatter binary cancel contents =
   let pad s =
     let spaces_pad = Bytes.make padding ' ' |> Bytes.to_string in
     String.concat ~sep:"\n" (List.map (String.split_lines s) ~f:(( ^ ) spaces_pad))
-    |> String.trim ~drop:(( = ) ' ')
+    |> String.strip ~drop:(( = ) ' ')
   in
   let open Fiber.O in
   let* margin = compute_modified_margin binary cancel padding formatter in

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -123,10 +123,10 @@ end = struct
   let array = lazy (Array.of_list list)
 
   let to_legend =
-    let cache = lazy (Hashtbl.create 3) in
+    let cache = lazy (Stdlib.Hashtbl.create 3) in
     fun t ->
       let cache = Lazy.force cache in
-      match Hashtbl.find_opt cache t with
+      match Stdlib.Hashtbl.find_opt cache t with
       | Some x -> x
       | None ->
         let rec translate t i acc : string list =
@@ -136,7 +136,7 @@ end = struct
           if Int.equal t' 0 then List.rev acc' else translate (i + 1) t' acc'
         in
         let res = translate t 0 [] in
-        Hashtbl.add cache t res;
+        Stdlib.Hashtbl.add cache t res;
         res
   ;;
 end
@@ -1006,7 +1006,14 @@ let on_request_full : State.t -> SemanticTokensParams.t -> SemanticTokens.t opti
 let find_diff ~(old : int array) ~(new_ : int array) : SemanticTokensEdit.t list =
   let old_len = Array.length old in
   let new_len = Array.length new_ in
-  let left_offset = Array.common_prefix_len ~equal:Int.equal old new_ in
+  let left_offset =
+    let i = ref 0 in
+    let min_len = min old_len new_len in
+    while !i < min_len && Int.equal (Array.get old !i) (Array.get new_ !i) do
+      Int.incr i
+    done;
+    !i
+  in
   if left_offset = old_len
   then
     if left_offset = new_len

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -1,6 +1,4 @@
 open Import
-module List = Merlin_utils.Std.List
-module String = Merlin_utils.Std.String
 module Misc_utils = Merlin_analysis.Misc_utils
 module Type_utils = Merlin_analysis.Type_utils
 

--- a/ocaml-lsp-server/src/typed_hole.ml
+++ b/ocaml-lsp-server/src/typed_hole.ml
@@ -8,7 +8,7 @@ let in_range range holes =
 
 let find_prev ~range ~position holes =
   let holes = in_range range holes in
-  Base.List.fold_until
+  List.fold_until
     ~init:None
     ~f:(fun prev hole ->
       if Lsp.Position.compare hole.end_ position < 0
@@ -17,7 +17,7 @@ let find_prev ~range ~position holes =
     ~finish:Fun.id
     holes
   |> function
-  | None -> Base.List.last holes
+  | None -> List.last holes
   | hole -> hole
 ;;
 
@@ -25,7 +25,7 @@ let find_next ~range ~position holes =
   let holes = in_range range holes in
   List.find ~f:(fun hole -> Lsp.Position.compare hole.start position > 0) holes
   |> function
-  | None -> Base.List.hd holes
+  | None -> List.hd holes
   | hole -> hole
 ;;
 

--- a/ocaml-lsp-server/src/workspace_symbol.ml
+++ b/ocaml-lsp-server/src/workspace_symbol.ml
@@ -223,11 +223,11 @@ let outline_kind kind : SymbolKind.t =
   | `Method -> Method
 ;;
 
-let make_uri_resolver ~root_dir ~build_dir : (Loc.t -> Uri.t option) Base.Staged.t =
-  let cache = ref String.Map.empty in
-  Base.Staged.stage (fun (location : Loc.t) ->
+let make_uri_resolver ~root_dir ~build_dir : (Loc.t -> Uri.t option) Staged.t =
+  let cache = ref (Map.empty (module String)) in
+  Staged.stage (fun (location : Loc.t) ->
     let fname = location.loc_start.pos_fname in
-    match String.Map.find !cache fname with
+    match Map.find !cache fname with
     | Some uri -> uri
     | None ->
       let uri =
@@ -241,7 +241,7 @@ let make_uri_resolver ~root_dir ~build_dir : (Loc.t -> Uri.t option) Base.Staged
           in
           List.find candidates ~f:Sys.file_exists |> Option.map ~f:Uri.of_path)
       in
-      cache := String.Map.set !cache fname uri;
+      cache := Map.set !cache ~key:fname ~data:uri;
       uri)
 ;;
 
@@ -313,17 +313,18 @@ let find_cm_files dir =
       then loop acc path
       else (
         match String.rsplit2 ~on:'.' path with
-        | Some (path_without_ext, "cmt") -> String.Map.set acc path_without_ext (Cmt path)
+        | Some (path_without_ext, "cmt") ->
+          Map.set acc ~key:path_without_ext ~data:(Cmt path)
         | Some (path_without_ext, "cmti") ->
-          let current_file = String.Map.find acc path_without_ext in
+          let current_file = Map.find acc path_without_ext in
           let cmi_file = Cmti path in
           (match current_file with
-           | None -> String.Map.set acc path_without_ext cmi_file
+           | None -> Map.set acc ~key:path_without_ext ~data:cmi_file
            | Some current_file ->
-             String.Map.set acc path_without_ext (choose_file current_file cmi_file))
+             Map.set acc ~key:path_without_ext ~data:(choose_file current_file cmi_file))
         | _ -> acc))
   in
-  loop String.Map.empty dir |> String.Map.values
+  loop (Map.empty (module String)) dir |> Map.data
 ;;
 
 let run
@@ -346,9 +347,7 @@ let run
          | None -> []
          | Some build_dir ->
            let cm_files = find_cm_files build_dir in
-           let resolve_uri =
-             Base.Staged.unstage (make_uri_resolver ~root_dir ~build_dir)
-           in
+           let resolve_uri = Staged.unstage (make_uri_resolver ~root_dir ~build_dir) in
            List.concat_map ~f:(symbols_from_cm_file ~filter ~resolve_uri cancel) cm_files))
   with
   | Cancelled -> Error `Cancelled

--- a/ocaml-lsp-server/src/workspaces.ml
+++ b/ocaml-lsp-server/src/workspaces.ml
@@ -1,5 +1,5 @@
 open Import
-module Uri_map = Map.Make (Uri)
+module Uri_map = Stdlib.MoreLabels.Map.Make (Uri)
 
 type t =
   { workspace_folders : WorkspaceFolder.t Uri_map.t option

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -55,7 +55,8 @@ let print_code_actions
 
 let find_action action_name action =
   match action with
-  | `CodeAction { CodeAction.kind = Some (Other name); _ } -> name = action_name
+  | `CodeAction { CodeAction.kind = Some (Other name); _ } ->
+    String.equal name action_name
   | _ -> false
 ;;
 
@@ -67,11 +68,11 @@ let position_of_offset src x =
   let cnum = ref 0
   and lnum = ref 0 in
   for i = 0 to x - 1 do
-    if src.[i] = '\n'
+    if Char.equal src.[i] '\n'
     then (
-      incr lnum;
+      Int.incr lnum;
       cnum := 0)
-    else incr cnum
+    else Int.incr cnum
   done;
   Position.create ~character:!cnum ~line:!lnum
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions_quick_fixes.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_quick_fixes.ml
@@ -4,12 +4,12 @@ open Code_actions
 
 let setup_inferred_intf_workspace () =
   let dir = Test.temp_dir "ocamllsp-code-action-" in
-  Test.write_file (Stdlib.Filename.concat dir "dune-project") "(lang dune 2.5)\n";
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 2.5)\n";
   Test.write_file
-    (Stdlib.Filename.concat dir "dune")
+    (Filename.concat dir "dune")
     "(library\n (name code_action_intf)\n (flags :standard -w -32))\n";
-  Test.write_file (Stdlib.Filename.concat dir "lib.ml") "let x = 1\n";
-  Test.write_file (Stdlib.Filename.concat dir "lib.mli") "";
+  Test.write_file (Filename.concat dir "lib.ml") "let x = 1\n";
+  Test.write_file (Filename.concat dir "lib.mli") "";
   Test.run_command ~cwd:dir "dune build";
   dir
 ;;
@@ -53,7 +53,7 @@ let print_inferred_intf_edits source path range =
 
 let%expect_test "opens the implementation if not in store" =
   let dir = setup_inferred_intf_workspace () in
-  let path = Stdlib.Filename.concat dir "lib.mli" in
+  let path = Filename.concat dir "lib.mli" in
   let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
   print_inferred_intf_edits "" path range;
   [%expect

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -37,7 +37,8 @@ let print_completion_response
        print_endline "Completions:";
        let originalLength = List.length items in
        items
-       |> List.take (min limit originalLength)
+       |> fun items ->
+       List.take items (min limit originalLength)
        |> List.iter ~f:(fun item ->
          item
          |> CompletionItem.yojson_of_t
@@ -1184,7 +1185,7 @@ let%expect_test "completes from a module" =
 let%expect_test "completes a module name" =
   let source = {ocaml|let f = L|ocaml} in
   let position = Position.create ~line:0 ~character:9 in
-  print_completions ~pre_print:(List.take 5) source position;
+  print_completions ~pre_print:(fun items -> List.take items 5) source position;
   [%expect
     {|
   Completions:
@@ -1341,7 +1342,7 @@ let%expect_test "completion doesn't autocomplete record fields" =
   print_completions
     ~pre_print:
       (List.filter ~f:(fun (compl : CompletionItem.t) ->
-         compl.label = "x" || compl.label = "y"))
+         String.equal compl.label "x" || String.equal compl.label "y"))
     source
     position;
   (* We expect 0 completions*)

--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -2,13 +2,11 @@ open Test.Import
 
 let setup_workspace () =
   let dir = Test.temp_dir "ocamllsp-declaration-" in
-  Test.write_file (Stdlib.Filename.concat dir "dune-project") "(lang dune 2.5)\n";
-  Test.write_file
-    (Stdlib.Filename.concat dir "dune")
-    "(library\n (name declaration_files))\n";
-  Test.write_file (Stdlib.Filename.concat dir "lib.ml") "let x = 1\n";
-  Test.write_file (Stdlib.Filename.concat dir "lib.mli") "val x : int\n";
-  Test.write_file (Stdlib.Filename.concat dir "main.ml") "let y = Lib.x\n";
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 2.5)\n";
+  Test.write_file (Filename.concat dir "dune") "(library\n (name declaration_files))\n";
+  Test.write_file (Filename.concat dir "lib.ml") "let x = 1\n";
+  Test.write_file (Filename.concat dir "lib.mli") "val x : int\n";
+  Test.write_file (Filename.concat dir "main.ml") "let y = Lib.x\n";
   Test.run_command ~cwd:dir "dune build";
   dir
 ;;
@@ -17,13 +15,13 @@ let print_locations = function
   | None -> print_endline "[]"
   | Some (`Location locations) ->
     List.iter locations ~f:(fun (location : Location.t) ->
-      print_endline (DocumentUri.to_path location.uri |> Stdlib.Filename.basename);
+      print_endline (DocumentUri.to_path location.uri |> Filename.basename);
       Range.yojson_of_t location.range
       |> Yojson.Safe.pretty_to_string ~std:false
       |> print_endline)
   | Some (`LocationLink links) ->
     List.iter links ~f:(fun (location : LocationLink.t) ->
-      print_endline (DocumentUri.to_path location.targetUri |> Stdlib.Filename.basename);
+      print_endline (DocumentUri.to_path location.targetUri |> Filename.basename);
       Range.yojson_of_t location.targetRange
       |> Yojson.Safe.pretty_to_string ~std:false
       |> print_endline)
@@ -31,7 +29,7 @@ let print_locations = function
 
 let%expect_test "returns location of a declaration" =
   let dir = setup_workspace () in
-  let path = Stdlib.Filename.concat dir "main.ml" in
+  let path = Filename.concat dir "main.ml" in
   let uri = DocumentUri.of_path path in
   let source = Fs_io.read_file path |> Result.ok_exn in
   let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in

--- a/ocaml-lsp-server/test/e2e-new/document_flow.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_flow.ml
@@ -89,9 +89,9 @@ let%expect_test "it should allow double opening the same document" =
 let%expect_test "missing dune leaves an opened document unavailable (#1417)" =
   let dir = Test.temp_dir "ocamllsp-missing-dune-" in
   let source = "let answer = 42\n" in
-  let path = Stdlib.Filename.concat dir "main.ml" in
-  Test.write_file (Stdlib.Filename.concat dir "dune-project") "(lang dune 3.24)\n";
-  Test.write_file (Stdlib.Filename.concat dir "dune") "(executable (name main))\n";
+  let path = Filename.concat dir "main.ml" in
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.24)\n";
+  Test.write_file (Filename.concat dir "dune") "(executable (name main))\n";
   Test.write_file path source;
   let uri = DocumentUri.of_path path in
   let workspace = WorkspaceFolder.create ~uri:(DocumentUri.of_path dir) ~name:"test" in

--- a/ocaml-lsp-server/test/e2e-new/formatting.ml
+++ b/ocaml-lsp-server/test/e2e-new/formatting.ml
@@ -22,7 +22,7 @@ wrap-comments=true
 
 let setup_ocamlformat content =
   let tmpdir = Test.temp_dir "ocamllsp-test-" in
-  let ocamlformat_path = Stdlib.Filename.concat tmpdir ".ocamlformat" in
+  let ocamlformat_path = Filename.concat tmpdir ".ocamlformat" in
   Test.write_file ocamlformat_path content;
   tmpdir
 ;;
@@ -76,9 +76,7 @@ let%expect_test "can format an ocaml impl file" =
   | _, _ -> gcd a (b mod a)
 |ocaml}
   in
-  let path =
-    Stdlib.Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml"
-  in
+  let path = Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml" in
   print_formatting source path;
   [%expect
     {|
@@ -104,9 +102,7 @@ let%expect_test "leaves unchanged files alone" =
   | _, _ -> gcd a (b mod a)
 |ocaml}
   in
-  let path =
-    Stdlib.Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml"
-  in
+  let path = Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml" in
   print_formatting source path;
   [%expect {| No formatting needed |}]
 ;;
@@ -121,9 +117,7 @@ let%expect_test "can format an ocaml intf file" =
 end
 |ocaml}
   in
-  let path =
-    Stdlib.Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.mli"
-  in
+  let path = Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.mli" in
   print_formatting source path;
   [%expect
     {|
@@ -150,8 +144,8 @@ let%expect_test "does not format ignored files" =
   in
   let tmpdir = setup_ocamlformat ocamlformat_config in
   let name = "dont_format_me.ml" in
-  Test.write_file (Stdlib.Filename.concat tmpdir ".ocamlformat-ignore") (name ^ "\n");
-  let path = Stdlib.Filename.concat tmpdir name in
+  Test.write_file (Filename.concat tmpdir ".ocamlformat-ignore") (name ^ "\n");
+  let path = Filename.concat tmpdir name in
   print_formatting source path;
   [%expect {| No formatting needed |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
@@ -21,7 +21,7 @@ val iter_lsp_response_result
   -> language_id:string
   -> makeRequest:(TextDocumentIdentifier.t -> 'a Client.out_request)
   -> source:string
-  -> (('a, Jsonrpc.Response.Error.t) result -> unit)
+  -> (('a, Jsonrpc.Response.Error.t) Result.t -> unit)
   -> unit
 
 (** Opens the file in the specified path with source code as specified in src.

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
@@ -96,8 +96,8 @@ let annotate_src_with_tokens
   let token_types = legend.SemanticTokensLegend.tokenTypes |> Array.of_list in
   let token_mods = legend.SemanticTokensLegend.tokenModifiers |> Array.of_list in
   let src_ix = ref 0 in
-  let tokens = Array.Iter.create (tokens encoded_tokens) in
-  let token = ref @@ Array.Iter.next_exn tokens in
+  let tokens = Array_iter.create (tokens encoded_tokens) in
+  let token = ref @@ Array_iter.next_exn tokens in
   let token_id = ref 0 in
   let line = ref !token.delta_line in
   let character = ref !token.delta_char in
@@ -114,16 +114,16 @@ let annotate_src_with_tokens
          then "|" ^ String.concat ~sep:"," (modifiers ~legend:token_mods !token.mods)
          else "")
         !token_id;
-      Buffer.add_substring b src !src_ix !token.len;
+      Buffer.add_substring b src ~pos:!src_ix ~len:!token.len;
       src_ix := !src_ix + !token.len;
       Printf.bprintf b "</%d>" !token_id;
-      match Array.Iter.next tokens with
+      match Array_iter.next tokens with
       | None ->
         (* copy the rest of src *)
-        Buffer.add_substring b src !src_ix (src_len - !src_ix);
+        Buffer.add_substring b src ~pos:!src_ix ~len:(src_len - !src_ix);
         src_ix := src_len
       | Some next_token ->
-        incr token_id;
+        Int.incr token_id;
         character := next_token.delta_char - !token.len;
         token := next_token;
         line := !token.delta_line)
@@ -131,13 +131,13 @@ let annotate_src_with_tokens
       let ch = src.[!src_ix] in
       (match ch with
        | '\n' ->
-         decr line;
+         Int.decr line;
          character := !token.delta_char
-       | _ -> decr character);
+       | _ -> Int.decr character);
       Buffer.add_char b ch;
-      incr src_ix)
+      Int.incr src_ix)
   done;
-  Buffer.to_bytes b |> Bytes.to_string
+  Buffer.contents b
 ;;
 
 (* for tests below *)

--- a/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/switch_impl_intf.ml
@@ -3,12 +3,11 @@ module Req = Ocaml_lsp_server.Custom_request.Switch_impl_intf
 
 let setup_files exts =
   let dir = Test.temp_dir "ocamllsp-switch-" in
-  List.iter exts ~f:(fun ext ->
-    Test.write_file (Stdlib.Filename.concat dir ("test." ^ ext)) "");
+  List.iter exts ~f:(fun ext -> Test.write_file (Filename.concat dir ("test." ^ ext)) "");
   dir
 ;;
 
-let uri_of_ext dir ext = DocumentUri.of_path (Stdlib.Filename.concat dir ("test." ^ ext))
+let uri_of_ext dir ext = DocumentUri.of_path (Filename.concat dir ("test." ^ ext))
 
 let open_document client uri =
   let textDocument =
@@ -30,7 +29,7 @@ let switch_impl_intf client uri =
 let print_response json =
   Yojson.Safe.Util.to_list json
   |> List.map ~f:(fun json -> DocumentUri.t_of_yojson json |> DocumentUri.to_path)
-  |> List.map ~f:Stdlib.Filename.basename
+  |> List.map ~f:Filename.basename
   |> List.iter ~f:print_endline
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -1,96 +1,60 @@
 module Import = struct
   include struct
-    include Base
+    open Base
+    module Array = Array
+    module Buffer = Buffer
+    module Char = Char
+    module Either = Either
+    module Float = Float
+    module Hashtbl = Hashtbl
+    module Int = Int
+    module List = List
+    module Map = Map
+    module Option = Option
+    module Poly = Poly
+    module Queue = Queue
+    module Result = Result
+    module Set = Set
+    module String = String
+  end
 
-    type nonrec ('a, 'b) result = ('a, 'b) Stdlib.result
+  let sprintf = Printf.sprintf
 
-    let ( = ) = Stdlib.( = )
-    let ( <> ) = Stdlib.( <> )
-    let ( < ) = Stdlib.( < )
-    let ( <= ) = Stdlib.( <= )
-    let ( > ) = Stdlib.( > )
-    let ( >= ) = Stdlib.( >= )
-    let incr = Stdlib.incr
-    let decr = Stdlib.decr
-    let sprintf = Stdlib.Printf.sprintf
-    let print_endline = Stdlib.print_endline
-    let print_string = Stdlib.print_string
-    let print_int = Stdlib.print_int
-    let print_newline = Stdlib.print_newline
-    let output_string = Stdlib.output_string
-    let close_out = Stdlib.close_out
-    let stdout = Stdlib.stdout
+  module Option = struct
+    include Option
 
-    module Buffer = Stdlib.Buffer
-    module Exn_with_backtrace = Stdune.Exn_with_backtrace
-    module Filename = Stdlib.Filename
-    module Format = Stdlib.Format
-    module Fun = Stdlib.Fun
-    module Printf = Stdlib.Printf
-    module Sys = Stdlib.Sys
-
-    module Option = struct
-      include Option
-
-      module O = struct
-        let ( let+ ) value f = map value ~f
-        let ( let* ) value f = bind value ~f
-      end
+    module O = struct
+      let ( let+ ) value f = map value ~f
+      let ( let* ) value f = bind value ~f
     end
+  end
 
-    module List = struct
-      include List
+  module Exn_with_backtrace = Stdune.Exn_with_backtrace
 
-      let take n l =
-        if n < 0 || n > List.length l
-        then failwith "list shorter than n"
-        else
-          let open Base in
-          List.take l n
-      ;;
+  module Array_iter : sig
+    type 'a t
 
-      let fold_left_map values ~init ~f =
-        let state, values =
-          Stdlib.List.fold_left
-            (fun (state, values) value ->
-               let state, value = f state value in
-               state, value :: values)
-            (init, [])
-            values
-        in
-        state, rev values
-      ;;
-    end
+    val create : 'a array -> 'a t
+    val has_next : 'a t -> bool
+    val next : 'a t -> 'a option
+    val next_exn : 'a t -> 'a
+  end = struct
+    type 'a t =
+      { contents : 'a array
+      ; mutable ix : int
+      }
 
-    module Array = struct
-      include Array
+    let create contents = { contents; ix = 0 }
+    let has_next t = t.ix < Array.length t.contents
 
-      module Iter : sig
-        type 'a t
+    let next_exn t =
+      let { contents; ix } = t in
+      let v = contents.(ix) in
+      t.ix <- ix + 1;
+      v
+    ;;
 
-        val create : 'a array -> 'a t
-        val has_next : 'a t -> bool
-        val next : 'a t -> 'a option
-        val next_exn : 'a t -> 'a
-      end = struct
-        type 'a t =
-          { contents : 'a array
-          ; mutable ix : int
-          }
-
-        let create contents = { contents; ix = 0 }
-        let has_next t = t.ix < Array.length t.contents
-
-        let next_exn t =
-          let { contents; ix } = t in
-          let v = contents.(ix) in
-          t.ix <- ix + 1;
-          v
-        ;;
-
-        let next t = if has_next t then Some (next_exn t) else None
-      end
-    end
+    let next t = if has_next t then Some (next_exn t) else None
   end
 
   include Fiber.O
@@ -128,7 +92,7 @@ let waitpid ?(timeout = 5.0) pid =
   let deadline = Unix.gettimeofday () +. timeout in
   let rec wait () =
     match Unix.waitpid [ Unix.WNOHANG ] pid with
-    | 0, _ when Unix.gettimeofday () < deadline ->
+    | 0, _ when Float.(Unix.gettimeofday () < deadline) ->
       Unix.sleepf 0.01;
       wait ()
     | 0, _ ->
@@ -280,8 +244,8 @@ include T
 let write_file path data = Fs_io.write_file ~perm:0o666 ~path ~data |> Result.ok_exn
 
 let temp_dir ?temp_dir prefix =
-  let dir = Stdlib.Filename.temp_file ?temp_dir prefix "" in
-  Stdlib.Sys.remove dir;
+  let dir = Filename.temp_file ?temp_dir prefix "" in
+  Sys.remove dir;
   Unix.mkdir dir 0o700;
   dir
 ;;
@@ -290,9 +254,9 @@ let run_command ?cwd command =
   let command =
     match cwd with
     | None -> command
-    | Some cwd -> Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote cwd) command
+    | Some cwd -> Printf.sprintf "cd %s && %s" (Filename.quote cwd) command
   in
-  if Stdlib.Sys.command command <> 0 then failwith command
+  if Sys.command command <> 0 then failwith command
 ;;
 
 let null_device = if Sys.win32 then "NUL" else "/dev/null"
@@ -355,8 +319,8 @@ let open_document ?(language_id = "ocaml") ~client ~uri ~source () =
 let offset_of_position src (pos : Position.t) =
   let line_offset =
     String.split_lines src
-    |> List.take pos.line
-    |> List.fold_left ~init:0 ~f:(fun s l -> s + String.length l)
+    |> fun lines ->
+    List.take lines pos.line |> List.fold_left ~init:0 ~f:(fun s l -> s + String.length l)
   in
   line_offset + pos.line (* account for line endings *) + pos.character
 ;;
@@ -380,10 +344,12 @@ let apply_edits src edits =
     List.map edits ~f:(fun (e : TextEdit.t) ->
       e.newText, offset_of_position src e.range.start, offset_of_position src e.range.end_)
     (* update the offsets to account for preceding edits *)
-    |> List.fold_left_map ~init:0 ~f:(fun offset (new_text, start, end_) ->
-      if end_ < start then failwith "invalid edit: end before start";
-      ( offset + (String.length new_text - (end_ - start))
-      , (new_text, start + offset, end_ + offset) ))
+    |> Stdlib.List.fold_left_map
+         (fun offset (new_text, start, end_) ->
+            if end_ < start then failwith "invalid edit: end before start";
+            ( offset + (String.length new_text - (end_ - start))
+            , (new_text, start + offset, end_ + offset) ))
+         0
   in
   (* apply edits *)
   List.fold_left edits ~init:src ~f:(fun src (new_text, start, end_) ->

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -8,9 +8,7 @@ let codelens client textDocument =
 ;;
 
 let%expect_test "can add the first workspace folder after initialization" =
-  let stderr_path, stderr_chan =
-    Stdlib.Filename.open_temp_file "ocamllsp-workspace" ".log"
-  in
+  let stderr_path, stderr_chan = Filename.open_temp_file "ocamllsp-workspace" ".log" in
   let stderr = Unix.descr_of_out_channel stderr_chan in
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
   Test.run_initialized ~handler ~stderr ~workspaceFolders:None (fun client ->
@@ -21,9 +19,9 @@ let%expect_test "can add the first workspace folder after initialization" =
     let change = DidChangeWorkspaceFoldersParams.create ~event in
     let* () = Client.notification client (ChangeWorkspaceFolders change) in
     Test.exit_client client);
-  Stdlib.close_out stderr_chan;
+  close_out stderr_chan;
   let stderr = Fs_io.read_file stderr_path |> Result.ok_exn in
-  Stdlib.Sys.remove stderr_path;
+  Sys.remove stderr_path;
   Printf.printf "stderr: %s\n" (Yojson.Safe.to_string (`String stderr));
   [%expect {| stderr: "" |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_partial_build.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_partial_build.ml
@@ -70,11 +70,11 @@ let%expect_test "mixed workspaces return symbols only from built workspaces" =
 
 let setup_generated_workspace () =
   let path = Test.temp_dir "ocamllsp-generated-workspace-symbol-" in
-  let lib = Stdlib.Filename.concat path "lib" in
+  let lib = Filename.concat path "lib" in
   mkdir lib;
-  Test.write_file (Stdlib.Filename.concat path "dune-project") "(lang dune 2.5)\n";
+  Test.write_file (Filename.concat path "dune-project") "(lang dune 2.5)\n";
   Test.write_file
-    (Stdlib.Filename.concat lib "dune")
+    (Filename.concat lib "dune")
     {dune|
 (library
  (name generated_source))
@@ -93,7 +93,7 @@ let setup_generated_workspace () =
 ;;
 
 let relative_path ~root path =
-  let prefix = root ^ Stdlib.Filename.dir_sep in
+  let prefix = root ^ Filename.dir_sep in
   if Stdlib.String.starts_with ~prefix path
   then String.drop_prefix path (String.length prefix)
   else path

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
@@ -159,7 +159,7 @@ let b_main_ml =
 |workspace_symbol}
 ;;
 
-let mkdir path = if not (Stdlib.Sys.file_exists path) then Unix.mkdir path 0o700
+let mkdir path = if not (Sys.file_exists path) then Unix.mkdir path 0o700
 
 type workspace =
   { name : string
@@ -168,7 +168,7 @@ type workspace =
   }
 
 let create_workspace root name =
-  let path = Stdlib.Filename.concat root name in
+  let path = Filename.concat root name in
   mkdir path;
   let uri = DocumentUri.of_path path in
   { name; path; folder = WorkspaceFolder.create ~name ~uri }
@@ -179,11 +179,11 @@ let setup_workspaces () =
   let workspace_a = create_workspace root "workspace_symbol_A" in
   let workspace_b = create_workspace root "workspace_symbol_B" in
   let write workspace rel content =
-    Test.write_file (Stdlib.Filename.concat workspace.path rel) content
+    Test.write_file (Filename.concat workspace.path rel) content
   in
-  mkdir (Stdlib.Filename.concat workspace_a.path "bin");
-  mkdir (Stdlib.Filename.concat workspace_a.path "lib");
-  mkdir (Stdlib.Filename.concat workspace_a.path "vendor");
+  mkdir (Filename.concat workspace_a.path "bin");
+  mkdir (Filename.concat workspace_a.path "lib");
+  mkdir (Filename.concat workspace_a.path "vendor");
   write workspace_a "dune-project" "(lang dune 2.5)\n";
   write workspace_a "lib.opam" "";
   write workspace_a "main.opam" "";
@@ -227,7 +227,7 @@ let to_test_result workspaces (symbol : SymbolInformation.t) =
     match workspace_path with
     | None -> path
     | Some workspace_path ->
-      let parent = Stdlib.Filename.dirname workspace_path in
+      let parent = Filename.dirname workspace_path in
       String.drop_prefix path (String.length parent)
   in
   Printf.sprintf


### PR DESCRIPTION
Remove the accumulated Base and Stdlib compatibility wrappers from the server and e2e test imports. Call sites now use the imported Base APIs directly, while Stdlib is qualified only where its API collides with an imported Base module.

The changes remain scoped to `ocaml-lsp-server`; the `lsp` library is unchanged.
