### PR TITLE
fix(server): suppress help for completed applications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ## Fixes
 
+- Suppress signature help for completed applications. (#1982, #1162, @rgrinberg)
 - Exclude surrounding parentheses from infix operator rename placeholders and
   edits. (#1966, fixes #1190, @rgrinberg)
 - Suppress signature help for applications after the cursor. (#1965, #1162,

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -57,7 +57,17 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
             let function_position =
               Mpipeline.get_lexing_pos pipeline signature.function_position
             in
-            if pos.pos_cnum < function_position.pos_cnum then None else Some signature)
+            let has_unassigned_parameter =
+              List.exists signature.parameters ~f:(fun parameter ->
+                match parameter.argument with
+                | Omitted _ -> true
+                | Arg argument -> argument.exp_loc.loc_ghost)
+            in
+            if
+              pos.pos_cnum < function_position.pos_cnum
+              || (Option.is_none signature.active_param && not has_unassigned_parameter)
+            then None
+            else Some signature)
     in
     (match application_signature with
      | None ->

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -442,29 +442,13 @@ let%expect_test "signature help after a completed application or closed scope" =
   [%expect
     {|
     after completed application
-    {
-      "activeSignature": 0,
-      "signatures": [
-        {
-          "label": "add : int -> int -> int",
-          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
-        }
-      ]
-    }
+    { "signatures": [] }
     |}];
   check "on blank line after terminator" (Position.create ~line:3 ~character:1);
   [%expect
     {|
     on blank line after terminator
-    {
-      "activeSignature": 0,
-      "signatures": [
-        {
-          "label": "add : int -> int -> int",
-          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
-        }
-      ]
-    }
+    { "signatures": [] }
     |}]
 ;;
 


### PR DESCRIPTION
Merlin can keep a completed application selected after the cursor moves beyond it. Suppress signature help when no parameter remains to edit.

Omitted and ghost recovery arguments still count as unassigned, preserving help for incomplete calls and infix expressions. The regression coverage landed first in #1962 and #1975.

Addresses another failure mode from #1162.
