### PR TITLE
revert(jsonrpc-fiber): reject requests after stop

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -310,12 +310,6 @@ struct
     if (not t.running) || t.closing then Code_error.raise "jsonrpc must be running" []
   ;;
 
-  let check_accepting_requests t =
-    check_running t;
-    if t.pending_requests_stopped
-    then Code_error.raise "jsonrpc is not accepting requests" []
-  ;;
-
   let notification t (n : Notification.t) =
     Fiber.of_thunk (fun () ->
       check_running t;
@@ -352,7 +346,7 @@ struct
 
   let request t (req : Request.t) =
     Fiber.of_thunk (fun () ->
-      check_accepting_requests t;
+      check_running t;
       let ivar = Fiber.Ivar.create () in
       Fiber.finalize
         (fun () ->
@@ -386,7 +380,7 @@ struct
     in
     let resp =
       Fiber.of_thunk (fun () ->
-        check_accepting_requests t;
+        check_running t;
         let* cancelled = Fiber.Ivar.peek ivar in
         match cancelled with
         | Some (Error `Cancelled) -> Fiber.return `Cancelled
@@ -422,7 +416,7 @@ struct
 
   let submit (t : _ t) (batch : Batch.t) =
     Fiber.of_thunk (fun () ->
-      check_accepting_requests t;
+      check_running t;
       let pending = !batch in
       batch := [];
       let pending, ivars =

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -213,7 +213,7 @@ let%expect_test "cleanup precedes explicit output close" =
     <opaque> |}]
 ;;
 
-let%expect_test "requests are rejected before reaching the transport after stop" =
+let%expect_test "requests may reach the transport after stop" =
   let channel = lifecycle_channel () in
   let session = Lifecycle_jrpc.create ~name:"test" channel () in
   let classify = function
@@ -238,7 +238,7 @@ let%expect_test "requests are rejected before reaching the transport after stop"
   [%expect
     {|
     request: error
-    transport attempts: 0
+    transport attempts: 1
     <opaque> |}]
 ;;
 


### PR DESCRIPTION
Revert #1938 because its blanket batch guard rejects notification-only batches while the server is draining shutdown work, breaking the end-to-end test suite.

We will revisit the stopped-session output semantics separately with focused lifecycle tests.
