### PR TITLE
fix(destruct): return null for inapplicable ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Return `null` from the destruct custom request for inapplicable ranges.
+  (#2048, @rgrinberg)
 - Return `null` from the construct custom request when the cursor is not at a
   typed hole. (#2047, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal

--- a/ocaml-lsp-server/src/custom_requests/req_destruct.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_destruct.ml
@@ -47,8 +47,16 @@ let dispatch_destruct range pipeline =
   let start = range.Range.start |> Position.logical
   and stop = range.Range.end_ |> Position.logical in
   let command = make_destruct_command start stop in
-  let loc, content = Query_commands.dispatch pipeline command in
-  yojson_of_t { content; range = Range.of_loc loc }
+  try
+    let loc, content = Query_commands.dispatch pipeline command in
+    yojson_of_t { content; range = Range.of_loc loc }
+  with
+  | Merlin_analysis.Destruct.Wrong_parent _
+  | Query_commands.No_nodes
+  | Merlin_analysis.Destruct.Not_allowed _
+  | Merlin_analysis.Destruct.Useless_refine
+  | Merlin_analysis.Destruct.Ill_typed
+  | Merlin_analysis.Destruct.Nothing_to_do -> `Null
 ;;
 
 let on_request ~params state =

--- a/ocaml-lsp-server/test/e2e-new/destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/destruct.ml
@@ -26,15 +26,15 @@ module Util = struct
   ;;
 end
 
-let%expect_test "destruct at a non-destructible range raises an internal error" =
+let%expect_test "destruct at a non-destructible range returns null" =
   let source = "let x = 1" in
   let request client =
     let position = Position.create ~line:0 ~character:0 in
     let range = Range.create ~start:position ~end_:position in
     let* result = Fiber.collect_errors (fun () -> Util.call_destruct client range) in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       let data = Option.value_exn error.data in
       let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
       Printf.printf
@@ -50,8 +50,7 @@ let%expect_test "destruct at a non-destructible range raises an internal error" 
   Helpers.test source request;
   [%expect
     {|
-    code: InternalError
-    exception: Merlin_analysis.Destruct.Not_allowed("value_binding")
+    null
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/destruct.ml
@@ -26,6 +26,35 @@ module Util = struct
   ;;
 end
 
+let%expect_test "destruct at a non-destructible range raises an internal error" =
+  let source = "let x = 1" in
+  let request client =
+    let position = Position.create ~line:0 ~character:0 in
+    let range = Range.create ~start:position ~end_:position in
+    let* result = Fiber.collect_errors (fun () -> Util.call_destruct client range) in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      Test.print_result response;
+      Fiber.return ()
+  in
+  Helpers.test source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: Merlin_analysis.Destruct.Not_allowed("value_binding")
+    |}]
+;;
+
 let%expect_test "Perform `destruct` as custom request - 1" =
   let source =
     {|


### PR DESCRIPTION
Handle the same expected non-applicability conditions as the destruct code action in the custom request, returning null instead of InternalError.
