### PR TITLE
fix(workspace-symbol): preserve deprecated status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
   (#2048, @rgrinberg)
 - Return `null` from the construct custom request when the cursor is not at a
   typed hole. (#2047, @rgrinberg)
+- Preserve deprecation status in workspace-symbol results. (#2044, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal
   error. (#2038, @rgrinberg)
 - Respect client support for signature-help parameter-label offsets. (#2009,

--- a/ocaml-lsp-server/src/workspace_symbol.ml
+++ b/ocaml-lsp-server/src/workspace_symbol.ml
@@ -260,7 +260,7 @@ let rec symbol_info ~containerName resolve_uri (item : Query_protocol.item) =
       SymbolInformation.create
         ~name:item.outline_name
         ~kind
-        ~deprecated:false
+        ~deprecated:item.deprecated
         ~location
         ?containerName
         ()

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -51,6 +51,35 @@ let%expect_test "returns all symbols from workspace" =
     |}]
 ;;
 
+let%expect_test "reports deprecated workspace symbols as non-deprecated" =
+  let workspace_a, _workspace_b = setup_workspaces () in
+  Test.write_file
+    (Filename.concat workspace_a.path "lib/lib.mli")
+    (a_lib_mli ^ "\nval deprecated_value : int [@@deprecated]\n");
+  build_project workspace_a;
+  run [ workspace_a ] (fun client ->
+    let* symbols = workspace_symbol client "deprecated_value" in
+    (match symbols with
+     | Some [ symbol ] ->
+       let deprecated =
+         Option.value_map symbol.deprecated ~default:"missing" ~f:Bool.to_string
+       in
+       let tags = Option.value_map symbol.tags ~default:"missing" ~f:(fun _ -> "present") in
+       Printf.printf
+         "name: %s\ndeprecated: %s\ntags: %s\n"
+         symbol.name
+         deprecated
+         tags
+     | _ -> print_endline "expected exactly one symbol");
+    Fiber.return ());
+  [%expect
+    {|
+    name: deprecated_value
+    deprecated: false
+    tags: missing
+    |}]
+;;
+
 let%expect_test "returns filtered symbols from workspace" =
   let workspace_a, _workspace_b = setup_workspaces () in
   build_project workspace_a;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -51,11 +51,11 @@ let%expect_test "returns all symbols from workspace" =
     |}]
 ;;
 
-let%expect_test "reports deprecated workspace symbols as non-deprecated" =
+let%expect_test "reports deprecated workspace symbols" =
   let workspace_a, _workspace_b = setup_workspaces () in
   Test.write_file
-    (Filename.concat workspace_a.path "lib/lib.mli")
-    (a_lib_mli ^ "\nval deprecated_value : int [@@deprecated]\n");
+    (Filename.concat workspace_a.path "lib/LibTypes.mli")
+    (a_lib_types_mli ^ "\nval deprecated_value : int [@@deprecated]\n");
   build_project workspace_a;
   run [ workspace_a ] (fun client ->
     let* symbols = workspace_symbol client "deprecated_value" in
@@ -64,18 +64,16 @@ let%expect_test "reports deprecated workspace symbols as non-deprecated" =
        let deprecated =
          Option.value_map symbol.deprecated ~default:"missing" ~f:Bool.to_string
        in
-       let tags = Option.value_map symbol.tags ~default:"missing" ~f:(fun _ -> "present") in
-       Printf.printf
-         "name: %s\ndeprecated: %s\ntags: %s\n"
-         symbol.name
-         deprecated
-         tags
+       let tags =
+         Option.value_map symbol.tags ~default:"missing" ~f:(fun _ -> "present")
+       in
+       Printf.printf "name: %s\ndeprecated: %s\ntags: %s\n" symbol.name deprecated tags
      | _ -> print_endline "expected exactly one symbol");
     Fiber.return ());
   [%expect
     {|
     name: deprecated_value
-    deprecated: false
+    deprecated: true
     tags: missing
     |}]
 ;;


### PR DESCRIPTION
Propagate the deprecation bit from indexed outline items into workspace SymbolInformation instead of hard-coding false. The fixture uses an interface-only module so the indexed cmti carries the attribute.
