### PR TITLE
fix(code-actions): encode remove-unused ranges correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 ## Fixes
 
 - Suppress signature help for completed applications. (#1982, #1162, @rgrinberg)
+- Encode remove-unused code-action edits using the client's negotiated position
+  encoding. (#1969, @rgrinberg)
 - Exclude surrounding parentheses from infix operator rename placeholders and
   edits. (#1966, fixes #1190, @rgrinberg)
 - Suppress signature help for applications after the cursor. (#1965, #1162,

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -144,6 +144,43 @@ let absolute_range t (range : Range.t) =
   start, stop
 ;;
 
+let position_of_utf8_offset t target =
+  let text = text t in
+  if target < 0 || target > String.length text
+  then invalid_arg "Text_document.range_of_utf8_offsets: offset out of bounds";
+  let rec loop offset line character =
+    if offset = target
+    then Position.create ~line ~character
+    else (
+      let decoded = String.get_utf_8_uchar text offset in
+      if not (Uchar.utf_decode_is_valid decoded)
+      then raise (Invalid_utf (Malformed (String.make 1 (String.get text offset))));
+      let uchar = Uchar.utf_decode_uchar decoded in
+      let byte_length = Uchar.utf_decode_length decoded in
+      if offset + byte_length > target
+      then
+        invalid_arg "Text_document.range_of_utf8_offsets: offset is not a UTF-8 boundary";
+      if Uchar.equal uchar (Uchar.of_char '\n')
+      then loop (offset + byte_length) (line + 1) 0
+      else (
+        let width =
+          match t.position_encoding with
+          | `UTF8 -> byte_length
+          | `UTF16 -> Uchar.utf_16_byte_length uchar / 2
+        in
+        loop (offset + byte_length) line (character + width)))
+  in
+  loop 0 0 0
+;;
+
+let range_of_utf8_offsets t ~start_offset ~end_offset =
+  if start_offset > end_offset
+  then invalid_arg "Text_document.range_of_utf8_offsets: start follows end";
+  let start = position_of_utf8_offset t start_offset in
+  let end_ = position_of_utf8_offset t end_offset in
+  Range.create ~start ~end_
+;;
+
 let substring t range =
   let start, end_ = absolute_range t range in
   let text = text t in

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -47,6 +47,12 @@ val absolute_position : t -> Position.t -> int
    absolute_position t range.end_)] but possibly faster *)
 val absolute_range : t -> Range.t -> int * int
 
+(** [range_of_utf8_offsets t ~start_offset ~end_offset] converts the half-open
+    UTF-8 byte offsets [[start_offset, end_offset)] in [text t] to a range in the
+    document's position encoding. Raises [Invalid_argument] if the offsets are
+    unordered, out of bounds, or not UTF-8 character boundaries. *)
+val range_of_utf8_offsets : t -> start_offset:int -> end_offset:int -> Range.t
+
 (** [substring t range] returns the text within [range], interpreted using the
     document's position encoding. Returns [None] when the range's start follows
     its end. *)

--- a/lsp/test/text_document_quickcheck_tests.ml
+++ b/lsp/test/text_document_quickcheck_tests.ml
@@ -142,6 +142,13 @@ let apply_operation state = function
     let actual_start, actual_stop = Text_document.absolute_range state.document range in
     if actual_start <> first.byte_offset || actual_stop <> second.byte_offset
     then fail state "absolute range differs";
+    let round_trip =
+      Text_document.range_of_utf8_offsets
+        state.document
+        ~start_offset:first.byte_offset
+        ~end_offset:second.byte_offset
+    in
+    if not (Poly.equal round_trip range) then fail state "UTF-8 offset range differs";
     state
   | Set_version version ->
     let version = normalized_version version in

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -333,6 +333,30 @@ let%expect_test "substring uses the document's position encoding" =
     |}]
 ;;
 
+let%expect_test "range_of_utf8_offsets rejects invalid offsets" =
+  let doc = make_document ~position_encoding:`UTF16 (Uri.of_path "foo.ml") ~text:"a😀b" in
+  let print_exception f =
+    match f () with
+    | exception exn -> Printexc.to_string exn |> print_endline
+    | _ -> print_endline "<no exception>"
+  in
+  print_exception (fun () ->
+    Text_document.range_of_utf8_offsets doc ~start_offset:(-1) ~end_offset:0);
+  print_exception (fun () ->
+    Text_document.range_of_utf8_offsets doc ~start_offset:0 ~end_offset:7);
+  print_exception (fun () ->
+    Text_document.range_of_utf8_offsets doc ~start_offset:5 ~end_offset:1);
+  print_exception (fun () ->
+    Text_document.range_of_utf8_offsets doc ~start_offset:1 ~end_offset:2);
+  [%expect
+    {|
+    Invalid_argument("Text_document.range_of_utf8_offsets: offset out of bounds")
+    Invalid_argument("Text_document.range_of_utf8_offsets: offset out of bounds")
+    Invalid_argument("Text_document.range_of_utf8_offsets: start follows end")
+    Invalid_argument("Text_document.range_of_utf8_offsets: offset is not a UTF-8 boundary")
+    |}]
+;;
+
 let%expect_test "replace second line first line is \\n" =
   let range = tuple_range (1, 2) (1, 2) in
   let doc = make_document (Uri.of_path "foo.ml") ~text:"\nfoo\nbar\nbaz\n" in

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -258,27 +258,20 @@ let rec_regex =
     (Re.seq [ Re.bos; Re.rep Re.any; Re.group (Re.str "rec"); Re.rep Re.space; Re.stop ])
 ;;
 
-let find_preceding doc pos regex =
+let find_preceding text_document ~end_offset regex =
   let open Option.O in
-  let src = Document.source doc in
-  let (`Offset end_) = Msource.get_offset src @@ Position.logical pos in
-  let* groups = Re.exec_opt ~len:end_ regex (Msource.text src) in
-  let match_start, match_end = Re.Group.offset groups 1 in
-  let filename = Uri.to_path (Document.uri doc) in
-  let* start =
-    Msource.get_lexing_pos ~filename src (`Offset match_start)
-    |> Position.of_lexical_position
-  in
-  let+ end_ =
-    Msource.get_lexing_pos ~filename src (`Offset match_end)
-    |> Position.of_lexical_position
-  in
-  Range.create ~start ~end_
+  let+ groups = Re.exec_opt ~len:end_offset regex (Text_document.text text_document) in
+  Re.Group.offset groups 1
 ;;
 
 let action_remove_rec doc (d : Diagnostic.t) =
+  let text_document = Document.text_document doc in
   let open Option.O in
-  let+ rec_range = find_preceding doc d.range.start rec_regex in
+  let end_offset = Text_document.absolute_position text_document d.range.start in
+  let+ start_offset, end_offset = find_preceding text_document ~end_offset rec_regex in
+  let rec_range =
+    Text_document.range_of_utf8_offsets text_document ~start_offset ~end_offset
+  in
   code_action_remove_range ~title:"Remove unused rec" doc d rec_range
 ;;
 
@@ -301,14 +294,17 @@ let action_remove_case pipeline doc (d : Diagnostic.t) =
       | _ -> None)
   in
   let* case_start, case_end = case_range in
-  let* start = Position.of_lexical_position case_start in
-  let* end_ = Position.of_lexical_position case_end in
-  let+ preceding_bar = find_preceding doc start bar_regex in
-  let edit =
-    Text_document.workspace_edit
-      (Document.text_document doc)
-      [ { range = Range.create ~start:preceding_bar.start ~end_; newText = "" } ]
+  let text_document = Document.text_document doc in
+  let+ start_offset, _ =
+    find_preceding text_document ~end_offset:case_start.pos_cnum bar_regex
   in
+  let range =
+    Text_document.range_of_utf8_offsets
+      text_document
+      ~start_offset
+      ~end_offset:case_end.pos_cnum
+  in
+  let edit = Text_document.workspace_edit text_document [ { range; newText = "" } ] in
   CodeAction.create
     ~diagnostics:[ d ]
     ~title:"Remove unused case"

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -216,7 +216,7 @@ let f = function
               {
                 "newText": "",
                 "range": {
-                  "end": { "character": 14, "line": 3 },
+                  "end": { "character": 12, "line": 3 },
                   "start": { "character": 1, "line": 3 }
                 }
               }
@@ -269,8 +269,8 @@ let café = let rec $f$ = 0 in f
               {
                 "newText": "",
                 "range": {
-                  "end": { "character": 19, "line": 1 },
-                  "start": { "character": 16, "line": 1 }
+                  "end": { "character": 18, "line": 1 },
+                  "start": { "character": 15, "line": 1 }
                 }
               }
             ],


### PR DESCRIPTION
Adds `Text_document.range_of_utf8_offsets`, a checked inverse for converting internal UTF-8 byte spans into ranges in a document's negotiated position encoding.

The remove-unused source matchers now retain `Re` and Merlin locations as UTF-8 offsets internally, converting complete spans only when constructing LSP edits. This corrects the remove-rec regression exposed by #1968 and the remove-case regression exposed by #1984 without branching on the negotiated encoding in the code action.
