### PR TITLE
test(rename): cover edits across open and closed files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,14 @@
             ];
           });
 
+          ocaml-index = buildDunePackage {
+            pname = "ocaml-index";
+            src = pkgs.ocamlPackages.merlin-lib.src;
+            version = pkgs.ocamlPackages.merlin-lib.version;
+            doCheck = false;
+            propagatedBuildInputs = [ pkgs.ocamlPackages.merlin-lib ];
+          };
+
           ocaml-lsp = with pkgs.ocamlPackages;
             buildDunePackage (basePackage // {
               pname = package;
@@ -88,6 +96,7 @@
                 p.ppx_expect
                 p.ppx_sexp_conv
                 p.ppx_yojson_conv
+                ocaml-index
                 (ocamlformat pkgs)
               ];
               buildInputs = [
@@ -161,7 +170,7 @@
         checkPackages = makeLocalPackages checkPkgs;
         devShell = localPackages: nixpkgs:
           nixpkgs.mkShell {
-            buildInputs = [ nixpkgs.ocamlPackages.utop ];
+            buildInputs = [ nixpkgs.ocamlPackages.utop localPackages.ocaml-index ];
             inputsFrom =
               builtins.map (x: x.overrideAttrs (p: n: { doCheck = true; }))
               (builtins.attrValues localPackages);
@@ -195,6 +204,7 @@
               base_quickcheck
               ppx_expect
               ppx_sexp_conv
+              checkPackages.ocaml-index
               (ocamlformat checkPkgs)
             ];
             # Keep Dune RPC Unix socket paths below the platform limit.

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -10,6 +10,7 @@
   (enabled_if
    (= %{os_type} Unix))
   (deps
+   %{bin:ocaml-index}
    %{bin:ocamlformat-rpc}
    for_ppx.ml
    for_pp.ml

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -203,3 +203,113 @@ ignore (bar ?foo ())
     }
     |}]
 ;;
+
+let setup_multi_file_workspace () =
+  let dir = Test.temp_dir "ocamllsp-rename-" in
+  Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.0)\n";
+  Test.write_file
+    (Filename.concat dir "dune")
+    "(library\n (name rename_files)\n (wrapped false))\n";
+  Test.write_file (Filename.concat dir "lib.ml") "let value = 1\n";
+  Test.write_file (Filename.concat dir "main.ml") "let result = Lib.value\n";
+  Test.write_file (Filename.concat dir "other.ml") "let other = Lib.value\n";
+  Test.run_command ~cwd:dir "dune build @ocaml-index";
+  dir
+;;
+
+let open_project_document client ~uri ~version ~text =
+  let textDocument =
+    TextDocumentItem.create ~uri ~languageId:(LanguageKind.Other "ocaml") ~version ~text
+  in
+  Client.notification
+    client
+    (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
+;;
+
+let print_document_changes (edit : WorkspaceEdit.t) =
+  match edit.documentChanges with
+  | None -> print_endline "missing documentChanges"
+  | Some changes ->
+    List.iter changes ~f:(function
+      | `TextDocumentEdit { textDocument = { uri; version }; edits } ->
+        let version = Option.value_map version ~default:"null" ~f:Int.to_string in
+        Printf.printf
+          "%s (version %s)\n"
+          (DocumentUri.to_path uri |> Filename.basename)
+          version;
+        List.iter edits ~f:(function
+          | `TextEdit edit -> TextEdit.yojson_of_t edit |> Test.print_result
+          | `AnnotatedTextEdit _ | `SnippetTextEdit _ ->
+            failwith "unexpected annotated or snippet edit")
+      | `CreateFile _ | `RenameFile _ | `DeleteFile _ ->
+        failwith "unexpected resource operation")
+;;
+
+let%expect_test "rename a symbol across open and closed files" =
+  let dir = setup_multi_file_workspace () in
+  let uri name = Filename.concat dir name |> DocumentUri.of_path in
+  let lib_uri = uri "lib.ml" in
+  let main_uri = uri "main.ml" in
+  let workspace = WorkspaceFolder.create ~uri:(DocumentUri.of_path dir) ~name:"rename" in
+  let stderr = Unix.openfile Test.null_device [ O_WRONLY ] 0 in
+  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
+  (Test.run_initialized
+     ~cwd:dir
+     ~stderr
+     ~handler
+     ~capabilities:(capabilities ~documentChanges:true)
+     ~workspaceFolders:(Some [ workspace ])
+   @@ fun client ->
+   let* () =
+     open_project_document client ~uri:lib_uri ~version:7 ~text:"let value = 1\n"
+   in
+   let* () =
+     open_project_document
+       client
+       ~uri:main_uri
+       ~version:3
+       ~text:"let result = Lib.value\n"
+   in
+   let textDocument = TextDocumentIdentifier.create ~uri:main_uri in
+   let* response =
+     Client.request
+       client
+       (TextDocumentRename
+          (RenameParams.create
+             ~textDocument
+             ~position:(Position.create ~line:0 ~character:20)
+             ~newName:"renamed"
+             ()))
+   in
+   print_document_changes response;
+   let* () = Client.request client Shutdown in
+   Client.stop client);
+  Unix.close stderr;
+  [%expect
+    {|
+    lib.ml (version 3)
+    {
+      "newText": "renamed",
+      "range": {
+        "end": { "character": 9, "line": 0 },
+        "start": { "character": 4, "line": 0 }
+      }
+    }
+    main.ml (version 3)
+    {
+      "newText": "renamed",
+      "range": {
+        "end": { "character": 22, "line": 0 },
+        "start": { "character": 17, "line": 0 }
+      }
+    }
+    other.ml (version 3)
+    {
+      "newText": "renamed",
+      "range": {
+        "end": { "character": 21, "line": 0 },
+        "start": { "character": 16, "line": 0 }
+      }
+    }
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -81,7 +81,8 @@ let waitpid ?(timeout = 5.0) pid =
 
 module T : sig
   val run_with_status
-    :  ?extra_env:string list
+    :  ?cwd:string
+    -> ?extra_env:string list
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
@@ -90,7 +91,8 @@ module T : sig
     -> Unix.process_status * 'a
 
   val run
-    :  ?extra_env:string list
+    :  ?cwd:string
+    -> ?extra_env:string list
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
@@ -101,7 +103,8 @@ module T : sig
   (** Run a test after starting and initializing its client. The test remains
       responsible for shutting the client down. *)
   val run_initialized
-    :  ?extra_env:string list
+    :  ?cwd:string
+    -> ?extra_env:string list
     -> ?handler:unit Client.Handler.t
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
@@ -113,6 +116,7 @@ module T : sig
     -> 'a
 end = struct
   let run_with_status
+        ?cwd
         ?(extra_env = [])
         ?handler
         ?(stderr = Unix.stderr)
@@ -124,7 +128,16 @@ end = struct
     let stdout_i, stdout_o = Unix.pipe ~cloexec:true () in
     let pid =
       let env = extra_env @ Array.to_list (Unix.environment ()) |> Spawn.Env.of_list in
-      Spawn.spawn ~env ~prog:bin ~argv:[ bin ] ~stdin:stdin_i ~stdout:stdout_o ~stderr ()
+      let cwd = Option.map cwd ~f:(fun cwd -> Spawn.Working_dir.Path cwd) in
+      Spawn.spawn
+        ?cwd
+        ~env
+        ~prog:bin
+        ~argv:[ bin ]
+        ~stdin:stdin_i
+        ~stdout:stdout_o
+        ~stderr
+        ()
     in
     Option.iter on_spawn ~f:(fun on_spawn -> on_spawn pid);
     Unix.close stdin_i;
@@ -186,11 +199,12 @@ end = struct
     |> Lev_fiber.Error.ok_exn
   ;;
 
-  let run ?extra_env ?handler ?stderr ?timeout ?on_spawn f =
-    snd @@ run_with_status ?extra_env ?handler ?stderr ?timeout ?on_spawn f
+  let run ?cwd ?extra_env ?handler ?stderr ?timeout ?on_spawn f =
+    snd @@ run_with_status ?cwd ?extra_env ?handler ?stderr ?timeout ?on_spawn f
   ;;
 
   let run_initialized
+        ?cwd
         ?extra_env
         ?handler
         ?stderr
@@ -201,7 +215,7 @@ end = struct
         ?on_spawn
         f
     =
-    run ?extra_env ?handler ?stderr ?timeout ?on_spawn
+    run ?cwd ?extra_env ?handler ?stderr ?timeout ?on_spawn
     @@ fun client ->
     let run_client () = start_client ~capabilities ?workspaceFolders ?trace client in
     let run_test () =


### PR DESCRIPTION
Add an indexed end-to-end rename scenario spanning two open documents with different versions and one closed document. It verifies the text edits returned for the definition and both cross-file references, and characterizes the current per-edit version values without changing server behavior.

The fixture builds its project through Dune's `@ocaml-index` alias. Since `ocaml-index` is a separate package in the Merlin repository, expose it directly from Merlin's source in the Nix development and check environments.
