### PR TITLE
fix(hover): tolerate empty odoc tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Render empty odoc tables in hover documentation without raising an internal
+  error. (#2038, @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)
 - Suppress triggered completion and signature help inside comments after Unicode.
   (#1994, @rgrinberg)

--- a/ocaml-lsp-server/src/doc_to_md.ml
+++ b/ocaml-lsp-server/src/doc_to_md.ml
@@ -109,37 +109,37 @@ let rec nestable_block_element_to_block
     Block.Paragraph (paragraph, meta)
   | { value = `Table ((grid, alignment), _); location } ->
     let meta = loc_to_meta location in
-    let tbl =
-      let rows =
-        let alignment_row =
-          match alignment with
-          | None -> []
-          | Some alignment ->
-            let alignment =
-              List.map ~f:(fun x -> (x, 1 (* nb of separator *)), Meta.none) alignment
-            in
-            [ (`Sep alignment, Meta.none), "" ]
-        in
-        let cell ((c, _) : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.cell) =
-          let c = nestable_block_element_list_to_inlines c in
-          c, (" ", " ")
-          (* Initial and trailing blanks *)
-        in
-        let data_row (row : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.row) =
-          let row = List.map ~f:cell row in
-          (`Data row, Meta.none), ""
-        in
-        let header_row (row : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.row) =
-          let row = List.map ~f:cell row in
-          (`Header row, Meta.none), ""
-        in
-        match grid with
-        | [] -> assert false
-        | h :: t -> (header_row h :: alignment_row) @ List.map ~f:data_row t
-      in
-      Block.Table.make rows
-    in
-    Block.Ext_table (tbl, meta)
+    (match grid with
+     | [] -> Block.empty
+     | h :: t ->
+       let rows =
+         let alignment_row =
+           match alignment with
+           | None -> []
+           | Some alignment ->
+             let alignment =
+               List.map ~f:(fun x -> (x, 1 (* nb of separator *)), Meta.none) alignment
+             in
+             [ (`Sep alignment, Meta.none), "" ]
+         in
+         let cell ((c, _) : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.cell) =
+           let c = nestable_block_element_list_to_inlines c in
+           c, (" ", " ")
+           (* Initial and trailing blanks *)
+         in
+         let data_row (row : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.row) =
+           let row = List.map ~f:cell row in
+           (`Data row, Meta.none), ""
+         in
+         let header_row (row : Odoc_parser.Ast.nestable_block_element Odoc_parser.Ast.row)
+           =
+           let row = List.map ~f:cell row in
+           (`Header row, Meta.none), ""
+         in
+         (header_row h :: alignment_row) @ List.map ~f:data_row t
+       in
+       let tbl = Block.Table.make rows in
+       Block.Ext_table (tbl, meta))
   | { value = `List (kind, style, xs); location } ->
     let l =
       let list_items =

--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -295,8 +295,8 @@ let _ = x
     let position = Position.create ~line:2 ~character:8 in
     let* result = Fiber.collect_errors (fun () -> Hover_helpers.hover client position) in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       let data = Option.value_exn error.data in
       let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
       Printf.printf
@@ -312,8 +312,13 @@ let _ = x
   Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source request;
   [%expect
     {|
-    code: InternalError
-    exception: File "ocaml-lsp-server/src/doc_to_md.ml", line 137, characters 16-22: Assertion failed
+    {
+      "contents": { "kind": "markdown", "value": "```ocaml\nint\n```\n***\n" },
+      "range": {
+        "end": { "character": 9, "line": 2 },
+        "start": { "character": 8, "line": 2 }
+      }
+    }
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -284,6 +284,39 @@ let%expect_test "FIXME: reproduce [#344](https://github.com/ocaml/ocaml-lsp/issu
     |}]
 ;;
 
+let%expect_test "empty odoc table raises an internal error" =
+  let source =
+    {ocaml|(** {table} *)
+let x = 1
+let _ = x
+|ocaml}
+  in
+  let request client =
+    let position = Position.create ~line:2 ~character:8 in
+    let* result = Fiber.collect_errors (fun () -> Hover_helpers.hover client position) in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok hover ->
+      Hover_helpers.print_hover hover;
+      Fiber.return ()
+  in
+  Helpers.test ~capabilities:Hover_helpers.markdown_capabilities source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: File "ocaml-lsp-server/src/doc_to_md.ml", line 137, characters 16-22: Assertion failed
+    |}]
+;;
+
 let%expect_test "object method call" =
   let source =
     {ocaml|


### PR DESCRIPTION
Treat an empty odoc table as an empty Markdown block instead of asserting during hover rendering. The first commit records the InternalError; the second updates it to a normal hover response.
