### PR TITLE
fix(lsp-fiber): memoize concurrent lazy fiber forces

### DIFF
--- a/lsp-fiber/src/lazy_fiber.ml
+++ b/lsp-fiber/src/lazy_fiber.ml
@@ -1,18 +1,30 @@
+type 'a result = ('a, Stdune.Exn_with_backtrace.t list) Result.t
+
 type 'a t =
-  { value : 'a Fiber.Ivar.t
+  { value : 'a result Fiber.Ivar.t
   ; mutable f : (unit -> 'a Fiber.t) option
   }
 
 let create f = { f = Some f; value = Fiber.Ivar.create () }
 
+let await t =
+  let open Fiber.O in
+  Fiber.Ivar.read t.value
+  >>= function
+  | Ok value -> Fiber.return value
+  | Error errors -> Fiber.reraise_all errors
+;;
+
 let force t =
   let open Fiber.O in
-  match t.f with
-  | None -> Fiber.Ivar.read t.value
-  | Some f ->
-    Fiber.of_thunk (fun () ->
+  Fiber.of_thunk (fun () ->
+    match t.f with
+    | None -> await t
+    | Some f ->
       t.f <- None;
-      let* v = f () in
-      let+ () = Fiber.Ivar.fill t.value v in
-      v)
+      let* result = Fiber.collect_errors f in
+      let* () = Fiber.Ivar.fill t.value result in
+      (match result with
+       | Ok value -> Fiber.return value
+       | Error errors -> Fiber.reraise_all errors))
 ;;

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -451,8 +451,7 @@ let%expect_test "duplicate incoming request IDs are both handled" =
   [%expect {| responses: ok, ok |}]
 ;;
 
-let%expect_test "forcing a lazy fiber twice may run it twice" =
-  Printexc.record_backtrace false;
+let%expect_test "concurrent lazy fibers share the computation" =
   let run () =
     let runs = ref 0 in
     let lazy_fiber =
@@ -469,17 +468,17 @@ let%expect_test "forcing a lazy fiber twice may run it twice" =
     in
     let result =
       match result with
+      | Ok () -> "ok"
       | Error [ _ ] -> "error"
-      | Ok () | Error _ -> "unexpected"
+      | Error _ -> "unexpected"
     in
     Printf.printf "result: %s; runs: %d\n" result !runs
   in
   Lev_fiber.run run |> Lev_fiber.Error.ok_exn;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| (Failure Fiber.Ivar.fill) |}]
+  [%expect {| result: ok; runs: 1 |}]
 ;;
 
-let%expect_test "concurrent failing lazy fibers run the computation twice" =
+let%expect_test "concurrent failing lazy fibers share the computation" =
   let run () =
     let runs = ref 0 in
     let lazy_fiber =
@@ -501,7 +500,7 @@ let%expect_test "concurrent failing lazy fibers run the computation twice" =
     Printf.printf "results: %s, %s; runs: %d\n" (classify first) (classify second) !runs
   in
   Lev_fiber.run run |> Lev_fiber.Error.ok_exn;
-  [%expect {| results: error, error; runs: 2 |}]
+  [%expect {| results: error, error; runs: 1 |}]
 ;;
 
 let%expect_test "end to end run of lsp tests" =


### PR DESCRIPTION
Memoize a lazy fiber's in-flight computation so concurrent callers share its result. Successful values and failures are both cached.

Updates the characterizations from #1922 and #1944.
