### PR TITLE
fix(code-actions): reject cross-line destruct recovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@
   rather than `<sys/statfs.h>`. (#2070, fixes #1069, @dayangac)
 - Deduplicate identical rename text edits returned by Merlin recovery.
   (#2064, @rgrinberg)
+- Reject cross-line destruct recovery locations before applying line-local
+  source offsets. (#2063, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Reject cross-line destruct recovery locations before applying line-local
+  source offsets. (#2063, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -56,12 +56,12 @@ let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postpr
   let+ res = dispatch range in
   match res with
   | Ok reply ->
-    let reply = postprocess reply in
-    let supportsJumpToNextHole =
-      State.experimental_client_capabilities state
-      |> Client.Experimental_capabilities.supportsJumpToNextHole
-    in
-    Some (code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
+    Option.map (postprocess reply) ~f:(fun reply ->
+      let supportsJumpToNextHole =
+        State.experimental_client_capabilities state
+        |> Client.Experimental_capabilities.supportsJumpToNextHole
+      in
+      code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
   | Error
       { exn =
           ( Merlin_analysis.Destruct.Wrong_parent _
@@ -80,7 +80,7 @@ let code_action (state : State.t) dispatch doc (params : CodeActionParams.t) =
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
   | `Merlin _ ->
-    run state doc ~dispatch ~action_kind ~range:params.range ~postprocess:Fun.id
+    run state doc ~dispatch ~action_kind ~range:params.range ~postprocess:Option.some
 ;;
 
 let t ~dispatch state =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -53,14 +53,15 @@ let cached_dispatch merlin =
 ;;
 
 let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postprocess =
-  let+ res = dispatch range in
-  match res with
+  dispatch range
+  >>| function
   | Ok reply ->
-    let reply = postprocess reply in
-    let supportsJumpToNextHole =
-      Experimental.bool (State.experimental_client_capabilities state) "jumpToNextHole"
-    in
-    Some (code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
+    postprocess reply
+    |> Option.map ~f:(fun reply ->
+      let supportsJumpToNextHole =
+        Experimental.bool (State.experimental_client_capabilities state) "jumpToNextHole"
+      in
+      code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
   | Error
       { exn =
           ( Merlin_analysis.Destruct.Wrong_parent _
@@ -79,7 +80,7 @@ let code_action (state : State.t) dispatch doc (params : CodeActionParams.t) =
   | `Other -> Fiber.return None
   | `Merlin m when Document.Merlin.kind m = Intf -> Fiber.return None
   | `Merlin _ ->
-    run state doc ~dispatch ~action_kind ~range:params.range ~postprocess:Fun.id
+    run state doc ~dispatch ~action_kind ~range:params.range ~postprocess:Option.some
 ;;
 
 let t ~dispatch state =

--- a/ocaml-lsp-server/src/code_actions/action_destruct.mli
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.mli
@@ -6,14 +6,15 @@ val kind : CodeActionKind.t
 val cached_dispatch : Document.Merlin.t -> dispatch
 
 (** Run Merlin's case analysis and turn its reply into a code action.
-    [postprocess] may adjust the replacement location and text. *)
+    [postprocess] may adjust the replacement location and text, or reject an
+    unusable recovery result. *)
 val run
   :  State.t
   -> Document.t
   -> dispatch:dispatch
   -> action_kind:string
   -> range:Range.t
-  -> postprocess:(Loc.t * string -> Loc.t * string)
+  -> postprocess:(Loc.t * string -> (Loc.t * string) option)
   -> CodeAction.t option Fiber.t
 
 val t : dispatch:dispatch -> State.t -> Code_action.t

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -151,18 +151,23 @@ let get_reply_range (code : string) (kind : statement_kind) (query_range : Range
 
 (** Adjusts the location Merlin gave us to ensure the right text gets
     overwritten. *)
-let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) : Loc.t =
-  let start_offset =
-    statement.reply_range.start.character - statement.query_range.start.character
-  in
-  let end_offset =
-    statement.reply_range.end_.character - statement.query_range.end_.character
-  in
-  let loc_start =
-    { loc.loc_start with pos_cnum = loc.loc_start.pos_cnum + start_offset }
-  in
-  let loc_end = { loc.loc_end with pos_cnum = loc.loc_end.pos_cnum + end_offset } in
-  { loc with loc_start; loc_end }
+let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) =
+  if
+    loc.loc_start.pos_lnum - 1 <> statement.query_range.start.line
+    || loc.loc_end.pos_lnum - 1 <> statement.query_range.end_.line
+  then None
+  else (
+    let start_offset =
+      statement.reply_range.start.character - statement.query_range.start.character
+    in
+    let end_offset =
+      statement.reply_range.end_.character - statement.query_range.end_.character
+    in
+    let loc_start =
+      { loc.loc_start with pos_cnum = loc.loc_start.pos_cnum + start_offset }
+    in
+    let loc_end = { loc.loc_end with pos_cnum = loc.loc_end.pos_cnum + end_offset } in
+    Some { loc with loc_start; loc_end })
 ;;
 
 (** Tries to find a statement we know how to handle on the line where the range
@@ -259,9 +264,9 @@ let code_action
          ~action_kind
          ~range:statement.query_range
          ~postprocess:(fun (loc, newText) ->
-           let loc = adjust_reply_location ~statement loc in
-           let newText = format_merlin_reply ~statement newText in
-           loc, newText))
+           Option.map (adjust_reply_location ~statement loc) ~f:(fun loc ->
+             let newText = format_merlin_reply ~statement newText in
+             loc, newText)))
 ;;
 
 let t ~dispatch state =

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -252,18 +252,23 @@ let get_reply_range (code : string) (kind : statement_kind) (query_range : Range
 
 (** Adjusts the location Merlin gave us to ensure the right text gets
     overwritten. *)
-let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) : Loc.t =
-  let start_offset =
-    statement.reply_range.start.character - statement.query_range.start.character
-  in
-  let end_offset =
-    statement.reply_range.end_.character - statement.query_range.end_.character
-  in
-  let loc_start =
-    { loc.loc_start with pos_cnum = loc.loc_start.pos_cnum + start_offset }
-  in
-  let loc_end = { loc.loc_end with pos_cnum = loc.loc_end.pos_cnum + end_offset } in
-  { loc with loc_start; loc_end }
+let adjust_reply_location ~(statement : destructable_statement) (loc : Loc.t) =
+  if
+    loc.loc_start.pos_lnum - 1 <> statement.query_range.start.line
+    || loc.loc_end.pos_lnum - 1 <> statement.query_range.end_.line
+  then None
+  else (
+    let start_offset =
+      statement.reply_range.start.character - statement.query_range.start.character
+    in
+    let end_offset =
+      statement.reply_range.end_.character - statement.query_range.end_.character
+    in
+    let loc_start =
+      { loc.loc_start with pos_cnum = loc.loc_start.pos_cnum + start_offset }
+    in
+    let loc_end = { loc.loc_end with pos_cnum = loc.loc_end.pos_cnum + end_offset } in
+    Some { loc with loc_start; loc_end })
 ;;
 
 let statement_of_code ~prefix_len code range =
@@ -384,9 +389,10 @@ let code_action
          ~action_kind
          ~range:statement.query_range
          ~postprocess:(fun (loc, newText) ->
-           let loc = adjust_reply_location ~statement loc in
-           let newText = format_merlin_reply ~statement newText in
-           loc, newText))
+           adjust_reply_location ~statement loc
+           |> Option.map ~f:(fun loc ->
+             let newText = format_merlin_reply ~statement newText in
+             loc, newText)))
 ;;
 
 let t ~dispatch state =

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -42,7 +42,7 @@ let%expect_test "malformed object method leaks a destruct assertion" =
     |}]
 ;;
 
-let%expect_test "destruct-line returns an edit inside a UTF-8 scalar" =
+let%expect_test "destruct-line rejects a cross-line recovery location" =
   let source = "𐐀 = 1\nmatch th | 0 -)et x = 1" in
   let range = range ~start_line:1 ~start_character:11 ~end_line:1 ~end_character:23 in
   let general =
@@ -61,31 +61,7 @@ let%expect_test "destruct-line returns an edit inside a UTF-8 scalar" =
       response
       ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
     Fiber.return ());
-  [%expect
-    {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match ((1 0) - (( *type-error* ) ( *type-error* ))) = 1 with\n| false -> _\n| true -> _",
-                "range": {
-                  "end": { "character": 23, "line": 1 },
-                  "start": { "character": 1, "line": 0 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///test.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
-    |}]
+  [%expect {| No code actions |}]
 ;;
 
 let%expect_test "can destruct sum types" =


### PR DESCRIPTION
Destruct-line computes preprocessing offsets relative to the queried source line. Applying those offsets to a Merlin recovery location beginning on another line can move the edit endpoint into the middle of a UTF-8 scalar and can also target unrelated source.

Allow destruct post-processing to reject unusable replies and return no destruct-line action when either recovered endpoint escapes the query line.