### PR TITLE
fix(rename): deduplicate identical text edits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
   running. (#1919, @rgrinberg)
 - Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`
   rather than `<sys/statfs.h>`. (#2070, fixes #1069, @dayangac)
+- Deduplicate identical rename text edits returned by Merlin recovery.
+  (#2064, @rgrinberg)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/ocaml-lsp-server/src/position.ml
+++ b/ocaml-lsp-server/src/position.ml
@@ -1,5 +1,5 @@
 open Import
-include Lsp.Types.Position
+include Lsp.Position
 
 let to_dyn { line; character } =
   Dyn.record [ "line", Dyn.int line; "character", Dyn.int character ]
@@ -25,8 +25,8 @@ let of_lexical_position (lex_position : Lexing.position) : t option =
           ; "pos_bol", `Int lex_position.pos_bol
           ; "pos_cnum", `Int lex_position.pos_cnum
           ]);
-    let line = max line 0 in
-    let character = max character 0 in
+    let line = Int.max line 0 in
+    let character = Int.max character 0 in
     Some { line; character })
 ;;
 

--- a/ocaml-lsp-server/src/position.mli
+++ b/ocaml-lsp-server/src/position.mli
@@ -1,5 +1,5 @@
 open! Import
-include module type of Lsp.Types.Position with type t = Lsp.Types.Position.t
+include module type of Lsp.Position with type t = Lsp.Position.t
 
 val logical : t -> [> `Logical of int * int ]
 val of_lexical_position : Lexing.position -> t option

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -6,6 +6,12 @@ let position_of_offset source offset =
   Position.create ~line:(line - 1) ~character
 ;;
 
+let compare_text_edit (a : TextEdit.t) (b : TextEdit.t) =
+  match Range.compare a.range b.range with
+  | 0 -> String.compare a.newText b.newText
+  | ordering -> ordering
+;;
+
 let is_parenthesized source ~start_offset ~end_offset =
   end_offset - start_offset >= 3
   && Char.equal source.[start_offset] '('
@@ -135,7 +141,8 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
                  { edit.range with start = occur_end_pos }
                in
                TextEdit.create ~range:empty_range_at_occur_end ~newText:(":" ^ newName)
-             | _ -> edit)))
+             | _ -> edit))
+        |> List.stable_dedup ~compare:compare_text_edit)
     in
     let workspace_edits =
       let documentChanges =

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -85,7 +85,7 @@ let%expect_test "prepare rename leaks a lexer error on an astral character" =
     |}]
 ;;
 
-let%expect_test "rename returns overlapping edits for an incomplete binding" =
+let%expect_test "rename deduplicates edits for an incomplete binding" =
   run "let rec ma" (fun client ->
     let* response =
       rename ~newName:"fuzz_renamed" client (Position.create ~line:0 ~character:10)
@@ -97,13 +97,6 @@ let%expect_test "rename returns overlapping edits for an incomplete binding" =
     {
       "changes": {
         "file:///test.ml": [
-          {
-            "newText": "fuzz_renamed",
-            "range": {
-              "end": { "character": 10, "line": 0 },
-              "start": { "character": 8, "line": 0 }
-            }
-          },
           {
             "newText": "fuzz_renamed",
             "range": {


### PR DESCRIPTION
Merlin recovery can report the same occurrence more than once for an incomplete binding such as `let rec ma`. Forwarding both locations creates duplicate overlapping edits, which are invalid in an LSP workspace edit.

Defensively deduplicate identical final text edits per document while preserving their original order. Distinct rename edits and named-argument rewriting remain unchanged.