### PR TITLE
fix(rename): exclude operator parentheses from rename ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Exclude surrounding parentheses from infix operator rename placeholders and
+  edits. (#1966, fixes #1190, @rgrinberg)
 - Use each document's current version in multi-file rename edits. (#1958, @rgrinberg)
 - Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -249,6 +249,7 @@ include struct
   module OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIdentifier
   module ParameterInformation = ParameterInformation
   module PositionEncodingKind = PositionEncodingKind
+  module PrepareRenameParams = PrepareRenameParams
   module ProgressParams = ProgressParams
   module ProgressToken = ProgressToken
   module PublishDiagnosticsParams = PublishDiagnosticsParams

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -724,30 +724,7 @@ let on_request
   | TextDocumentTypeDefinition { textDocument = { uri }; position; _ } ->
     later (fun state () -> Definition_query.run `Type_definition state uri position) ()
   | TextDocumentCompletion params -> later (fun _ () -> Compl.complete state params) ()
-  | TextDocumentPrepareRename { textDocument = { uri }; position; workDoneToken = _ } ->
-    later
-      (fun _ () ->
-         let doc = Document_store.get store uri in
-         match Document.kind doc with
-         | `Other -> Fiber.return None
-         | `Merlin doc ->
-           let+ occurrences, _synced =
-             Document.Merlin.dispatch_exn
-               ~name:"occurrences"
-               doc
-               (Occurrences (`Ident_at (Position.logical position), `Buffer))
-           in
-           let loc =
-             List.find_map occurrences ~f:(fun (occurrence : Query_protocol.occurrence) ->
-               let loc = occurrence.loc in
-               let range = Range.of_loc loc in
-               match occurrence.is_stale with
-               | false when Lsp.Range.contains_position range position ~inclusive_end:true
-                 -> Some loc
-               | _ -> None)
-           in
-           Option.map loc ~f:Range.of_loc)
-      ()
+  | TextDocumentPrepareRename req -> later Rename.prepare req
   | TextDocumentRename req -> later Rename.rename req
   | TextDocumentFoldingRange req -> later Folding_range.compute req
   | SignatureHelp req -> later Signature_help.run req

--- a/ocaml-lsp-server/src/ocaml_operator.ml
+++ b/ocaml-lsp-server/src/ocaml_operator.ml
@@ -1,0 +1,4 @@
+open Import
+
+let symbolic_characters = {|$&*+-/=>@^|~!?%<:.#|}
+let is_symbolic_character = String.mem symbolic_characters

--- a/ocaml-lsp-server/src/ocaml_operator.mli
+++ b/ocaml-lsp-server/src/ocaml_operator.mli
@@ -1,0 +1,2 @@
+val symbolic_characters : string
+val is_symbolic_character : char -> bool

--- a/ocaml-lsp-server/src/prefix_parser.ml
+++ b/ocaml-lsp-server/src/prefix_parser.ml
@@ -17,9 +17,7 @@ include struct
     Re.seq [ name_char; white_space |> rep; char '.'; white_space |> rep ]
   ;;
 
-  let core_operator_str = {|$&*+-/=>@^||}
-  let operator = core_operator_str ^ {|~!?%<:.|}
-  let infix = set (operator ^ "#")
+  let infix = set Ocaml_operator.symbolic_characters
 
   let name_or_label =
     let name = alt [ name_char; name_with_dot ] in

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -1,6 +1,78 @@
 open Import
 open Fiber.O
 
+let position_of_offset source offset =
+  let (`Logical (line, character)) = Msource.get_logical source (`Offset offset) in
+  Position.create ~line:(line - 1) ~character
+;;
+
+let is_parenthesized source ~start_offset ~end_offset =
+  end_offset - start_offset >= 3
+  && Char.equal source.[start_offset] '('
+  && Char.equal source.[end_offset - 1] ')'
+;;
+
+(* Merlin includes the syntactically required parentheses in symbolic operator
+   locations. Rename only the operator so that clients do not use the
+   parentheses as part of its name. *)
+let identifier_range source loc =
+  let range = Range.of_loc loc in
+  let (`Offset start_offset) = Msource.get_offset source (Position.logical range.start) in
+  let (`Offset end_offset) = Msource.get_offset source (Position.logical range.end_) in
+  let source_text = Msource.text source in
+  match is_parenthesized source_text ~start_offset ~end_offset with
+  | false -> range
+  | true ->
+    let rec skip_whitespace_forward offset =
+      if offset < end_offset - 1 && Char.is_whitespace source_text.[offset]
+      then skip_whitespace_forward (offset + 1)
+      else offset
+    in
+    let operator_start = skip_whitespace_forward (start_offset + 1) in
+    let rec skip_whitespace_backward offset =
+      if operator_start < offset && Char.is_whitespace source_text.[offset - 1]
+      then skip_whitespace_backward (offset - 1)
+      else offset
+    in
+    let operator_end = skip_whitespace_backward (end_offset - 1) in
+    let rec contains_only_operator_characters offset =
+      offset = operator_end
+      || (Ocaml_operator.is_symbolic_character source_text.[offset]
+          && contains_only_operator_characters (offset + 1))
+    in
+    if operator_start < operator_end && contains_only_operator_characters operator_start
+    then
+      { Range.start = position_of_offset source operator_start
+      ; end_ = position_of_offset source operator_end
+      }
+    else range
+;;
+
+let prepare
+      (state : State.t)
+      { PrepareRenameParams.textDocument = { uri }; position; workDoneToken = _ }
+  =
+  let doc = Document_store.get state.store uri in
+  match Document.kind doc with
+  | `Other -> Fiber.return None
+  | `Merlin merlin ->
+    let+ occurrences, (_ : Query_protocol.occurrences_status) =
+      Document.Merlin.dispatch_exn
+        ~name:"occurrences"
+        merlin
+        (Query_protocol.Occurrences (`Ident_at (Position.logical position), `Buffer))
+    in
+    let source = Document.source doc in
+    List.find_map occurrences ~f:(fun (occurrence : Query_protocol.occurrence) ->
+      if occurrence.is_stale
+      then None
+      else (
+        let range = identifier_range source occurrence.loc in
+        if Lsp.Range.contains_position range position ~inclusive_end:true
+        then Some range
+        else None))
+;;
+
 let rename (state : State.t) { RenameParams.textDocument = { uri }; position; newName; _ }
   =
   let doc = Document_store.get state.store uri in
@@ -19,23 +91,20 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
         | true -> None
         | false -> Some occurrence.loc)
     in
-    let uri = Document.uri doc in
-    let edits =
+    let locs =
       List.fold_left
         locs
         ~init:(Map.empty (module Uri))
         ~f:(fun acc (loc : Warnings.loc) ->
-          let range = Range.of_loc loc in
-          let edit = TextEdit.create ~range ~newText:newName in
           let uri =
             match loc.loc_start.pos_fname with
             | "" -> uri
             | path -> Uri.of_path path
           in
-          Map.add_multi acc ~key:uri ~data:edit)
+          Map.add_multi acc ~key:uri ~data:loc)
     in
     let edits =
-      Map.mapi edits ~f:(fun ~key:doc_uri ~data:edits ->
+      Map.mapi locs ~f:(fun ~key:doc_uri ~data:locs ->
         let source =
           match Document_store.get_opt state.store doc_uri with
           | Some doc when DocumentUri.equal doc_uri (Document.uri doc) ->
@@ -44,7 +113,9 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
             let source_path = Uri.to_path doc_uri in
             In_channel.with_open_text source_path In_channel.input_all |> Msource.make
         in
-        List.map edits ~f:(fun (edit : TextEdit.t) ->
+        List.map locs ~f:(fun loc ->
+          let range = identifier_range source loc in
+          let edit = TextEdit.create ~range ~newText:newName in
           let start_position = edit.range.start in
           match start_position with
           | { character = 0; _ } -> edit

--- a/ocaml-lsp-server/src/rename.mli
+++ b/ocaml-lsp-server/src/rename.mli
@@ -1,3 +1,4 @@
 open Import
 
+val prepare : State.t -> Lsp.Types.PrepareRenameParams.t -> Range.t option Fiber.t
 val rename : State.t -> RenameParams.t -> WorkspaceEdit.t Fiber.t

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -334,36 +334,14 @@ end = struct
   ;;
 
   let is_operator_name name =
-    let is_operator_initial = function
-      | '!'
-      | '?'
-      | '~'
-      | '='
-      | '<'
-      | '>'
-      | '@'
-      | '^'
-      | '|'
-      | '&'
-      | '+'
-      | '-'
-      | '*'
-      | '/'
-      | '$'
-      | '%'
-      | '#'
-      | '.'
-      | ':' -> true
-      | _ -> false
-    in
     List.mem
       [ "asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or" ]
       name
       ~equal:String.equal
-    || ((not (String.is_empty name)) && is_operator_initial name.[0])
+    || ((not (String.is_empty name)) && Ocaml_operator.is_symbolic_character name.[0])
     || (String.length name > 3
         && (String.is_prefix name ~prefix:"let" || String.is_prefix name ~prefix:"and")
-        && is_operator_initial name.[3])
+        && Ocaml_operator.is_symbolic_character name.[3])
   ;;
 
   let rec longident_components ({ txt; loc } : Longident.t Loc.loc) =

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -60,14 +60,15 @@ let%expect_test "allows valid rename request" =
     |}]
 ;;
 
-let%expect_test "prepare rename includes operator parentheses (#1190)" =
+let%expect_test "rename excludes operator parentheses (#1190)" =
   let source =
     {ocaml|let (^*$) a = a + 1
 let b = (^*$) 1
 |ocaml}
   in
   run source (fun client ->
-    let* response = prepare_rename client (Position.create ~line:0 ~character:6) in
+    let position = Position.create ~line:0 ~character:6 in
+    let* response = prepare_rename client position in
     print_prepare_rename response;
     (match response with
      | None -> ()
@@ -76,14 +77,36 @@ let b = (^*$) 1
          String.sub source ~pos:start.character ~len:(end_.character - start.character)
        in
        Printf.printf "placeholder: %s\n" placeholder);
+    let* response = rename ~newName:"^+$" client position in
+    print_workspace_edit response;
     Fiber.return ());
   [%expect
     {|
     {
-      "end": { "character": 9, "line": 0 },
-      "start": { "character": 4, "line": 0 }
+      "end": { "character": 8, "line": 0 },
+      "start": { "character": 5, "line": 0 }
     }
-    placeholder: (^*$)
+    placeholder: ^*$
+    {
+      "changes": {
+        "file:///test.ml": [
+          {
+            "newText": "^+$",
+            "range": {
+              "end": { "character": 12, "line": 1 },
+              "start": { "character": 9, "line": 1 }
+            }
+          },
+          {
+            "newText": "^+$",
+            "range": {
+              "end": { "character": 8, "line": 0 },
+              "start": { "character": 5, "line": 0 }
+            }
+          }
+        ]
+      }
+    }
     |}]
 ;;
 


### PR DESCRIPTION
Merlin occurrence locations include the syntactically required parentheses around symbolic operators. Restrict `prepareRename` and rename edit ranges to the operator token so clients prefill the bare name while edits preserve the surrounding syntax.

The symbolic operator alphabet is centralized and shared with prefix parsing and semantic highlighting. The reproducer was merged separately in #1961.

Fixes #1190.
