### PR TITLE
fix(lsp): escape snippet text

### DIFF
--- a/lsp/src/snippet.ml
+++ b/lsp/src/snippet.ml
@@ -110,7 +110,7 @@ let pp_impl add_string (snippet : t) : unit =
   in
   let rec go ctx = function
     | Text s ->
-      add_string s;
+      add_string (escape s);
       ctx
     | Concat (l, r) -> go (go ctx l) r
     | Tabstop (i, `None) -> with_ctx ctx i (fun i -> sprintf "$%d" i)

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -1,6 +1,6 @@
-let%expect_test "snippet text is not escaped" =
+let%expect_test "snippet text escapes metacharacters" =
   Lsp.Snippet.text "$}\\" |> Lsp.Snippet.to_string |> print_endline;
-  [%expect {| $}\ |}]
+  [%expect {| \$\}\\ |}]
 ;;
 
 let%expect_test "snippet choices escape metacharacters" =


### PR DESCRIPTION
Plain snippet text currently emits `$`, `}`, and backslashes without escaping them, which can change how an editor parses the snippet.

Render text through the snippet escaping function and update the focused regression expectation to the valid serialization.
