### PR TITLE
fix(lsp-fiber): handle remote request cancellation

### DIFF
--- a/lsp-fiber/src/rpc.ml
+++ b/lsp-fiber/src/rpc.ml
@@ -275,10 +275,7 @@ struct
     in
     match cancel_status with
     | Cancelled () -> `Cancelled
-    | Not_cancelled ->
-      (match resp with
-       | `Ok resp -> `Ok resp
-       | `Cancelled -> assert false)
+    | Not_cancelled -> resp
   ;;
 
   let notification (t : _ t) (n : Out_notification.t) : unit Fiber.t =

--- a/lsp-fiber/test/lsp_fiber_test.ml
+++ b/lsp-fiber/test/lsp_fiber_test.ml
@@ -300,7 +300,7 @@ let%expect_test "server enforces initialization ordering" =
     notification handled: workspace/didChangeConfiguration |}]
 ;;
 
-let%expect_test "remote request cancellation raises" =
+let%expect_test "remote request cancellation returns Cancelled" =
   let make_server io =
     let on_request =
       let on_request
@@ -351,7 +351,7 @@ let%expect_test "remote request cancellation raises" =
   test make_client make_server;
   [%expect
     {|
-    request_with_cancel: raised
+    request_with_cancel: cancelled
     Successful termination of test
     [TEST] finished |}]
 ;;


### PR DESCRIPTION
Return `Cancelled` when the peer responds with `RequestCancelled`, even when the local cancellation token was not fired.

Updates the focused characterization from #1924.
