### PR TITLE
fix(rename): version multi-file edits per document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ## Fixes
 
+- Use each document's current version in multi-file rename edits. (#1958, @rgrinberg)
 - Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -19,7 +19,6 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
         | true -> None
         | false -> Some occurrence.loc)
     in
-    let version = Document.version doc in
     let uri = Document.uri doc in
     let edits =
       List.fold_left
@@ -82,8 +81,11 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
         let documentChanges =
           Map.to_alist edits
           |> List.map ~f:(fun (uri, edits) ->
+            let version =
+              Document_store.get_opt state.store uri |> Option.map ~f:Document.version
+            in
             let textDocument =
-              OptionalVersionedTextDocumentIdentifier.create ~uri ~version ()
+              OptionalVersionedTextDocumentIdentifier.create ~uri ?version ()
             in
             let edits = List.map edits ~f:(fun e -> `TextEdit e) in
             `TextDocumentEdit (TextDocumentEdit.create ~textDocument ~edits))

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -314,7 +314,7 @@ let%expect_test "rename a symbol across open and closed files" =
   Unix.close stderr;
   [%expect
     {|
-    lib.ml (version 3)
+    lib.ml (version 7)
     {
       "newText": "renamed",
       "range": {
@@ -330,7 +330,7 @@ let%expect_test "rename a symbol across open and closed files" =
         "start": { "character": 17, "line": 0 }
       }
     }
-    other.ml (version 3)
+    other.ml (version null)
     {
       "newText": "renamed",
       "range": {


### PR DESCRIPTION
The cross-file rename test added in #1956 shows that every `TextDocumentEdit` currently receives the initiating document's version. That gives other open documents the wrong version and gives closed documents a version even though their contents are not managed by the server.

Look up each edited URI in the document store instead. Open documents now carry their own version, while closed documents use `null` as required by `OptionalVersionedTextDocumentIdentifier`.
