### PR TITLE
fix(server): enable function param inlay hints without configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 - Preserve deprecation status in workspace-symbol results. (#2044, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal
   error. (#2038, @rgrinberg)
+- Enable function parameter inlay hints when the client sends no configuration.
+  (#2013, fixes #1371, @dayangac)
 - Respect client support for signature-help parameter-label offsets. (#2009,
   @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)

--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -62,7 +62,7 @@ interface config {
 
     /**
     * Enable/Disable Inlay Hints for function params
-    * @default false
+    * @default true
     * @since 1.23
     */
     hintFunctionParams : boolean

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -950,7 +950,7 @@ let default =
       Some
         { hint_pattern_variables = false
         ; hint_let_bindings = false
-        ; hint_function_params = false
+        ; hint_function_params = true
         }
   ; dune_diagnostics = Some { enable = true }
   ; syntax_documentation = Some { enable = false }

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -6,6 +6,7 @@ let apply_inlay_hints
       ?(hint_pattern_variables = false)
       ?(hint_let_bindings = false)
       ?hint_function_params
+      ?(configure = true)
       ~source
       ()
   =
@@ -34,10 +35,13 @@ let apply_inlay_hints
     | None -> []
     | Some hint_function_params -> [ "hintFunctionParams", `Bool hint_function_params ]
   in
+  let settings =
+    if configure then Some (`Assoc [ "inlayHints", `Assoc regular_config ]) else None
+  in
   let inlay_hints =
     Test.run_request
       ~prep:(fun client -> Test.open_document ~client ~uri ~source ())
-      ~settings:(`Assoc [ "inlayHints", `Assoc regular_config ])
+      ?settings
       (InlayHint request)
   in
   match inlay_hints with
@@ -114,4 +118,11 @@ let%expect_test "function params (deactivated)" =
   let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
   apply_inlay_hints ~hint_function_params:false ~source ();
   [%expect {| let f a b c d = (a + b, c ^ string_of_bool d) |}]
+;;
+
+let%expect_test "function params (no configuration sent)" =
+  let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
+  apply_inlay_hints ~configure:false ~source ();
+  [%expect
+    {| let f a$: int$ b$: int$ c$: string$ d$: bool$ = (a + b, c ^ string_of_bool d) |}]
 ;;


### PR DESCRIPTION
b7faaf23 (#1517) made function parameter inlay hints default to enabled, but it
only changed the `[@default true]` used when deserializing an `inlayHints`
object. `Config_data.default`, which applies when the client sends no
configuration at all, still had `hint_function_params = false`.

Clients that never send `workspace/didChangeConfiguration` therefore saw no
function parameter hints, while clients sending even an empty `inlayHints`
object saw them. `config.md` documented the pre-#1517 default, so it disagreed
with both paths. Set `hint_function_params` to `true` in `Config_data.default`
and update the documentation to match.

The inlay hint test helper always sends a configuration, so no test covered the
default path; add a `configure` flag to the helper and a test for it.

If you would rather not change the no-configuration default, the `config.md`
change alone also closes the issue and I am happy to drop that commit.

Fixes #1371.
