### PR TITLE
refactor(test): simplify code-action application helper

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -2,13 +2,12 @@ open Test.Import
 
 let run_test ~title ~message source =
   let src, range = Code_actions.parse_selection source in
-  Option.iter
-    (Code_actions.apply_code_action
-       ~diagnostics:[ Diagnostic.create ~message:(`String message) ~range () ]
-       title
-       src
-       range)
-    ~f:print_string
+  Code_actions.apply_code_action
+    ~diagnostics:[ Diagnostic.create ~message:(`String message) ~range () ]
+    title
+    src
+    range
+  |> Option.iter ~f:print_string
 ;;
 
 let mark_test = function


### PR DESCRIPTION
Reformat the code-action application helper separately from the position-encoding regression coverage that follows.
