### PR TITLE
test(lsp): demonstrate renumbered final snippet tab stop

### DIFF
--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -9,3 +9,8 @@ let%expect_test "snippet choices double escape metacharacters" =
   |> print_endline;
   [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
 ;;
+
+let%expect_test "the final tab stop is renumbered" =
+  Lsp.Snippet.tabstop 0 |> Lsp.Snippet.to_string |> print_endline;
+  [%expect {| $1 |}]
+;;


### PR DESCRIPTION
LSP reserves tab stop zero as the final cursor position, but `Snippet.tabstop 0` currently serializes as `$1`.

This passing expect test records the current invalid output so the bug is visible independently of its eventual fix.
