### PR TITLE
test(workspaces): cover initialization fallbacks

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -120,6 +120,7 @@
     with_pp
     with_ppx
     workspace_change_config
+    workspace_initialization
     workspace_symbol
     workspace_symbol_partial_build
     wrapping_ast_node))))

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -36,6 +36,7 @@ module Lifecycle_events : sig
     }
 
   val create : unit -> t
+  val handler : t -> unit Client.Handler.t
 end
 
 val for_uri : Uri.t -> PublishDiagnosticsParams.t -> bool

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -43,11 +43,15 @@ open Import
 
 let start_client
       ?(capabilities = ClientCapabilities.create ())
+      ?rootPath
+      ?rootUri
       ?workspaceFolders
       ?trace
       client
   =
-  Client.start client (InitializeParams.create ~capabilities ?workspaceFolders ?trace ())
+  Client.start
+    client
+    (InitializeParams.create ~capabilities ?rootPath ?rootUri ?workspaceFolders ?trace ())
 ;;
 
 let shutdown_client client =
@@ -109,6 +113,8 @@ module T : sig
     -> ?stderr:Unix.file_descr
     -> ?timeout:float
     -> ?capabilities:ClientCapabilities.t
+    -> ?rootPath:string option
+    -> ?rootUri:DocumentUri.t
     -> ?workspaceFolders:WorkspaceFolder.t list option
     -> ?trace:TraceValue.t
     -> ?on_spawn:(int -> unit)
@@ -210,6 +216,8 @@ end = struct
         ?stderr
         ?timeout
         ?(capabilities = ClientCapabilities.create ())
+        ?rootPath
+        ?rootUri
         ?workspaceFolders
         ?trace
         ?on_spawn
@@ -217,7 +225,9 @@ end = struct
     =
     run ?cwd ?extra_env ?handler ?stderr ?timeout ?on_spawn
     @@ fun client ->
-    let run_client () = start_client ~capabilities ?workspaceFolders ?trace client in
+    let run_client () =
+      start_client ~capabilities ?rootPath ?rootUri ?workspaceFolders ?trace client
+    in
     let run_test () =
       let* (_ : InitializeResult.t) = Client.initialized client in
       f client

--- a/ocaml-lsp-server/test/e2e-new/workspace_initialization.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_initialization.ml
@@ -1,0 +1,148 @@
+open Test.Import
+open Dune_rpc_test
+
+let diagnostic_shape (params : PublishDiagnosticsParams.t) =
+  let params = only_dune_diagnostics params in
+  let diagnostics =
+    List.map params.diagnostics ~f:(fun (diagnostic : Diagnostic.t) ->
+      `Assoc
+        [ "range", Range.yojson_of_t diagnostic.range
+        ; ( "severity"
+          , Option.value_map
+              diagnostic.severity
+              ~default:`Null
+              ~f:DiagnosticSeverity.yojson_of_t )
+        ; ( "source"
+          , Option.value_map diagnostic.source ~default:`Null ~f:(fun x -> `String x) )
+        ])
+  in
+  `Assoc [ "uri", Uri.yojson_of_t params.uri; "diagnostics", `List diagnostics ]
+;;
+
+let run_case
+      ?cwd
+      ?rootPath
+      ?rootUri
+      ?workspaceFolders
+      (project : Dune_rpc_test.project)
+      label
+  =
+  let events = Lifecycle_events.create () in
+  Test.run_initialized
+    ?cwd
+    ~extra_env:[ "OCAMLLSP_TEST=false"; "XDG_RUNTIME_DIR=" ^ project.runtime_dir ]
+    ~timeout:30.0
+    ~handler:(Lifecycle_events.handler events)
+    ?rootPath
+    ?rootUri
+    ?workspaceFolders
+  @@ fun client ->
+  let* () = Signal.wait (Events.dune_ready events.dune) in
+  Test.write_file project.gate "";
+  let* params =
+    Events.wait_for_diagnostics events.dune ~f:(fun params ->
+      for_uri (Uri.of_path project.expected) params && has_dune_diagnostic params)
+  in
+  print_payload project (label ^ ":") (diagnostic_shape params);
+  Test.shutdown_client client
+;;
+
+let with_project name f =
+  let project = create_project name in
+  Fun.protect ~finally:(fun () -> destroy_project project) (fun () -> f project)
+;;
+
+let other_root (project : Dune_rpc_test.project) name =
+  let path = Filename.concat project.temp name in
+  Unix.mkdir path 0o700;
+  path
+;;
+
+let%expect_test "workspace initialization precedence and fallbacks" =
+  with_project "workspace-precedence" (fun project ->
+    let workspace =
+      WorkspaceFolder.create ~uri:(Uri.of_path project.root) ~name:"workspace-folder"
+    in
+    let other = other_root project "other-root" in
+    run_case
+      project
+      "workspaceFolders over roots"
+      ~workspaceFolders:(Some [ workspace ])
+      ~rootUri:(Uri.of_path other)
+      ~rootPath:(Some other));
+  with_project "root-uri-precedence" (fun project ->
+    let other = other_root project "other-root" in
+    run_case
+      project
+      "rootUri over rootPath"
+      ~workspaceFolders:None
+      ~rootUri:(Uri.of_path project.root)
+      ~rootPath:(Some other));
+  with_project "root-path" (fun project ->
+    run_case
+      project
+      "rootPath fallback"
+      ~workspaceFolders:None
+      ~rootPath:(Some project.root));
+  with_project "cwd" (fun project ->
+    run_case project "cwd fallback" ~workspaceFolders:None ~cwd:project.root);
+  [%expect
+    {|
+    workspaceFolders over roots:
+    {
+      "uri": "<document-uri>",
+      "diagnostics": [
+        {
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ]
+    }
+    rootUri over rootPath:
+    {
+      "uri": "<document-uri>",
+      "diagnostics": [
+        {
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ]
+    }
+    rootPath fallback:
+    {
+      "uri": "<document-uri>",
+      "diagnostics": [
+        {
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ]
+    }
+    cwd fallback:
+    {
+      "uri": "<document-uri>",
+      "diagnostics": [
+        {
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ]
+    }
+    |}]
+;;


### PR DESCRIPTION
Exercise workspace selection through an ocamllsp subprocess and real Dune watch processes.

Verify workspaceFolders precedence over legacy roots, rootUri precedence over rootPath, and the rootPath and cwd fallbacks by observing Dune diagnostics from the selected workspace. Extend the e2e client helper so tests can set the complete initialization root fields.