### PR TITLE
test(hover): exercise documentation rendering through LSP

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/doc_to_md.ml
+++ b/ocaml-lsp-server/test/e2e-new/doc_to_md.ml
@@ -52,52 +52,6 @@ let%expect_test "problematic_translation" =
     |  - first item - second item | |}]
 ;;
 
-let%expect_test "raw HTML, math, modules, and documentation tags" =
-  let cases =
-    [ "html", "{%html:<span>raw</span>%}"
-    ; "math", "inline {m x + y}\n\n{math z = x + y}"
-    ; "modules", "{!modules:List Array}"
-    ; ( "tags"
-      , "Summary.\n\n\
-         @param value input\n\
-         @return output\n\
-         @canonical Package.Module\n\
-         @version 2.0" )
-    ]
-  in
-  List.iter
-    (fun (label, doc) ->
-       Printf.printf "%s:\n" label;
-       translate doc |> print_doc)
-    cases;
-  [%expect
-    {|
-    html:
-    <span>raw</span>
-    math:
-    inline $x + y$
-
-    ```
-    z = x + y
-    ```
-    modules:
-    * List
-    * Array
-    tags:
-    Summary.
-
-    ***@param*** `value`
-    input
-
-    ***@return***
-    output
-
-    ***@canonical*** Package.Module
-
-    ***@version*** `2.0`
-    |}]
-;;
-
 let%expect_test "code_with_output" =
   let doc = {| {@ocaml[foo][output {b foo}]} |} in
   translate doc |> print_doc;

--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -93,6 +93,43 @@ let%expect_test "returns type inferred under cursor with documentation" =
     |}]
 ;;
 
+let%expect_test "renders extended documentation markup in hover" =
+  let source =
+    {ocaml|(** {%html:<span>raw</span>%}
+
+    Inline math: {m x + y}
+
+    {math z = x + y}
+
+    {!modules:List Array}
+
+    @param value input
+    @return output
+    @canonical Package.Module
+    @version 2.0
+*)
+let documented value = value
+|ocaml}
+  in
+  Hover_helpers.test_hover
+    ~capabilities:Hover_helpers.markdown_capabilities
+    source
+    [ Position.create ~line:13 ~character:5 ];
+  [%expect
+    {|
+    {
+      "contents": {
+        "kind": "markdown",
+        "value": "```ocaml\n'a -> 'a\n```\n***\n<span>raw</span>\n\nInline math: $x + y$\n\n```\nz = x + y\n```\n\n* List\n* Array\n\n***@param*** `value`\ninput\n\n***@return***\noutput\n\n***@canonical*** Package.Module\n\n***@version*** `2.0`"
+      },
+      "range": {
+        "end": { "character": 14, "line": 13 },
+        "start": { "character": 4, "line": 13 }
+      }
+    }
+    |}]
+;;
+
 let%expect_test
     "returns type inferred under cursor with documentation with tags (markdown \
      formatting)"


### PR DESCRIPTION
Replace the direct renderer expectation with a hover request against an ocamllsp subprocess.

Attach raw HTML, inline and block math, module lists, and common documentation tags to an OCaml definition, then assert the Markdown returned through the standard hover protocol.