### PR TITLE
fix(lsp): escape snippet choices in a safe order

### DIFF
--- a/lsp/src/snippet.ml
+++ b/lsp/src/snippet.ml
@@ -75,9 +75,9 @@ let concat ?sep ts =
 let escape ?(in_choice = false) str =
   let str =
     str
+    |> String.replace_all ~pattern:"\\" ~with_:"\\\\"
     |> String.replace_all ~pattern:"$" ~with_:"\\$"
     |> String.replace_all ~pattern:"}" ~with_:"\\}"
-    |> String.replace_all ~pattern:"\\" ~with_:"\\\\"
   in
   if not in_choice
   then str

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -3,11 +3,11 @@ let%expect_test "snippet text is not escaped" =
   [%expect {| $}\ |}]
 ;;
 
-let%expect_test "snippet choices double escape metacharacters" =
+let%expect_test "snippet choices escape metacharacters" =
   Lsp.Snippet.choice [ "$"; "}"; "\\"; ","; "|" ]
   |> Lsp.Snippet.to_string
   |> print_endline;
-  [%expect {snippet| ${1|\\$,\\},\\,\,,\||} |snippet}]
+  [%expect {snippet| ${1|\$,\},\\,\,,\||} |snippet}]
 ;;
 
 let%expect_test "the final tab stop is renumbered" =


### PR DESCRIPTION
Snippet choice rendering currently escapes `$` and `}` before escaping backslashes, so the backslashes introduced by those replacements are escaped a second time.

Escape existing backslashes first so each snippet metacharacter is escaped exactly once. The focused regression expectation is updated to the valid serialization.
