### PR TITLE
fix(lsp-fiber): reject duplicate incoming request IDs

### DIFF
--- a/lsp-fiber/src/rpc.ml
+++ b/lsp-fiber/src/rpc.ml
@@ -167,6 +167,11 @@ struct
         let code = Jsonrpc.Response.Error.Code.InvalidParams in
         let error = Jsonrpc.Response.Error.make ~code ~message () in
         Fiber.return (Jsonrpc_fiber.Reply.now (Jsonrpc.Response.error req.id error), state)
+      | Ok (In_request.E _) when Table.mem t.pending req.id ->
+        let code = Jsonrpc.Response.Error.Code.InvalidRequest in
+        let message = "duplicate request id" in
+        let error = Jsonrpc.Response.Error.make ~code ~message () in
+        Fiber.return (Jsonrpc_fiber.Reply.now (Jsonrpc.Response.error req.id error), state)
       | Ok (In_request.E r) ->
         let cancel = Fiber.Cancel.create () in
         let remove = lazy (Table.remove t.pending req.id) in
@@ -178,7 +183,7 @@ struct
                  exn))
             (fun () ->
                Fiber.Var.set cancel_token cancel (fun () ->
-                 Table.replace t.pending req.id cancel;
+                 Table.add t.pending req.id cancel;
                  h_on_request.on_request t r))
         in
         let to_response x =

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -356,7 +356,7 @@ let%expect_test "remote request cancellation raises" =
     [TEST] finished |}]
 ;;
 
-let%expect_test "duplicate incoming request IDs are both handled" =
+let%expect_test "duplicate incoming request IDs are rejected" =
   let run () =
     let request_started = Fiber.Ivar.create () in
     let release_requests = Fiber.Ivar.create () in
@@ -432,15 +432,17 @@ let%expect_test "duplicate incoming request IDs are both handled" =
       let* () = send_request request in
       let* () = Fiber.Ivar.read request_started in
       let* () = send_request request in
+      let* duplicate = receive_response () in
       let* () = Fiber.Ivar.fill release_requests () in
-      let* first = receive_response () in
-      let* second = receive_response () in
+      let* original = receive_response () in
       let classify (response : Jsonrpc.Response.t) =
         match response.result with
         | Ok _ -> "ok"
         | Error error -> Jsonrpc.Response.Error.Code.to_string error.code
       in
-      let responses = List.sort String.compare [ classify first; classify second ] in
+      let responses =
+        List.sort String.compare [ classify duplicate; classify original ]
+      in
       Printf.printf "responses: %s\n" (String.concat ", " responses);
       let exit = Jsonrpc.Notification.create ~method_:"exit" () in
       Fiber_io.send client_io [ Jsonrpc.Packet.Notification exit ]
@@ -448,7 +450,7 @@ let%expect_test "duplicate incoming request IDs are both handled" =
     Fiber.all_concurrently_unit [ Server.start server; exchange () ]
   in
   Lev_fiber.run run |> Lev_fiber.Error.ok_exn;
-  [%expect {| responses: ok, ok |}]
+  [%expect {| responses: InvalidRequest, ok |}]
 ;;
 
 let%expect_test "forcing a lazy fiber twice may run it twice" =


### PR DESCRIPTION
Reject a second in-flight request using the same ID with `InvalidRequest`, while allowing the original request to finish normally.

Updates the focused characterization from #1923.
