### PR TITLE
refactor(server): prefer Base utilities

### DIFF
--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -123,10 +123,10 @@ end = struct
   let array = lazy (Array.of_list list)
 
   let to_legend =
-    let cache = lazy (Stdlib.Hashtbl.create 3) in
+    let cache = lazy (Hashtbl.create (module Int)) in
     fun t ->
       let cache = Lazy.force cache in
-      match Stdlib.Hashtbl.find_opt cache t with
+      match Hashtbl.find cache t with
       | Some x -> x
       | None ->
         let rec translate t i acc : string list =
@@ -136,7 +136,7 @@ end = struct
           if Int.equal t' 0 then List.rev acc' else translate (i + 1) t' acc'
         in
         let res = translate t 0 [] in
-        Stdlib.Hashtbl.add cache t res;
+        Hashtbl.set cache ~key:t ~data:res;
         res
   ;;
 end

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -97,15 +97,14 @@ module Events = struct
   let on_notification t _ (notification : Lsp.Server_notification.t) =
     match notification with
     | PublishDiagnostics diagnostic -> publish_diagnostics t diagnostic
-    | LogMessage { message; _ }
-      when Stdlib.String.starts_with ~prefix:"Connected to dune " message ->
-      Signal.notify t.dune_connected
+    | LogMessage { message; _ } when String.is_prefix message ~prefix:"Connected to dune "
+      -> Signal.notify t.dune_connected
     | LogTrace { message = "Connected to Dune RPC"; verbose = None } ->
       Signal.notify t.dune_connection_traced
     | LogTrace { message = "Connected to Dune RPC"; verbose = Some _ } ->
       failwith "messages-level Dune connection trace included verbose details"
     | LogTrace { message = "Dune build finished"; verbose = Some verbose }
-      when Stdlib.String.starts_with ~prefix:"Dune root: " verbose ->
+      when String.is_prefix verbose ~prefix:"Dune root: " ->
       Signal.notify t.build_finished_traced
     | LogTrace { message = "Dune build finished"; verbose = None } ->
       failwith "verbose Dune build trace omitted details"
@@ -129,8 +128,7 @@ module Events = struct
         ; verbose = None
         } -> failwith "verbose Merlin configuration process trace omitted details"
     | WorkDoneProgress { token = `String token; value = Lsp.Progress.End _ }
-      when Stdlib.String.starts_with ~prefix:"dune-build-" token ->
-      Signal.notify t.build_finished
+      when String.is_prefix token ~prefix:"dune-build-" -> Signal.notify t.build_finished
     | _ -> Fiber.return ()
   ;;
 end
@@ -181,9 +179,7 @@ let start_dune root runtime_dir =
   let prog = Bin.which "dune" |> Option.value_exn in
   let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
   let env =
-    let is_runtime_dir value =
-      Stdlib.String.starts_with ~prefix:"XDG_RUNTIME_DIR=" value
-    in
+    let is_runtime_dir value = String.is_prefix value ~prefix:"XDG_RUNTIME_DIR=" in
     Unix.environment ()
     |> Array.to_list
     |> List.filter ~f:(fun value -> not (is_runtime_dir value))

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -200,9 +200,7 @@ let start_dune root runtime_dir =
   let prog = Bin.which "dune" |> Option.value_exn in
   let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
   let env =
-    let is_runtime_dir value =
-      Stdlib.String.starts_with ~prefix:"XDG_RUNTIME_DIR=" value
-    in
+    let is_runtime_dir value = String.is_prefix value ~prefix:"XDG_RUNTIME_DIR=" in
     Unix.environment ()
     |> Array.to_list
     |> List.filter ~f:(fun value -> not (is_runtime_dir value))

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
@@ -79,8 +79,8 @@ let modifiers ~(legend : string array) (encoded_mods : int) =
     if encoded_mods = 0
     then acc
     else (
-      let k = Stdlib.Int.logand encoded_mods 1 in
-      let new_val = Stdlib.Int.shift_right encoded_mods 1 in
+      let k = Int.bit_and encoded_mods 1 in
+      let new_val = Int.shift_right encoded_mods 1 in
       if k = 0 then loop new_val (i + 1) acc else loop new_val (i + 1) (legend.(k) :: acc))
   in
   loop encoded_mods 0 [] |> List.rev

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_helpers.ml
@@ -96,8 +96,11 @@ let annotate_src_with_tokens
   let token_types = legend.SemanticTokensLegend.tokenTypes |> Array.of_list in
   let token_mods = legend.SemanticTokensLegend.tokenModifiers |> Array.of_list in
   let src_ix = ref 0 in
-  let tokens = Array_iter.create (tokens encoded_tokens) in
-  let token = ref @@ Array_iter.next_exn tokens in
+  let token, remaining_tokens =
+    tokens encoded_tokens |> Array.to_sequence |> Sequence.next |> Option.value_exn
+  in
+  let token = ref token in
+  let remaining_tokens = ref remaining_tokens in
   let token_id = ref 0 in
   let line = ref !token.delta_line in
   let character = ref !token.delta_char in
@@ -117,12 +120,13 @@ let annotate_src_with_tokens
       Buffer.add_substring b src ~pos:!src_ix ~len:!token.len;
       src_ix := !src_ix + !token.len;
       Printf.bprintf b "</%d>" !token_id;
-      match Array_iter.next tokens with
+      match Sequence.next !remaining_tokens with
       | None ->
         (* copy the rest of src *)
         Buffer.add_substring b src ~pos:!src_ix ~len:(src_len - !src_ix);
         src_ix := src_len
-      | Some next_token ->
+      | Some (next_token, rest) ->
+        remaining_tokens := rest;
         Int.incr token_id;
         character := next_token.delta_char - !token.len;
         token := next_token;

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -14,6 +14,7 @@ module Import = struct
     module Poly = Poly
     module Queue = Queue
     module Result = Result
+    module Sequence = Sequence
     module Set = Set
     module String = String
   end
@@ -30,33 +31,6 @@ module Import = struct
   end
 
   module Exn_with_backtrace = Stdune.Exn_with_backtrace
-
-  module Array_iter : sig
-    type 'a t
-
-    val create : 'a array -> 'a t
-    val has_next : 'a t -> bool
-    val next : 'a t -> 'a option
-    val next_exn : 'a t -> 'a
-  end = struct
-    type 'a t =
-      { contents : 'a array
-      ; mutable ix : int
-      }
-
-    let create contents = { contents; ix = 0 }
-    let has_next t = t.ix < Array.length t.contents
-
-    let next_exn t =
-      let { contents; ix } = t in
-      let v = contents.(ix) in
-      t.ix <- ix + 1;
-      v
-    ;;
-
-    let next t = if has_next t then Some (next_exn t) else None
-  end
-
   include Fiber.O
   module Bin = Ocaml_lsp_server.Testing.Bin
   module Client = Lsp_fiber.Client

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -344,12 +344,10 @@ let apply_edits src edits =
     List.map edits ~f:(fun (e : TextEdit.t) ->
       e.newText, offset_of_position src e.range.start, offset_of_position src e.range.end_)
     (* update the offsets to account for preceding edits *)
-    |> Stdlib.List.fold_left_map
-         (fun offset (new_text, start, end_) ->
-            if end_ < start then failwith "invalid edit: end before start";
-            ( offset + (String.length new_text - (end_ - start))
-            , (new_text, start + offset, end_ + offset) ))
-         0
+    |> List.fold_map ~init:0 ~f:(fun offset (new_text, start, end_) ->
+      if end_ < start then failwith "invalid edit: end before start";
+      ( offset + (String.length new_text - (end_ - start))
+      , (new_text, start + offset, end_ + offset) ))
   in
   (* apply edits *)
   List.fold_left edits ~init:src ~f:(fun src (new_text, start, end_) ->

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_partial_build.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_partial_build.ml
@@ -94,7 +94,7 @@ let setup_generated_workspace () =
 
 let relative_path ~root path =
   let prefix = root ^ Filename.dir_sep in
-  if Stdlib.String.starts_with ~prefix path
+  if String.is_prefix path ~prefix
   then String.drop_prefix path (String.length prefix)
   else path
 ;;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
@@ -219,9 +219,7 @@ let to_test_result workspaces (symbol : SymbolInformation.t) =
   let path = DocumentUri.to_path location.uri in
   let workspace_path =
     List.find_map workspaces ~f:(fun workspace ->
-      if Stdlib.String.starts_with ~prefix:workspace.path path
-      then Some workspace.path
-      else None)
+      if String.is_prefix path ~prefix:workspace.path then Some workspace.path else None)
   in
   let relative_path =
     match workspace_path with

--- a/ocaml-lsp-server/test/semantic_tokens_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/semantic_tokens_quickcheck_tests.ml
@@ -3,7 +3,7 @@ open Base_quickcheck
 open Lsp.Types
 module Semantic_tokens = Ocaml_lsp_server.Testing.Semantic_tokens
 
-let select selector ~choices = Int.rem (selector land Stdlib.max_int) choices
+let select selector ~choices = Int.rem (selector land Int.max_value) choices
 let check label condition = if not condition then failwith label
 
 module Token_case = struct


### PR DESCRIPTION
Replace the remaining straightforward utility implementations and Stdlib calls with Base equivalents:

- use `List.fold_map` in edit application
- prefer Base string and integer helpers in tests
- use a Base hashtable for the semantic-token modifier cache
- replace the custom mutable `Array_iter` with `Array.to_sequence` and `Sequence.next`

Each cleanup is kept in a separate commit.
