### PR TITLE
fix(lsp): align declaration and prepare-rename contracts

### DIFF
--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -19,7 +19,6 @@ let skipped_ts_decls =
   ; "ProgressToken"
   ; "ProgressParams"
   ; "TextDocumentFilter"
-  ; "PrepareRenameResult"
   ; "LSPAny"
   ; "LSPObject"
   ; "LSPArray"

--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -7,7 +7,7 @@ type _ t =
   | Initialize : InitializeParams.t -> InitializeResult.t t
   | TextDocumentHover : HoverParams.t -> Hover.t option t
   | TextDocumentDefinition : DefinitionParams.t -> Locations.t option t
-  | TextDocumentDeclaration : TextDocumentPositionParams.t -> Locations.t option t
+  | TextDocumentDeclaration : DeclarationParams.t -> Locations.t option t
   | TextDocumentTypeDefinition : TypeDefinitionParams.t -> Locations.t option t
   | TextDocumentImplementation : ImplementationParams.t -> Locations.t option t
   | TextDocumentCompletion :
@@ -32,7 +32,7 @@ type _ t =
   | TextDocumentPrepareTypeHierarchy :
       TypeHierarchyPrepareParams.t
       -> TypeHierarchyItem.t list option t
-  | TextDocumentPrepareRename : PrepareRenameParams.t -> Range.t option t
+  | TextDocumentPrepareRename : PrepareRenameParams.t -> PrepareRenameResult.t option t
   | TextDocumentRangeFormatting :
       DocumentRangeFormattingParams.t
       -> TextEdit.t list option t
@@ -164,7 +164,7 @@ let yojson_of_result (type a) (req : a t) (result : a) =
   | TextDocumentPrepareTypeHierarchy _, result ->
     Json.Option.yojson_of_t (Json.To.list TypeHierarchyItem.yojson_of_t) result
   | TextDocumentPrepareRename _, result ->
-    Json.Option.yojson_of_t Range.yojson_of_t result
+    Json.Option.yojson_of_t PrepareRenameResult.yojson_of_t result
   | TextDocumentRangeFormatting _, result ->
     Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
   | TextDocumentRangesFormatting _, result ->
@@ -334,7 +334,7 @@ let of_jsonrpc (r : Jsonrpc.Request.t) =
     let+ params = parse DocumentColorParams.t_of_yojson in
     E (TextDocumentColor params)
   | "textDocument/declaration" ->
-    let+ params = parse TextDocumentPositionParams.t_of_yojson in
+    let+ params = parse DeclarationParams.t_of_yojson in
     E (TextDocumentDeclaration params)
   | "textDocument/selectionRange" ->
     let+ params = parse SelectionRangeParams.t_of_yojson in
@@ -510,8 +510,7 @@ let params =
     | TextDocumentColorPresentation params ->
       ret (ColorPresentationParams.yojson_of_t params)
     | TextDocumentColor params -> ret (DocumentColorParams.yojson_of_t params)
-    | TextDocumentDeclaration params ->
-      ret (TextDocumentPositionParams.yojson_of_t params)
+    | TextDocumentDeclaration params -> ret (DeclarationParams.yojson_of_t params)
     | SelectionRange params -> ret (SelectionRangeParams.yojson_of_t params)
     | ExecuteCommand params -> ret (ExecuteCommandParams.yojson_of_t params)
     | SemanticTokensFull params -> ret (SemanticTokensParams.yojson_of_t params)
@@ -573,7 +572,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   | TextDocumentCodeLensResolve _ -> CodeLens.t_of_yojson json
   | TextDocumentPrepareCallHierarchy _ ->
     option_of_yojson (list_of_yojson CallHierarchyItem.t_of_yojson) json
-  | TextDocumentPrepareRename _ -> option_of_yojson Range.t_of_yojson json
+  | TextDocumentPrepareRename _ -> option_of_yojson PrepareRenameResult.t_of_yojson json
   | TextDocumentRangeFormatting _ ->
     option_of_yojson (list_of_yojson TextEdit.t_of_yojson) json
   | TextDocumentRangesFormatting _ ->

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -7,7 +7,7 @@ type _ t =
   | Initialize : InitializeParams.t -> InitializeResult.t t
   | TextDocumentHover : HoverParams.t -> Hover.t option t
   | TextDocumentDefinition : DefinitionParams.t -> Locations.t option t
-  | TextDocumentDeclaration : TextDocumentPositionParams.t -> Locations.t option t
+  | TextDocumentDeclaration : DeclarationParams.t -> Locations.t option t
   | TextDocumentTypeDefinition : TypeDefinitionParams.t -> Locations.t option t
   | TextDocumentImplementation : ImplementationParams.t -> Locations.t option t
   | TextDocumentCompletion :
@@ -32,7 +32,7 @@ type _ t =
   | TextDocumentPrepareTypeHierarchy :
       TypeHierarchyPrepareParams.t
       -> TypeHierarchyItem.t list option t
-  | TextDocumentPrepareRename : PrepareRenameParams.t -> Range.t option t
+  | TextDocumentPrepareRename : PrepareRenameParams.t -> PrepareRenameResult.t option t
   | TextDocumentRangeFormatting :
       DocumentRangeFormattingParams.t
       -> TextEdit.t list option t

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -48972,6 +48972,33 @@ module PrepareRenamePlaceholder = struct
   let create ~(placeholder : string) ~(range : Range.t) : t = { placeholder; range }
 end
 
+module PrepareRenameResult = struct
+  type t =
+    [ `Range of Range.t
+    | `PrepareRenamePlaceholder of PrepareRenamePlaceholder.t
+    | `PrepareRenameDefaultBehavior of PrepareRenameDefaultBehavior.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json -> `Range (Range.t_of_yojson json))
+      ; (fun json ->
+          `PrepareRenamePlaceholder (PrepareRenamePlaceholder.t_of_yojson json))
+      ; (fun json ->
+          `PrepareRenameDefaultBehavior (PrepareRenameDefaultBehavior.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `Range s -> Range.yojson_of_t s
+    | `PrepareRenamePlaceholder s -> PrepareRenamePlaceholder.yojson_of_t s
+    | `PrepareRenameDefaultBehavior s -> PrepareRenameDefaultBehavior.yojson_of_t s
+  ;;
+end
+
 module PreviousResultId = struct
   type t =
     { uri : DocumentUri.t

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -5382,6 +5382,16 @@ module PrepareRenamePlaceholder : sig
   include Json.Jsonable.S with type t := t
 end
 
+module PrepareRenameResult : sig
+  type t =
+    [ `Range of Range.t
+    | `PrepareRenamePlaceholder of PrepareRenamePlaceholder.t
+    | `PrepareRenameDefaultBehavior of PrepareRenameDefaultBehavior.t
+    ]
+
+  include Json.Jsonable.S with type t := t
+end
+
 module PreviousResultId : sig
   type t =
     { uri : DocumentUri.t

--- a/lsp/test/request_tests.ml
+++ b/lsp/test/request_tests.ml
@@ -105,8 +105,10 @@ let%expect_test "declaration request round trip" =
     {
       "method": "textDocument/declaration",
       "params": {
+        "partialResultToken": "partial",
         "position": { "character": 4, "line": 2 },
-        "textDocument": { "uri": "file:///workspace/test.ml" }
+        "textDocument": { "uri": "file:///workspace/test.ml" },
+        "workDoneToken": "work"
       }
     }
     |}]
@@ -139,8 +141,8 @@ let%expect_test "prepare rename result decoding" =
   [%expect
     {|
     range: accepted
-    placeholder: rejected
-    default behavior: rejected
+    placeholder: accepted
+    default behavior: accepted
     null: accepted
     |}]
 ;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -721,14 +721,19 @@ let on_request
      | _ -> now [])
   | TextDocumentHighlight req -> later highlight req
   | DocumentSymbol { textDocument = { uri }; _ } -> later document_symbol uri
-  | TextDocumentDeclaration { textDocument = { uri }; position } ->
+  | TextDocumentDeclaration { textDocument = { uri }; position; _ } ->
     later (fun state () -> Definition_query.run `Declaration state uri position) ()
   | TextDocumentDefinition { textDocument = { uri }; position; _ } ->
     later (fun state () -> Definition_query.run `Definition state uri position) ()
   | TextDocumentTypeDefinition { textDocument = { uri }; position; _ } ->
     later (fun state () -> Definition_query.run `Type_definition state uri position) ()
   | TextDocumentCompletion params -> later (fun _ () -> Compl.complete state params) ()
-  | TextDocumentPrepareRename req -> later Rename.prepare req
+  | TextDocumentPrepareRename req ->
+    later
+      (fun state req ->
+         let+ result = Rename.prepare state req in
+         Option.map result ~f:(fun range -> `Range range))
+      req
   | TextDocumentRename req -> later Rename.rename req
   | TextDocumentFoldingRange req -> later Folding_range.compute req
   | SignatureHelp req -> later Signature_help.run req

--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -54,9 +54,10 @@ let%expect_test "returns location of a declaration" =
      Client.request
        client
        (TextDocumentDeclaration
-          (TextDocumentPositionParams.create
+          (DeclarationParams.create
              ~textDocument
-             ~position:(Position.create ~line:0 ~character:13)))
+             ~position:(Position.create ~line:0 ~character:13)
+             ()))
    in
    print_locations response;
    let* () = Client.request client Shutdown in

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -22,7 +22,7 @@ let rename ?(newName = "new_num") client position =
 
 let print_prepare_rename = function
   | None -> print_endline "null"
-  | Some range -> Range.yojson_of_t range |> Test.print_result
+  | Some result -> PrepareRenameResult.yojson_of_t result |> Test.print_result
 ;;
 
 let print_workspace_edit edit = WorkspaceEdit.yojson_of_t edit |> Test.print_result
@@ -72,11 +72,13 @@ let b = (^*$) 1
     print_prepare_rename response;
     (match response with
      | None -> ()
-     | Some { Range.start; end_ } ->
+     | Some (`Range { Range.start; end_ }) ->
        let placeholder =
          String.sub source ~pos:start.character ~len:(end_.character - start.character)
        in
-       Printf.printf "placeholder: %s\n" placeholder);
+       Printf.printf "placeholder: %s\n" placeholder
+     | Some (`PrepareRenamePlaceholder _ | `PrepareRenameDefaultBehavior _) ->
+       assert false);
     let* response = rename ~newName:"^+$" client position in
     print_workspace_edit response;
     Fiber.return ());


### PR DESCRIPTION
Built on #1981, which captures the previous wire behavior in expect snapshots.

Generate the complete `PrepareRenameResult` union and use it in the typed client-request contract, preserving range, placeholder, default-behavior, and null responses.

Use `DeclarationParams` for declaration requests so work-done and partial-result tokens survive JSON encoding and decoding. The server keeps its existing behavior by wrapping prepare-rename ranges in the generated result variant.