### PR TITLE
fix(code-actions): register Dune promotions as quick fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Advertise Dune promotion code actions using their returned `quickfix` kind.
+  (#2055, @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)
 - Suppress triggered completion and signature help inside comments after Unicode.
   (#1994, @rgrinberg)

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -80,7 +80,7 @@ let register_request t uris =
           in
           CodeActionRegistrationOptions.create
             ~documentSelector
-            ~codeActionKinds:[ CodeActionKind.Other "Promote" ]
+            ~codeActionKinds:[ CodeActionKind.QuickFix ]
             ()
           |> CodeActionRegistrationOptions.yojson_of_t
         in

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
@@ -60,7 +60,7 @@ let%expect_test "promotion registrations when Dune disconnects" =
           "id": "ocamllsp-promote/<document-uri>",
           "method": "textDocument/codeAction",
           "registerOptions": {
-            "codeActionKinds": [ "Promote" ],
+            "codeActionKinds": [ "quickfix" ],
             "documentSelector": [
               { "language": null, "scheme": null, "pattern": "<document-path>" }
             ]

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_execute.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_execute.ml
@@ -6,7 +6,7 @@ let request_promotion client uri =
   let range = Range.create ~start:position ~end_:position in
   let textDocument = TextDocumentIdentifier.create ~uri in
   let context =
-    CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.Other "Promote" ] ()
+    CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.QuickFix ] ()
   in
   let params = CodeActionParams.create ~textDocument ~range ~context () in
   let* actions = Client.request client (CodeAction params) in

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
@@ -68,7 +68,7 @@ let%expect_test "promotion removal while its document is open" =
           "id": "ocamllsp-promote/<document-uri>",
           "method": "textDocument/codeAction",
           "registerOptions": {
-            "codeActionKinds": [ "Promote" ],
+            "codeActionKinds": [ "quickfix" ],
             "documentSelector": [
               { "language": null, "scheme": null, "pattern": "<document-path>" }
             ]

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -65,7 +65,7 @@ let%expect_test "connected Dune does not process workspace removal" =
           "id": "ocamllsp-promote/<document-uri>",
           "method": "textDocument/codeAction",
           "registerOptions": {
-            "codeActionKinds": [ "Promote" ],
+            "codeActionKinds": [ "quickfix" ],
             "documentSelector": [
               { "language": null, "scheme": null, "pattern": "<document-path>" }
             ]


### PR DESCRIPTION
Dune promotion actions are returned with the standard `quickfix` kind, but their dynamic registration advertised the custom `Promote` kind. Clients using that registration to populate `CodeActionContext.only` could consequently request one kind and receive another.

Advertise `quickfix` consistently and update the promotion requests and registration snapshots.
