### PR TITLE
test(code-actions): expose UTF-16 remove-rec range

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -178,13 +178,57 @@ let f = function
      | 0 -> 0 |}]
 ;;
 
-let%expect_test "remove rec flag" =
-  remove_test
-    `Rec
+let%expect_test "remove rec flag after Unicode" =
+  let source, range =
+    Code_actions.parse_selection
+      {|
+let café = let rec $f$ = 0 in f
+|}
+  in
+  let diagnostics =
+    [ Diagnostic.create ~message:(`String "unused rec flag") ~range () ]
+  in
+  Code_actions.print_code_actions
+    ~diagnostics
+    ~filter:(function
+      | `CodeAction { title; _ } -> String.equal title "Remove unused rec"
+      | `Command _ -> false)
+    source
+    range;
+  [%expect
     {|
-let rec $f$ = 0
-|};
-  [%expect {| let  f = 0 |}]
+    Code actions:
+    {
+      "diagnostics": [
+        {
+          "message": "unused rec flag",
+          "range": {
+            "end": { "character": 20, "line": 1 },
+            "start": { "character": 19, "line": 1 }
+          }
+        }
+      ],
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": { "character": 19, "line": 1 },
+                  "start": { "character": 16, "line": 1 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "quickfix",
+      "title": "Remove unused rec"
+    }
+    |}]
 ;;
 
 let%expect_test "remove constructor" =

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -63,18 +63,26 @@ let find_action action_name action =
 let find_annotate_action action = find_action "type-annotate" action
 let find_remove_annotation_action action = find_action "remove type annotation" action
 
-let position_of_offset src x =
-  assert (0 <= x && x < String.length src);
-  let cnum = ref 0
-  and lnum = ref 0 in
-  for i = 0 to x - 1 do
-    if Char.equal src.[i] '\n'
-    then (
-      Int.incr lnum;
-      cnum := 0)
-    else Int.incr cnum
-  done;
-  Position.create ~character:!cnum ~line:!lnum
+let position_of_offset src target =
+  assert (0 <= target && target < String.length src);
+  let rec loop offset line character =
+    if offset = target
+    then Position.create ~line ~character
+    else (
+      let decoded = Stdlib.String.get_utf_8_uchar src offset in
+      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
+      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
+      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
+      assert (offset + byte_length <= target);
+      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
+      then loop (offset + byte_length) (line + 1) 0
+      else
+        loop
+          (offset + byte_length)
+          line
+          (character + (Stdlib.Uchar.utf_16_byte_length uchar / 2)))
+  in
+  loop 0 0 0
 ;;
 
 let parse_selection src =


### PR DESCRIPTION
Records the current `Remove unused rec` edit range after Unicode so the position-encoding fix can be reviewed separately.

The existing remove-rec expect test is strengthened rather than duplicated: selection markers now produce UTF-16 positions, and the snapshot exposes the byte-column range currently returned by the server. A follow-up will update this same snapshot with the fix.
