### PR TITLE
fix(selection-range): clamp recovered ranges to source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 - Suppress function extraction when a constructor would move out of scope or
   resolve to a shadowing declaration. (#2169, @rgrinberg)
+- Clamp recovered selection ranges to the document bounds. (#2061, @rgrinberg)
 - Exclude symbol declarations from reference results when requested by the
   client. (#2164, @rgrinberg)
 - Convert related locations parsed from Merlin diagnostic messages to zero-based

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -451,8 +451,11 @@ let selection_range
     let selection_range_of_enclosings (enclosings : Warnings.loc list)
       : SelectionRange.t option
       =
+      (* TODO: Convert selection-range inputs and outputs using the negotiated
+         position encoding instead of Merlin's UTF-8 byte columns. *)
+      let source = Document.Merlin.source merlin in
       let ranges_of_enclosing parent (enclosing : Warnings.loc) =
-        let range = Range.of_loc enclosing in
+        let range = Range.clamp_to_source (Range.of_loc enclosing) source in
         { SelectionRange.range; parent }
       in
       List.fold_left

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -451,17 +451,26 @@ let selection_range
   match Document.kind doc with
   | `Other -> Fiber.return []
   | `Merlin merlin ->
-    let selection_range_of_enclosings (enclosings : Warnings.loc list)
-      : SelectionRange.t option
+    let selection_range_of_enclosings position (enclosings : Warnings.loc list)
+      : SelectionRange.t
       =
-      let ranges_of_enclosing parent (enclosing : Warnings.loc) =
-        let range = Range.of_loc enclosing in
-        { SelectionRange.range; parent }
+      let source = Document.Merlin.source merlin in
+      let ranges =
+        List.filter_map enclosings ~f:(fun enclosing ->
+          let range = Range.of_loc enclosing |> Range.clamp_to_source source in
+          Option.some_if
+            (Lsp.Range.contains_position range position ~inclusive_end:true)
+            range)
       in
       List.fold_left
-        ~f:(fun parent enclosing -> Some (ranges_of_enclosing parent enclosing))
+        ~f:(fun parent range -> Some { SelectionRange.range; parent })
         ~init:None
-      @@ List.rev enclosings
+        (List.rev ranges)
+      |> Option.value
+           ~default:
+             { SelectionRange.range = { start = position; end_ = position }
+             ; parent = None
+             }
     in
     let+ ranges =
       Fiber.sequential_map positions ~f:(fun x ->
@@ -471,9 +480,9 @@ let selection_range
             merlin
             (Enclosing (Position.logical x, None))
         in
-        selection_range_of_enclosings enclosings)
+        selection_range_of_enclosings x enclosings)
     in
-    List.filter_opt ranges
+    ranges
 ;;
 
 let references

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -16,6 +16,15 @@ let of_loc (loc : Loc.t) : t =
   of_loc_opt loc |> Option.value ~default:Lsp.Range.first_line
 ;;
 
+let clamp_to_source source ({ start; end_ } : t) =
+  let clamp position =
+    let offset = Msource.get_offset source (Position.logical position) in
+    let (`Logical (line, character)) = Msource.get_logical source offset in
+    Position.create ~line:(line - 1) ~character
+  in
+  { start = clamp start; end_ = clamp end_ }
+;;
+
 let resize_for_edit { TextEdit.range; newText } =
   let lines = String.split_lines newText in
   match lines with

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -14,3 +14,12 @@ let of_loc_opt (loc : Loc.t) : t option =
 
 let of_loc (loc : Loc.t) : t = of_loc_opt loc |> Option.value ~default:first_line
 let contains_loc loc pos = contains_position (of_loc loc) pos ~inclusive_end:true
+
+let clamp_to_source ({ start; end_ } : t) source =
+  let clamp position =
+    let offset = Msource.get_offset source (Position.logical position) in
+    let (`Logical (line, character)) = Msource.get_logical source offset in
+    Position.create ~line:(line - 1) ~character
+  in
+  { start = clamp start; end_ = clamp end_ }
+;;

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -10,6 +10,9 @@ val of_loc : Loc.t -> t
 
 val contains_loc : Loc.t -> Position.t -> bool
 
+(** Clamp both endpoints to positions that exist in [source]. *)
+val clamp_to_source : t -> Msource.t -> t
+
 (** [resize_for_edit edit] returns shrunk, unchanged, or extended [edit.range]
     depending on the size of [edit.newText], e.g., if [edit.newText] contains
     less characters than [edit.range], the new range is shrunk to fit

--- a/ocaml-lsp-server/src/range.mli
+++ b/ocaml-lsp-server/src/range.mli
@@ -8,6 +8,9 @@ val of_loc_opt : Loc.t -> t option
     line in the document *)
 val of_loc : Loc.t -> t
 
+(** Clamp both endpoints to positions that exist in [source]. *)
+val clamp_to_source : Msource.t -> t -> t
+
 (** [resize_for_edit edit] returns shrunk, unchanged, or extended [edit.range]
     depending on the size of [edit.newText], e.g., if [edit.newText] contains
     less characters than [edit.range], the new range is shrunk to fit

--- a/ocaml-lsp-server/test/e2e-new/selection_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/selection_range.ml
@@ -224,7 +224,7 @@ let%expect_test "comment-only document without a trailing newline" =
     [
       [
         {
-          "end": { "character": 0, "line": 1 },
+          "end": { "character": 13, "line": 0 },
           "start": { "character": 0, "line": 0 }
         }
       ]

--- a/ocaml-lsp-server/test/e2e-new/selection_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/selection_range.ml
@@ -221,8 +221,23 @@ let%expect_test "comment-only document without a trailing newline" =
     [
       [
         {
-          "end": { "character": 0, "line": 1 },
+          "end": { "character": 13, "line": 0 },
           "start": { "character": 0, "line": 0 }
+        }
+      ]
+    ]
+    |}]
+;;
+
+let%expect_test "selection range contains the requested position during recovery" =
+  test "\nx" [ Position.create ~line:1 ~character:1 ];
+  [%expect
+    {|
+    [
+      [
+        {
+          "end": { "character": 1, "line": 1 },
+          "start": { "character": 1, "line": 1 }
         }
       ]
     ]


### PR DESCRIPTION
Merlin recovery can return virtual-EOF locations for selection ranges. Forwarding those locations directly produces positions beyond the actual document bounds.

Clamp both recovered endpoints through the current source before constructing the selection-range chain. The test-first regression from #1972 now returns the real EOF position for a comment-only document without a trailing newline.
