### PR TITLE
fix(document-symbol): preserve deprecation metadata

### DIFF
--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -124,14 +124,12 @@ module Complete_by_prefix = struct
         ~sort_text_width
     =
     let kind = completion_kind ~supports_enum_member entry.kind in
-    let deprecated, tags =
-      if not entry.deprecated
-      then None, None
-      else if supports_deprecated_tag
-      then None, Some [ CompletionItemTag.Deprecated ]
-      else if supports_deprecated_field
-      then Some true, None
-      else None, None
+    let { Deprecation.deprecated; tags } =
+      Deprecation.create
+        ~deprecated:entry.deprecated
+        ~tag:CompletionItemTag.Deprecated
+        ~supports_tag:supports_deprecated_tag
+        ~supports_deprecated_field
     in
     let textEdit = `TextEdit { TextEdit.range; newText = entry.name } in
     CompletionItem.create
@@ -367,7 +365,7 @@ let complete
         with
         | None -> false
         | Some { valueSet } ->
-          List.mem valueSet CompletionItemTag.Deprecated ~equal:Poly.equal
+          Deprecation.tag_supported valueSet ~tag:CompletionItemTag.Deprecated
       in
       let supports_deprecated_field =
         (not supports_deprecated_tag)

--- a/ocaml-lsp-server/src/deprecation.ml
+++ b/ocaml-lsp-server/src/deprecation.ml
@@ -1,0 +1,18 @@
+open Import
+
+type 'tag t =
+  { deprecated : bool option
+  ; tags : 'tag list option
+  }
+
+let tag_supported value_set ~tag = List.mem value_set tag ~equal:Poly.equal
+
+let create ~deprecated ~tag ~supports_tag ~supports_deprecated_field =
+  if not deprecated
+  then { deprecated = None; tags = None }
+  else if supports_tag
+  then { deprecated = None; tags = Some [ tag ] }
+  else if supports_deprecated_field
+  then { deprecated = Some true; tags = None }
+  else { deprecated = None; tags = None }
+;;

--- a/ocaml-lsp-server/src/deprecation.mli
+++ b/ocaml-lsp-server/src/deprecation.mli
@@ -1,0 +1,13 @@
+type 'tag t =
+  { deprecated : bool option
+  ; tags : 'tag list option
+  }
+
+val tag_supported : 'tag list -> tag:'tag -> bool
+
+val create
+  :  deprecated:bool
+  -> tag:'tag
+  -> supports_tag:bool
+  -> supports_deprecated_field:bool
+  -> 'tag t

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -23,11 +23,18 @@ let normalize_selection_range ~(range : Range.t) = function
     else Option.value (Lsp.Range.intersection range selection_range) ~default:range
 ;;
 
-let rec items_to_symbols items =
+let rec items_to_symbols ~supports_deprecated_tag items =
   List.rev_map
     ~f:
       (fun
-        { Query_protocol.outline_name; outline_kind; location; selection; children; _ } ->
+        { Query_protocol.outline_name
+        ; outline_kind
+        ; location
+        ; selection
+        ; children
+        ; deprecated
+        ; _
+        } ->
       let range = Range.of_loc location in
       (* The LSP spec requires [selectionRange] to be contained in [range].
          Preserve valid selections, clip non-empty overlaps, and fall back to
@@ -35,12 +42,21 @@ let rec items_to_symbols items =
       let selectionRange =
         normalize_selection_range ~range (Range.of_loc_opt selection)
       in
+      let { Deprecation.deprecated; tags } =
+        Deprecation.create
+          ~deprecated
+          ~tag:Lsp.Types.SymbolTag.Deprecated
+          ~supports_tag:supports_deprecated_tag
+          ~supports_deprecated_field:true
+      in
       DocumentSymbol.create
         ~name:outline_name
         ~kind:(symbol_kind_of_outline_kind outline_kind)
         ~range
         ~selectionRange
-        ~children:(items_to_symbols children)
+        ?deprecated
+        ?tags
+        ~children:(items_to_symbols ~supports_deprecated_tag children)
         ())
     items
 ;;
@@ -53,6 +69,8 @@ let rec flatten_document_symbols ~uri ~container_name (symbols : DocumentSymbol.
         ~kind:symbol.kind
         ~location:{ range = symbol.range; uri }
         ~name:symbol.name
+        ?deprecated:symbol.deprecated
+        ?tags:symbol.tags
         ()
     in
     let children =
@@ -72,14 +90,29 @@ let run (client_capabilities : ClientCapabilities.t) doc uri =
       Document.Merlin.with_pipeline_exn ~name:"document-symbols" merlin (fun pipeline ->
         Query_commands.dispatch pipeline Query_protocol.Outline)
     in
-    let symbols = items_to_symbols outline in
+    let document_symbol_capabilities =
+      let open Option.O in
+      let* text_document = client_capabilities.textDocument in
+      text_document.documentSymbol
+    in
+    let supports_deprecated_tag =
+      Option.value
+        ~default:false
+        (let open Option.O in
+         let* document_symbol = document_symbol_capabilities in
+         let* tag_support = document_symbol.tagSupport in
+         Some
+           (Deprecation.tag_supported
+              tag_support.valueSet
+              ~tag:Lsp.Types.SymbolTag.Deprecated))
+    in
+    let symbols = items_to_symbols ~supports_deprecated_tag outline in
     (match
        Option.value
          ~default:false
          (let open Option.O in
-          let* textDocument = client_capabilities.textDocument in
-          let* ds = textDocument.documentSymbol in
-          ds.hierarchicalDocumentSymbolSupport)
+          let* document_symbol = document_symbol_capabilities in
+          document_symbol.hierarchicalDocumentSymbolSupport)
      with
      | true -> Some (`DocumentSymbol symbols)
      | false ->

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -201,7 +201,7 @@ end
     |}]
 ;;
 
-let%expect_test "hierarchical symbols drop the deprecated tag" =
+let%expect_test "deprecated hierarchical symbols use tags when supported" =
   let source = "let old_value = 1 [@@deprecated]" in
   let capabilities =
     let tagSupport = ClientSymbolTagOptions.create ~valueSet:[ SymbolTag.Deprecated ] in
@@ -234,7 +234,8 @@ let%expect_test "hierarchical symbols drop the deprecated tag" =
         "selectionRange": {
           "end": { "character": 13, "line": 0 },
           "start": { "character": 4, "line": 0 }
-        }
+        },
+        "tags": [ 1 ]
       }
     ]
     |}]


### PR DESCRIPTION
Merlin's outline marks deprecated bindings, but document-symbol conversion discarded that metadata. Translate it to `SymbolTag.Deprecated` when the client advertises support, fall back to the legacy `deprecated` field for older clients, and preserve it in flattened `SymbolInformation` responses.

Updates the reproduction introduced in #2042.
