### PR TITLE
fix(lsp): generate document filter contracts

### DIFF
--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -17,7 +17,6 @@ let skipped_ts_decls =
   ; "MarkedString"
   ; "ProgressToken"
   ; "ProgressParams"
-  ; "TextDocumentFilter"
   ; "LSPAny"
   ; "LSPObject"
   ; "LSPArray"
@@ -419,6 +418,7 @@ end = struct
                | Ident Number -> "Int", [ type_ t ]
                | Ident Object -> "Assoc", [ type_ t ]
                | Ident Bool -> "Bool", [ type_ t ]
+               | Ident Uri -> "DocumentUri", [ type_ t ]
                | List _ | Ident List -> "List", [ type_ t ]
                | Ident (Resolved r) -> (Entities.find db r).name, [ type_ t ]
                | Tuple [ Ident Uinteger; Ident Uinteger ] -> "Offset", [ type_ t ]

--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -17,14 +17,10 @@ let skipped_ts_decls =
   ; "MarkedString"
   ; "ProgressToken"
   ; "ProgressParams"
-  ; "TextDocumentFilter"
   ; "LSPAny"
   ; "LSPObject"
   ; "LSPArray"
   ; "LSPErrorCodes"
-  ; "NotebookDocumentSyncOptions"
-  ; "NotebookDocumentFilter"
-  ; "NotebookDocumentSyncRegistrationOptions"
   ; "URI"
   ]
 ;;
@@ -419,6 +415,7 @@ end = struct
                | Ident Number -> "Int", [ type_ t ]
                | Ident Object -> "Assoc", [ type_ t ]
                | Ident Bool -> "Bool", [ type_ t ]
+               | Ident Uri -> "DocumentUri", [ type_ t ]
                | List _ | Ident List -> "List", [ type_ t ]
                | Ident (Resolved r) -> (Entities.find db r).name, [ type_ t ]
                | Tuple [ Ident Uinteger; Ident Uinteger ] -> "Offset", [ type_ t ]

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -189,131 +189,6 @@ module ProgressParams = struct
   let create ~(token : ProgressToken.t) ~value = { token; value }
 end
 
-module TextDocumentFilter = struct
-  type t =
-    { language : string option
-    ; scheme : string option
-    ; pattern : string option
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilter.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let language_field = ref Ppx_yojson_conv_lib.Option.None
-       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
-       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "language" ->
-              (match Ppx_yojson_conv_lib.( ! ) language_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "scheme" ->
-              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "pattern" ->
-              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) language_field
-                , Ppx_yojson_conv_lib.( ! ) scheme_field
-                , Ppx_yojson_conv_lib.( ! ) pattern_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some language_value
-                , Ppx_yojson_conv_lib.Option.Some scheme_value
-                , Ppx_yojson_conv_lib.Option.Some pattern_value ) ->
-                { language = language_value
-                ; scheme = scheme_value
-                ; pattern = pattern_value
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) language_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "language" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) scheme_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "scheme" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "pattern" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { language = v_language; scheme = v_scheme; pattern = v_pattern } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_pattern in
-         ("pattern", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_scheme in
-         ("scheme", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_language in
-         ("language", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ?language ?scheme ?pattern () = { language; scheme; pattern }
-end
-
 (*$ Lsp_gen.print_ml () *)
 module ApplyKind = struct
   type t =
@@ -5571,8 +5446,28 @@ module WorkspaceFolder = struct
 end
 
 module RelativePattern = struct
+  type baseUri_pvar =
+    [ `WorkspaceFolder of WorkspaceFolder.t
+    | `DocumentUri of DocumentUri.t
+    ]
+
+  let baseUri_pvar_of_yojson (json : Json.t) : baseUri_pvar =
+    Json.Of.untagged_union
+      "baseUri_pvar"
+      [ (fun json -> `WorkspaceFolder (WorkspaceFolder.t_of_yojson json))
+      ; (fun json -> `DocumentUri (DocumentUri.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_baseUri_pvar (baseUri_pvar : baseUri_pvar) : Json.t =
+    match baseUri_pvar with
+    | `WorkspaceFolder s -> WorkspaceFolder.yojson_of_t s
+    | `DocumentUri s -> DocumentUri.yojson_of_t s
+  ;;
+
   type t =
-    { baseUri : unit
+    { baseUri : baseUri_pvar
     ; pattern : Pattern.t
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -5593,7 +5488,7 @@ module RelativePattern = struct
             | "baseUri" ->
               (match Ppx_yojson_conv_lib.( ! ) baseUri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = unit_of_yojson _field_yojson in
+                 let fvalue = baseUri_pvar_of_yojson _field_yojson in
                  baseUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -5659,7 +5554,7 @@ module RelativePattern = struct
          ("pattern", arg) :: bnds
        in
        let bnds =
-         let arg = yojson_of_unit v_baseUri in
+         let arg = yojson_of_baseUri_pvar v_baseUri in
          ("baseUri", arg) :: bnds
        in
        `Assoc bnds
@@ -5670,7 +5565,7 @@ module RelativePattern = struct
 
   [@@@end]
 
-  let create ~(baseUri : unit) ~(pattern : Pattern.t) : t = { baseUri; pattern }
+  let create ~(baseUri : baseUri_pvar) ~(pattern : Pattern.t) : t = { baseUri; pattern }
 end
 
 module GlobPattern = struct
@@ -6700,6 +6595,34 @@ module TextDocumentFilterLanguage = struct
     : t
     =
     { language; pattern; scheme }
+  ;;
+end
+
+module TextDocumentFilter = struct
+  type t =
+    [ `TextDocumentFilterLanguage of TextDocumentFilterLanguage.t
+    | `TextDocumentFilterScheme of TextDocumentFilterScheme.t
+    | `TextDocumentFilterPattern of TextDocumentFilterPattern.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `TextDocumentFilterLanguage (TextDocumentFilterLanguage.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentFilterScheme (TextDocumentFilterScheme.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentFilterPattern (TextDocumentFilterPattern.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `TextDocumentFilterLanguage s -> TextDocumentFilterLanguage.yojson_of_t s
+    | `TextDocumentFilterScheme s -> TextDocumentFilterScheme.yojson_of_t s
+    | `TextDocumentFilterPattern s -> TextDocumentFilterPattern.yojson_of_t s
   ;;
 end
 

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -1,42 +1,6 @@
 open! Import
 open Json.Conv
 
-module NotebookDocumentSyncOptions = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
-module NotebookDocumentSyncRegistrationOptions = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
-module NotebookDocumentFilter = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
 module MarkedString = struct
   type t =
     { value : string
@@ -187,131 +151,6 @@ module ProgressParams = struct
   [@@@end]
 
   let create ~(token : ProgressToken.t) ~value = { token; value }
-end
-
-module TextDocumentFilter = struct
-  type t =
-    { language : string option
-    ; scheme : string option
-    ; pattern : string option
-    }
-  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
-
-  let _ = fun (_ : t) -> ()
-
-  let t_of_yojson =
-    (let _tp_loc = "lsp/src/types.ml.TextDocumentFilter.t" in
-     function
-     | `Assoc field_yojsons as yojson ->
-       let language_field = ref Ppx_yojson_conv_lib.Option.None
-       and scheme_field = ref Ppx_yojson_conv_lib.Option.None
-       and pattern_field = ref Ppx_yojson_conv_lib.Option.None
-       and duplicates = ref []
-       and extra = ref [] in
-       let rec iter = function
-         | (field_name, _field_yojson) :: tail ->
-           (match field_name with
-            | "language" ->
-              (match Ppx_yojson_conv_lib.( ! ) language_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 language_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "scheme" ->
-              (match Ppx_yojson_conv_lib.( ! ) scheme_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 scheme_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | "pattern" ->
-              (match Ppx_yojson_conv_lib.( ! ) pattern_field with
-               | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = option_of_yojson string_of_yojson _field_yojson in
-                 pattern_field := Ppx_yojson_conv_lib.Option.Some fvalue
-               | Ppx_yojson_conv_lib.Option.Some _ ->
-                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
-            | _ -> ());
-           iter tail
-         | [] -> ()
-       in
-       iter field_yojsons;
-       (match Ppx_yojson_conv_lib.( ! ) duplicates with
-        | _ :: _ ->
-          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
-            _tp_loc
-            (Ppx_yojson_conv_lib.( ! ) duplicates)
-            yojson
-        | [] ->
-          (match Ppx_yojson_conv_lib.( ! ) extra with
-           | _ :: _ ->
-             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
-               _tp_loc
-               (Ppx_yojson_conv_lib.( ! ) extra)
-               yojson
-           | [] ->
-             (match
-                ( Ppx_yojson_conv_lib.( ! ) language_field
-                , Ppx_yojson_conv_lib.( ! ) scheme_field
-                , Ppx_yojson_conv_lib.( ! ) pattern_field )
-              with
-              | ( Ppx_yojson_conv_lib.Option.Some language_value
-                , Ppx_yojson_conv_lib.Option.Some scheme_value
-                , Ppx_yojson_conv_lib.Option.Some pattern_value ) ->
-                { language = language_value
-                ; scheme = scheme_value
-                ; pattern = pattern_value
-                }
-              | _ ->
-                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
-                  _tp_loc
-                  yojson
-                  [ ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) language_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "language" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) scheme_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "scheme" )
-                  ; ( Ppx_yojson_conv_lib.poly_equal
-                        (Ppx_yojson_conv_lib.( ! ) pattern_field)
-                        Ppx_yojson_conv_lib.Option.None
-                    , "pattern" )
-                  ])))
-     | _ as yojson ->
-       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
-     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  ;;
-
-  let _ = t_of_yojson
-
-  let yojson_of_t =
-    (function
-     | { language = v_language; scheme = v_scheme; pattern = v_pattern } ->
-       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_pattern in
-         ("pattern", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_scheme in
-         ("scheme", arg) :: bnds
-       in
-       let bnds =
-         let arg = yojson_of_option yojson_of_string v_language in
-         ("language", arg) :: bnds
-       in
-       `Assoc bnds
-     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  ;;
-
-  let _ = yojson_of_t
-
-  [@@@end]
-
-  let create ?language ?scheme ?pattern () = { language; scheme; pattern }
 end
 
 (*$ Lsp_gen.print_ml () *)
@@ -5571,8 +5410,28 @@ module WorkspaceFolder = struct
 end
 
 module RelativePattern = struct
+  type baseUri_pvar =
+    [ `WorkspaceFolder of WorkspaceFolder.t
+    | `DocumentUri of DocumentUri.t
+    ]
+
+  let baseUri_pvar_of_yojson (json : Json.t) : baseUri_pvar =
+    Json.Of.untagged_union
+      "baseUri_pvar"
+      [ (fun json -> `WorkspaceFolder (WorkspaceFolder.t_of_yojson json))
+      ; (fun json -> `DocumentUri (DocumentUri.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_baseUri_pvar (baseUri_pvar : baseUri_pvar) : Json.t =
+    match baseUri_pvar with
+    | `WorkspaceFolder s -> WorkspaceFolder.yojson_of_t s
+    | `DocumentUri s -> DocumentUri.yojson_of_t s
+  ;;
+
   type t =
-    { baseUri : unit
+    { baseUri : baseUri_pvar
     ; pattern : Pattern.t
     }
   [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
@@ -5593,7 +5452,7 @@ module RelativePattern = struct
             | "baseUri" ->
               (match Ppx_yojson_conv_lib.( ! ) baseUri_field with
                | Ppx_yojson_conv_lib.Option.None ->
-                 let fvalue = unit_of_yojson _field_yojson in
+                 let fvalue = baseUri_pvar_of_yojson _field_yojson in
                  baseUri_field := Ppx_yojson_conv_lib.Option.Some fvalue
                | Ppx_yojson_conv_lib.Option.Some _ ->
                  duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
@@ -5659,7 +5518,7 @@ module RelativePattern = struct
          ("pattern", arg) :: bnds
        in
        let bnds =
-         let arg = yojson_of_unit v_baseUri in
+         let arg = yojson_of_baseUri_pvar v_baseUri in
          ("baseUri", arg) :: bnds
        in
        `Assoc bnds
@@ -5670,7 +5529,7 @@ module RelativePattern = struct
 
   [@@@end]
 
-  let create ~(baseUri : unit) ~(pattern : Pattern.t) : t = { baseUri; pattern }
+  let create ~(baseUri : baseUri_pvar) ~(pattern : Pattern.t) : t = { baseUri; pattern }
 end
 
 module GlobPattern = struct
@@ -6129,6 +5988,36 @@ module NotebookDocumentFilterNotebookType = struct
     : t
     =
     { notebookType; pattern; scheme }
+  ;;
+end
+
+module NotebookDocumentFilter = struct
+  type t =
+    [ `NotebookDocumentFilterNotebookType of NotebookDocumentFilterNotebookType.t
+    | `NotebookDocumentFilterScheme of NotebookDocumentFilterScheme.t
+    | `NotebookDocumentFilterPattern of NotebookDocumentFilterPattern.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `NotebookDocumentFilterNotebookType
+            (NotebookDocumentFilterNotebookType.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterScheme (NotebookDocumentFilterScheme.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterPattern (NotebookDocumentFilterPattern.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `NotebookDocumentFilterNotebookType s ->
+      NotebookDocumentFilterNotebookType.yojson_of_t s
+    | `NotebookDocumentFilterScheme s -> NotebookDocumentFilterScheme.yojson_of_t s
+    | `NotebookDocumentFilterPattern s -> NotebookDocumentFilterPattern.yojson_of_t s
   ;;
 end
 
@@ -6700,6 +6589,34 @@ module TextDocumentFilterLanguage = struct
     : t
     =
     { language; pattern; scheme }
+  ;;
+end
+
+module TextDocumentFilter = struct
+  type t =
+    [ `TextDocumentFilterLanguage of TextDocumentFilterLanguage.t
+    | `TextDocumentFilterScheme of TextDocumentFilterScheme.t
+    | `TextDocumentFilterPattern of TextDocumentFilterPattern.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `TextDocumentFilterLanguage (TextDocumentFilterLanguage.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentFilterScheme (TextDocumentFilterScheme.t_of_yojson json))
+      ; (fun json ->
+          `TextDocumentFilterPattern (TextDocumentFilterPattern.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `TextDocumentFilterLanguage s -> TextDocumentFilterLanguage.yojson_of_t s
+    | `TextDocumentFilterScheme s -> TextDocumentFilterScheme.yojson_of_t s
+    | `TextDocumentFilterPattern s -> TextDocumentFilterPattern.yojson_of_t s
   ;;
 end
 
@@ -41690,6 +41607,323 @@ module NotebookDocumentFilterWithNotebook = struct
     : t
     =
     { cells; notebook }
+  ;;
+end
+
+module NotebookDocumentSyncRegistrationOptions = struct
+  type notebookSelector_pvar =
+    [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+    | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+    ]
+
+  let notebookSelector_pvar_of_yojson (json : Json.t) : notebookSelector_pvar =
+    Json.Of.untagged_union
+      "notebookSelector_pvar"
+      [ (fun json ->
+          `NotebookDocumentFilterWithNotebook
+            (NotebookDocumentFilterWithNotebook.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterWithCells
+            (NotebookDocumentFilterWithCells.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_notebookSelector_pvar (notebookSelector_pvar : notebookSelector_pvar)
+    : Json.t
+    =
+    match notebookSelector_pvar with
+    | `NotebookDocumentFilterWithNotebook s ->
+      NotebookDocumentFilterWithNotebook.yojson_of_t s
+    | `NotebookDocumentFilterWithCells s -> NotebookDocumentFilterWithCells.yojson_of_t s
+  ;;
+
+  type t =
+    { id : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    ; notebookSelector : notebookSelector_pvar list
+    ; save : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentSyncRegistrationOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let id_field = ref Ppx_yojson_conv_lib.Option.None
+       and notebookSelector_field = ref Ppx_yojson_conv_lib.Option.None
+       and save_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "id" ->
+              (match Ppx_yojson_conv_lib.( ! ) id_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 id_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "notebookSelector" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookSelector_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson notebookSelector_pvar_of_yojson _field_yojson
+                 in
+                 notebookSelector_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "save" ->
+              (match Ppx_yojson_conv_lib.( ! ) save_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 save_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) id_field
+                , Ppx_yojson_conv_lib.( ! ) notebookSelector_field
+                , Ppx_yojson_conv_lib.( ! ) save_field )
+              with
+              | ( id_value
+                , Ppx_yojson_conv_lib.Option.Some notebookSelector_value
+                , save_value ) ->
+                { id =
+                    (match id_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; notebookSelector = notebookSelector_value
+                ; save =
+                    (match save_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebookSelector_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebookSelector" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { id = v_id; notebookSelector = v_notebookSelector; save = v_save } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_save
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_save in
+           let bnd = "save", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_list yojson_of_notebookSelector_pvar v_notebookSelector in
+         ("notebookSelector", arg) :: bnds
+       in
+       let bnds =
+         if None = v_id
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_id in
+           let bnd = "id", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(id : string option)
+        ~(notebookSelector : notebookSelector_pvar list)
+        ?(save : bool option)
+        (() : unit)
+    : t
+    =
+    { id; notebookSelector; save }
+  ;;
+end
+
+module NotebookDocumentSyncOptions = struct
+  type notebookSelector_pvar =
+    [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+    | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+    ]
+
+  let notebookSelector_pvar_of_yojson (json : Json.t) : notebookSelector_pvar =
+    Json.Of.untagged_union
+      "notebookSelector_pvar"
+      [ (fun json ->
+          `NotebookDocumentFilterWithNotebook
+            (NotebookDocumentFilterWithNotebook.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterWithCells
+            (NotebookDocumentFilterWithCells.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_notebookSelector_pvar (notebookSelector_pvar : notebookSelector_pvar)
+    : Json.t
+    =
+    match notebookSelector_pvar with
+    | `NotebookDocumentFilterWithNotebook s ->
+      NotebookDocumentFilterWithNotebook.yojson_of_t s
+    | `NotebookDocumentFilterWithCells s -> NotebookDocumentFilterWithCells.yojson_of_t s
+  ;;
+
+  type t =
+    { notebookSelector : notebookSelector_pvar list
+    ; save : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentSyncOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let notebookSelector_field = ref Ppx_yojson_conv_lib.Option.None
+       and save_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "notebookSelector" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookSelector_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson notebookSelector_pvar_of_yojson _field_yojson
+                 in
+                 notebookSelector_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "save" ->
+              (match Ppx_yojson_conv_lib.( ! ) save_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 save_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) notebookSelector_field
+                , Ppx_yojson_conv_lib.( ! ) save_field )
+              with
+              | Ppx_yojson_conv_lib.Option.Some notebookSelector_value, save_value ->
+                { notebookSelector = notebookSelector_value
+                ; save =
+                    (match save_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebookSelector_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebookSelector" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { notebookSelector = v_notebookSelector; save = v_save } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_save
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_save in
+           let bnd = "save", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_list yojson_of_notebookSelector_pvar v_notebookSelector in
+         ("notebookSelector", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(notebookSelector : notebookSelector_pvar list)
+        ?(save : bool option)
+        (() : unit)
+    : t
+    =
+    { notebookSelector; save }
   ;;
 end
 

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -49,16 +49,6 @@ module NotebookDocumentFilter : sig
   include Json.Jsonable.S with type t := t
 end
 
-module TextDocumentFilter : sig
-  type t =
-    { language : string option
-    ; scheme : string option
-    ; pattern : string option
-    }
-
-  val create : ?language:string -> ?scheme:string -> ?pattern:string -> unit -> t
-end
-
 (*$ Lsp_gen.print_mli () *)
 module ApplyKind : sig
   type t =
@@ -971,11 +961,14 @@ end
 
 module RelativePattern : sig
   type t =
-    { baseUri : unit
+    { baseUri : [ `WorkspaceFolder of WorkspaceFolder.t | `DocumentUri of DocumentUri.t ]
     ; pattern : Pattern.t
     }
 
-  val create : baseUri:unit -> pattern:Pattern.t -> t
+  val create
+    :  baseUri:[ `WorkspaceFolder of WorkspaceFolder.t | `DocumentUri of DocumentUri.t ]
+    -> pattern:Pattern.t
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1089,6 +1082,16 @@ module TextDocumentFilterLanguage : sig
     }
 
   val create : language:string -> ?pattern:GlobPattern.t -> ?scheme:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentFilter : sig
+  type t =
+    [ `TextDocumentFilterLanguage of TextDocumentFilterLanguage.t
+    | `TextDocumentFilterScheme of TextDocumentFilterScheme.t
+    | `TextDocumentFilterPattern of TextDocumentFilterPattern.t
+    ]
 
   include Json.Jsonable.S with type t := t
 end

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -31,34 +31,6 @@ module ProgressParams : sig
   include Json.Jsonable.S1 with type 'a t := 'a t
 end
 
-module NotebookDocumentSyncOptions : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
-module NotebookDocumentSyncRegistrationOptions : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
-module NotebookDocumentFilter : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
-module TextDocumentFilter : sig
-  type t =
-    { language : string option
-    ; scheme : string option
-    ; pattern : string option
-    }
-
-  val create : ?language:string -> ?scheme:string -> ?pattern:string -> unit -> t
-end
-
 (*$ Lsp_gen.print_mli () *)
 module ApplyKind : sig
   type t =
@@ -971,11 +943,14 @@ end
 
 module RelativePattern : sig
   type t =
-    { baseUri : unit
+    { baseUri : [ `WorkspaceFolder of WorkspaceFolder.t | `DocumentUri of DocumentUri.t ]
     ; pattern : Pattern.t
     }
 
-  val create : baseUri:unit -> pattern:Pattern.t -> t
+  val create
+    :  baseUri:[ `WorkspaceFolder of WorkspaceFolder.t | `DocumentUri of DocumentUri.t ]
+    -> pattern:Pattern.t
+    -> t
 
   include Json.Jsonable.S with type t := t
 end
@@ -1040,6 +1015,16 @@ module NotebookDocumentFilterNotebookType : sig
   include Json.Jsonable.S with type t := t
 end
 
+module NotebookDocumentFilter : sig
+  type t =
+    [ `NotebookDocumentFilterNotebookType of NotebookDocumentFilterNotebookType.t
+    | `NotebookDocumentFilterScheme of NotebookDocumentFilterScheme.t
+    | `NotebookDocumentFilterPattern of NotebookDocumentFilterPattern.t
+    ]
+
+  include Json.Jsonable.S with type t := t
+end
+
 module NotebookCellTextDocumentFilter : sig
   type t =
     { language : string option
@@ -1089,6 +1074,16 @@ module TextDocumentFilterLanguage : sig
     }
 
   val create : language:string -> ?pattern:GlobPattern.t -> ?scheme:string -> unit -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module TextDocumentFilter : sig
+  type t =
+    [ `TextDocumentFilterLanguage of TextDocumentFilterLanguage.t
+    | `TextDocumentFilterScheme of TextDocumentFilterScheme.t
+    | `TextDocumentFilterPattern of TextDocumentFilterPattern.t
+    ]
 
   include Json.Jsonable.S with type t := t
 end
@@ -4591,6 +4586,54 @@ module NotebookDocumentFilterWithNotebook : sig
     :  ?cells:NotebookCellLanguage.t list
     -> notebook:
          [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentSyncRegistrationOptions : sig
+  type t =
+    { id : string option
+    ; notebookSelector :
+        [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+        | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+        ]
+          list
+    ; save : bool option
+    }
+
+  val create
+    :  ?id:string
+    -> notebookSelector:
+         [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+         | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+         ]
+           list
+    -> ?save:bool
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentSyncOptions : sig
+  type t =
+    { notebookSelector :
+        [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+        | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+        ]
+          list
+    ; save : bool option
+    }
+
+  val create
+    :  notebookSelector:
+         [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+         | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+         ]
+           list
+    -> ?save:bool
     -> unit
     -> t
 

--- a/lsp/test/contract_tests.ml
+++ b/lsp/test/contract_tests.ml
@@ -13,7 +13,9 @@ let check_decode label decode json =
 let%expect_test "document filter wire contract" =
   let encoded =
     DocumentFilter.yojson_of_t
-      (`TextDocumentFilter (TextDocumentFilter.create ~language:"ocaml" ()))
+      (`TextDocumentFilter
+          (`TextDocumentFilterLanguage
+              (TextDocumentFilterLanguage.create ~language:"ocaml" ())))
   in
   print_json encoded;
   check_decode
@@ -26,14 +28,16 @@ let%expect_test "document filter wire contract" =
     (`Assoc [ "baseUri", `String "file:///workspace"; "pattern", `String "**/*.ml" ]);
   [%expect
     {|
-    { "language": "ocaml", "scheme": null, "pattern": null }
-    language filter: rejected
-    relative pattern: rejected
+    { "language": "ocaml" }
+    language filter: accepted
+    relative pattern: accepted
     |}]
 ;;
 
 let%expect_test "notebook sync wire contract" =
-  print_json (NotebookDocumentSyncOptions.yojson_of_t ());
+  print_json
+    (NotebookDocumentSyncOptions.yojson_of_t
+       (NotebookDocumentSyncOptions.create ~notebookSelector:[] ()));
   check_decode
     "sync options"
     NotebookDocumentSyncOptions.t_of_yojson
@@ -48,9 +52,9 @@ let%expect_test "notebook sync wire contract" =
     (`Assoc [ "notebookType", `String "jupyter-notebook" ]);
   [%expect
     {|
-    null
-    sync options: rejected
-    registration options: rejected
-    notebook filter: rejected
+    { "notebookSelector": [] }
+    sync options: accepted
+    registration options: accepted
+    notebook filter: accepted
     |}]
 ;;

--- a/lsp/test/contract_tests.ml
+++ b/lsp/test/contract_tests.ml
@@ -10,25 +10,36 @@ let check_decode label decode json =
   | exception _ -> Stdlib.print_endline "rejected"
 ;;
 
+let print_decoded label decode encode json =
+  Stdlib.Printf.printf "%s:\n" label;
+  decode json |> encode |> print_json
+;;
+
 let%expect_test "document filter wire contract" =
   let encoded =
     DocumentFilter.yojson_of_t
-      (`TextDocumentFilter (TextDocumentFilter.create ~language:"ocaml" ()))
+      (`TextDocumentFilter
+          (`TextDocumentFilterLanguage
+              (TextDocumentFilterLanguage.create ~language:"ocaml" ())))
   in
   print_json encoded;
-  check_decode
+  print_decoded
     "language filter"
     DocumentFilter.t_of_yojson
+    DocumentFilter.yojson_of_t
     (`Assoc [ "language", `String "ocaml" ]);
-  check_decode
+  print_decoded
     "relative pattern"
     RelativePattern.t_of_yojson
+    RelativePattern.yojson_of_t
     (`Assoc [ "baseUri", `String "file:///workspace"; "pattern", `String "**/*.ml" ]);
   [%expect
     {|
-    { "language": "ocaml", "scheme": null, "pattern": null }
-    language filter: rejected
-    relative pattern: rejected
+    { "language": "ocaml" }
+    language filter:
+    { "language": "ocaml" }
+    relative pattern:
+    { "baseUri": "file:///workspace", "pattern": "**/*.ml" }
     |}]
 ;;
 

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -73,7 +73,10 @@ let register_request t uris =
         let registerOptions =
           let documentSelector =
             [ `TextDocumentFilter
-                (TextDocumentFilter.create ~pattern:(Uri.to_path uri) ())
+                (`TextDocumentFilterPattern
+                    (TextDocumentFilterPattern.create
+                       ~pattern:(`Pattern (Uri.to_path uri))
+                       ()))
             ]
           in
           CodeActionRegistrationOptions.create

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -75,7 +75,10 @@ let register_request t uris =
         let registerOptions =
           let documentSelector =
             [ `TextDocumentFilter
-                (TextDocumentFilter.create ~pattern:(Uri.to_path uri) ())
+                (`TextDocumentFilterPattern
+                    (TextDocumentFilterPattern.create
+                       ~pattern:(`Pattern (Uri.to_path uri))
+                       ()))
             ]
           in
           CodeActionRegistrationOptions.create

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -288,6 +288,8 @@ include struct
   module TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument
   module TextDocumentEdit = TextDocumentEdit
   module TextDocumentFilter = TextDocumentFilter
+  module TextDocumentFilterLanguage = TextDocumentFilterLanguage
+  module TextDocumentFilterPattern = TextDocumentFilterPattern
   module TextDocumentIdentifier = TextDocumentIdentifier
   module TextDocumentItem = TextDocumentItem
   module TextDocumentRegistrationOptions = TextDocumentRegistrationOptions

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -293,6 +293,8 @@ include struct
   module TextDocumentContentChangeWholeDocument = TextDocumentContentChangeWholeDocument
   module TextDocumentEdit = TextDocumentEdit
   module TextDocumentFilter = TextDocumentFilter
+  module TextDocumentFilterLanguage = TextDocumentFilterLanguage
+  module TextDocumentFilterPattern = TextDocumentFilterPattern
   module TextDocumentIdentifier = TextDocumentIdentifier
   module TextDocumentItem = TextDocumentItem
   module TextDocumentRegistrationOptions = TextDocumentRegistrationOptions

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -240,7 +240,8 @@ let register_dune_and_cram_text_document_sync server (capabilities : ClientCapab
     let documentSelector =
       [ "cram"; "dune"; "dune-project"; "dune-workspace" ]
       |> List.map ~f:(fun language ->
-        `TextDocumentFilter (TextDocumentFilter.create ~language ()))
+        `TextDocumentFilter
+          (`TextDocumentFilterLanguage (TextDocumentFilterLanguage.create ~language ())))
     in
     let registerOptions =
       TextDocumentRegistrationOptions.create ~documentSelector ()

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -251,7 +251,8 @@ let register_dune_and_cram_text_document_sync server (capabilities : ClientCapab
     let documentSelector =
       [ "cram"; "dune"; "dune-project"; "dune-workspace" ]
       |> List.map ~f:(fun language ->
-        `TextDocumentFilter (TextDocumentFilter.create ~language ()))
+        `TextDocumentFilter
+          (`TextDocumentFilterLanguage (TextDocumentFilterLanguage.create ~language ())))
     in
     let registerOptions =
       TextDocumentRegistrationOptions.create ~documentSelector ()

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
@@ -76,9 +76,7 @@ let%expect_test "promotion registrations when Dune disconnects" =
           "method": "textDocument/codeAction",
           "registerOptions": {
             "codeActionKinds": [ "quickfix" ],
-            "documentSelector": [
-              { "language": null, "scheme": null, "pattern": "<document-path>" }
-            ]
+            "documentSelector": [ { "pattern": "<document-path>" } ]
           }
         }
       ]
@@ -119,9 +117,7 @@ let%expect_test "promotion registrations when Dune disconnects" =
           "method": "textDocument/codeAction",
           "registerOptions": {
             "codeActionKinds": [ "quickfix" ],
-            "documentSelector": [
-              { "language": null, "scheme": null, "pattern": "<document-path>" }
-            ]
+            "documentSelector": [ { "pattern": "<document-path>" } ]
           }
         }
       ]

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
@@ -71,9 +71,7 @@ let%expect_test "promotion removal while its document is open" =
           "method": "textDocument/codeAction",
           "registerOptions": {
             "codeActionKinds": [ "quickfix" ],
-            "documentSelector": [
-              { "language": null, "scheme": null, "pattern": "<document-path>" }
-            ]
+            "documentSelector": [ { "pattern": "<document-path>" } ]
           }
         }
       ]

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
@@ -165,13 +165,7 @@ let%expect_test "duplicate shared-source promotions do not hang the server" =
             "method": "textDocument/codeAction",
             "registerOptions": {
               "codeActionKinds": [ "quickfix" ],
-              "documentSelector": [
-                {
-                  "language": null,
-                  "scheme": null,
-                  "pattern": "<document-path>"
-                }
-              ]
+              "documentSelector": [ { "pattern": "<document-path>" } ]
             }
           }
         ]

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -94,9 +94,7 @@ let%expect_test "connected Dune cleans up after workspace removal" =
           "method": "textDocument/codeAction",
           "registerOptions": {
             "codeActionKinds": [ "quickfix" ],
-            "documentSelector": [
-              { "language": null, "scheme": null, "pattern": "<document-path>" }
-            ]
+            "documentSelector": [ { "pattern": "<document-path>" } ]
           }
         }
       ]
@@ -151,9 +149,7 @@ let%expect_test "connected Dune cleans up after workspace removal" =
           "method": "textDocument/codeAction",
           "registerOptions": {
             "codeActionKinds": [ "quickfix" ],
-            "documentSelector": [
-              { "language": null, "scheme": null, "pattern": "<document-path>" }
-            ]
+            "documentSelector": [ { "pattern": "<document-path>" } ]
           }
         }
       ]

--- a/ocaml-lsp-server/test/e2e-new/registration_order.ml
+++ b/ocaml-lsp-server/test/e2e-new/registration_order.ml
@@ -58,10 +58,10 @@ let%expect_test "dynamic registration waits for initialized" =
           "method": "textDocument/didOpen",
           "registerOptions": {
             "documentSelector": [
-              { "language": "cram", "scheme": null, "pattern": null },
-              { "language": "dune", "scheme": null, "pattern": null },
-              { "language": "dune-project", "scheme": null, "pattern": null },
-              { "language": "dune-workspace", "scheme": null, "pattern": null }
+              { "language": "cram" },
+              { "language": "dune" },
+              { "language": "dune-project" },
+              { "language": "dune-workspace" }
             ]
           }
         },
@@ -70,10 +70,10 @@ let%expect_test "dynamic registration waits for initialized" =
           "method": "textDocument/didClose",
           "registerOptions": {
             "documentSelector": [
-              { "language": "cram", "scheme": null, "pattern": null },
-              { "language": "dune", "scheme": null, "pattern": null },
-              { "language": "dune-project", "scheme": null, "pattern": null },
-              { "language": "dune-workspace", "scheme": null, "pattern": null }
+              { "language": "cram" },
+              { "language": "dune" },
+              { "language": "dune-project" },
+              { "language": "dune-workspace" }
             ]
           }
         }


### PR DESCRIPTION
Generate the LSP 3.18 text-document filter contract instead of retaining the stale handwritten record. This preserves omitted optional fields, so registrations emit valid selectors such as `{ "language": "ocaml" }` rather than filling unrelated fields with `null`.

Teach generated unions to represent `URI` as `DocumentUri`, allowing relative glob patterns to use URI or workspace-folder bases. Server call sites now construct the generated language and pattern filter variants explicitly, and the regression from #1996 prints the resulting round trips.
