### PR TITLE
test(hover): expose range after requested position

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -178,6 +178,21 @@ let sum = f i f
     |}]
 ;;
 
+let%expect_test "returned range does not contain the hover position" =
+  let source = "let rec f x = x :: f x" in
+  Hover_helpers.test_hover source [ Position.create ~line:0 ~character:18 ];
+  [%expect
+    {|
+    {
+      "contents": { "kind": "plaintext", "value": "'a list" },
+      "range": {
+        "end": { "character": 22, "line": 0 },
+        "start": { "character": 19, "line": 0 }
+      }
+    }
+    |}]
+;;
+
 let%expect_test "regression test for #343" =
   let source =
     {ocaml|type t = s


### PR DESCRIPTION
Hovering the whitespace before an application currently returns information for the following expression together with a range starting after the requested position. This adds a minimal reproduction showing the query at character 18 and range 19–22.
