### PR TITLE
test(lsp): demonstrate unescaped snippet text

### DIFF
--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -2,3 +2,10 @@ let%expect_test "snippet text is not escaped" =
   Lsp.Snippet.text "$}\\" |> Lsp.Snippet.to_string |> print_endline;
   [%expect {| $}\ |}]
 ;;
+
+let%expect_test "snippet choices double escape metacharacters" =
+  Lsp.Snippet.choice [ "$"; "}"; "\\"; ","; "|" ]
+  |> Lsp.Snippet.to_string
+  |> print_endline;
+  [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
+;;

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -1,0 +1,4 @@
+let%expect_test "snippet text is not escaped" =
+  Lsp.Snippet.text "$}\\" |> Lsp.Snippet.to_string |> print_endline;
+  [%expect {| $}\ |}]
+;;

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -9,3 +9,8 @@ let%expect_test "snippet choices double escape metacharacters" =
   |> print_endline;
   [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
 ;;
+
+let%expect_test "the final tab stop is renumbered" =
+  Lsp.Snippet.tabstop 0 |> Lsp.Snippet.to_string |> print_endline;
+  [%expect {| $1 |}]
+;;


### PR DESCRIPTION
`Snippet.text` currently emits `$`, `}`, and `\` without escaping them, allowing clients to interpret literal source text as snippet syntax.

This passing expect test records the current invalid output so the bug is visible independently of its eventual fix.
