### PR TITLE
fix(completion): replace incorrect identifier suffixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 - Use constructor completion kinds when clients do not support enum members. (#1887, @rgrinberg)
 - Use completion deprecation tags when supported by the client. (#1903, @rgrinberg)
 - Keep completion sort keys lexically ordered beyond 9,999 items. (#1883, @rgrinberg)
+- Replace incorrect identifier suffixes when applying completions. (#1964, fixes #838, @rgrinberg)
 - Give synthetic completion items stable ordering metadata. (#1882, @rgrinberg)
 - Correct code-action ranges after multiline text insertions. (#1748, @rgrinberg)
 - Allow clients to add their first workspace folder dynamically. (#1747, @rgrinberg)

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -164,10 +164,17 @@ module Complete_by_prefix = struct
         (completion : Query_protocol.completions)
     =
     let range =
+      let source = Document.Merlin.source doc in
       let logical_pos = Position.logical pos in
-      range_prefix
-        pos
-        (prefix_of_position ~short_path:true (Document.Merlin.source doc) logical_pos)
+      let range =
+        range_prefix pos (prefix_of_position ~short_path:true source logical_pos)
+      in
+      let suffix =
+        let text_document = Document.Merlin.to_doc doc |> Document.text_document in
+        let offset = Text_document.absolute_position text_document pos in
+        suffix_of_position source (`Offset offset)
+      in
+      { range with end_ = { pos with character = pos.character + String.length suffix } }
     in
     let completion_entries =
       match completion.context with

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -175,7 +175,7 @@ let%expect_test "can start completion at arbitrary position" =
         "textEdit": {
           "newText": "String",
           "range": {
-            "end": { "character": 6, "line": 0 },
+            "end": { "character": 12, "line": 0 },
             "start": { "character": 0, "line": 0 }
           }
         }
@@ -188,7 +188,7 @@ let%expect_test "can start completion at arbitrary position" =
         "textEdit": {
           "newText": "StringLabels",
           "range": {
-            "end": { "character": 6, "line": 0 },
+            "end": { "character": 12, "line": 0 },
             "start": { "character": 0, "line": 0 }
           }
         }
@@ -210,7 +210,7 @@ let%expect_test "can start completion at arbitrary position 2" =
       "textEdit": {
         "newText": "StringLabels",
         "range": {
-          "end": { "character": 7, "line": 0 },
+          "end": { "character": 12, "line": 0 },
           "start": { "character": 0, "line": 0 }
         }
       }
@@ -238,7 +238,7 @@ let _ = String.is_prword|ocaml}
       "textEdit": {
         "newText": "is_prefix",
         "range": {
-          "end": { "character": 20, "line": 1 },
+          "end": { "character": 24, "line": 1 },
           "start": { "character": 15, "line": 1 }
         }
       }


### PR DESCRIPTION
Extend completion text edits through the identifier suffix after the cursor. In the #838 reproduction, selecting `is_prefix` now replaces all of `is_prword` instead of leaving `word` behind.

Fixes #838.
