### PR TITLE
test(navigation): cover definition and declaration behavior

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/declaration.ml
+++ b/ocaml-lsp-server/test/e2e-new/declaration.ml
@@ -27,7 +27,7 @@ let print_locations = function
       |> print_endline)
 ;;
 
-let%expect_test "returns location of a declaration" =
+let%expect_test "distinguishes a definition from a declaration" =
   let dir = setup_workspace () in
   let path = Filename.concat dir "main.ml" in
   let uri = DocumentUri.of_path path in
@@ -50,22 +50,34 @@ let%expect_test "returns location of a declaration" =
        (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
    in
    let textDocument = TextDocumentIdentifier.create ~uri in
-   let* response =
+   let position = Position.create ~line:0 ~character:13 in
+   let* definition =
      Client.request
        client
-       (TextDocumentDeclaration
-          (DeclarationParams.create
-             ~textDocument
-             ~position:(Position.create ~line:0 ~character:13)
-             ()))
+       (TextDocumentDefinition (DefinitionParams.create ~textDocument ~position ()))
    in
-   print_locations response;
+   print_endline "definition:";
+   print_locations definition;
+   let* declaration =
+     Client.request
+       client
+       (TextDocumentDeclaration (DeclarationParams.create ~textDocument ~position ()))
+   in
+   print_endline "declaration:";
+   print_locations declaration;
    let* () = Client.request client Shutdown in
    let* () = Fiber.Ivar.read diagnostics in
    Client.stop client);
   Unix.close stderr;
   [%expect
     {|
+    definition:
+    lib.ml
+    {
+      "end": { "character": 4, "line": 0 },
+      "start": { "character": 4, "line": 0 }
+    }
+    declaration:
     lib.mli
     {
       "end": { "character": 4, "line": 0 },

--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -9,6 +9,50 @@ let definition client position =
     (TextDocumentDefinition (DefinitionParams.create ~textDocument ~position ()))
 ;;
 
+let print_definition_error label = function
+  | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+    ->
+    Printf.printf "%s: %s" label error.message;
+    Option.iter error.data ~f:(fun data ->
+      Printf.printf " (%s)" (Yojson.Safe.to_string data));
+    print_newline ();
+    Fiber.return ()
+  | Error errors -> Fiber.reraise_all errors
+  | Ok _ ->
+    Printf.printf "%s unexpectedly succeeded\n" label;
+    Fiber.return ()
+;;
+
+let%expect_test "reports definition lookup failures without stopping the server" =
+  let source =
+    "let origin = 1\n\
+     let missing_use = missing\n\
+     let sum = 1 + 2\n\
+     let typed : int = 1\n\
+     let use = origin\n"
+  in
+  let req client =
+    let check label position =
+      let* result = Fiber.collect_errors (fun () -> definition client position) in
+      print_definition_error label result
+    in
+    let* () = check "at origin" (Position.create ~line:0 ~character:4) in
+    let* () = check "missing" (Position.create ~line:1 ~character:18) in
+    let* () = check "builtin" (Position.create ~line:3 ~character:12) in
+    let* response = definition client (Position.create ~line:4 ~character:10) in
+    Printf.printf "server remains usable: %b\n" (Option.is_some response);
+    Fiber.return ()
+  in
+  Helpers.test source req;
+  [%expect
+    {|
+    at origin: Request "Jump to definition" failed. ("Locate: Already at definition point")
+    missing: Request "Jump to definition" failed. ("Locate: Not in environment: missing")
+    builtin: Request "Jump to definition" failed. ("Locate: \"int\" is a builtin, it is not possible to jump to its definition")
+    server remains usable: true
+    |}]
+;;
+
 let%expect_test "returns location of a definition" =
   let source =
     {ocaml|let x = 43


### PR DESCRIPTION
Verify that definition lookup reports at-origin, missing-identifier, and builtin errors without making the server unusable for subsequent requests.

Extend the cross-file navigation fixture to assert that definition resolves to the implementation while declaration resolves to the interface.