### PR TITLE
fix(server): reject signature help after the cursor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 - Exclude surrounding parentheses from infix operator rename placeholders and
   edits. (#1966, fixes #1190, @rgrinberg)
+- Suppress signature help for applications after the cursor. (#1965, #1162,
+  @rgrinberg)
 - Use each document's current version in multi-file rename edits. (#1958, @rgrinberg)
 - Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -49,7 +49,15 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
           let typer = Mpipeline.typer_result pipeline in
           let pos = Mpipeline.get_lexing_pos pipeline pos in
           let node = Mtyper.node_at typer pos in
-          Merlin_analysis.Signature_help.application_signature node ~prefix ~cursor:pos)
+          match
+            Merlin_analysis.Signature_help.application_signature node ~prefix ~cursor:pos
+          with
+          | None -> None
+          | Some signature ->
+            let function_position =
+              Mpipeline.get_lexing_pos pipeline signature.function_position
+            in
+            if pos.pos_cnum < function_position.pos_cnum then None else Some signature)
     in
     (match application_signature with
      | None ->

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -430,31 +430,13 @@ let%expect_test "signature help after a completed application or closed scope" =
   [%expect
     {|
     after in
-    {
-      "activeParameter": 1,
-      "activeSignature": 0,
-      "signatures": [
-        {
-          "label": "add : int -> int -> int",
-          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
-        }
-      ]
-    }
+    { "signatures": [] }
     |}];
   check "on blank line before application" (Position.create ~line:1 ~character:1);
   [%expect
     {|
     on blank line before application
-    {
-      "activeParameter": 1,
-      "activeSignature": 0,
-      "signatures": [
-        {
-          "label": "add : int -> int -> int",
-          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
-        }
-      ]
-    }
+    { "signatures": [] }
     |}];
   check "after completed application" (Position.create ~line:2 ~character:10);
   [%expect
@@ -497,7 +479,7 @@ let rec censor_backtraces = function
   | json -> json
 ;;
 
-let%expect_test "malformed Unicode application returns an internal error" =
+let%expect_test "malformed Unicode application returns no signature help" =
   Helpers.test "a>😀" (fun client ->
     let* result =
       Fiber.collect_errors (fun () ->
@@ -512,17 +494,7 @@ let%expect_test "malformed Unicode application returns an internal error" =
     | Ok response ->
       print_signature_help response;
       Fiber.return ());
-  [%expect
-    {|
-    {
-      "data": {
-        "exn": "Ocaml_preprocess.Lexer_raw.Error(_, _)",
-        "backtrace": "<censored>"
-      },
-      "code": -32603,
-      "message": "uncaught exception"
-    }
-    |}]
+  [%expect {| { "signatures": [] } |}]
 ;;
 
 let%expect_test "signature help after expression boundaries" =


### PR DESCRIPTION
Merlin recovery can return an application whose function starts after the requested cursor position. Ignore that application before resolving its documentation, suppressing stale help and avoiding errors from malformed trailing input.

The regression coverage landed first in #1962 and #1973.

Addresses one failure mode from #1162.
