### PR TITLE
fix(jsonrpc-fiber): model draining explicitly

### DIFF
--- a/jsonrpc-fiber/src/jsonrpc_fiber.ml
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.ml
@@ -65,17 +65,23 @@ module Make (Chan : sig
     val close : t -> [ `Read | `Write ] -> unit Fiber.t
   end) =
 struct
+  type phase =
+    | Created
+    | Running
+    | Draining
+    | Closing
+    | Closed
+
   type 'state t =
     { chan : Chan.t
     ; on_request : ('state, Request.t) context -> (Reply.t * 'state) Fiber.t
     ; on_notification : ('state, Notification.t) context -> (Notify.t * 'state) Fiber.t
     ; pending : (Response.t, [ `Stopped | `Cancelled ]) result Fiber.Ivar.t Id.Table.t
     ; name : string
-    ; mutable running : bool
+    ; mutable phase : phase
     ; mutable tick : int
     ; mutable state : 'state
     ; mutable pending_requests_stopped : bool
-    ; mutable closing : bool
     ; close_result : (unit, Exn_with_backtrace.t list) result Fiber.Ivar.t
     }
 
@@ -150,11 +156,10 @@ struct
     ; on_notification
     ; pending
     ; name
-    ; running = false
+    ; phase = Created
     ; tick = 0
     ; state
     ; pending_requests_stopped = false
-    ; closing = false
     ; close_result = Fiber.Ivar.create ()
     }
   ;;
@@ -166,10 +171,31 @@ struct
     ()
   ;;
 
+  let begin_draining t =
+    match t.phase with
+    | Created | Running -> t.phase <- Draining
+    | Draining | Closing | Closed -> ()
+  ;;
+
+  let check_sending t =
+    match t.phase with
+    | Running | Draining -> ()
+    | Created | Closing | Closed -> Code_error.raise "jsonrpc must be running" []
+  ;;
+
+  let check_accepting_requests t =
+    match t.phase with
+    | Running -> ()
+    | Draining -> Code_error.raise "jsonrpc is not accepting requests" []
+    | Created | Closing | Closed -> Code_error.raise "jsonrpc must be running" []
+  ;;
+
   let stop t =
-    Fiber.fork_and_join_unit
-      (fun () -> Chan.close t.chan `Read)
-      (fun () -> stop_pending_requests t)
+    Fiber.of_thunk (fun () ->
+      begin_draining t;
+      Fiber.fork_and_join_unit
+        (fun () -> Chan.close t.chan `Read)
+        (fun () -> stop_pending_requests t))
   ;;
 
   let await_close t =
@@ -181,24 +207,24 @@ struct
 
   let close t =
     Fiber.of_thunk (fun () ->
-      if t.closing
-      then await_close t
-      else (
-        t.closing <- true;
-        let* () =
-          let* result =
-            Fiber.collect_errors (fun () ->
-              Fiber.fork_and_join_unit
-                (fun () -> stop t)
-                (fun () -> Chan.close t.chan `Write))
-          in
-          Fiber.Ivar.fill t.close_result result
+      match t.phase with
+      | Closing | Closed -> await_close t
+      | Created | Running | Draining ->
+        t.phase <- Closing;
+        let* result =
+          Fiber.collect_errors (fun () ->
+            Fiber.fork_and_join_unit
+              (fun () -> stop t)
+              (fun () -> Chan.close t.chan `Write))
         in
-        await_close t))
+        t.phase <- Closed;
+        let* () = Fiber.Ivar.fill t.close_result result in
+        await_close t)
   ;;
 
   let run_until_stopped t =
     let send_response resp =
+      check_sending t;
       log t (fun () ->
         Log.msg "sending response" [ "response", Response.yojson_of_t resp ]);
       Chan.send t.chan [ Response resp ]
@@ -293,11 +319,16 @@ struct
         loop ()
     in
     Fiber.of_thunk (fun () ->
-      t.running <- true;
+      (match t.phase with
+       | Created -> t.phase <- Running
+       | Draining -> ()
+       | Running | Closing | Closed ->
+         Code_error.raise "jsonrpc session cannot be started" []);
       let* () =
         Fiber.fork_and_join_unit
           (fun () ->
              let* () = loop () in
+             begin_draining t;
              Fiber.Pool.stop later)
           (fun () -> Fiber.Pool.run later)
       in
@@ -306,13 +337,9 @@ struct
 
   let run t = Fiber.finalize (fun () -> run_until_stopped t) ~finally:(fun () -> close t)
 
-  let check_running t =
-    if (not t.running) || t.closing then Code_error.raise "jsonrpc must be running" []
-  ;;
-
   let notification t (n : Notification.t) =
     Fiber.of_thunk (fun () ->
-      check_running t;
+      check_sending t;
       Chan.send t.chan [ Notification n ])
   ;;
 
@@ -346,7 +373,7 @@ struct
 
   let request t (req : Request.t) =
     Fiber.of_thunk (fun () ->
-      check_running t;
+      check_accepting_requests t;
       let ivar = Fiber.Ivar.create () in
       Fiber.finalize
         (fun () ->
@@ -380,7 +407,7 @@ struct
     in
     let resp =
       Fiber.of_thunk (fun () ->
-        check_running t;
+        check_accepting_requests t;
         let* cancelled = Fiber.Ivar.peek ivar in
         match cancelled with
         | Some (Error `Cancelled) -> Fiber.return `Cancelled
@@ -416,7 +443,12 @@ struct
 
   let submit (t : _ t) (batch : Batch.t) =
     Fiber.of_thunk (fun () ->
-      check_running t;
+      let has_requests =
+        List.exists !batch ~f:(function
+          | `Request _ -> true
+          | `Notification _ -> false)
+      in
+      if has_requests then check_accepting_requests t else check_sending t;
       let pending = !batch in
       batch := [];
       let pending, ivars =

--- a/jsonrpc-fiber/src/jsonrpc_fiber.mli
+++ b/jsonrpc-fiber/src/jsonrpc_fiber.mli
@@ -44,7 +44,11 @@ module Make (Chan : sig
     -> 'state t
 
   val state : 'a t -> 'a
+
+  (** Stop reading and enter the draining phase. New requests are rejected, but
+      responses and one-way notifications may be sent until [close] begins. *)
   val stop : _ t -> unit Fiber.t
+
   val stopped : _ t -> unit Fiber.t
 
   (** Close the session's input and output channels. This operation is
@@ -84,5 +88,8 @@ module Make (Chan : sig
     val request : t -> Jsonrpc.Request.t -> response
   end
 
+  (** Submit a batch without consuming it if the current phase rejects it.
+      Notification-only batches may be submitted while draining; batches that
+      contain requests may only be submitted while running. *)
   val submit : _ t -> Batch.t -> unit Fiber.t
 end

--- a/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
+++ b/jsonrpc-fiber/test/jsonrpc_fiber_tests.ml
@@ -216,7 +216,7 @@ let%expect_test "cleanup precedes explicit output close" =
     <opaque> |}]
 ;;
 
-let%expect_test "stopped sessions drain notifications but send requests" =
+let%expect_test "stopped sessions drain notifications and reject requests" =
   let channel = lifecycle_channel () in
   let session = Lifecycle_jrpc.create ~name:"test" channel () in
   let classify = function
@@ -266,11 +266,11 @@ let%expect_test "stopped sessions drain notifications but send requests" =
     notification batch: accepted
     request: error
     cancellable request: error
-    transport attempts: 4
+    transport attempts: 2
     <opaque> |}]
 ;;
 
-let%expect_test "a request batch rejected while draining is consumed" =
+let%expect_test "a request batch rejected while draining is not consumed" =
   let stopped_channel = lifecycle_channel () in
   let stopped = Lifecycle_jrpc.create ~name:"stopped" stopped_channel () in
   let retry_channel = lifecycle_channel () in
@@ -321,10 +321,10 @@ let%expect_test "a request batch rejected while draining is consumed" =
   [%expect
     {|
     stopped submit: error
-    stopped transport attempts: 1
+    stopped transport attempts: 0
     retry submit: accepted
     retry wire packets:
-    [ [] ]
+    [ [ { "id": 1, "method": "batched", "jsonrpc": "2.0" } ] ]
     <opaque> |}]
 ;;
 


### PR DESCRIPTION
Model the JSON-RPC lifecycle explicitly as created, running, draining, closing, and closed.

Requests are accepted only while running. Responses and one-way notifications may continue while draining, and all output is rejected once closing begins. Batch eligibility is checked before the batch is consumed, so a request-bearing batch rejected during draining remains available to the caller.

Updates the focused lifecycle characterizations in #1952.
