### PR TITLE
refactor(server): use Option.all directly

### DIFF
--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -164,7 +164,7 @@ let extract_function doc typedtree range =
       List.map free_vars ~f:(function
         | Longident.Lident id -> Some id
         | _ -> None)
-      |> Option.List.all
+      |> Option.all
     in
     let s = String.concat ~sep:" " args in
     if String.is_empty s then "()" else s

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -231,7 +231,7 @@ let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
       match p.Parsetree.pparam_desc with
       | Pparam_val (Nolabel, _, pat) -> Some pat
       | _ -> None)
-    |> Option.List.all
+    |> Option.all
   in
   match app.pexp_desc with
   | Pexp_apply ({ pexp_desc = Pexp_function (params, None, Pfunction_body body); _ }, args)

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -65,17 +65,6 @@ module Option = struct
     let ( let* ) x f = Stdlib.Option.bind x f
   end
 
-  module List = struct
-    let all =
-      let rec loop acc = function
-        | [] -> Some (List.rev acc)
-        | None :: _ -> None
-        | Some x :: xs -> loop (x :: acc) xs
-      in
-      fun xs -> loop [] xs
-    ;;
-  end
-
   include Base.Option
 end
 


### PR DESCRIPTION
Use `Base.Option.all` at the two remaining call sites and remove the equivalent `Option.List.all` compatibility helper from the server import.
