### PR TITLE
fix(jsonrpc-fiber): reject deferred replies without responses

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -262,7 +262,11 @@ struct
             let+ res =
               Fiber.map_reduce_errors
                 (module Stdune.Monoid.Unit)
-                (fun () -> Reply.send reply sender)
+                (fun () ->
+                   let* () = Reply.send reply sender in
+                   if sender.called
+                   then Fiber.return ()
+                   else Code_error.raise "deferred reply did not send a response" [])
                 ~on_error:(fun exn_bt ->
                   if sender.called
                   then (* TODO we should log *)

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -384,7 +384,7 @@ let%expect_test "delayed replies may return without sending a response" =
   [%expect
     {|
     <opaque>
-    no response sent
+    InternalError
     |}]
 ;;
 


### PR DESCRIPTION
Treat a deferred reply that returns without invoking its callback as an internal error, ensuring every accepted request receives a response.

Updates the characterization added in #1920 to expect `InternalError`.
