### PR TITLE
test(lsp): snapshot values instead of scalar checks

### DIFF
--- a/lsp/test/string_zipper_tests.ml
+++ b/lsp/test/string_zipper_tests.ml
@@ -195,11 +195,12 @@ let%expect_test "squashing" =
   let t = String_zipper.goto_line t 1 |> checked in
   let t, str' = String_zipper.squash t in
   check_invariants t;
-  assert (String.equal str str');
-  printfn "squashing: %S" (String_zipper.to_string_debug t);
+  printfn "squashed text: %S" str';
+  printfn "zipper: %S" (String_zipper.to_string_debug t);
   [%expect
     {|
-    squashing: "foo\n|bar" |}]
+    squashed text: "foo\nbar"
+    zipper: "foo\n|bar" |}]
 ;;
 
 let%expect_test "add buffer between" =
@@ -223,6 +224,17 @@ let%expect_test "drop_until bug" =
   [%expect
     {|
     "foo\nbar\n|" |}];
-  printfn "abs_pos: %d" (String_zipper.Private.reflect t).abs_pos;
-  [%expect {| abs_pos: 0 |}]
+  String_zipper.Private.reflect t |> to_dyn |> Dyn.to_string |> print_endline;
+  [%expect
+    {|
+    { left = []
+    ; rel_pos = 8
+    ; abs_pos = 0
+    ; current = "foo\n\
+                 bar\n\
+                 "
+    ; right = []
+    ; line = 2
+    }
+    |}]
 ;;

--- a/lsp/test/text_document_tests.ml
+++ b/lsp/test/text_document_tests.ml
@@ -281,37 +281,52 @@ let%expect_test "absolute_position" =
   let td = make_document (Uri.of_path "foo.ml") ~text in
   let test (line, character) =
     let offset = Text_document.absolute_position td (Position.create ~line ~character) in
-    printf "position: %d/%d\n" offset (String.length text)
+    let before = String.sub text ~pos:0 ~len:offset in
+    let after = String.sub text ~pos:offset ~len:(String.length text - offset) in
+    printf "position (%d, %d) -> offset %d: %S | %S\n" line character offset before after
   in
   test (0, 0);
-  [%expect {| position: 0/13 |}];
+  [%expect {| position (0, 0) -> offset 0: "" | "foo|bar\nbaz.x" |}];
   test (3, 0);
-  [%expect {| position: 13/13 |}];
+  [%expect {| position (3, 0) -> offset 13: "foo|bar\nbaz.x" | "" |}];
   test (1, 0);
-  [%expect {| position: 8/13 |}];
+  [%expect {| position (1, 0) -> offset 8: "foo|bar\n" | "baz.x" |}];
   test (1, 100);
-  [%expect {| position: 13/13 |}];
+  [%expect {| position (1, 100) -> offset 13: "foo|bar\nbaz.x" | "" |}];
   test (0, 100);
-  [%expect {| position: 7/13 |}];
+  [%expect {| position (0, 100) -> offset 7: "foo|bar" | "\nbaz.x" |}];
   test (100, 0);
-  [%expect {| position: 13/13 |}]
+  [%expect {| position (100, 0) -> offset 13: "foo|bar\nbaz.x" | "" |}]
 ;;
 
-let%test_unit "workspace edits identify the document and its version" =
+let%expect_test "workspace edits identify the document and its version" =
   let uri = Uri.of_string "file:///foo.ml" in
   let doc = make_document uri ~text:"old" in
   let range = tuple_range (0, 0) (0, 3) in
   let text_edit = TextEdit.create ~range ~newText:"new" in
-  match (Text_document.workspace_edit doc [ text_edit ]).documentChanges with
-  | Some
-      [ `TextDocumentEdit
-          { textDocument = { uri = actual_uri; version = Some 1 }
-          ; edits = [ `TextEdit actual_edit ]
-          }
-      ] ->
-    assert (Uri.equal uri actual_uri);
-    assert (text_edit = actual_edit)
-  | _ -> assert false
+  Text_document.workspace_edit doc [ text_edit ]
+  |> WorkspaceEdit.yojson_of_t
+  |> Yojson.Safe.pretty_to_string ~std:false
+  |> print_endline;
+  [%expect
+    {|
+    {
+      "documentChanges": [
+        {
+          "edits": [
+            {
+              "newText": "new",
+              "range": {
+                "end": { "character": 3, "line": 0 },
+                "start": { "character": 0, "line": 0 }
+              }
+            }
+          ],
+          "textDocument": { "uri": "file:///foo.ml", "version": 1 }
+        }
+      ]
+    }
+    |}]
 ;;
 
 let%expect_test "substring uses the document's position encoding" =

--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -74,13 +74,15 @@ let%expect_test "serialization disambiguates a path beginning with two slashes" 
   let serialized = Uri.to_string uri in
   let round_trip = Uri.of_string serialized in
   Printf.printf
-    "serialized: %s\nround trip equal: %b\n"
+    "original: %s\nserialized: %s\nparsed serialization: %s\n"
+    (Uri.to_string uri)
     serialized
-    (Uri.equal uri round_trip);
+    (Uri.to_string round_trip);
   [%expect
     {|
+    original: untitled:////Module.ml
     serialized: untitled:////Module.ml
-    round trip equal: true
+    parsed serialization: untitled:////Module.ml
     |}]
 ;;
 
@@ -111,16 +113,20 @@ let%expect_test "serialization preserves a non-letter drive-like path" =
 let%expect_test "JSON URI serialization normalizes wire spelling" =
   let encoded_slash = `String "file:///pro%2Fjects/test.ml" in
   let literal_slash = `String "file:///pro/jects/test.ml" in
-  let encoded_uri = Uri.t_of_yojson encoded_slash in
-  let literal_uri = Uri.t_of_yojson literal_slash in
-  Uri.yojson_of_t encoded_uri |> Yojson.Safe.to_string |> print_endline;
-  Printf.printf
-    "encoded and literal slash compare equal: %b\n"
-    (Uri.equal encoded_uri literal_uri);
+  let print_normalized label input =
+    let normalized = Uri.t_of_yojson input |> Uri.yojson_of_t in
+    Printf.printf
+      "%s: %s -> %s\n"
+      label
+      (Yojson.Safe.to_string input)
+      (Yojson.Safe.to_string normalized)
+  in
+  print_normalized "encoded slash" encoded_slash;
+  print_normalized "literal slash" literal_slash;
   [%expect
     {|
-    "file:///pro/jects/test.ml"
-    encoded and literal slash compare equal: true
+    encoded slash: "file:///pro%2Fjects/test.ml" -> "file:///pro/jects/test.ml"
+    literal slash: "file:///pro/jects/test.ml" -> "file:///pro/jects/test.ml"
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -2,9 +2,16 @@ open Lsp.Types
 module Position = Lsp.Position
 module Range = Lsp.Range
 
-let%test_unit "convert an LSP position to a Merlin logical position" =
+let%expect_test "convert an LSP position to a Merlin logical position" =
   let position = Position.create ~line:2 ~character:3 in
-  assert (Ocaml_lsp_server.Testing.Position.logical position = `Logical (3, 3))
+  let (`Logical (line, column)) = Ocaml_lsp_server.Testing.Position.logical position in
+  Printf.printf
+    "LSP position (%d, %d) -> Merlin logical position (%d, %d)\n"
+    position.line
+    position.character
+    line
+    column;
+  [%expect {| LSP position (2, 3) -> Merlin logical position (3, 3) |}]
 ;;
 
 let%expect_test "replacement ranges preserve trailing newlines" =
@@ -127,23 +134,30 @@ let%expect_test "normalize document-symbol selection ranges" =
     |}]
 ;;
 
-let%expect_test "eat_message tests" =
-  let test e1 e2 expected =
-    let result = Ocaml_lsp_server.Diagnostics.equal_message e1 e2 in
-    if result = expected then print_endline "[PASS]" else print_endline "[FAIL]"
+let%expect_test "diagnostic message equality ignores insignificant whitespace" =
+  let test left right =
+    let relation =
+      if Ocaml_lsp_server.Diagnostics.equal_message left right
+      then "equal"
+      else "different"
+    in
+    Printf.printf "%S <> %S: %s\n" left right relation
   in
-  test "foo bar" "foo  bar" true;
-  [%expect {| [PASS] |}];
-  test " foobar" "foobar" true;
-  [%expect {| [PASS] |}];
-  test "foobar" "foobar " true;
-  [%expect {| [PASS] |}];
-  test "foobar" "foobar\t" true;
-  [%expect {| [PASS] |}];
-  test "foobar" "foobar\n" true;
-  [%expect {| [PASS] |}];
-  test "foobar" "foo bar" false;
-  [%expect {| [PASS] |}];
-  test "foo bar" "foo Bar" false;
-  [%expect {| [PASS] |}]
+  test "foo bar" "foo  bar";
+  test " foobar" "foobar";
+  test "foobar" "foobar ";
+  test "foobar" "foobar\t";
+  test "foobar" "foobar\n";
+  test "foobar" "foo bar";
+  test "foo bar" "foo Bar";
+  [%expect
+    {|
+    "foo bar" <> "foo  bar": equal
+    " foobar" <> "foobar": equal
+    "foobar" <> "foobar ": equal
+    "foobar" <> "foobar\t": equal
+    "foobar" <> "foobar\n": equal
+    "foobar" <> "foo bar": different
+    "foo bar" <> "foo Bar": different
+    |}]
 ;;

--- a/ocaml-lsp-server/test/position_prefix_tests.ml
+++ b/ocaml-lsp-server/test/position_prefix_tests.ml
@@ -121,12 +121,13 @@ let%expect_test "completion sort text preserves order above 9999 items" =
   |> List.map (fun index ->
     index, Testing.Compl.For_tests.sortText_of_index ~item_count index)
   |> List.sort (fun (_, left) (_, right) -> String.compare left right)
-  |> List.iter (fun (index, _) -> Printf.printf "%d\n" index);
+  |> List.iter (fun (index, sort_text) ->
+    Printf.printf "item %d -> sortText %S\n" index sort_text);
   [%expect
     {|
-    9998
-    9999
-    10000
-    10001
+    item 9998 -> sortText "09998"
+    item 9999 -> sortText "09999"
+    item 10000 -> sortText "10000"
+    item 10001 -> sortText "10001"
     |}]
 ;;


### PR DESCRIPTION
Replace equality booleans and compact counters in URI, text-document, zipper, position-conversion, diagnostic-message, and completion-sort tests with concrete transformed values. This exposes full workspace edits, normalized URIs, and ordering keys in failures.
