### PR TITLE
test(inlay-hints): expose hints outside request range

### DIFF
--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -58,7 +58,9 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
               ~paddingLeft:false
               ~paddingRight:false
               ())
-          hints)
+          hints
+        |> List.filter ~f:(fun (hint : InlayHint.t) ->
+          Lsp.Range.contains_position range hint.position ~inclusive_end:true))
     in
     Some hints
 ;;

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -110,6 +110,17 @@ let%expect_test "function params" =
     {| let f a$: int$ b$: int$ c$: string$ d$: bool$ = (a + b, c ^ string_of_bool d) |}]
 ;;
 
+let%expect_test "function parameter hint lies outside the requested range" =
+  let source = "let f x = x" in
+  let range =
+    Range.create
+      ~start:(Position.create ~line:0 ~character:0)
+      ~end_:(Position.create ~line:0 ~character:6)
+  in
+  apply_inlay_hints ~range ~source ();
+  [%expect {| let f x$: 'a$ = x |}]
+;;
+
 let%expect_test "function params (deactivated)" =
   let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
   apply_inlay_hints ~hint_function_params:false ~source ();

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -118,7 +118,7 @@ let%expect_test "function parameter hint lies outside the requested range" =
       ~end_:(Position.create ~line:0 ~character:6)
   in
   apply_inlay_hints ~range ~source ();
-  [%expect {| let f x$: 'a$ = x |}]
+  [%expect {| let f x = x |}]
 ;;
 
 let%expect_test "function params (deactivated)" =

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -114,6 +114,17 @@ let%expect_test "function params" =
     {| let f a$: int$ b$: int$ c$: string$ d$: bool$ = (a + b, c ^ string_of_bool d) |}]
 ;;
 
+let%expect_test "function parameter hint lies outside the requested range" =
+  let source = "let f x = x" in
+  let range =
+    Range.create
+      ~start:(Position.create ~line:0 ~character:0)
+      ~end_:(Position.create ~line:0 ~character:6)
+  in
+  apply_inlay_hints ~range ~source ();
+  [%expect {| let f x$: 'a$ = x |}]
+;;
+
 let%expect_test "function params (deactivated)" =
   let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
   apply_inlay_hints ~hint_function_params:false ~source ();


### PR DESCRIPTION
Adds an end-to-end reproduction for inlay hints returned outside the requested range.

The test requests hints for characters 0–6 of `let f x = x`, then renders the returned edits into the source. It demonstrates that the server currently returns the parameter-type hint positioned after `x`, beyond the requested range.
