### PR TITLE
fix(construct): return null away from holes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Return `null` from the construct custom request when the cursor is not at a
+  typed hole. (#2047, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal
   error. (#2038, @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)

--- a/ocaml-lsp-server/src/custom_requests/req_construct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_construct.ml
@@ -79,8 +79,11 @@ let make_construct_command position with_values depth =
 let dispatch_construct position with_values depth pipeline =
   let position = Position.logical position in
   let command = make_construct_command position with_values depth in
-  let pos, result = Query_commands.dispatch pipeline command in
-  yojson_of_t { position = Range.of_loc pos; result }
+  try
+    let pos, result = Query_commands.dispatch pipeline command in
+    yojson_of_t { position = Range.of_loc pos; result }
+  with
+  | Merlin_analysis.Construct.Not_a_hole -> `Null
 ;;
 
 let on_request ~params state =

--- a/ocaml-lsp-server/test/e2e-new/construct.ml
+++ b/ocaml-lsp-server/test/e2e-new/construct.ml
@@ -22,6 +22,34 @@ module Util = struct
   ;;
 end
 
+let%expect_test "construct at a non-hole raises an internal error" =
+  let source = "let x = 1" in
+  let request client =
+    let position = Position.create ~line:0 ~character:4 in
+    let* result = Fiber.collect_errors (fun () -> Util.call_construct client position) in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      Test.print_result response;
+      Fiber.return ()
+  in
+  Helpers.test source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: Merlin_analysis.Construct.Not_a_hole
+    |}]
+;;
+
 let%expect_test "Example sample from merlin 1" =
   let source =
     {|type r = {the_t: t; id: int}

--- a/ocaml-lsp-server/test/e2e-new/construct.ml
+++ b/ocaml-lsp-server/test/e2e-new/construct.ml
@@ -22,14 +22,14 @@ module Util = struct
   ;;
 end
 
-let%expect_test "construct at a non-hole raises an internal error" =
+let%expect_test "construct at a non-hole returns null" =
   let source = "let x = 1" in
   let request client =
     let position = Position.create ~line:0 ~character:4 in
     let* result = Fiber.collect_errors (fun () -> Util.call_construct client position) in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       let data = Option.value_exn error.data in
       let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
       Printf.printf
@@ -45,8 +45,7 @@ let%expect_test "construct at a non-hole raises an internal error" =
   Helpers.test source request;
   [%expect
     {|
-    code: InternalError
-    exception: Merlin_analysis.Construct.Not_a_hole
+    null
     |}]
 ;;
 


### PR DESCRIPTION
Handle Merlin’s expected Not_a_hole result in the construct custom request and return null rather than exposing it as JSON-RPC InternalError.
