### PR TITLE
test(lsp): expose request contract drift

### DIFF
--- a/lsp/test/request_tests.ml
+++ b/lsp/test/request_tests.ml
@@ -76,3 +76,71 @@ let%expect_test "workspace text document content refresh request round trip" =
     decoded result
     |}]
 ;;
+
+let protocol_uri = DocumentUri.of_string "file:///workspace/test.ml"
+let protocol_position = Position.create ~line:2 ~character:4
+let protocol_range = Range.create ~start:protocol_position ~end_:protocol_position
+let protocol_document = TextDocumentIdentifier.create ~uri:protocol_uri
+
+let%expect_test "declaration request round trip" =
+  let params =
+    `Assoc
+      [ "partialResultToken", `String "partial"
+      ; "position", Position.yojson_of_t protocol_position
+      ; "textDocument", TextDocumentIdentifier.yojson_of_t protocol_document
+      ; "workDoneToken", `String "work"
+      ]
+  in
+  let jsonrpc =
+    Jsonrpc.Request.create ~id:(`Int 1) ~method_:"textDocument/declaration" ~params ()
+  in
+  (match Client_request.of_jsonrpc jsonrpc with
+   | Ok (Client_request.E (Client_request.TextDocumentDeclaration _ as parsed_request)) ->
+     let reencoded = Client_request.to_jsonrpc_request parsed_request ~id:jsonrpc.id in
+     print_json (request_payload reencoded.method_ reencoded.params)
+   | Ok _ -> Stdlib.print_endline "parsed as the wrong request"
+   | Error message -> Stdlib.Printf.printf "parse error: %s\n" message);
+  [%expect
+    {|
+    {
+      "method": "textDocument/declaration",
+      "params": {
+        "position": { "character": 4, "line": 2 },
+        "textDocument": { "uri": "file:///workspace/test.ml" }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "prepare rename result decoding" =
+  let request =
+    Client_request.TextDocumentPrepareRename
+      (PrepareRenameParams.create
+         ~position:protocol_position
+         ~textDocument:protocol_document
+         ())
+  in
+  let results =
+    [ "range", Range.yojson_of_t protocol_range
+    ; ( "placeholder"
+      , `Assoc
+          [ "placeholder", `String "value"; "range", Range.yojson_of_t protocol_range ] )
+    ; "default behavior", `Assoc [ "defaultBehavior", `Bool true ]
+    ; "null", `Null
+    ]
+  in
+  Stdlib.List.iter
+    (fun (name, json) ->
+       Stdlib.Printf.printf "%s: " name;
+       match Client_request.response_of_json request json with
+       | _ -> Stdlib.print_endline "accepted"
+       | exception _ -> Stdlib.print_endline "rejected")
+    results;
+  [%expect
+    {|
+    range: accepted
+    placeholder: rejected
+    default behavior: rejected
+    null: accepted
+    |}]
+;;


### PR DESCRIPTION
Capture the current request-contract behavior before #1979:

- declaration request round trips discard work-done and partial-result tokens;
- prepare-rename accepts range and null results but rejects placeholder and default-behavior results.

The expect snapshots provide a standalone baseline for the follow-up correction.