### PR TITLE
fix(lsp): type initialized notification params

### DIFF
--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -7,8 +7,7 @@ open! Ts_types
 (* These declarations are all excluded because we don't support them or their
    definitions are hand written *)
 let skipped_ts_decls =
-  [ "InitializedParams"
-  ; "NotificationMessage"
+  [ "NotificationMessage"
   ; "RequestMessage"
   ; "ResponseError"
   ; "DocumentUri"

--- a/lsp/src/client_notification.ml
+++ b/lsp/src/client_notification.ml
@@ -13,7 +13,7 @@ type t =
   | DidRenameFiles of RenameFilesParams.t
   | ChangeWorkspaceFolders of DidChangeWorkspaceFoldersParams.t
   | ChangeConfiguration of DidChangeConfigurationParams.t
-  | Initialized
+  | Initialized of InitializedParams.t
   | Exit
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
@@ -30,7 +30,7 @@ let method_ = function
   | TextDocumentDidChange _ -> "textDocument/didChange"
   | TextDocumentDidClose _ -> "textDocument/didClose"
   | Exit -> "exit"
-  | Initialized -> "initialized"
+  | Initialized _ -> "initialized"
   | ChangeWorkspaceFolders _ -> "workspace/didChangeWorkspaceFolders"
   | ChangeConfiguration _ -> "workspace/didChangeConfiguration"
   | WillSaveTextDocument _ -> "textDocument/willSave"
@@ -55,7 +55,7 @@ let yojson_of_t = function
   | TextDocumentDidChange params -> Some (DidChangeTextDocumentParams.yojson_of_t params)
   | TextDocumentDidClose params -> Some (DidCloseTextDocumentParams.yojson_of_t params)
   | Exit -> None
-  | Initialized -> None
+  | Initialized params -> Some (InitializedParams.yojson_of_t params)
   | ChangeWorkspaceFolders params ->
     Some (DidChangeWorkspaceFoldersParams.yojson_of_t params)
   | ChangeConfiguration params -> Some (DidChangeConfigurationParams.yojson_of_t params)
@@ -96,7 +96,9 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
     let+ params = Json.message_params params DidCloseTextDocumentParams.t_of_yojson in
     TextDocumentDidClose params
   | "exit" -> Ok Exit
-  | "initialized" -> Ok Initialized
+  | "initialized" ->
+    let+ params = Json.message_params params InitializedParams.t_of_yojson in
+    Initialized params
   | "workspace/didChangeWorkspaceFolders" ->
     let+ params =
       Json.message_params params DidChangeWorkspaceFoldersParams.t_of_yojson

--- a/lsp/src/client_notification.mli
+++ b/lsp/src/client_notification.mli
@@ -13,7 +13,7 @@ type t =
   | DidRenameFiles of RenameFilesParams.t
   | ChangeWorkspaceFolders of DidChangeWorkspaceFoldersParams.t
   | ChangeConfiguration of DidChangeConfigurationParams.t
-  | Initialized
+  | Initialized of InitializedParams.t
   | Exit
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -44936,6 +44936,18 @@ module InitializeResult = struct
   ;;
 end
 
+module InitializedParams = struct
+  type t = Json.Object.t [@@deriving_inline yojson]
+
+  let _ = fun (_ : t) -> ()
+  let t_of_yojson = (Json.Object.t_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  let _ = t_of_yojson
+  let yojson_of_t = (Json.Object.yojson_of_t : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  let _ = yojson_of_t
+
+  [@@@end]
+end
+
 module InitializedParams_ = struct
   type t =
     { capabilities : ClientCapabilities.t

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -4959,6 +4959,12 @@ module InitializeResult : sig
   include Json.Jsonable.S with type t := t
 end
 
+module InitializedParams : sig
+  type t = Json.Object.t
+
+  include Json.Jsonable.S with type t := t
+end
+
 module InitializedParams_ : sig
   type t =
     { capabilities : ClientCapabilities.t

--- a/lsp/test/initialized_contract_tests.ml
+++ b/lsp/test/initialized_contract_tests.ml
@@ -3,7 +3,7 @@ open Lsp
 let print_json json = Yojson.Safe.pretty_to_string json |> Stdlib.print_endline
 
 let%expect_test "initialized notification params" =
-  let encoded = Client_notification.to_jsonrpc Client_notification.Initialized in
+  let encoded = Client_notification.to_jsonrpc (Client_notification.Initialized []) in
   (match encoded.params with
    | None -> Stdlib.print_endline "encoded params: omitted"
    | Some params -> print_json (params :> Yojson.Safe.t));
@@ -18,8 +18,8 @@ let%expect_test "initialized notification params" =
   check "array params" (`List []);
   [%expect
     {|
-    encoded params: omitted
+    {}
     object params: accepted
-    array params: accepted
+    array params: rejected
     |}]
 ;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -845,7 +845,7 @@ let on_notification server (notification : Client_notification.t) : State.t Fibe
     in
     Dune.update_workspaces (State.dune state) (State.workspaces state);
     Fiber.return state
-  | Initialized ->
+  | Initialized _ ->
     let+ () =
       task_if_running state.detached ~f:(fun () ->
         register_dune_and_cram_text_document_sync server (State.client_capabilities state))

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -310,7 +310,7 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
          ~workspaceFolders:(Some [ workspace ])
          ~trace:Messages
        @@ fun client ->
-       let* () = Client.notification client Initialized in
+       let* () = Client.notification client (Initialized []) in
        (* The blocked initial build makes Dune RPC connection deterministic. *)
        let* () = Signal.wait events.dune_connected in
        let* () = Signal.wait events.dune_connection_traced in

--- a/ocaml-lsp-server/test/e2e-new/registration_order.ml
+++ b/ocaml-lsp-server/test/e2e-new/registration_order.ml
@@ -39,7 +39,7 @@ let%expect_test "dynamic registration waits for initialized" =
      print_endline "received initialize response";
      print_endline "sending initialized";
      sending_initialized := true;
-     let* () = Client.notification client Initialized in
+     let* () = Client.notification client (Initialized []) in
      let* registration = Fiber.Ivar.read registration_received in
      print_endline "received client/registerCapability after sending initialized:";
      RegistrationParams.yojson_of_t registration |> Test.print_result;


### PR DESCRIPTION
Generates `InitializedParams` from the LSP metamodel and carries it through the typed client-notification API.

Outgoing `initialized` notifications now emit the required `{}` object, and incoming params are decoded as an object instead of accepting arbitrary structured values. The baseline snapshot from #2016 is updated accordingly.
