### PR TITLE
test(semantic-highlighting): cover spaced operator references

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -1154,6 +1154,11 @@ let x = { M . foo = 0 ; bar = "bar"}
     |}]
 ;;
 
+let%expect_test "parenthesized operator with spaces (#1533)" =
+  test_semantic_tokens_full "let add = ( + )";
+  [%expect {| let <variable|-0>add</0> = ( <operator|-1>+</1> ) |}]
+;;
+
 let%expect_test "operators" =
   test_semantic_tokens_full
   @@ String.strip


### PR DESCRIPTION
Add explicit regression coverage for the exact unqualified, spaced parenthesized operator syntax reported in #1533:

```ocaml
let add = ( + )
```

#1831 fixed the semantic-token range and covered nearby syntax variants, but not this exact case. The expectation verifies that only `+` receives the `operator` token.

Closes #1533.
