### PR TITLE
test(selection-range): reproduce range past EOF

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/selection_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/selection_range.ml
@@ -214,6 +214,21 @@ end|ocaml}
     |}]
 ;;
 
+let%expect_test "comment-only document without a trailing newline" =
+  test "(* comment *)" [ Position.create ~line:0 ~character:7 ];
+  [%expect
+    {|
+    [
+      [
+        {
+          "end": { "character": 0, "line": 1 },
+          "start": { "character": 0, "line": 0 }
+        }
+      ]
+    ]
+    |}]
+;;
+
 let%expect_test "returns a reasonable selection range in the presence of syntax errors" =
   let source =
     {ocaml|module M = struct


### PR DESCRIPTION
Adds an expect-test reproducer for a comment-only document without a trailing newline.

The snapshot records the current invalid response: `textDocument/selectionRange` returns an end position of `(1, 0)` even though the document only contains line 0. This is a test-only, test-first change; a follow-up fix can update the expectation to the valid EOF position `(0, 13)`.
