### PR TITLE
test(lsp): demonstrate invalid snippet choice escapes

### DIFF
--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -2,3 +2,10 @@ let%expect_test "snippet text is not escaped" =
   Lsp.Snippet.text "$}\\" |> Lsp.Snippet.to_string |> print_endline;
   [%expect {| $}\ |}]
 ;;
+
+let%expect_test "snippet choices double escape metacharacters" =
+  Lsp.Snippet.choice [ "$"; "}"; "\\"; ","; "|" ]
+  |> Lsp.Snippet.to_string
+  |> print_endline;
+  [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
+;;

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -9,3 +9,8 @@ let%expect_test "snippet choices double escape metacharacters" =
   |> print_endline;
   [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
 ;;
+
+let%expect_test "the final tab stop is renumbered" =
+  Lsp.Snippet.tabstop 0 |> Lsp.Snippet.to_string |> print_endline;
+  [%expect {| $1 |}]
+;;


### PR DESCRIPTION
Snippet choices currently double the escape characters introduced for `$` and `}`, producing different text when a client expands the snippet.

This passing expect test records the current invalid output so the bug is visible independently of its eventual fix.
