### PR TITLE
fix(server): honor signature-help label offset support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   (#2055, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal
   error. (#2038, @rgrinberg)
+- Respect client support for signature-help parameter-label offsets. (#2009,
+  @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)
 - Suppress triggered completion and signature help inside comments after Unicode.
   (#1994, @rgrinberg)

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -128,6 +128,17 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
          sprintf "%s : " fun_name
        in
        let offset = String.length prefix in
+       let supports_parameter_label_offsets =
+         let open Option.O in
+         let support =
+           let* text_document = (State.client_capabilities state).textDocument in
+           let* signature_help = text_document.signatureHelp in
+           let* signature_information = signature_help.signatureInformation in
+           let* parameter_information = signature_information.parameterInformation in
+           parameter_information.labelOffsetSupport
+         in
+         Option.value support ~default:false
+       in
        let+ doc =
          Document.Merlin.doc_comment
            ~name:"signature help-position"
@@ -139,7 +150,16 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
            List.map
              application_signature.parameters
              ~f:(fun (p : Merlin_analysis.Signature_help.parameter_info) ->
-               let label = `Offset (offset + p.param_start, offset + p.param_end) in
+               let label =
+                 if supports_parameter_label_offsets
+                 then `Offset (offset + p.param_start, offset + p.param_end)
+                 else
+                   `String
+                     (String.sub
+                        application_signature.signature
+                        ~pos:p.param_start
+                        ~len:(p.param_end - p.param_start))
+               in
                ParameterInformation.create ~label ())
          in
          let documentation =

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -126,13 +126,13 @@ let%expect_test "parameter label representation follows client capabilities" =
   [%expect
     {|
     labelOffsetSupport omitted
-    [ [ 6, 18 ], [ 22, 29 ] ]
+    [ "f:('a -> 'b)", "'a list" ]
     |}];
   check "labelOffsetSupport false" (Some false);
   [%expect
     {|
     labelOffsetSupport false
-    [ [ 6, 18 ], [ 22, 29 ] ]
+    [ "f:('a -> 'b)", "'a list" ]
     |}];
   check "labelOffsetSupport true" (Some true);
   [%expect


### PR DESCRIPTION
`ParameterInformation.label` offsets require clients to advertise `labelOffsetSupport`. Return substring labels when that capability is absent or false, while preserving offset labels for clients that support them.

The capability matrix landed first in #2000.
