### PR TITLE
test(server): snapshot definition and semantic-token behavior

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -40,7 +40,8 @@ let%expect_test "reports definition lookup failures without stopping the server"
     let* () = check "missing" (Position.create ~line:1 ~character:18) in
     let* () = check "builtin" (Position.create ~line:3 ~character:12) in
     let* response = definition client (Position.create ~line:4 ~character:10) in
-    Printf.printf "server remains usable: %b\n" (Option.is_some response);
+    print_endline "definition after errors:";
+    print_locations response;
     Fiber.return ()
   in
   Helpers.test source req;
@@ -49,7 +50,16 @@ let%expect_test "reports definition lookup failures without stopping the server"
     at origin: Request "Jump to definition" failed. ("Locate: Already at definition point")
     missing: Request "Jump to definition" failed. ("Locate: Not in environment: missing")
     builtin: Request "Jump to definition" failed. ("Locate: \"int\" is a builtin, it is not possible to jump to its definition")
-    server remains usable: true
+    definition after errors:
+    [
+      {
+        "range": {
+          "end": { "character": 4, "line": 0 },
+          "start": { "character": 4, "line": 0 }
+        },
+        "uri": "file:///test.ml"
+      }
+    ]
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -569,6 +569,7 @@ let%expect_test "does not advertise or send unsupported semantic token modifiers
 ;;
 
 let%expect_test "remaps supported semantic token modifiers" =
+  let src = "let f () = 0\n" in
   let capabilities =
     semantic_tokens_client_capabilities
       ~full:(`Bool true)
@@ -578,7 +579,7 @@ let%expect_test "remaps supported semantic token modifiers" =
   in
   test
     ~capabilities
-    ~src:"let f () = 0\n"
+    ~src
     (fun params -> SemanticTokensFull params)
     (fun { initializeResult; resp } ->
        let legend = semantic_tokens_legend initializeResult in
@@ -586,12 +587,27 @@ let%expect_test "remaps supported semantic token modifiers" =
        (match resp with
         | None -> print_endline "empty response"
         | Some { SemanticTokens.data; _ } ->
-          Printf.printf "first token modifiers: %d\n" data.(4));
+          Semantic_hl_helpers.annotate_src_with_tokens
+            ~legend
+            ~encoded_tokens:data
+            ~annot_mods:false
+            src
+          |> print_string;
+          let enabled_modifiers =
+            List.mapi legend.tokenModifiers ~f:(fun index modifier ->
+              let mask = Int.shift_left 1 index in
+              if Int.bit_and data.(4) mask = 0 then None else Some modifier)
+            |> List.filter_opt
+          in
+          Printf.printf
+            "function token modifiers: %s\n"
+            (String.concat ~sep:", " enabled_modifiers));
        Fiber.return ());
   [%expect
     {|
     modifiers: definition
-    first token modifiers: 1
+    let <function-0>f</0> () = <number-1>0</1>
+    function token modifiers: definition
     |}]
 ;;
 
@@ -600,16 +616,19 @@ let%expect_test "semantic tokens use UTF-16 positions" =
   test
     ~src
     (fun params -> SemanticTokensFull params)
-    (fun { resp; _ } ->
+    (fun { initializeResult; resp } ->
        (match resp with
         | None -> print_endline "empty response"
         | Some { SemanticTokens.data; _ } ->
-          Array.iteri data ~f:(fun index value ->
-            if index > 0 then print_string "; ";
-            print_int value);
-          print_newline ());
+          let legend = semantic_tokens_legend initializeResult in
+          Semantic_hl_helpers.annotate_src_with_tokens
+            ~legend
+            ~encoded_tokens:data
+            ~annot_mods:true
+            src
+          |> print_string);
        Fiber.return ());
-  [%expect {| 0; 4; 5; 8; 0; 0; 8; 1; 19; 0 |}]
+  [%expect {| let <variable|-0>café</0> = <number|-1>1</1> |}]
 ;;
 
 let%expect_test "tokens for ocaml_lsp_server.ml" =


### PR DESCRIPTION
Snapshot the successful definition location returned after error cases, and render semantic-token payloads as source annotations and modifier names instead of opaque integer encodings.