### PR TITLE
fix(jsonrpc-fiber): reject messages after close

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -307,7 +307,7 @@ struct
   let run t = Fiber.finalize (fun () -> run_until_stopped t) ~finally:(fun () -> close t)
 
   let check_running t =
-    if not t.running then Code_error.raise "jsonrpc must be running" []
+    if (not t.running) || t.closing then Code_error.raise "jsonrpc must be running" []
   ;;
 
   let notification t (n : Notification.t) =

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -242,7 +242,7 @@ let%expect_test "requests may reach the transport after stop" =
     <opaque> |}]
 ;;
 
-let%expect_test "notifications may reach the transport after close" =
+let%expect_test "notifications are rejected before reaching the transport after close" =
   let channel = lifecycle_channel () in
   let session = Lifecycle_jrpc.create ~name:"test" channel () in
   let classify = function
@@ -266,8 +266,8 @@ let%expect_test "notifications may reach the transport after close" =
     Fiber.fork_and_join_unit (fun () -> Lifecycle_jrpc.run session) operations);
   [%expect
     {|
-    notification: accepted
-    transport attempts: 1
+    notification: rejected
+    transport attempts: 0
     <opaque> |}]
 ;;
 


### PR DESCRIPTION
Reject outgoing messages once session close has begun, before they can reach the transport.

Updates the close characterization from #1925.
