### PR TITLE
fix(lsp): accept generic progress notifications

### DIFF
--- a/lsp/src/client_notification.ml
+++ b/lsp/src/client_notification.ml
@@ -19,6 +19,7 @@ type t =
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
   | SetTrace of SetTraceParams.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | NotebookDocumentDidOpen of DidOpenNotebookDocumentParams.t
   | NotebookDocumentDidChange of DidChangeNotebookDocumentParams.t
   | NotebookDocumentDidSave of DidSaveNotebookDocumentParams.t
@@ -42,7 +43,7 @@ let method_ = function
   | SetTrace _ -> "$/setTrace"
   | CancelRequest _ -> Cancel_request.meth_
   | WorkDoneProgressCancel _ -> "window/workDoneProgress/cancel"
-  | WorkDoneProgress _ -> Progress.method_
+  | WorkDoneProgress _ | Progress _ -> Progress.method_
   | NotebookDocumentDidOpen _ -> "notebookDocument/didOpen"
   | NotebookDocumentDidChange _ -> "notebookDocument/didChange"
   | NotebookDocumentDidSave _ -> "notebookDocument/didSave"
@@ -71,6 +72,7 @@ let yojson_of_t = function
   | SetTrace params -> Some (SetTraceParams.yojson_of_t params)
   | WorkDoneProgress params ->
     Some ((ProgressParams.yojson_of_t Progress.yojson_of_t) params)
+  | Progress params -> Some ((ProgressParams.yojson_of_t Fun.id) params)
   | NotebookDocumentDidOpen params ->
     Some (DidOpenNotebookDocumentParams.yojson_of_t params)
   | NotebookDocumentDidClose params ->
@@ -149,10 +151,10 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
     in
     NotebookDocumentDidChange params
   | m when m = Progress.method_ ->
-    let+ params =
-      Json.message_params params (ProgressParams.t_of_yojson Progress.t_of_yojson)
-    in
-    WorkDoneProgress params
+    let+ params = Json.message_params params (ProgressParams.t_of_yojson Fun.id) in
+    (match Progress.t_of_yojson params.value with
+     | value -> WorkDoneProgress (ProgressParams.create ~token:params.token ~value)
+     | exception _ -> Progress params)
   | _ -> Ok (UnknownNotification r)
 ;;
 

--- a/lsp/src/client_notification.ml
+++ b/lsp/src/client_notification.ml
@@ -19,6 +19,7 @@ type t =
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
   | SetTrace of SetTraceParams.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | NotebookDocumentDidOpen of DidOpenNotebookDocumentParams.t
   | NotebookDocumentDidChange of DidChangeNotebookDocumentParams.t
   | NotebookDocumentDidSave of DidSaveNotebookDocumentParams.t
@@ -42,7 +43,7 @@ let method_ = function
   | SetTrace _ -> "$/setTrace"
   | CancelRequest _ -> Cancel_request.meth_
   | WorkDoneProgressCancel _ -> "window/workDoneProgress/cancel"
-  | WorkDoneProgress _ -> Progress.method_
+  | WorkDoneProgress _ | Progress _ -> Progress.method_
   | NotebookDocumentDidOpen _ -> "notebookDocument/didOpen"
   | NotebookDocumentDidChange _ -> "notebookDocument/didChange"
   | NotebookDocumentDidSave _ -> "notebookDocument/didSave"
@@ -71,6 +72,7 @@ let yojson_of_t = function
   | SetTrace params -> Some (SetTraceParams.yojson_of_t params)
   | WorkDoneProgress params ->
     Some ((ProgressParams.yojson_of_t Progress.yojson_of_t) params)
+  | Progress params -> Some ((ProgressParams.yojson_of_t Fun.id) params)
   | NotebookDocumentDidOpen params ->
     Some (DidOpenNotebookDocumentParams.yojson_of_t params)
   | NotebookDocumentDidClose params ->
@@ -149,10 +151,10 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
     in
     NotebookDocumentDidChange params
   | m when m = Progress.method_ ->
-    let+ params =
-      Json.message_params params (ProgressParams.t_of_yojson Progress.t_of_yojson)
-    in
-    WorkDoneProgress params
+    let+ params = Json.message_params params (ProgressParams.t_of_yojson Fun.id) in
+    (match Progress.t_of_yojson_opt params.value with
+     | Some value -> WorkDoneProgress (ProgressParams.create ~token:params.token ~value)
+     | None -> Progress params)
   | _ -> Ok (UnknownNotification r)
 ;;
 

--- a/lsp/src/client_notification.mli
+++ b/lsp/src/client_notification.mli
@@ -19,6 +19,7 @@ type t =
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
   | SetTrace of SetTraceParams.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | NotebookDocumentDidOpen of DidOpenNotebookDocumentParams.t
   | NotebookDocumentDidChange of DidChangeNotebookDocumentParams.t
   | NotebookDocumentDidSave of DidSaveNotebookDocumentParams.t

--- a/lsp/src/client_notification.mli
+++ b/lsp/src/client_notification.mli
@@ -19,6 +19,11 @@ type t =
   | WorkDoneProgressCancel of WorkDoneProgressCancelParams.t
   | SetTrace of SetTraceParams.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  (** Typed work-done progress, used by decoding when conversion is lossless. *)
+  | Progress of Json.t ProgressParams.t
+  (** Raw progress values, including partial results and work-done-looking objects
+      that would lose fields in typed conversion. Decoding uses payload shape, not
+      token state: an exact work-done payload decodes as [WorkDoneProgress]. *)
   | NotebookDocumentDidOpen of DidOpenNotebookDocumentParams.t
   | NotebookDocumentDidChange of DidChangeNotebookDocumentParams.t
   | NotebookDocumentDidSave of DidSaveNotebookDocumentParams.t

--- a/lsp/src/progress.ml
+++ b/lsp/src/progress.ml
@@ -22,4 +22,11 @@ let t_of_yojson json =
     json
 ;;
 
+let t_of_yojson_opt json =
+  match t_of_yojson json with
+  | value when Yojson.Safe.equal json (yojson_of_t value) -> Some value
+  | _ -> None
+  | exception Json.Conv.Of_yojson_error (_, _) -> None
+;;
+
 let method_ = "$/progress"

--- a/lsp/src/progress.mli
+++ b/lsp/src/progress.mli
@@ -8,4 +8,9 @@ type t =
 
 val yojson_of_t : t -> Json.t
 val t_of_yojson : Json.t -> t
+
+(** Attempt a lossless work-done conversion. Return [None] if decoding fails or
+    re-encoding would lose fields or explicit nulls. Object key order is ignored. *)
+val t_of_yojson_opt : Json.t -> t option
+
 val method_ : string

--- a/lsp/src/server_notification.ml
+++ b/lsp/src/server_notification.ml
@@ -9,6 +9,7 @@ type t =
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | UnknownNotification of Jsonrpc.Notification.t
 
 let method_ = function
@@ -18,7 +19,7 @@ let method_ = function
   | LogTrace _ -> "$/logTrace"
   | TelemetryNotification _ -> "telemetry/event"
   | CancelRequest _ -> Cancel_request.meth_
-  | WorkDoneProgress _ -> Progress.method_
+  | WorkDoneProgress _ | Progress _ -> Progress.method_
   | UnknownNotification n -> n.method_
 ;;
 
@@ -31,6 +32,7 @@ let yojson_of_t = function
   | CancelRequest params -> Some (Cancel_request.yojson_of_t params)
   | WorkDoneProgress params ->
     Some ((ProgressParams.yojson_of_t Progress.yojson_of_t) params)
+  | Progress params -> Some ((ProgressParams.yojson_of_t Fun.id) params)
   | UnknownNotification n -> (n.params :> Json.t option)
 ;;
 
@@ -64,10 +66,10 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
     let+ params = Json.message_params params (fun x -> x) in
     TelemetryNotification params
   | m when m = Progress.method_ ->
-    let+ params =
-      Json.message_params params (ProgressParams.t_of_yojson Progress.t_of_yojson)
-    in
-    WorkDoneProgress params
+    let+ params = Json.message_params params (ProgressParams.t_of_yojson Fun.id) in
+    (match Progress.t_of_yojson params.value with
+     | value -> WorkDoneProgress (ProgressParams.create ~token:params.token ~value)
+     | exception _ -> Progress params)
   | m when m = Cancel_request.meth_ ->
     let+ params = Json.message_params params Cancel_request.t_of_yojson in
     CancelRequest params

--- a/lsp/src/server_notification.ml
+++ b/lsp/src/server_notification.ml
@@ -9,6 +9,7 @@ type t =
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | UnknownNotification of Jsonrpc.Notification.t
 
 let method_ = function
@@ -18,7 +19,7 @@ let method_ = function
   | LogTrace _ -> "$/logTrace"
   | TelemetryNotification _ -> "telemetry/event"
   | CancelRequest _ -> Cancel_request.meth_
-  | WorkDoneProgress _ -> Progress.method_
+  | WorkDoneProgress _ | Progress _ -> Progress.method_
   | UnknownNotification n -> n.method_
 ;;
 
@@ -31,6 +32,7 @@ let yojson_of_t = function
   | CancelRequest params -> Some (Cancel_request.yojson_of_t params)
   | WorkDoneProgress params ->
     Some ((ProgressParams.yojson_of_t Progress.yojson_of_t) params)
+  | Progress params -> Some ((ProgressParams.yojson_of_t Fun.id) params)
   | UnknownNotification n -> (n.params :> Json.t option)
 ;;
 
@@ -64,10 +66,10 @@ let of_jsonrpc (r : Jsonrpc.Notification.t) =
     let+ params = Json.message_params params (fun x -> x) in
     TelemetryNotification params
   | m when m = Progress.method_ ->
-    let+ params =
-      Json.message_params params (ProgressParams.t_of_yojson Progress.t_of_yojson)
-    in
-    WorkDoneProgress params
+    let+ params = Json.message_params params (ProgressParams.t_of_yojson Fun.id) in
+    (match Progress.t_of_yojson_opt params.value with
+     | Some value -> WorkDoneProgress (ProgressParams.create ~token:params.token ~value)
+     | None -> Progress params)
   | m when m = Cancel_request.meth_ ->
     let+ params = Json.message_params params Cancel_request.t_of_yojson in
     CancelRequest params

--- a/lsp/src/server_notification.mli
+++ b/lsp/src/server_notification.mli
@@ -9,6 +9,7 @@ type t =
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  | Progress of Json.t ProgressParams.t
   | UnknownNotification of Jsonrpc.Notification.t
 
 val to_jsonrpc : t -> Jsonrpc.Notification.t

--- a/lsp/src/server_notification.mli
+++ b/lsp/src/server_notification.mli
@@ -9,6 +9,11 @@ type t =
   | TelemetryNotification of Json.t
   | CancelRequest of Jsonrpc.Id.t
   | WorkDoneProgress of Progress.t ProgressParams.t
+  (** Typed work-done progress, used by decoding when conversion is lossless. *)
+  | Progress of Json.t ProgressParams.t
+  (** Raw progress values, including partial results and work-done-looking objects
+      that would lose fields in typed conversion. Decoding uses payload shape, not
+      token state: an exact work-done payload decodes as [WorkDoneProgress]. *)
   | UnknownNotification of Jsonrpc.Notification.t
 
 val to_jsonrpc : t -> Jsonrpc.Notification.t

--- a/lsp/test/progress_contract_tests.ml
+++ b/lsp/test/progress_contract_tests.ml
@@ -21,7 +21,7 @@ let%expect_test "generic progress notifications" =
   print_result "server to client" (Server_notification.of_jsonrpc notification);
   [%expect
     {|
-    client to server: rejected
-    server to client: rejected
+    client to server: accepted
+    server to client: accepted
     |}]
 ;;

--- a/lsp/test/progress_contract_tests.ml
+++ b/lsp/test/progress_contract_tests.ml
@@ -15,6 +15,13 @@ let print_work_done { ProgressParams.token; value } =
     (Yojson.Safe.to_string (Progress.yojson_of_t value))
 ;;
 
+let print_progress { ProgressParams.token; value } =
+  Printf.printf
+    "Progress token=%s value=%s\n"
+    (Yojson.Safe.to_string (ProgressToken.yojson_of_t token))
+    (Yojson.Safe.to_string value)
+;;
+
 let check label ?params () =
   print_endline label;
   let notification = Jsonrpc.Notification.create ~method_:"$/progress" ?params () in
@@ -32,6 +39,7 @@ let check label ?params () =
     "client to server"
     (function
       | Client_notification.WorkDoneProgress params -> print_work_done params
+      | Progress params -> print_progress params
       | _ -> failwith "expected a progress notification")
     Client_notification.to_jsonrpc
     (Client_notification.of_jsonrpc notification);
@@ -39,6 +47,7 @@ let check label ?params () =
     "server to client"
     (function
       | Server_notification.WorkDoneProgress params -> print_work_done params
+      | Progress params -> print_progress params
       | _ -> failwith "expected a progress notification")
     Server_notification.to_jsonrpc
     (Server_notification.of_jsonrpc notification)
@@ -63,8 +72,10 @@ let%expect_test "generic progress notifications" =
   [%expect
     {|
     partial reference results
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token="partial" value=[{"range":{"end":{"character":4,"line":2},"start":{"character":4,"line":2}},"uri":"file:///workspace/test.ml"}]
+    round-trip preserved: true
+    server to client: Progress token="partial" value=[{"range":{"end":{"character":4,"line":2},"start":{"character":4,"line":2}},"uri":"file:///workspace/test.ml"}]
+    round-trip preserved: true
     |}]
 ;;
 
@@ -86,32 +97,50 @@ let%expect_test "generic progress values with integer tokens" =
   [%expect
     {|
     empty array
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value=[]
+    round-trip preserved: true
+    server to client: Progress token=42 value=[]
+    round-trip preserved: true
     semantic token chunk
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value={"data":[0,0,3,0,0]}
+    round-trip preserved: true
+    server to client: Progress token=42 value={"data":[0,0,3,0,0]}
+    round-trip preserved: true
     nested object
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value={"items":[{"id":1,"metadata":null}]}
+    round-trip preserved: true
+    server to client: Progress token=42 value={"items":[{"id":1,"metadata":null}]}
+    round-trip preserved: true
     empty object
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value={}
+    round-trip preserved: true
+    server to client: Progress token=42 value={}
+    round-trip preserved: true
     string
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value="chunk"
+    round-trip preserved: true
+    server to client: Progress token=42 value="chunk"
+    round-trip preserved: true
     integer
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value=17
+    round-trip preserved: true
+    server to client: Progress token=42 value=17
+    round-trip preserved: true
     decimal
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value=1.5
+    round-trip preserved: true
+    server to client: Progress token=42 value=1.5
+    round-trip preserved: true
     boolean
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value=true
+    round-trip preserved: true
+    server to client: Progress token=42 value=true
+    round-trip preserved: true
     null
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token=42 value=null
+    round-trip preserved: true
+    server to client: Progress token=42 value=null
+    round-trip preserved: true
     |}]
 ;;
 
@@ -167,7 +196,7 @@ let%expect_test "work-done notifications preserve typed variants and payloads" =
     |}]
 ;;
 
-let%expect_test "work-done-looking generic values expose rejection and data loss" =
+let%expect_test "work-done-looking generic values preserve payloads" =
   (* A generic payload may use work-done field names with unrelated meanings. *)
   List.iter
     (fun (label, value) ->
@@ -184,37 +213,74 @@ let%expect_test "work-done-looking generic values expose rejection and data loss
   [%expect
     {|
     unknown kind
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token="partial" value={"kind":"chunk","items":[1]}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"chunk","items":[1]}
+    round-trip preserved: true
     non-string kind
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token="partial" value={"kind":7,"items":[1]}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":7,"items":[1]}
+    round-trip preserved: true
     missing work-done field
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token="partial" value={"kind":"begin"}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"begin"}
+    round-trip preserved: true
     wrong work-done field type
-    client to server: rejected
-    server to client: rejected
+    client to server: Progress token="partial" value={"kind":"report","percentage":"half"}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"report","percentage":"half"}
+    round-trip preserved: true
     extra begin field
-    client to server: WorkDoneProgress/begin token="partial" value={"kind":"begin","title":"Chunk"}
-    round-trip preserved: false
-    server to client: WorkDoneProgress/begin token="partial" value={"kind":"begin","title":"Chunk"}
-    round-trip preserved: false
+    client to server: Progress token="partial" value={"kind":"begin","title":"Chunk","items":[1]}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"begin","title":"Chunk","items":[1]}
+    round-trip preserved: true
     extra report field
-    client to server: WorkDoneProgress/report token="partial" value={"kind":"report"}
-    round-trip preserved: false
-    server to client: WorkDoneProgress/report token="partial" value={"kind":"report"}
-    round-trip preserved: false
+    client to server: Progress token="partial" value={"kind":"report","items":[1]}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"report","items":[1]}
+    round-trip preserved: true
     extra end field
-    client to server: WorkDoneProgress/end token="partial" value={"kind":"end","message":"done"}
-    round-trip preserved: false
-    server to client: WorkDoneProgress/end token="partial" value={"kind":"end","message":"done"}
-    round-trip preserved: false
+    client to server: Progress token="partial" value={"kind":"end","message":"done","items":[1]}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"end","message":"done","items":[1]}
+    round-trip preserved: true
     null optional field
-    client to server: WorkDoneProgress/report token="partial" value={"kind":"report"}
-    round-trip preserved: false
-    server to client: WorkDoneProgress/report token="partial" value={"kind":"report"}
-    round-trip preserved: false
+    client to server: Progress token="partial" value={"kind":"report","message":null}
+    round-trip preserved: true
+    server to client: Progress token="partial" value={"kind":"report","message":null}
+    round-trip preserved: true
+    |}]
+;;
+
+let%expect_test "generic constructors can send exact work-done shapes" =
+  let token = `Int 42 in
+  let value = `Assoc [ "message", `String "done"; "kind", `String "end" ] in
+  let params = ProgressParams.create ~token ~value in
+  let expected =
+    Jsonrpc.Notification.create
+      ~method_:"$/progress"
+      ~params:(`Assoc [ "token", ProgressToken.yojson_of_t token; "value", value ])
+      ()
+    |> Jsonrpc.Notification.yojson_of_t
+  in
+  List.iter
+    (fun notification ->
+       assert (Yojson.Safe.equal expected (Jsonrpc.Notification.yojson_of_t notification)))
+    [ Client_notification.to_jsonrpc (Progress params)
+    ; Server_notification.to_jsonrpc (Progress params)
+    ];
+  (* The wire payload is preserved, but decoding chooses the typed constructor. *)
+  check_progress "exact work-done shape" (ProgressToken.yojson_of_t token) value;
+  [%expect
+    {|
+    exact work-done shape
+    client to server: WorkDoneProgress/end token=42 value={"kind":"end","message":"done"}
+    round-trip preserved: true
+    server to client: WorkDoneProgress/end token=42 value={"kind":"end","message":"done"}
+    round-trip preserved: true
     |}]
 ;;
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -858,6 +858,7 @@ let on_notification server (notification : Client_notification.t) : State.t Fibe
   | WillSaveTextDocument _
   | WorkDoneProgressCancel _
   | WorkDoneProgress _
+  | Progress _
   | NotebookDocumentDidOpen _
   | NotebookDocumentDidChange _
   | NotebookDocumentDidSave _

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -934,6 +934,7 @@ let on_notification server (notification : Client_notification.t) : State.t Fibe
   | WillSaveTextDocument _
   | WorkDoneProgressCancel _
   | WorkDoneProgress _
+  | Progress _
   | NotebookDocumentDidOpen _
   | NotebookDocumentDidChange _
   | NotebookDocumentDidSave _


### PR DESCRIPTION
Accept generic `$/progress` values in both notification directions, including partial results, while continuing to reject malformed parameter envelopes.

Decode as `WorkDoneProgress` only when converting the value is lossless; otherwise retain the original JSON in `Progress`, including extra fields and explicit nulls. Fallback catches only JSON conversion errors. Dispatch uses payload shape, not token state: an exact work-done-shaped value still decodes to the typed constructor.

Update the contracts merged in #2197 and cover explicitly encoding a work-done-shaped value through the generic constructors. API documentation calls out the new constructors and downstream exhaustive-match impact.

This fixes the protocol library; it does not add partial-result streaming to `ocamllsp`.
