### PR TITLE
fix(completion): capture the request document snapshot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Keep completion ranges tied to the request's document snapshot when
+  `didChange` races with completion. (#1974, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -350,10 +350,10 @@ end
 
 let complete
       (state : State.t)
-      ({ textDocument = { uri }; position = pos; context; _ } : CompletionParams.t)
+      doc
+      ({ textDocument = _; position = pos; context; _ } : CompletionParams.t)
   =
   Fiber.of_thunk (fun () ->
-    let doc = Document_store.get state.store uri in
     match Document.kind doc with
     | `Other -> Fiber.return None
     | `Merlin merlin ->

--- a/ocaml-lsp-server/src/compl.mli
+++ b/ocaml-lsp-server/src/compl.mli
@@ -14,6 +14,7 @@ end
 
 val complete
   :  State.t
+  -> Document.t
   -> CompletionParams.t
   -> [> `CompletionList of CompletionList.t ] option Fiber.t
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -727,7 +727,9 @@ let on_request
     later (fun state () -> Definition_query.run `Definition state uri position) ()
   | TextDocumentTypeDefinition { textDocument = { uri }; position; _ } ->
     later (fun state () -> Definition_query.run `Type_definition state uri position) ()
-  | TextDocumentCompletion params -> later (fun _ () -> Compl.complete state params) ()
+  | TextDocumentCompletion ({ textDocument = { uri }; _ } as params) ->
+    let doc = Document_store.get store uri in
+    later (fun _ () -> Compl.complete state doc params) ()
   | TextDocumentPrepareRename req ->
     later
       (fun state req ->

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -1729,3 +1729,69 @@ let%expect_test "construct completion edit stays on the request line" =
     }
     |}]
 ;;
+
+let%expect_test "completion raced with a document change keeps valid ranges" =
+  Helpers.test "\nx" (fun client ->
+    let position = Position.create ~line:1 ~character:0 in
+    let version = ref 0 in
+    let change_document text =
+      incr version;
+      let textDocument =
+        VersionedTextDocumentIdentifier.create ~uri:Helpers.uri ~version:!version
+      in
+      let contentChanges =
+        [ `TextDocumentContentChangeWholeDocument
+            (TextDocumentContentChangeWholeDocument.create ~text)
+        ]
+      in
+      Client.notification
+        client
+        (TextDocumentDidChange
+           (DidChangeTextDocumentParams.create ~textDocument ~contentChanges))
+    in
+    let operator_items
+          (response :
+            [ `CompletionList of CompletionList.t | `List of CompletionItem.t list ]
+              option)
+      =
+      match response with
+      | None -> []
+      | Some (`CompletionList { items; _ } | `List items) ->
+        List.filter items ~f:(fun (item : CompletionItem.t) ->
+          String.equal item.label "|>" || String.equal item.label "||")
+    in
+    let has_negative_range (item : CompletionItem.t) =
+      match item.textEdit with
+      | Some (`TextEdit { range = { start; _ }; _ }) -> start.character < 0
+      | Some (`InsertReplaceEdit _) | None -> false
+    in
+    let synchronize_document () =
+      let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+      let position = Position.create ~line:0 ~character:0 in
+      let+ (_ : string option) =
+        Client.request
+          client
+          (DebugTextDocumentGet
+             (TextDocumentPositionParams.create ~textDocument ~position))
+      in
+      ()
+    in
+    let rec check attempts =
+      let* response, () =
+        Fiber.fork_and_join
+          (fun () -> request_completions client position)
+          (fun () -> change_document "|")
+      in
+      let items = operator_items response in
+      if List.exists items ~f:has_negative_range
+      then failwith "completion returned a negative edit range"
+      else if attempts = 1
+      then Fiber.return ()
+      else
+        let* () = change_document "\nx" in
+        let* () = synchronize_document () in
+        check (attempts - 1)
+    in
+    check 20);
+  [%expect {| |}]
+;;


### PR DESCRIPTION
Completion parameters identify a position in the document visible when the request is received. The deferred handler previously looked the document up later, allowing `didChange` to replace it before prefix and edit-range calculation and yielding negative coordinates.

Capture the document while dispatching the request and carry that immutable snapshot through completion. Request/change race replays now produce only ranges from the request snapshot.