### PR TITLE
test(rename): expose Not_found on incomplete local module

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -97,6 +97,29 @@ let%expect_test "prepare rename leaks a lexer error on an astral character" =
     |}]
 ;;
 
+let%expect_test "prepare rename leaks Not_found on an incomplete local module" =
+  run "let module X" (fun client ->
+    Fiber.collect_errors (fun () ->
+      prepare_rename client (Position.create ~line:0 ~character:12))
+    >>= function
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
+      Jsonrpc.Response.Error.yojson_of_t error |> censor_backtraces |> Test.print_result;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      print_prepare_rename response;
+      Fiber.return ());
+  [%expect
+    {|
+    {
+      "data": { "exn": "Not_found", "backtrace": "<censored>" },
+      "code": -32603,
+      "message": "uncaught exception"
+    }
+    |}]
+;;
+
 let%expect_test "rename deduplicates edits for an incomplete binding" =
   test_rename ~newName:"fuzz_renamed" "let rec ma$";
   [%expect {| let rec fuzz_renamed |}]

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -85,6 +85,31 @@ let%expect_test "prepare rename leaks a lexer error on an astral character" =
     |}]
 ;;
 
+let%expect_test "prepare rename leaks Not_found on an incomplete local module" =
+  run "let module X" (fun client ->
+    let* result =
+      Fiber.collect_errors (fun () ->
+        prepare_rename client (Position.create ~line:0 ~character:12))
+    in
+    match result with
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
+      Jsonrpc.Response.Error.yojson_of_t error |> censor_backtraces |> Test.print_result;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      print_prepare_rename response;
+      Fiber.return ());
+  [%expect
+    {|
+    {
+      "data": { "exn": "Not_found", "backtrace": "<censored>" },
+      "code": -32603,
+      "message": "uncaught exception"
+    }
+    |}]
+;;
+
 let%expect_test "rename returns overlapping edits for an incomplete binding" =
   run "let rec ma" (fun client ->
     let* response =


### PR DESCRIPTION
Adds a regression test for occurrence lookup on the incomplete local-module expression `let module X`.

`textDocument/prepareRename` at the valid EOF position currently leaks `Not_found` from `Merlin_analysis.Occurrences.uid_and_loc_of_node` as JSON-RPC `InternalError`. The test censors the unstable backtrace and preserves the exception and response code for a test-first fix.
