### PR TITLE
fix(refactor-extract): return null for empty ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Return `null` from the refactor-extract custom request for empty ranges.
+  (#2049, @rgrinberg)
 - Return `null` from the destruct custom request for inapplicable ranges.
   (#2048, @rgrinberg)
 - Return `null` from the construct custom request when the cursor is not at a

--- a/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_refactor_extract.ml
@@ -52,14 +52,17 @@ let dispatch ~range ~extract_name pipeline =
   let start = Position.logical range.Range.start in
   let end_ = Position.logical range.Range.end_ in
   let command = Query_protocol.Refactor_extract_region (start, end_, extract_name) in
-  let { Query_protocol.loc; content; selection_range } =
-    Query_commands.dispatch pipeline command
-  in
-  yojson_of_t
-    { position = Range.of_loc loc
-    ; content
-    ; selection_range = Range.of_loc selection_range
-    }
+  try
+    let { Query_protocol.loc; content; selection_range } =
+      Query_commands.dispatch pipeline command
+    in
+    yojson_of_t
+      { position = Range.of_loc loc
+      ; content
+      ; selection_range = Range.of_loc selection_range
+      }
+  with
+  | Merlin_analysis.Refactor_extract_region.Nothing_to_do -> `Null
 ;;
 
 let on_request ~params state =

--- a/ocaml-lsp-server/test/e2e-new/refactor_extract.ml
+++ b/ocaml-lsp-server/test/e2e-new/refactor_extract.ml
@@ -22,6 +22,35 @@ module Util = struct
   ;;
 end
 
+let%expect_test "extracting an empty range raises an internal error" =
+  let source = "let x = 1" in
+  let request client =
+    let position = Position.create ~line:0 ~character:0 in
+    let range = Range.create ~start:position ~end_:position in
+    let* result = Fiber.collect_errors (fun () -> Util.call_extract ~range client) in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      Test.print_result response;
+      Fiber.return ()
+  in
+  Helpers.test source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: Merlin_analysis.Refactor_extract_region.Nothing_to_do
+    |}]
+;;
+
 let%expect_test "Example sample from merlin 1" =
   let source =
     {|module type EMPTY = sig end

--- a/ocaml-lsp-server/test/e2e-new/refactor_extract.ml
+++ b/ocaml-lsp-server/test/e2e-new/refactor_extract.ml
@@ -22,15 +22,15 @@ module Util = struct
   ;;
 end
 
-let%expect_test "extracting an empty range raises an internal error" =
+let%expect_test "extracting an empty range returns null" =
   let source = "let x = 1" in
   let request client =
     let position = Position.create ~line:0 ~character:0 in
     let range = Range.create ~start:position ~end_:position in
     let* result = Fiber.collect_errors (fun () -> Util.call_extract ~range client) in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       let data = Option.value_exn error.data in
       let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
       Printf.printf
@@ -46,8 +46,7 @@ let%expect_test "extracting an empty range raises an internal error" =
   Helpers.test source request;
   [%expect
     {|
-    code: InternalError
-    exception: Merlin_analysis.Refactor_extract_region.Nothing_to_do
+    null
     |}]
 ;;
 


### PR DESCRIPTION
Translate Merlin’s expected Nothing_to_do result for an empty extraction range to null rather than JSON-RPC InternalError.
