### PR TITLE
fix(server): detect comments after Unicode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Suppress triggered completion and signature help inside comments after Unicode.
+  (#1994, @rgrinberg)
 - Emit semantic tokens in source order so their relative positions remain valid.
   (#1992, @rgrinberg)
 - Stop stale signature help at expression boundaries. (#1987, fixes #1162,

--- a/ocaml-lsp-server/src/check_for_comments.ml
+++ b/ocaml-lsp-server/src/check_for_comments.ml
@@ -1,15 +1,13 @@
 open Import
 
 let position_in_comment ~position ~merlin =
-  let loc_contains_position (_, (loc : Loc.t)) =
-    let start = Position.of_lexical_position loc.loc_start in
-    let end_ = Position.of_lexical_position loc.loc_end in
-    match Option.both start end_ with
-    | Some (start, end_) ->
-      let range = Range.create ~start ~end_ in
-      Lsp.Range.contains_position range position ~inclusive_end:true
-    | None -> false
+  let position =
+    Document.Merlin.to_doc merlin
+    |> Document.text_document
+    |> fun document -> Text_document.absolute_position document position
   in
   Document.Merlin.with_pipeline_exn ~name:"get-comments" merlin (fun pipeline ->
-    Mpipeline.reader_comments pipeline |> List.exists ~f:loc_contains_position)
+    Mpipeline.reader_comments pipeline
+    |> List.exists ~f:(fun (_, (loc : Loc.t)) ->
+      loc.loc_start.pos_cnum <= position && position <= loc.loc_end.pos_cnum))
 ;;

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -82,24 +82,7 @@ let%expect_test "triggered completion inside a comment after Unicode" =
     ~source
     ~position
     (print_completion_response ~limit:1);
-  [%expect
-    {|
-    Completions:
-    {
-      "detail": "'a0 * 'a0 list -> 'a0 List.t",
-      "kind": 4,
-      "label": "(::)",
-      "sortText": "0000",
-      "textEdit": {
-        "newText": "(::)",
-        "range": {
-          "end": { "character": 26, "line": 0 },
-          "start": { "character": 25, "line": 0 }
-        }
-      }
-    }
-    .............
-    |}]
+  [%expect {| No completion Items |}]
 ;;
 
 let%expect_test "completion converts UTF-16 positions before querying Merlin" =

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -71,19 +71,7 @@ let test source position =
 let%expect_test "signature help inside a comment after Unicode" =
   let source = "let add a b = a + b\nlet _ = \"😀😀\"; add 1 (* x *)" in
   test source (Position.create ~line:1 ~character:24);
-  [%expect
-    {|
-    {
-      "activeParameter": 0,
-      "activeSignature": 0,
-      "signatures": [
-        {
-          "label": "add : int -> int -> int",
-          "parameters": [ { "label": [ 6, 9 ] }, { "label": [ 13, 16 ] } ]
-        }
-      ]
-    }
-    |}]
+  [%expect {| { "signatures": [] } |}]
 ;;
 
 let%expect_test "can provide signature help after a function-type value" =


### PR DESCRIPTION
Convert negotiated LSP positions to UTF-8 offsets before comparing them with Merlin comment locations.

This prevents triggered completion and signature help from leaking out of comments when preceding astral characters make UTF-8 and UTF-16 columns differ. The incorrect responses were recorded in #1993.
