### PR TITLE
test(server): reproduce stale signature help (#1162)

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -419,3 +419,69 @@ let _ = div 1
     }
     |}]
 ;;
+
+let%expect_test "signature help after a completed application or closed scope" =
+  let source = "let add a b = a + b in \n \nadd 1 1;; \n " in
+  let check description position =
+    print_endline description;
+    test source position
+  in
+  check "after in" (Position.create ~line:0 ~character:23);
+  [%expect
+    {|
+    after in
+    {
+      "activeParameter": 1,
+      "activeSignature": 0,
+      "signatures": [
+        {
+          "label": "add : int -> int -> int",
+          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
+        }
+      ]
+    }
+    |}];
+  check "on blank line before application" (Position.create ~line:1 ~character:1);
+  [%expect
+    {|
+    on blank line before application
+    {
+      "activeParameter": 1,
+      "activeSignature": 0,
+      "signatures": [
+        {
+          "label": "add : int -> int -> int",
+          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
+        }
+      ]
+    }
+    |}];
+  check "after completed application" (Position.create ~line:2 ~character:10);
+  [%expect
+    {|
+    after completed application
+    {
+      "activeSignature": 0,
+      "signatures": [
+        {
+          "label": "add : int -> int -> int",
+          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
+        }
+      ]
+    }
+    |}];
+  check "on blank line after terminator" (Position.create ~line:3 ~character:1);
+  [%expect
+    {|
+    on blank line after terminator
+    {
+      "activeSignature": 0,
+      "signatures": [
+        {
+          "label": "add : int -> int -> int",
+          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
+        }
+      ]
+    }
+    |}]
+;;


### PR DESCRIPTION
Adds a passing expect test that captures the stale signature-help responses reported in #1162. The expected output deliberately records the current incorrect behavior so a follow-up fix can update it.
