### PR TITLE
fix(jsonrpc-fiber): reject requests after stop

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -310,6 +310,12 @@ struct
     if not t.running then Code_error.raise "jsonrpc must be running" []
   ;;
 
+  let check_accepting_requests t =
+    check_running t;
+    if t.pending_requests_stopped
+    then Code_error.raise "jsonrpc is not accepting requests" []
+  ;;
+
   let notification t (n : Notification.t) =
     Fiber.of_thunk (fun () ->
       check_running t;
@@ -346,7 +352,7 @@ struct
 
   let request t (req : Request.t) =
     Fiber.of_thunk (fun () ->
-      check_running t;
+      check_accepting_requests t;
       let ivar = Fiber.Ivar.create () in
       Fiber.finalize
         (fun () ->
@@ -380,7 +386,7 @@ struct
     in
     let resp =
       Fiber.of_thunk (fun () ->
-        check_running t;
+        check_accepting_requests t;
         let* cancelled = Fiber.Ivar.peek ivar in
         match cancelled with
         | Some (Error `Cancelled) -> Fiber.return `Cancelled
@@ -416,7 +422,7 @@ struct
 
   let submit (t : _ t) (batch : Batch.t) =
     Fiber.of_thunk (fun () ->
-      check_running t;
+      check_accepting_requests t;
       let pending = !batch in
       batch := [];
       let pending, ivars =

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -213,7 +213,7 @@ let%expect_test "cleanup precedes explicit output close" =
     <opaque> |}]
 ;;
 
-let%expect_test "requests may reach the transport after stop" =
+let%expect_test "requests are rejected before reaching the transport after stop" =
   let channel = lifecycle_channel () in
   let session = Lifecycle_jrpc.create ~name:"test" channel () in
   let classify = function
@@ -238,7 +238,7 @@ let%expect_test "requests may reach the transport after stop" =
   [%expect
     {|
     request: error
-    transport attempts: 1
+    transport attempts: 0
     <opaque> |}]
 ;;
 


### PR DESCRIPTION
Reject requests, cancellable requests, and request-bearing batches after the session has stopped accepting requests. Rejection happens before the transport is called.

Updates the stop characterization from #1925.
