### PR TITLE
test(code-actions): expose invalid UTF-8 destruct edit

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -42,6 +42,52 @@ let%expect_test "malformed object method leaks a destruct assertion" =
     |}]
 ;;
 
+let%expect_test "destruct-line returns an edit inside a UTF-8 scalar" =
+  let source = "𐐀 = 1\nmatch th | 0 -)et x = 1" in
+  let range = range ~start_line:1 ~start_character:11 ~end_line:1 ~end_character:23 in
+  let general =
+    GeneralClientCapabilities.create ~positionEncodings:[ PositionEncodingKind.UTF8 ] ()
+  in
+  let capabilities = ClientCapabilities.create ~general () in
+  Helpers.test ~capabilities source (fun client ->
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let context = CodeActionContext.create ~diagnostics:[] () in
+    let* response =
+      Client.request
+        client
+        (CodeAction (CodeActionParams.create ~textDocument ~range ~context ()))
+    in
+    print_code_action_result
+      response
+      ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+    Fiber.return ());
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "match ((1 0) - (( *type-error* ) ( *type-error* ))) = 1 with\n| false -> _\n| true -> _",
+                "range": {
+                  "end": { "character": 23, "line": 1 },
+                  "start": { "character": 1, "line": 0 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///test.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
+;;
+
 let%expect_test "can destruct sum types" =
   let source =
     {ocaml|


### PR DESCRIPTION
With UTF-8 position encoding, destruct-line can return a workspace edit whose start position splits the four-byte encoding of `𐐀`. The raw Merlin destruct reply is source-valid (`(0,7)..(1,23)`); ocamllsp's `adjust_reply_location` applies a line-local `-6` preprocessing offset even though Merlin's recovered range starts on the preceding line, producing invalid `(0,1)`. This is an ocamllsp post-processing bug.

This adds a test-only regression that negotiates UTF-8 and snapshots the invalid edit.
