### PR TITLE
fix(code-actions): skip inapplicable inline edit construction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Prevent the inline code action from exhausting the stack on pathologically
+  deep recovery trees. (#2041, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,8 @@
   occurrences into workspace edits. (#2062, @rgrinberg)
 - Reject malformed destruct-line recovery replies and find match separators
   lexically instead of treating identifier substrings as `with`. (#2043, @rgrinberg)
+- Skip inline edit construction for bindings without applicable uses, avoiding
+  stack exhaustion when printing deeply recovered expressions. (#2041, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -244,21 +244,18 @@ let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
   | _ -> app
 ;;
 
-let inlined_text pipeline task =
-  let open Option.O in
-  let+ expr = find_parsetree_loc pipeline task.inlined_expr.exp_loc in
-  let expr = strip_attribute "merlin.loc" expr in
-  Format.asprintf "(%a)" Pprintast.expression expr
+let inlined_text doc task =
+  Code_action.source_text doc task.inlined_expr.exp_loc |> Option.map ~f:(sprintf "(%s)")
 ;;
 
 (** [inline_edits pipeline task] returns a list of inlining edits and an
     optional error value. An error will be generated if any of the potential
     inlinings is not allowed due to shadowing. The successful edits will still
     be returned *)
-let inline_edits pipeline task =
+let inline_edits pipeline doc task =
   let module I = Ocaml_typing.Tast_iterator in
   let open Option.O in
-  let+ newText = inlined_text pipeline task in
+  let+ newText = inlined_text doc task in
   let make_edit newText loc = TextEdit.create ~newText ~range:(Range.of_loc loc) in
   let edits = Queue.create () in
   let error = ref None in
@@ -350,7 +347,7 @@ let code_action pipeline doc (params : CodeActionParams.t) =
     | `Implementation x -> Some x
   in
   let* task = find_inline_task typedtree params.range.start in
-  let m_edits = inline_edits pipeline task in
+  let m_edits = inline_edits pipeline doc task in
   let* edits, m_error = m_edits in
   match edits, m_error with
   | [], None -> None

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -398,22 +398,28 @@ let disabled_code_action error =
 ;;
 
 let code_action_for_task pipeline doc task =
-  let open Option.O in
-  let* edits, m_error = inline_edits pipeline task in
-  match edits, m_error with
-  | [], None -> None
-  | [], Some error -> Some (disabled_code_action error)
-  | _ :: _, (Some _ | None) ->
-    let action =
-      let edit = Text_document.workspace_edit (Document.text_document doc) edits in
-      CodeAction.create
-        ~title:action_title
-        ~kind:RefactorInline
-        ~edit
-        ~isPreferred:false
-        ()
-    in
-    Some action
+  (* Recovery can produce deeply nested parse trees even for short bindings.
+     Do not construct or print replacements unless there is an applicable use. *)
+  match inline_applicability pipeline task with
+  | `Not_applicable -> None
+  | `Disabled error -> Some (disabled_code_action error)
+  | `Applicable ->
+    let open Option.O in
+    let* edits, m_error = inline_edits pipeline task in
+    (match edits, m_error with
+     | [], None -> None
+     | [], Some error -> Some (disabled_code_action error)
+     | _ :: _, (Some _ | None) ->
+       let action =
+         let edit = Text_document.workspace_edit (Document.text_document doc) edits in
+         CodeAction.create
+           ~title:action_title
+           ~kind:RefactorInline
+           ~edit
+           ~isPreferred:false
+           ()
+       in
+       Some action)
 ;;
 
 module Resolve_data = struct

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -4,7 +4,23 @@ let inline_test ?print_none source =
   Code_actions.code_action_test ?print_none ~title:"Inline into uses" source
 ;;
 
-let%expect_test "eager inline action overflows on a deeply recovered expression" =
+let%expect_test "inline a shorthand function used as a value and a labelled argument" =
+  inline_test
+    {|
+let use ~f = f 0
+let $f x = x + 1
+let g = f
+let h = use ~f
+|};
+  [%expect
+    {|
+    let use ~f = f 0
+    let f x = x + 1
+    let g = (fun x -> x + 1)
+    let h = use ~f:(fun x -> x + 1) |}]
+;;
+
+let%expect_test "inline action handles a deeply recovered expression" =
   let source = "let opt[()\nlet claion A -x" in
   let range =
     Code_actions.range ~start_line:0 ~start_character:7 ~end_line:1 ~end_character:15
@@ -42,14 +58,7 @@ let%expect_test "eager inline action overflows on a deeply recovered expression"
          | Error errors -> Fiber.reraise_all errors)
   in
   test ();
-  [%expect
-    {|
-    {
-      "data": { "exn": "Stack overflow" },
-      "code": -32603,
-      "message": "uncaught exception"
-    }
-    |}];
+  [%expect {| No code actions |}];
   let resolveSupport = ClientCodeActionResolveOptions.create ~properties:[ "edit" ] in
   let codeAction =
     CodeActionClientCapabilities.create ~dataSupport:true ~resolveSupport ()

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -88,6 +88,22 @@ let%expect_test "destruct-line returns an edit inside a UTF-8 scalar" =
     |}]
 ;;
 
+let%expect_test "inline action handles a deeply recovered expression" =
+  let source = "let opt[()\nlet claion A -x" in
+  let range = range ~start_line:0 ~start_character:7 ~end_line:1 ~end_character:15 in
+  Helpers.test ~extra_env:[ "OCAMLRUNPARAM=l=10000" ] source (fun client ->
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let only = [ CodeActionKind.RefactorInline ] in
+    let context = CodeActionContext.create ~diagnostics:[] ~only () in
+    let+ response =
+      Client.request
+        client
+        (CodeAction (CodeActionParams.create ~textDocument ~range ~context ()))
+    in
+    print_code_action_result response);
+  [%expect {| No code actions |}]
+;;
+
 let%expect_test "can destruct sum types" =
   let source =
     {ocaml|


### PR DESCRIPTION
Check inline applicability before constructing replacement edits. Return no action for bindings without recognized inline uses, or a disabled action when all recognized uses are blocked by shadowing.

This avoids printing the deeply recovered expression in the crash reproducer merged in #2195. Retain AST-based rendering for applicable uses: shorthand function bindings must become complete `fun` expressions when inlined as values or labelled arguments, rather than using their source slices.

Update the crash regression and cover shorthand-function value and labelled-argument uses. This is a targeted avoidance of unnecessary rendering, not general stack-overflow protection for applicable expressions.
