### PR TITLE
fix(lsp): preserve final snippet tab stops

### DIFF
--- a/lsp/src/snippet.ml
+++ b/lsp/src/snippet.ml
@@ -99,6 +99,9 @@ let pp_impl add_string (snippet : t) : unit =
     | None ->
       add_string (f n);
       n + 1, m
+    | Some 0 ->
+      add_string (f 0);
+      n, m
     | Some i ->
       (match Int_map.find_opt i m with
        | Some j ->

--- a/lsp/test/snippet_tests.ml
+++ b/lsp/test/snippet_tests.ml
@@ -10,7 +10,7 @@ let%expect_test "snippet choices escape metacharacters" =
   [%expect {snippet| ${1|\$,\},\\,\,,\||} |snippet}]
 ;;
 
-let%expect_test "the final tab stop is renumbered" =
+let%expect_test "the final tab stop keeps index zero" =
   Lsp.Snippet.tabstop 0 |> Lsp.Snippet.to_string |> print_endline;
-  [%expect {| $1 |}]
+  [%expect {| $0 |}]
 ;;


### PR DESCRIPTION
Snippet tab stop zero marks the final cursor position, but the renderer currently renumbers it as the next ordinary tab stop.

Preserve explicit index zero without advancing the ordinary tab-stop sequence, and update the focused regression expectation from `$1` to `$0`.
