### PR TITLE
fix(type-enclosing): reject malformed parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Report malformed type-enclosing custom-request parameters as `InvalidParams`
+  instead of an internal error. (#2050, @rgrinberg)
 - Return `null` from the refactor-extract custom request for empty ranges.
   (#2049, @rgrinberg)
 - Return `null` from the destruct custom request for inapplicable ranges.

--- a/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_type_enclosing.ml
@@ -159,7 +159,9 @@ let on_request ~params state =
   Fiber.of_thunk (fun () ->
     let params = (Option.value ~default:(`Assoc []) params :> Json.t) in
     let Request_params.{ index; verbosity; text_document; at } =
-      Request_params.t_of_yojson params
+      try Request_params.t_of_yojson params with
+      | Yojson.Safe.Util.Type_error _ ->
+        Util.raise_invalid_params ~message:"Unexpected parameter format" ~data:params ()
     in
     let position, range_end =
       match at with

--- a/ocaml-lsp-server/test/e2e-new/type_enclosing.ml
+++ b/ocaml-lsp-server/test/e2e-new/type_enclosing.ml
@@ -30,7 +30,7 @@ module Util = struct
   ;;
 end
 
-let%expect_test "missing index is reported as an internal error" =
+let%expect_test "missing index is reported as invalid params" =
   let source = "let x = 1" in
   let request client =
     let params =
@@ -43,19 +43,12 @@ let%expect_test "missing index is reported as an internal error" =
       Fiber.collect_errors (fun () -> Test.custom_request client Req.meth params)
     in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
-      let data = Option.value_exn error.data in
-      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
-      let exn =
-        if String.is_prefix exn ~prefix:"Yojson__Safe.Util.Type_error"
-        then "Yojson__Safe.Util.Type_error"
-        else exn
-      in
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       Printf.printf
-        "code: %s\nexception: %s\n"
+        "code: %s\nmessage: %s\n"
         (Jsonrpc.Response.Error.Code.to_string error.code)
-        exn;
+        error.message;
       Fiber.return ()
     | Error errors -> Fiber.reraise_all errors
     | Ok response ->
@@ -65,8 +58,8 @@ let%expect_test "missing index is reported as an internal error" =
   Helpers.test source request;
   [%expect
     {|
-    code: InternalError
-    exception: Yojson__Safe.Util.Type_error
+    code: InvalidParams
+    message: Unexpected parameter format
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/type_enclosing.ml
+++ b/ocaml-lsp-server/test/e2e-new/type_enclosing.ml
@@ -30,6 +30,46 @@ module Util = struct
   ;;
 end
 
+let%expect_test "missing index is reported as an internal error" =
+  let source = "let x = 1" in
+  let request client =
+    let params =
+      `Assoc
+        [ "uri", DocumentUri.yojson_of_t Helpers.uri
+        ; "at", Position.yojson_of_t (Position.create ~line:0 ~character:4)
+        ]
+    in
+    let* result =
+      Fiber.collect_errors (fun () -> Test.custom_request client Req.meth params)
+    in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      let exn =
+        if String.is_prefix exn ~prefix:"Yojson__Safe.Util.Type_error"
+        then "Yojson__Safe.Util.Type_error"
+        else exn
+      in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      Test.print_result response;
+      Fiber.return ()
+  in
+  Helpers.test source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: Yojson__Safe.Util.Type_error
+    |}]
+;;
+
 let%expect_test "Application of function without range end" =
   let source = "string_of_int 42" in
   let line = 0


### PR DESCRIPTION
Translate Yojson decoding failures for malformed type-enclosing parameters to JSON-RPC InvalidParams, retaining the received parameters as error data.
