### PR TITLE
test(definition): expose Not_found for nullary exception

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -2,6 +2,17 @@ open Test.Import
 
 let print_locations = Test.print_option Locations.yojson_of_t
 
+let rec censor_backtraces = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map fields ~f:(fun (name, value) ->
+         if String.equal name "backtrace"
+         then name, `String "<censored>"
+         else name, censor_backtraces value))
+  | `List values -> `List (List.map values ~f:censor_backtraces)
+  | json -> json
+;;
+
 let definition client position =
   let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
   Client.request
@@ -50,6 +61,32 @@ let%expect_test "reports definition lookup failures without stopping the server"
     missing: Request "Jump to definition" failed. ("Locate: Not in environment: missing")
     builtin: Request "Jump to definition" failed. ("Locate: \"int\" is a builtin, it is not possible to jump to its definition")
     server remains usable: true
+    |}]
+;;
+
+let%expect_test "definition of a nullary exception leaks Not_found" =
+  let source = "exception E\nE" in
+  Helpers.test source (fun client ->
+    let* result =
+      Fiber.collect_errors (fun () ->
+        definition client (Position.create ~line:1 ~character:1))
+    in
+    match result with
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
+      Jsonrpc.Response.Error.yojson_of_t error |> censor_backtraces |> Test.print_result;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      print_locations response;
+      Fiber.return ());
+  [%expect
+    {|
+    {
+      "data": { "exn": "Not_found", "backtrace": "<censored>" },
+      "code": -32603,
+      "message": "uncaught exception"
+    }
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -2,6 +2,17 @@ open Test.Import
 
 let print_locations = Test.print_option Locations.yojson_of_t
 
+let rec censor_backtraces = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map fields ~f:(fun (name, value) ->
+         if String.equal name "backtrace"
+         then name, `String "<censored>"
+         else name, censor_backtraces value))
+  | `List values -> `List (List.map values ~f:censor_backtraces)
+  | json -> json
+;;
+
 let definition client position =
   let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
   Client.request
@@ -54,6 +65,32 @@ let%expect_test "reports no definition for lookup failures without stopping the 
         "uri": "file:///test.ml"
       }
     ]
+    |}]
+;;
+
+let%expect_test "definition of a nullary exception leaks Not_found" =
+  let source = "exception E\nE" in
+  Helpers.test source (fun client ->
+    let* result =
+      Fiber.collect_errors (fun () ->
+        definition client (Position.create ~line:1 ~character:1))
+    in
+    match result with
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
+      Jsonrpc.Response.Error.yojson_of_t error |> censor_backtraces |> Test.print_result;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      print_locations response;
+      Fiber.return ());
+  [%expect
+    {|
+    {
+      "data": { "exn": "Not_found", "backtrace": "<censored>" },
+      "code": -32603,
+      "message": "uncaught exception"
+    }
     |}]
 ;;
 


### PR DESCRIPTION
Adds a regression test for go-to-definition on a nullary exception used as a structure expression:

```ocaml
exception E
E
```

A definition request on the second `E` currently leaks `Not_found` from `Merlin_analysis.Locate.find_definition_uid` as JSON-RPC `InternalError`. The test censors the unstable backtrace and otherwise snapshots the error unchanged.
