### PR TITLE
feat(lsp): add semantic token helpers and use them in ocamllsp

### DIFF
--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -1,6 +1,7 @@
 module Progress = Progress
 module Position = Position
 module Range = Range
+module Semantic_tokens = Semantic_tokens
 module Client_notification = Client_notification
 module Client_request = Client_request
 module Experimental = Experimental

--- a/lsp/src/semantic_tokens.ml
+++ b/lsp/src/semantic_tokens.ml
@@ -1,0 +1,218 @@
+open Import
+open Types
+
+module Legend = struct
+  type t =
+    { token_types : string list
+    ; token_modifiers : string list
+    }
+
+  let create ~token_types ~token_modifiers = { token_types; token_modifiers }
+  let token_types t = t.token_types
+  let token_modifiers t = t.token_modifiers
+
+  let to_types t =
+    SemanticTokensLegend.create
+      ~tokenTypes:t.token_types
+      ~tokenModifiers:t.token_modifiers
+  ;;
+end
+
+module Encoding = struct
+  type t =
+    { legend : Legend.t
+    ; token_type_indices : int option array
+    ; token_modifier_bits : int option array
+    }
+
+  let mem value client = List.exists client ~f:(String.equal value)
+
+  let supported_values ~server ~client =
+    List.filter server ~f:(fun value -> mem value client)
+  ;;
+
+  let index_of values value =
+    let rec loop index = function
+      | [] -> None
+      | candidate :: rest ->
+        if String.equal value candidate then Some index else loop (index + 1) rest
+    in
+    loop 0 values
+  ;;
+
+  let negotiate_token_type_indices ~server_token_types ~token_types =
+    server_token_types
+    |> Array.of_list
+    |> Array.map ~f:(fun server_token_type -> index_of token_types server_token_type)
+  ;;
+
+  let negotiate_token_modifier_bits ~server_token_modifiers ~token_modifiers =
+    server_token_modifiers
+    |> Array.of_list
+    |> Array.map ~f:(fun server_modifier ->
+      match index_of token_modifiers server_modifier with
+      | None -> None
+      | Some index -> Some (1 lsl index))
+  ;;
+
+  let negotiate ~server ~client =
+    let token_types =
+      supported_values
+        ~server:(Legend.token_types server)
+        ~client:(Legend.token_types client)
+    in
+    let token_modifiers =
+      supported_values
+        ~server:(Legend.token_modifiers server)
+        ~client:(Legend.token_modifiers client)
+    in
+    let legend = Legend.create ~token_types ~token_modifiers in
+    let token_type_indices =
+      negotiate_token_type_indices
+        ~server_token_types:(Legend.token_types server)
+        ~token_types
+    in
+    let token_modifier_bits =
+      negotiate_token_modifier_bits
+        ~server_token_modifiers:(Legend.token_modifiers server)
+        ~token_modifiers
+    in
+    { legend; token_type_indices; token_modifier_bits }
+  ;;
+
+  let legend t = t.legend
+
+  let token_type_index t ~server_index =
+    if server_index < 0 || server_index >= Array.length t.token_type_indices
+    then None
+    else t.token_type_indices.(server_index)
+  ;;
+
+  let token_modifiers_bitset t ~server_bitset =
+    let rec loop server_index encoded result =
+      if Int.equal encoded 0
+      then result
+      else (
+        let result =
+          if Int.equal (encoded land 1) 0
+          then result
+          else if server_index < 0 || server_index >= Array.length t.token_modifier_bits
+          then result
+          else (
+            match t.token_modifier_bits.(server_index) with
+            | None -> result
+            | Some client_bit -> result lor client_bit)
+        in
+        loop (server_index + 1) (encoded lsr 1) result)
+    in
+    loop 0 server_bitset 0
+  ;;
+end
+
+module Token = struct
+  type t =
+    { start : Position.t
+    ; length : int
+    ; token_type : int
+    ; token_modifiers : int
+    }
+end
+
+let set_token
+      arr
+      ~delta_line_index
+      ~delta_line
+      ~delta_start
+      ~length
+      ~token_type
+      ~token_modifiers
+  =
+  arr.(delta_line_index) <- delta_line;
+  arr.(delta_line_index + 1) <- delta_start;
+  arr.(delta_line_index + 2) <- length;
+  arr.(delta_line_index + 3) <- token_type;
+  arr.(delta_line_index + 4) <- token_modifiers
+;;
+
+let compare_position (left : Position.t) (right : Position.t) =
+  match Int.compare left.line right.line with
+  | 0 -> Int.compare left.character right.character
+  | c -> c
+;;
+
+let encode (tokens : Token.t list) =
+  (* Stable so equal-position tokens keep caller order. *)
+  let tokens =
+    List.stable_sort tokens ~cmp:(fun (left : Token.t) right ->
+      compare_position left.start right.start)
+  in
+  let data = Array.make (List.length tokens * 5) 0 in
+  let rec loop index previous_line previous_character = function
+    | [] -> ()
+    | (token : Token.t) :: rest ->
+      let delta_line = token.start.line - previous_line in
+      let delta_start =
+        if Int.equal delta_line 0
+        then token.start.character - previous_character
+        else token.start.character
+      in
+      set_token
+        data
+        ~delta_line_index:(index * 5)
+        ~delta_line
+        ~delta_start
+        ~length:token.length
+        ~token_type:token.token_type
+        ~token_modifiers:token.token_modifiers;
+      loop (index + 1) token.start.line token.start.character rest
+  in
+  loop 0 0 0 tokens;
+  data
+;;
+
+let common_prefix_len old new_ =
+  let len = min (Array.length old) (Array.length new_) in
+  let rec loop i = if i = len || old.(i) <> new_.(i) then i else loop (i + 1) in
+  loop 0
+;;
+
+(* [find_diff] finds common prefix and common suffix and reports the rest as
+   array difference. This is not ideal but good enough. The idea comes from the
+   Rust Analyzer implementation of this function. *)
+let find_diff ~(old : int array) ~(new_ : int array) : SemanticTokensEdit.t list =
+  let old_len = Array.length old in
+  let new_len = Array.length new_ in
+  let left_offset = common_prefix_len old new_ in
+  if left_offset = old_len
+  then
+    if left_offset = new_len
+    then (* [old] and [new_] are simply equal *) []
+    else
+      (* [old] is prefix of [new_] *)
+      [ SemanticTokensEdit.create
+          ~start:left_offset
+          ~deleteCount:0
+          ~data:(Array.sub new_ ~pos:left_offset ~len:(new_len - left_offset))
+          ()
+      ]
+  else if left_offset = new_len
+  then
+    (* [new_] is prefix of [old] *)
+    [ SemanticTokensEdit.create ~start:left_offset ~deleteCount:(old_len - left_offset) ()
+    ]
+  else (
+    let common_suffix_len =
+      let old_noncommon = Array_view.make old ~pos:left_offset in
+      let new_noncommon = Array_view.make new_ ~pos:left_offset in
+      Array_view.common_suffix_len old_noncommon new_noncommon
+    in
+    let deleteCount =
+      let right_offset_old = old_len - common_suffix_len in
+      right_offset_old - left_offset
+    in
+    let data =
+      let right_offset_new = new_len - common_suffix_len in
+      Array.sub new_ ~pos:left_offset ~len:(right_offset_new - left_offset)
+    in
+    [ SemanticTokensEdit.create ~start:left_offset ~deleteCount ~data () ])
+;;

--- a/lsp/src/semantic_tokens.mli
+++ b/lsp/src/semantic_tokens.mli
@@ -1,0 +1,53 @@
+open Import
+open Types
+
+(** Helpers for the semantic-tokens wire format: legend negotiation, absolute
+    token encoding, and full/delta edits. *)
+
+module Legend : sig
+  type t
+
+  val create : token_types:string list -> token_modifiers:string list -> t
+  val token_types : t -> string list
+  val token_modifiers : t -> string list
+  val to_types : t -> SemanticTokensLegend.t
+end
+
+module Encoding : sig
+  (** Negotiated mapping from a server legend to a client-supported legend.
+
+      The advertised legend preserves server order and keeps only values the
+      client supports (by name membership). Client order and duplicates do not
+      affect the result. *)
+  type t
+
+  val negotiate : server:Legend.t -> client:Legend.t -> t
+
+  (** Legend the server should advertise after negotiation. *)
+  val legend : t -> Legend.t
+
+  (** Map a server token-type index to the negotiated legend index, or [None]
+      when the client does not support that type. *)
+  val token_type_index : t -> server_index:int -> int option
+
+  (** Remap a server-side modifier bitset into the negotiated legend. *)
+  val token_modifiers_bitset : t -> server_bitset:int -> int
+end
+
+module Token : sig
+  (** Absolute source token already mapped to negotiated legend indexes. *)
+  type t =
+    { start : Position.t
+    ; length : int
+    ; token_type : int
+    ; token_modifiers : int
+    }
+end
+
+(** Encode absolute tokens as an LSP semantic-tokens data array.
+
+    Tokens may be provided in any order; they are sorted by source position
+    before delta encoding. [length] must be positive. *)
+val encode : Token.t list -> int array
+
+val find_diff : old:int array -> new_:int array -> SemanticTokensEdit.t list

--- a/lsp/test/semantic_tokens_quickcheck_tests.ml
+++ b/lsp/test/semantic_tokens_quickcheck_tests.ml
@@ -1,0 +1,512 @@
+open Base
+open Base_quickcheck
+open Lsp.Types
+module Semantic_tokens = Lsp.Semantic_tokens
+
+let select selector ~choices = Int.rem (selector land Int.max_value) choices
+let check label condition = if not condition then failwith label
+
+let check_string_list label ~expected ~actual =
+  if not (List.equal String.equal expected actual)
+  then
+    failwith
+      (Printf.sprintf
+         "%s: expected %s, got %s"
+         label
+         (Sexp.to_string_hum ([%sexp_of: string list] expected))
+         (Sexp.to_string_hum ([%sexp_of: string list] actual)))
+;;
+
+let check_int_option label ~context ~expected ~actual =
+  if not (Option.equal Int.equal expected actual)
+  then
+    failwith
+      (Printf.sprintf
+         "%s (%s): expected %s, got %s"
+         label
+         context
+         (Sexp.to_string_hum ([%sexp_of: int option] expected))
+         (Sexp.to_string_hum ([%sexp_of: int option] actual)))
+;;
+
+let check_int label ~context ~expected ~actual =
+  if expected <> actual
+  then
+    failwith (Printf.sprintf "%s (%s): expected %d, got %d" label context expected actual)
+;;
+
+let value_index values value =
+  List.find_mapi values ~f:(fun index candidate ->
+    Option.some_if (String.equal value candidate) index)
+;;
+
+let supported_values server_values client_values =
+  List.filter server_values ~f:(fun server_value ->
+    List.mem client_values server_value ~equal:String.equal)
+;;
+
+let modifier_names_of_bits bits modifiers =
+  List.filter_mapi modifiers ~f:(fun index modifier ->
+    Option.some_if (bits land (1 lsl index) <> 0) modifier)
+;;
+
+let bits_of_modifier_names names modifiers =
+  List.fold_left names ~init:0 ~f:(fun bits name ->
+    match value_index modifiers name with
+    | None -> bits
+    | Some index -> bits lor (1 lsl index))
+;;
+
+let legend token_types token_modifiers =
+  Semantic_tokens.Legend.create ~token_types ~token_modifiers
+;;
+
+module Token_case = struct
+  type token =
+    { line_delta_selector : int
+    ; character_selector : int
+    ; length_selector : int
+    ; token_type_selector : int
+    ; token_modifiers_selector : int
+    }
+  [@@deriving quickcheck, sexp_of]
+
+  type t = token list [@@deriving quickcheck, sexp_of]
+end
+
+type absolute_token =
+  { line : int
+  ; character : int
+  ; length : int
+  ; token_type : int
+  ; token_modifiers : int
+  }
+
+let absolute_tokens seeds =
+  let _, _, tokens =
+    List.fold
+      seeds
+      ~init:(0, 0, [])
+      ~f:
+        (fun
+          (previous_line, previous_character, tokens)
+          { Token_case.line_delta_selector
+          ; character_selector
+          ; length_selector
+          ; token_type_selector
+          ; token_modifiers_selector
+          }
+        ->
+        let line_delta = select line_delta_selector ~choices:4 in
+        let line = previous_line + line_delta in
+        let character =
+          if line_delta = 0
+          then previous_character + select character_selector ~choices:8
+          else select character_selector ~choices:24
+        in
+        let length = select length_selector ~choices:12 + 1 in
+        let token_type = select token_type_selector ~choices:8 in
+        let token_modifiers = select token_modifiers_selector ~choices:16 in
+        ( line
+        , character
+        , { line; character; length; token_type; token_modifiers } :: tokens ))
+  in
+  List.rev tokens
+;;
+
+let decode encoded =
+  check "semantic token array length" (Int.rem (Array.length encoded) 5 = 0);
+  let rec loop index previous_line previous_character tokens =
+    if index = Array.length encoded
+    then List.rev tokens
+    else (
+      let delta_line = encoded.(index) in
+      let delta_start = encoded.(index + 1) in
+      let length = encoded.(index + 2) in
+      let token_type = encoded.(index + 3) in
+      let token_modifiers = encoded.(index + 4) in
+      check "negative delta line" (delta_line >= 0);
+      check "negative delta start" (delta_start >= 0);
+      check "nonpositive token length" (length > 0);
+      let line = previous_line + delta_line in
+      let character =
+        if delta_line = 0 then previous_character + delta_start else delta_start
+      in
+      loop
+        (index + 5)
+        line
+        character
+        ({ line; character; length; token_type; token_modifiers } :: tokens))
+  in
+  loop 0 0 0 []
+;;
+
+let equal_token left right =
+  left.line = right.line
+  && left.character = right.character
+  && left.length = right.length
+  && left.token_type = right.token_type
+  && left.token_modifiers = right.token_modifiers
+;;
+
+let sort_tokens tokens =
+  List.stable_sort tokens ~compare:(fun left right ->
+    match Int.compare left.line right.line with
+    | 0 -> Int.compare left.character right.character
+    | c -> c)
+;;
+
+let to_wire_token { line; character; length; token_type; token_modifiers } =
+  { Semantic_tokens.Token.start = Position.create ~line ~character
+  ; length
+  ; token_type
+  ; token_modifiers
+  }
+;;
+
+let check_token_case seeds =
+  let expected = absolute_tokens seeds |> sort_tokens in
+  let input = List.map expected ~f:to_wire_token in
+  let actual = Semantic_tokens.encode input |> decode in
+  check "semantic token round trip" (List.equal equal_token expected actual)
+;;
+
+let%test_unit "semantic token encoding sorts out-of-order tokens" =
+  let tokens =
+    [ { line = 2; character = 0; length = 1; token_type = 1; token_modifiers = 0 }
+    ; { line = 1; character = 4; length = 2; token_type = 2; token_modifiers = 1 }
+    ; { line = 1; character = 0; length = 3; token_type = 3; token_modifiers = 2 }
+    ]
+  in
+  let expected = sort_tokens tokens in
+  let actual = Semantic_tokens.encode (List.map tokens ~f:to_wire_token) |> decode in
+  check "semantic token out-of-order sort" (List.equal equal_token expected actual)
+;;
+
+module Capability_case = struct
+  type t =
+    { server_token_types : string list
+    ; server_token_modifiers : string list
+    ; client_token_types : string list
+    ; client_token_modifiers : string list
+    ; token_type_index : int
+    ; token_modifier_bits : int
+    }
+  [@@deriving sexp_of]
+
+  let unknown = "unknown"
+
+  let gen_names ~prefix ~count =
+    Generator.return
+      (List.init count ~f:(fun index -> Printf.sprintf "%s%d" prefix index))
+  ;;
+
+  let gen_client_values server_values =
+    Generator.bind
+      (Generator.list_with_length Generator.bool ~length:(List.length server_values))
+      ~f:(fun includes ->
+        let supported =
+          List.filter_mapi server_values ~f:(fun index server_value ->
+            Option.some_if (List.nth_exn includes index) server_value)
+        in
+        Generator.bind (Generator.int_inclusive 0 2) ~f:(fun unknown_count ->
+          let unknowns = List.init unknown_count ~f:(fun _ -> unknown) in
+          Generator.bind
+            (Generator.list_with_length Generator.bool ~length:(List.length supported))
+            ~f:(fun duplicate_flags ->
+              let duplicates =
+                List.filter_mapi supported ~f:(fun index value ->
+                  Option.some_if (List.nth_exn duplicate_flags index) value)
+              in
+              Generator.list_permutations (supported @ unknowns @ duplicates))))
+  ;;
+
+  let quickcheck_generator =
+    Generator.bind (Generator.int_inclusive 1 6) ~f:(fun type_count ->
+      Generator.bind (Generator.int_inclusive 1 6) ~f:(fun modifier_count ->
+        Generator.bind
+          (gen_names ~prefix:"type" ~count:type_count)
+          ~f:(fun server_token_types ->
+            Generator.bind
+              (gen_names ~prefix:"mod" ~count:modifier_count)
+              ~f:(fun server_token_modifiers ->
+                Generator.bind
+                  (gen_client_values server_token_types)
+                  ~f:(fun client_token_types ->
+                    Generator.bind
+                      (gen_client_values server_token_modifiers)
+                      ~f:(fun client_token_modifiers ->
+                        Generator.bind
+                          (Generator.int_inclusive 0 (type_count - 1))
+                          ~f:(fun token_type_index ->
+                            Generator.map
+                              (Generator.int_inclusive 0 ((1 lsl modifier_count) - 1))
+                              ~f:(fun token_modifier_bits ->
+                                { server_token_types
+                                ; server_token_modifiers
+                                ; client_token_types
+                                ; client_token_modifiers
+                                ; token_type_index
+                                ; token_modifier_bits
+                                }))))))))
+  ;;
+
+  let quickcheck_observer =
+    Observer.unmap
+      [%quickcheck.observer:
+        string list * string list * string list * string list * int * int]
+      ~f:
+        (fun
+          { server_token_types
+          ; server_token_modifiers
+          ; client_token_types
+          ; client_token_modifiers
+          ; token_type_index
+          ; token_modifier_bits
+          }
+        ->
+        ( server_token_types
+        , server_token_modifiers
+        , client_token_types
+        , client_token_modifiers
+        , token_type_index
+        , token_modifier_bits ))
+  ;;
+
+  let quickcheck_shrinker =
+    Shrinker.map
+      [%quickcheck.shrinker:
+        string list * string list * string list * string list * int * int]
+      ~f:
+        (fun
+          ( server_token_types
+          , server_token_modifiers
+          , client_token_types
+          , client_token_modifiers
+          , token_type_index
+          , token_modifier_bits ) ->
+        { server_token_types
+        ; server_token_modifiers
+        ; client_token_types
+        ; client_token_modifiers
+        ; token_type_index
+        ; token_modifier_bits
+        })
+      ~f_inverse:
+        (fun
+          { server_token_types
+          ; server_token_modifiers
+          ; client_token_types
+          ; client_token_modifiers
+          ; token_type_index
+          ; token_modifier_bits
+          } ->
+        ( server_token_types
+        , server_token_modifiers
+        , client_token_types
+        , client_token_modifiers
+        , token_type_index
+        , token_modifier_bits ))
+  ;;
+end
+
+let check_capability_case
+      { Capability_case.server_token_types
+      ; server_token_modifiers
+      ; client_token_types
+      ; client_token_modifiers
+      ; token_type_index
+      ; token_modifier_bits
+      }
+  =
+  let server = legend server_token_types server_token_modifiers in
+  let client = legend client_token_types client_token_modifiers in
+  let encoding = Semantic_tokens.Encoding.negotiate ~server ~client in
+  let negotiated = Semantic_tokens.Encoding.legend encoding in
+  let expected_token_types = supported_values server_token_types client_token_types in
+  let expected_token_modifiers =
+    supported_values server_token_modifiers client_token_modifiers
+  in
+  check_string_list
+    "negotiated semantic token types"
+    ~expected:expected_token_types
+    ~actual:(Semantic_tokens.Legend.token_types negotiated);
+  check_string_list
+    "negotiated semantic token modifiers"
+    ~expected:expected_token_modifiers
+    ~actual:(Semantic_tokens.Legend.token_modifiers negotiated);
+  let server_token_type = List.nth_exn server_token_types token_type_index in
+  let expected_type_index =
+    value_index (Semantic_tokens.Legend.token_types negotiated) server_token_type
+  in
+  let actual_type_index =
+    Semantic_tokens.Encoding.token_type_index encoding ~server_index:token_type_index
+  in
+  check_int_option
+    "semantic token type index remapping"
+    ~context:server_token_type
+    ~expected:expected_type_index
+    ~actual:actual_type_index;
+  let expected_modifier_names =
+    modifier_names_of_bits token_modifier_bits server_token_modifiers
+    |> List.filter ~f:(fun name ->
+      List.mem
+        (Semantic_tokens.Legend.token_modifiers negotiated)
+        name
+        ~equal:String.equal)
+  in
+  let expected_modifier_bits =
+    bits_of_modifier_names
+      expected_modifier_names
+      (Semantic_tokens.Legend.token_modifiers negotiated)
+  in
+  let actual_modifier_bits =
+    Semantic_tokens.Encoding.token_modifiers_bitset
+      encoding
+      ~server_bitset:token_modifier_bits
+  in
+  check_int
+    "semantic token modifier bit remapping"
+    ~context:(Sexp.to_string_hum ([%sexp_of: string list] expected_modifier_names))
+    ~expected:expected_modifier_bits
+    ~actual:actual_modifier_bits;
+  (* Encode through the public API when the type is supported. *)
+  match expected_type_index with
+  | None -> ()
+  | Some negotiated_type ->
+    let encoded =
+      Semantic_tokens.encode
+        [ { Semantic_tokens.Token.start = Position.create ~line:1 ~character:2
+          ; length = 3
+          ; token_type = negotiated_type
+          ; token_modifiers = actual_modifier_bits
+          }
+        ]
+    in
+    check_int
+      "encoded token count"
+      ~context:server_token_type
+      ~expected:5
+      ~actual:(Array.length encoded);
+    check_int
+      "encoded delta line"
+      ~context:server_token_type
+      ~expected:1
+      ~actual:encoded.(0);
+    check_int
+      "encoded delta start"
+      ~context:server_token_type
+      ~expected:2
+      ~actual:encoded.(1);
+    check_int "encoded length" ~context:server_token_type ~expected:3 ~actual:encoded.(2);
+    check_int
+      "encoded token type"
+      ~context:server_token_type
+      ~expected:negotiated_type
+      ~actual:encoded.(3);
+    check_int
+      "encoded token modifiers"
+      ~context:server_token_type
+      ~expected:actual_modifier_bits
+      ~actual:encoded.(4)
+;;
+
+let capability_regressions =
+  [ { Capability_case.server_token_types = [ "variable"; "number"; "function" ]
+    ; server_token_modifiers = [ "declaration"; "definition"; "readonly" ]
+    ; client_token_types = []
+    ; client_token_modifiers = []
+    ; token_type_index = 0
+    ; token_modifier_bits = 0
+    }
+  ; { server_token_types = [ "variable"; "number"; "function" ]
+    ; server_token_modifiers = [ "declaration"; "definition"; "readonly" ]
+    ; client_token_types = [ "unknown" ]
+    ; client_token_modifiers = [ "unknown" ]
+    ; token_type_index = 1
+    ; token_modifier_bits = 1 lsl 1
+    }
+  ; { server_token_types = [ "variable"; "number"; "function" ]
+    ; server_token_modifiers = [ "declaration"; "definition"; "readonly" ]
+    ; client_token_types = [ "number"; "variable"; "nope"; "variable" ]
+    ; client_token_modifiers = [ "definition"; "definition"; "unknown" ]
+    ; token_type_index = 0
+    ; token_modifier_bits = 1 lsl 1
+    }
+  ; { server_token_types = [ "variable"; "number"; "function" ]
+    ; server_token_modifiers = [ "declaration"; "definition"; "readonly" ]
+    ; client_token_types = [ "function"; "number"; "variable" ]
+    ; client_token_modifiers = [ "readonly"; "definition"; "declaration" ]
+    ; token_type_index = 2
+    ; token_modifier_bits = (1 lsl 3) - 1
+    }
+  ]
+;;
+
+module Diff_case = struct
+  type t =
+    { old : int list
+    ; new_ : int list
+    }
+  [@@deriving quickcheck, sexp_of]
+end
+
+let apply_edit
+      source
+      ({ SemanticTokensEdit.start; deleteCount; data } : SemanticTokensEdit.t)
+  =
+  check "negative semantic token edit start" (start >= 0);
+  check "negative semantic token delete count" (deleteCount >= 0);
+  check "semantic token edit start out of bounds" (start <= Array.length source);
+  check
+    "semantic token edit deletion out of bounds"
+    (deleteCount <= Array.length source - start);
+  let replacement = Option.value data ~default:[||] in
+  Array.concat
+    [ Array.sub source ~pos:0 ~len:start
+    ; replacement
+    ; Array.sub
+        source
+        ~pos:(start + deleteCount)
+        ~len:(Array.length source - start - deleteCount)
+    ]
+;;
+
+let check_diff_case { Diff_case.old; new_ } =
+  let old = Array.of_list old in
+  let expected = Array.of_list new_ in
+  let edits = Semantic_tokens.find_diff ~old ~new_:expected in
+  check "semantic token diff produced multiple edits" (List.length edits <= 1);
+  check
+    "equal semantic token arrays produced an edit"
+    (Bool.equal (List.is_empty edits) (Array.equal Int.equal old expected));
+  let actual = List.fold edits ~init:old ~f:apply_edit in
+  check "semantic token diff round trip" (Array.equal Int.equal expected actual)
+;;
+
+let diff_regressions =
+  [ { Diff_case.old = []; new_ = [] }
+  ; { old = []; new_ = [ 1; 2 ] }
+  ; { old = [ 1; 2 ]; new_ = [] }
+  ; { old = [ 1; 2 ]; new_ = [ 1; 2; 3 ] }
+  ; { old = [ 1; 2; 3 ]; new_ = [ 1; 2 ] }
+  ; { old = [ 1; 2; 1 ]; new_ = [ 1; 3; 1 ] }
+  ; { old = [ 1; 1 ]; new_ = [ 1 ] }
+  ; { old = [ 1 ]; new_ = [ 1; 1 ] }
+  ]
+;;
+
+let%test_unit "semantic token encoding round trips" =
+  Test.run_exn (module Token_case) ~f:check_token_case
+;;
+
+let%test_unit "semantic token capability negotiation preserves supported values" =
+  Test.run_exn
+    (module Capability_case)
+    ~examples:capability_regressions
+    ~f:check_capability_case
+;;
+
+let%test_unit "semantic token deltas reconstruct the new data" =
+  Test.run_exn (module Diff_case) ~examples:diff_regressions ~f:check_diff_case
+;;

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -1,6 +1,5 @@
 open Import
 open Fiber.O
-module Array_view = Lsp.Private.Array_view
 module Parsetree_utils = Merlin_analysis.Parsetree_utils
 
 (* TODO:
@@ -146,54 +145,17 @@ end = struct
   ;;
 end
 
-(** [token_type_indices] is indexed by the server's token type index. Each entry
-    contains the corresponding index in the negotiated legend, or [None] when
-    the client does not support that token type.
+type config = Lsp.Semantic_tokens.Encoding.t
 
-    [token_modifier_bits] is indexed by the server's token modifier index. Each
-    entry contains the corresponding bit in the negotiated legend, or [None]
-    when the client does not support that modifier. *)
-type config =
-  { legend : SemanticTokensLegend.t
-  ; token_type_indices : int option array
-  ; token_modifier_bits : int option array
-  }
-
-let negotiate_token_type_indices ~token_types =
-  Token_type.tokenTypes
-  |> Array.of_list
-  |> Array.map ~f:(fun server_token_type ->
-    List.find_mapi token_types ~f:(fun index negotiated_token_type ->
-      Option.some_if (String.equal server_token_type negotiated_token_type) index))
-;;
-
-let negotiate_token_modifier_bits ~token_modifiers =
-  Token_modifiers_set.list
-  |> Array.of_list
-  |> Array.map ~f:(fun server_modifier ->
-    List.find_mapi token_modifiers ~f:(fun index negotiated_modifier ->
-      Option.some_if (String.equal server_modifier negotiated_modifier) (1 lsl index)))
-;;
-
-let make_config ~token_types ~token_modifiers =
-  let legend =
-    SemanticTokensLegend.create ~tokenTypes:token_types ~tokenModifiers:token_modifiers
-  in
-  let token_type_indices = negotiate_token_type_indices ~token_types in
-  let token_modifier_bits = negotiate_token_modifier_bits ~token_modifiers in
-  { legend; token_type_indices; token_modifier_bits }
+let server_legend =
+  Lsp.Semantic_tokens.Legend.create
+    ~token_types:Token_type.tokenTypes
+    ~token_modifiers:Token_modifiers_set.list
 ;;
 
 let config_of_client_values ~token_types ~token_modifiers =
-  let token_types =
-    List.filter Token_type.tokenTypes ~f:(fun value ->
-      List.mem token_types value ~equal:String.equal)
-  in
-  let token_modifiers =
-    List.filter Token_modifiers_set.list ~f:(fun value ->
-      List.mem token_modifiers value ~equal:String.equal)
-  in
-  make_config ~token_types ~token_modifiers
+  let client = Lsp.Semantic_tokens.Legend.create ~token_types ~token_modifiers in
+  Lsp.Semantic_tokens.Encoding.negotiate ~server:server_legend ~client
 ;;
 
 let create_config (semantic_tokens : SemanticTokensClientCapabilities.t) =
@@ -203,35 +165,23 @@ let create_config (semantic_tokens : SemanticTokensClientCapabilities.t) =
 ;;
 
 let default_config =
-  make_config ~token_types:Token_type.tokenTypes ~token_modifiers:Token_modifiers_set.list
+  Lsp.Semantic_tokens.Encoding.negotiate ~server:server_legend ~client:server_legend
 ;;
 
-let legend config = config.legend
+let legend config =
+  Lsp.Semantic_tokens.Legend.to_types (Lsp.Semantic_tokens.Encoding.legend config)
+;;
 
 let token_type_index config token_type =
-  config.token_type_indices.(Token_type.to_int token_type)
-;;
-
-let remap_token_modifiers config encoded =
-  let rec loop server_index encoded result =
-    if Int.equal encoded 0
-    then result
-    else (
-      let result =
-        if Int.equal (encoded land 1) 0
-        then result
-        else (
-          match config.token_modifier_bits.(server_index) with
-          | None -> result
-          | Some client_bit -> result lor client_bit)
-      in
-      loop (server_index + 1) (encoded lsr 1) result)
-  in
-  loop 0 encoded 0
+  Lsp.Semantic_tokens.Encoding.token_type_index
+    config
+    ~server_index:(Token_type.to_int token_type)
 ;;
 
 let token_modifiers_bitset config token_modifiers =
-  remap_token_modifiers config (Token_modifiers_set.to_int token_modifiers)
+  Lsp.Semantic_tokens.Encoding.token_modifiers_bitset
+    config
+    ~server_bitset:(Token_modifiers_set.to_int token_modifiers)
 ;;
 
 (** Represents a collection of semantic tokens. *)
@@ -290,22 +240,6 @@ end = struct
     t.tokens <- new_token :: t.tokens
   ;;
 
-  let set_token
-        arr
-        ~delta_line_index
-        ~delta_line
-        ~delta_start
-        ~length
-        ~token_type
-        ~token_modifiers
-    =
-    arr.(delta_line_index) <- delta_line;
-    arr.(delta_line_index + 1) <- delta_start;
-    arr.(delta_line_index + 2) <- length;
-    arr.(delta_line_index + 3) <- token_type;
-    arr.(delta_line_index + 4) <- token_modifiers
-  ;;
-
   let yojson_of_token { start; length; token_type; token_modifiers } =
     `Assoc
       [ "start_pos", Position.yojson_of_t start
@@ -321,60 +255,21 @@ end = struct
   let yojson_of_t t = Json.Conv.yojson_of_list yojson_of_token (List.rev t.tokens)
 
   let encode (t : t) (config : config) : int array =
-    (* The parsetree traversal does not always visit nodes in source order. This
-       encoder works backwards, so put the latest token first. *)
-    let tokens =
-      List.sort t.tokens ~compare:(fun left right ->
-        Lsp.Position.compare right.start left.start)
-    in
-    let supported_token_count =
-      List.fold_left tokens ~init:0 ~f:(fun count token ->
-        match token_type_index config token.token_type with
-        | None -> count
-        | Some _ -> count + 1)
-    in
-    let data = Array.create ~len:(supported_token_count * 5) 0 in
-    let rec encode_tokens index current token_type = function
-      | [] ->
-        let { start; length; token_modifiers; _ } = current in
-        set_token
-          data
-          ~delta_line_index:0
-          ~delta_line:start.line
-          ~delta_start:start.character
-          ~length
-          ~token_type
-          ~token_modifiers:(token_modifiers_bitset config token_modifiers)
-      | previous :: rest ->
-        (match token_type_index config previous.token_type with
-         | None -> encode_tokens index current token_type rest
-         | Some previous_token_type ->
-           let delta_line = current.start.line - previous.start.line in
-           let delta_start =
-             if Int.equal delta_line 0
-             then current.start.character - previous.start.character
-             else current.start.character
-           in
-           let { length; token_modifiers } = current in
-           set_token
-             data
-             ~delta_line_index:((index - 1) * 5)
-             ~delta_line
-             ~delta_start
-             ~length
-             ~token_type
-             ~token_modifiers:(token_modifiers_bitset config token_modifiers);
-           encode_tokens (index - 1) previous previous_token_type rest)
-    in
-    let rec encode_first_supported = function
-      | [] -> ()
-      | token :: rest ->
-        (match token_type_index config token.token_type with
-         | None -> encode_first_supported rest
-         | Some token_type -> encode_tokens supported_token_count token token_type rest)
-    in
-    encode_first_supported tokens;
-    data
+    (* The parsetree traversal does not always visit nodes in source order.
+       Translate supported tokens into negotiated indexes and let the shared
+       encoder sort + delta-encode them. *)
+    t.tokens
+    |> List.filter_map ~f:(fun token ->
+      match token_type_index config token.token_type with
+      | None -> None
+      | Some token_type ->
+        Some
+          { Lsp.Semantic_tokens.Token.start = token.start
+          ; length = token.length
+          ; token_type
+          ; token_modifiers = token_modifiers_bitset config token.token_modifiers
+          })
+    |> Lsp.Semantic_tokens.encode
   ;;
 end
 
@@ -1091,53 +986,7 @@ let on_request_full : State.t -> SemanticTokensParams.t -> SemanticTokens.t opti
       Some { SemanticTokens.resultId = Some resultId; data = tokens })
 ;;
 
-(* [find_diff] finds common prefix and common suffix and reports the rest as
-   array difference. This is not ideal but good enough. The idea comes from the
-   Rust Analyzer implementation of this function. *)
-let find_diff ~(old : int array) ~(new_ : int array) : SemanticTokensEdit.t list =
-  let old_len = Array.length old in
-  let new_len = Array.length new_ in
-  let left_offset =
-    let i = ref 0 in
-    let min_len = min old_len new_len in
-    while !i < min_len && Int.equal (Array.get old !i) (Array.get new_ !i) do
-      Int.incr i
-    done;
-    !i
-  in
-  if left_offset = old_len
-  then
-    if left_offset = new_len
-    then (* [old] and [new_] are simply equal *) []
-    else
-      (* [old] is prefix of [new_] *)
-      [ SemanticTokensEdit.create
-          ~start:left_offset
-          ~deleteCount:0
-          ~data:(Array.sub new_ ~pos:left_offset ~len:(new_len - left_offset))
-          ()
-      ]
-  else if left_offset = new_len
-  then
-    (* [new_] is prefix of [old] *)
-    [ SemanticTokensEdit.create ~start:left_offset ~deleteCount:(old_len - left_offset) ()
-    ]
-  else (
-    let common_suffix_len =
-      let old_noncommon = Array_view.make old ~pos:left_offset in
-      let new_noncommon = Array_view.make new_ ~pos:left_offset in
-      Array_view.common_suffix_len old_noncommon new_noncommon
-    in
-    let deleteCount =
-      let right_offset_old = old_len - common_suffix_len in
-      right_offset_old - left_offset
-    in
-    let data =
-      let right_offset_new = new_len - common_suffix_len in
-      Array.sub new_ ~pos:left_offset ~len:(right_offset_new - left_offset)
-    in
-    [ SemanticTokensEdit.create ~start:left_offset ~deleteCount ~data () ])
-;;
+let find_diff = Lsp.Semantic_tokens.find_diff
 
 module For_tests = struct
   type nonrec config = config
@@ -1145,7 +994,7 @@ module For_tests = struct
   let server_token_types = Token_type.tokenTypes
   let server_token_modifiers = Token_modifiers_set.list
   let create_config = config_of_client_values
-  let legend config = config.legend
+  let legend = legend
   let default_token_type = Token_type.of_builtin Variable
   let token_type_index = Token_type.to_int default_token_type
   let token_modifiers_bitset = Token_modifiers_set.to_int Token_modifiers_set.empty

--- a/ocaml-lsp-server/test/semantic_tokens_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/semantic_tokens_quickcheck_tests.ml
@@ -3,86 +3,55 @@ open Base_quickcheck
 open Lsp.Types
 module Semantic_tokens = Ocaml_lsp_server.Testing.Semantic_tokens
 
-let select selector ~choices = Int.rem (selector land Int.max_value) choices
-let check label condition = if not condition then failwith label
-
-module Token_case = struct
-  type token =
-    { line_delta_selector : int
-    ; character_selector : int
-    ; length_selector : int
-    }
-  [@@deriving quickcheck, sexp_of]
-
-  type t = token list [@@deriving quickcheck, sexp_of]
-end
-
-type token =
-  { line : int
-  ; character : int
-  ; length : int
-  }
-
-let absolute_tokens seeds =
-  let _, _, tokens =
-    List.fold
-      seeds
-      ~init:(0, 0, [])
-      ~f:
-        (fun
-          (previous_line, previous_character, tokens)
-          { Token_case.line_delta_selector; character_selector; length_selector }
-        ->
-        let line_delta = select line_delta_selector ~choices:4 in
-        let line = previous_line + line_delta in
-        let character =
-          if line_delta = 0
-          then previous_character + select character_selector ~choices:8
-          else select character_selector ~choices:24
-        in
-        let length = select length_selector ~choices:12 + 1 in
-        line, character, { line; character; length } :: tokens)
-  in
-  List.rev tokens
+let check_string_list label ~expected ~actual =
+  if not (List.equal String.equal expected actual)
+  then
+    failwith
+      (Printf.sprintf
+         "%s: expected %s, got %s"
+         label
+         (Sexp.to_string_hum ([%sexp_of: string list] expected))
+         (Sexp.to_string_hum ([%sexp_of: string list] actual)))
 ;;
 
-let decode encoded =
-  check "semantic token array length" (Int.rem (Array.length encoded) 5 = 0);
-  let rec loop index previous_line previous_character tokens =
-    if index = Array.length encoded
-    then List.rev tokens
-    else (
-      let delta_line = encoded.(index) in
-      let delta_start = encoded.(index + 1) in
-      let length = encoded.(index + 2) in
-      check "negative delta line" (delta_line >= 0);
-      check "negative delta start" (delta_start >= 0);
-      check "nonpositive token length" (length > 0);
-      check "wrong token type" (encoded.(index + 3) = Semantic_tokens.token_type_index);
-      check
-        "wrong token modifiers"
-        (encoded.(index + 4) = Semantic_tokens.token_modifiers_bitset);
-      let line = previous_line + delta_line in
-      let character =
-        if delta_line = 0 then previous_character + delta_start else delta_start
-      in
-      loop (index + 5) line character ({ line; character; length } :: tokens))
-  in
-  loop 0 0 0 []
+let check_int_option label ~context ~expected ~actual =
+  if not (Option.equal Int.equal expected actual)
+  then
+    failwith
+      (Printf.sprintf
+         "%s (%s): expected %s, got %s"
+         label
+         context
+         (Sexp.to_string_hum ([%sexp_of: int option] expected))
+         (Sexp.to_string_hum ([%sexp_of: int option] actual)))
 ;;
 
-let equal_token left right =
-  left.line = right.line && left.character = right.character && left.length = right.length
+let check_int label ~context ~expected ~actual =
+  if expected <> actual
+  then
+    failwith (Printf.sprintf "%s (%s): expected %d, got %d" label context expected actual)
 ;;
 
-let check_token_case seeds =
-  let expected = absolute_tokens seeds in
-  let input =
-    List.map expected ~f:(fun { line; character; length } ->
-      Position.create ~line ~character, length)
-  in
-  let actual = Semantic_tokens.encode input |> decode in
-  check "semantic token round trip" (List.equal equal_token expected actual)
+let value_index values value =
+  List.find_mapi values ~f:(fun index candidate ->
+    Option.some_if (String.equal value candidate) index)
+;;
+
+let supported_values server_values client_values =
+  List.filter server_values ~f:(fun server_value ->
+    List.mem client_values server_value ~equal:String.equal)
+;;
+
+let modifier_names_of_bits bits modifiers =
+  List.filter_mapi modifiers ~f:(fun index modifier ->
+    Option.some_if (bits land (1 lsl index) <> 0) modifier)
+;;
+
+let bits_of_modifier_names names modifiers =
+  List.fold_left names ~init:0 ~f:(fun bits name ->
+    match value_index modifiers name with
+    | None -> bits
+    | Some index -> bits lor (1 lsl index))
 ;;
 
 module Capability_case = struct
@@ -157,57 +126,6 @@ module Capability_case = struct
   ;;
 end
 
-let supported_values server_values client_values =
-  List.filter server_values ~f:(fun server_value ->
-    List.mem client_values server_value ~equal:String.equal)
-;;
-
-let value_index values value =
-  List.find_mapi values ~f:(fun index candidate ->
-    Option.some_if (String.equal value candidate) index)
-;;
-
-let modifier_names_of_bits bits modifiers =
-  List.filter_mapi modifiers ~f:(fun index modifier ->
-    Option.some_if (bits land (1 lsl index) <> 0) modifier)
-;;
-
-let bits_of_modifier_names names modifiers =
-  List.fold_left names ~init:0 ~f:(fun bits name ->
-    match value_index modifiers name with
-    | None -> bits
-    | Some index -> bits lor (1 lsl index))
-;;
-
-let check_string_list label ~expected ~actual =
-  if not (List.equal String.equal expected actual)
-  then
-    failwith
-      (Printf.sprintf
-         "%s: expected %s, got %s"
-         label
-         (Sexp.to_string_hum ([%sexp_of: string list] expected))
-         (Sexp.to_string_hum ([%sexp_of: string list] actual)))
-;;
-
-let check_int_option label ~context ~expected ~actual =
-  if not (Option.equal Int.equal expected actual)
-  then
-    failwith
-      (Printf.sprintf
-         "%s (%s): expected %s, got %s"
-         label
-         context
-         (Sexp.to_string_hum ([%sexp_of: int option] expected))
-         (Sexp.to_string_hum ([%sexp_of: int option] actual)))
-;;
-
-let check_int label ~context ~expected ~actual =
-  if expected <> actual
-  then
-    failwith (Printf.sprintf "%s (%s): expected %d, got %d" label context expected actual)
-;;
-
 let sample_position = Position.create ~line:0 ~character:0
 
 let check_capability_case
@@ -258,8 +176,6 @@ let check_capability_case
     bits_of_modifier_names expected_modifier_names legend.tokenModifiers
   in
   let actual_modifier_bits = if Array.length encoded = 0 then 0 else encoded.(4) in
-  (* Unsupported token types are dropped entirely, so only check bit remapping when the
-     token type survives negotiation. *)
   match expected_type_index with
   | None ->
     check_int
@@ -309,70 +225,9 @@ let capability_regressions =
   ]
 ;;
 
-module Diff_case = struct
-  type t =
-    { old : int list
-    ; new_ : int list
-    }
-  [@@deriving quickcheck, sexp_of]
-end
-
-let apply_edit
-      source
-      ({ SemanticTokensEdit.start; deleteCount; data } : SemanticTokensEdit.t)
-  =
-  check "negative semantic token edit start" (start >= 0);
-  check "negative semantic token delete count" (deleteCount >= 0);
-  check "semantic token edit start out of bounds" (start <= Array.length source);
-  check
-    "semantic token edit deletion out of bounds"
-    (deleteCount <= Array.length source - start);
-  let replacement = Option.value data ~default:[||] in
-  Array.concat
-    [ Array.sub source ~pos:0 ~len:start
-    ; replacement
-    ; Array.sub
-        source
-        ~pos:(start + deleteCount)
-        ~len:(Array.length source - start - deleteCount)
-    ]
-;;
-
-let check_diff_case { Diff_case.old; new_ } =
-  let old = Array.of_list old in
-  let expected = Array.of_list new_ in
-  let edits = Semantic_tokens.find_diff ~old ~new_:expected in
-  check "semantic token diff produced multiple edits" (List.length edits <= 1);
-  check
-    "equal semantic token arrays produced an edit"
-    (Bool.equal (List.is_empty edits) (Array.equal Int.equal old expected));
-  let actual = List.fold edits ~init:old ~f:apply_edit in
-  check "semantic token diff round trip" (Array.equal Int.equal expected actual)
-;;
-
-let diff_regressions =
-  [ { Diff_case.old = []; new_ = [] }
-  ; { old = []; new_ = [ 1; 2 ] }
-  ; { old = [ 1; 2 ]; new_ = [] }
-  ; { old = [ 1; 2 ]; new_ = [ 1; 2; 3 ] }
-  ; { old = [ 1; 2; 3 ]; new_ = [ 1; 2 ] }
-  ; { old = [ 1; 2; 1 ]; new_ = [ 1; 3; 1 ] }
-  ; { old = [ 1; 1 ]; new_ = [ 1 ] }
-  ; { old = [ 1 ]; new_ = [ 1; 1 ] }
-  ]
-;;
-
-let%test_unit "semantic token encoding round trips" =
-  Test.run_exn (module Token_case) ~f:check_token_case
-;;
-
 let%test_unit "semantic token capability negotiation preserves supported values" =
   Test.run_exn
     (module Capability_case)
     ~examples:capability_regressions
     ~f:check_capability_case
-;;
-
-let%test_unit "semantic token deltas reconstruct the new data" =
-  Test.run_exn (module Diff_case) ~examples:diff_regressions ~f:check_diff_case
 ;;


### PR DESCRIPTION
Add a small public `Lsp.Semantic_tokens` helper API and switch
`ocaml-lsp-server` over to it.

The library covers the reusable wire-format pieces:

- legend negotiation from server/client token-type and modifier names
- mapping server indexes/bitsets onto the negotiated legend
- absolute-token encoding into the LSP data array
- full/delta edit calculation

`ocaml-lsp-server` now negotiates, encodes, and diffs through that API.
It still owns OCaml token classification, Merlin traversal, `Loc.t`
filtering, caching, and request handling.

Library property tests cover negotiation, encode round-trips, out-of-order
sorting, and delta reconstruction. The server keeps an integration test
for OCaml legend negotiation.
