### PR TITLE
test(dune): use real peers for multiple instances

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_connection_errors.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_connection_errors.ml
@@ -169,33 +169,11 @@ let%expect_test "a connected but uninitialized Dune rejects promotion commands" 
 
 let%expect_test "multiple Dune instances for one workspace are reported" =
   let project = create_project "multiple" in
-  let socket_path = Filename.concat project.temp "fake-rpc.sock" in
-  let listener = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
-  Unix.bind listener (Unix.ADDR_UNIX socket_path);
-  Unix.listen listener 1;
-  let fake_pid =
-    match Unix.fork () with
-    | 0 ->
-      let connection, _ = Unix.accept listener in
-      Unix.sleep 30;
-      Unix.close connection;
-      Unix._exit 0
-    | pid -> pid
-  in
-  let fake_dune =
-    Dune_rpc.Private.Registry.Dune.create
-      ~where:(`Unix socket_path)
-      ~root:project.root
-      ~pid:fake_pid
-  in
-  register project.runtime_dir fake_dune;
+  let build_dir = Filename.concat project.temp "second-build" in
+  let second_dune = start_dune ~build_dir project.root project.runtime_dir in
   Fun.protect
     ~finally:(fun () ->
-      (match Unix.kill fake_pid Sys.sigterm with
-       | () -> ()
-       | exception Unix.Unix_error (Unix.ESRCH, _, _) -> ());
-      ignore (Test.waitpid fake_pid : Unix.process_status);
-      Unix.close listener;
+      stop_process second_dune;
       destroy_project project)
     (fun () ->
        let events = Lifecycle_events.create () in

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -208,7 +208,7 @@ let stop_process pid =
   ignore (Test.waitpid pid : Unix.process_status)
 ;;
 
-let start_dune root runtime_dir =
+let start_dune ?build_dir root runtime_dir =
   let prog = Bin.which "dune" |> Option.value_exn in
   let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
   let env =
@@ -219,15 +219,15 @@ let start_dune root runtime_dir =
     |> List.cons ("XDG_RUNTIME_DIR=" ^ runtime_dir)
     |> Spawn.Env.of_list
   in
+  let argv =
+    [ prog; "build"; "--root"; root ]
+    @ (match build_dir with
+       | None -> []
+       | Some build_dir -> [ "--build-dir"; build_dir ])
+    @ [ "-w"; "@repro" ]
+  in
   let pid =
-    Spawn.spawn
-      ~env
-      ~cwd:(Path root)
-      ~prog
-      ~argv:[ prog; "build"; "--root"; root; "-w"; "@repro" ]
-      ~stdout:output
-      ~stderr:output
-      ()
+    Spawn.spawn ~env ~cwd:(Path root) ~prog ~argv ~stdout:output ~stderr:output ()
   in
   Unix.close output;
   pid

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -55,7 +55,7 @@ type project = private
   ; mutable dune_pid : int option
   }
 
-val start_dune : string -> string -> int
+val start_dune : ?build_dir:string -> string -> string -> int
 val stop_process : int -> unit
 val create_project : string -> project
 val stop_dune : project -> unit


### PR DESCRIPTION
Replace the idle socket peer in the multiple-instance test with a second real Dune watch process using an isolated build directory.

This keeps the two registry entries deterministic without mocking Dune initialization, avoids the idle connection that could deadlock the full suite, and exercises the actual multiple-Dune lifecycle.