### PR TITLE
fix(infer-intf): reject interface documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
+- Reject interface documents passed to the `ocamllsp/inferIntf` custom request
+  with `InvalidParams`. (#2051, @rgrinberg)
 - Report malformed type-enclosing custom-request parameters as `InvalidParams`
   instead of an internal error. (#2050, @rgrinberg)
 - Return `null` from the refactor-extract custom request for empty ranges.

--- a/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_infer_intf.ml
@@ -19,8 +19,14 @@ let on_request ~(params : Jsonrpc.Structured.t option) (state : State.t) =
                  first."
               ())
        | Some impl ->
-         let+ intf = Inference.infer_intf_for_impl impl in
-         Json.t_of_yojson (`String intf))
+         (match Document.kind impl with
+          | `Merlin merlin when Document.Merlin.kind merlin = Document.Kind.Impl ->
+            let+ intf = Inference.infer_intf_for_impl impl in
+            Json.t_of_yojson (`String intf)
+          | `Merlin _ | `Other ->
+            Util.raise_invalid_params
+              ~message:"ocamllsp/inferIntf expects an implementation document"
+              ()))
     | Some json ->
       Jsonrpc.Response.Error.raise
         (Jsonrpc.Response.Error.make

--- a/ocaml-lsp-server/test/e2e-new/infer_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/infer_intf.ml
@@ -5,20 +5,18 @@ let infer_intf ?(uri = Helpers.uri) client =
   Test.custom_request client Req.meth (`List [ DocumentUri.yojson_of_t uri ])
 ;;
 
-let%expect_test "an interface document raises an internal error" =
+let%expect_test "an interface document is rejected as invalid params" =
   let uri = DocumentUri.of_path "test.mli" in
   let source = "val x : int" in
   let request client =
     let* result = Fiber.collect_errors (fun () -> infer_intf ~uri client) in
     match result with
-    | Error
-        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
-      let data = Option.value_exn error.data in
-      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+    | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
+      ->
       Printf.printf
-        "code: %s\nexception: %s\n"
+        "code: %s\nmessage: %s\n"
         (Jsonrpc.Response.Error.Code.to_string error.code)
-        exn;
+        error.message;
       Fiber.return ()
     | Error errors -> Fiber.reraise_all errors
     | Ok response ->
@@ -28,8 +26,8 @@ let%expect_test "an interface document raises an internal error" =
   Helpers.test ~uri ~language_id:"ocaml.interface" source request;
   [%expect
     {|
-    code: InternalError
-    exception: Failure("expected an implementation document, got an interface instead")
+    code: InvalidParams
+    message: ocamllsp/inferIntf expects an implementation document
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/infer_intf.ml
+++ b/ocaml-lsp-server/test/e2e-new/infer_intf.ml
@@ -1,8 +1,36 @@
 open Test.Import
 module Req = Ocaml_lsp_server.Custom_request.Infer_intf
 
-let infer_intf client =
-  Test.custom_request client Req.meth (`List [ DocumentUri.yojson_of_t Helpers.uri ])
+let infer_intf ?(uri = Helpers.uri) client =
+  Test.custom_request client Req.meth (`List [ DocumentUri.yojson_of_t uri ])
+;;
+
+let%expect_test "an interface document raises an internal error" =
+  let uri = DocumentUri.of_path "test.mli" in
+  let source = "val x : int" in
+  let request client =
+    let* result = Fiber.collect_errors (fun () -> infer_intf ~uri client) in
+    match result with
+    | Error
+        [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ] ->
+      let data = Option.value_exn error.data in
+      let exn = Yojson.Safe.Util.(data |> member "exn" |> to_string) in
+      Printf.printf
+        "code: %s\nexception: %s\n"
+        (Jsonrpc.Response.Error.Code.to_string error.code)
+        exn;
+      Fiber.return ()
+    | Error errors -> Fiber.reraise_all errors
+    | Ok response ->
+      Test.print_result response;
+      Fiber.return ()
+  in
+  Helpers.test ~uri ~language_id:"ocaml.interface" source request;
+  [%expect
+    {|
+    code: InternalError
+    exception: Failure("expected an implementation document, got an interface instead")
+    |}]
 ;;
 
 let%expect_test "can infer module interfaces" =


### PR DESCRIPTION
Validate that ocamllsp/inferIntf targets an implementation before invoking inference, returning InvalidParams for loaded interfaces instead of leaking Failure.
