### PR TITLE
dev(nix): disable cppo tests on OCaml 5.5

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,8 @@
             dune_3 = duneLatest;
             # OUnit2's process signal test is flaky under GitHub Actions.
             ounit2 = osuper.ounit2.overrideAttrs (_: { doCheck = false; });
+            # cppo's expected error paths differ under OCaml 5.5.
+            cppo = osuper.cppo.overrideAttrs (_: { doCheck = false; });
           });
         };
         makeNixpkgs = ocaml: merlin:


### PR DESCRIPTION
The OCaml 5.5 development shell fails while building cppo because its expected error paths omit a `./` prefix. Disable cppo's package tests in the OCaml 5.5 overlay so `nix develop` can build successfully.
