### PR TITLE
test(server): expose comment positions after Unicode

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -73,6 +73,35 @@ let request_completions client position =
           ()))
 ;;
 
+let%expect_test "triggered completion inside a comment after Unicode" =
+  let source = "let _ = \"😀😀\"; List. (* x *)" in
+  let position = Position.create ~line:0 ~character:25 in
+  iter_completions
+    ~triggerCharacter:"."
+    ~triggerKind:CompletionTriggerKind.TriggerCharacter
+    ~source
+    ~position
+    (print_completion_response ~limit:1);
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "'a0 * 'a0 list -> 'a0 List.t",
+      "kind": 4,
+      "label": "(::)",
+      "sortText": "0000",
+      "textEdit": {
+        "newText": "(::)",
+        "range": {
+          "end": { "character": 26, "line": 0 },
+          "start": { "character": 25, "line": 0 }
+        }
+      }
+    }
+    .............
+    |}]
+;;
+
 let%expect_test "completion converts UTF-16 positions before querying Merlin" =
   let source = "let café = List.ma" in
   let position = Position.create ~line:0 ~character:18 in

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -68,6 +68,24 @@ let test source position =
     Fiber.return ())
 ;;
 
+let%expect_test "signature help inside a comment after Unicode" =
+  let source = "let add a b = a + b\nlet _ = \"😀😀\"; add 1 (* x *)" in
+  test source (Position.create ~line:1 ~character:24);
+  [%expect
+    {|
+    {
+      "activeParameter": 0,
+      "activeSignature": 0,
+      "signatures": [
+        {
+          "label": "add : int -> int -> int",
+          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
+        }
+      ]
+    }
+    |}]
+;;
+
 let%expect_test "can provide signature help after a function-type value" =
   let source =
     {ocaml|let map = ListLabels.map


### PR DESCRIPTION
Record triggered completion and signature help leaking from comments when preceding astral characters make UTF-8 byte columns differ from negotiated UTF-16 positions.

The snapshots intentionally preserve the current incorrect responses for a follow-up fix.
