### PR TITLE
fix(diagnostics): clamp Merlin ranges to source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ## Fixes
 
+- Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)
 - Suppress triggered completion and signature help inside comments after Unicode.
   (#1994, @rgrinberg)
 - Emit semantic tokens in source order so their relative positions remain valid.

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -296,6 +296,15 @@ let extract_related_errors uri raw_message =
   | _ -> raw_message, None
 ;;
 
+let clamp_range_to_source source ({ Range.start; end_ } : Range.t) =
+  let clamp position =
+    let offset = Msource.get_offset source (Position.logical position) in
+    let (`Logical (line, character)) = Msource.get_logical source offset in
+    Position.create ~line:(line - 1) ~character
+  in
+  Range.create ~start:(clamp start) ~end_:(clamp end_)
+;;
+
 let first_n_lines_of_range (range : Range.t) n =
   if range.end_.line - range.start.line < n
   then range
@@ -310,7 +319,8 @@ let error_to_diagnostics ~diagnostics ~merlin error =
   let create_diagnostic = Diagnostic.create ~source:ocamllsp_source in
   let uri = Document.uri doc in
   let loc = Loc.loc_of_report error in
-  let original_range = Range.of_loc loc in
+  let source = Document.Merlin.source merlin in
+  let original_range = Range.of_loc loc |> clamp_range_to_source source in
   let range =
     if diagnostics.shorten_merlin_diagnostics
     then first_n_lines_of_range original_range 1
@@ -334,7 +344,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
          , Some
              (List.map error.sub ~f:(fun (sub : Loc.msg) ->
                 let location =
-                  let range = Range.of_loc sub.loc in
+                  let range = Range.of_loc sub.loc |> clamp_range_to_source source in
                   Location.create ~range ~uri
                 in
                 let message = make_message Loc.print_sub_msg sub in
@@ -367,6 +377,7 @@ let error_to_diagnostics ~diagnostics ~merlin error =
 let merlin_diagnostics diagnostics merlin =
   let doc = Document.Merlin.to_doc merlin in
   let uri = Document.uri doc in
+  let source = Document.Merlin.source merlin in
   let create_diagnostic = Diagnostic.create ~source:ocamllsp_source in
   let open Fiber.O in
   let+ all_diagnostics =
@@ -390,7 +401,7 @@ let merlin_diagnostics diagnostics merlin =
         let holes_as_err_diags =
           Query_commands.dispatch pipeline Holes
           |> List.rev_map ~f:(fun (loc, typ) ->
-            let range = Range.of_loc loc in
+            let range = Range.of_loc loc |> clamp_range_to_source source in
             let severity = DiagnosticSeverity.Error in
             let message =
               "This typed hole should be replaced with an expression of type " ^ typ

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -50,14 +50,14 @@ let print_diagnostic expected_message params =
   | Some diagnostic -> Diagnostic.yojson_of_t diagnostic |> Test.print_result
 ;;
 
-let%expect_test "recovery diagnostic ends past EOF" =
+let%expect_test "recovery diagnostic is clamped to EOF" =
   test ~print:(print_diagnostic "Uninterpreted extension ''.") "(let";
   [%expect
     {|
     {
       "message": "Uninterpreted extension ''.",
       "range": {
-        "end": { "character": 0, "line": 1 },
+        "end": { "character": 4, "line": 0 },
         "start": { "character": 0, "line": 0 }
       },
       "severity": 1,


### PR DESCRIPTION
Follow-up to #1990.

Merlin recovery diagnostics can report locations beyond the current buffer. For example, the diagnostic for `(let` ends at line 1 even though the one-line document has no trailing newline.

Round-trip Merlin diagnostic positions through the source before publishing them, which clamps out-of-bounds positions to a valid source boundary. Apply the same normalization to primary diagnostics, related diagnostics, and typed-hole diagnostics. The reproducer now ends at the actual EOF, `(0,4)`.
