### PR TITLE
fix(rename): expand record puns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,9 @@
   running. (#1919, @rgrinberg)
 - Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`
   rather than `<sys/statfs.h>`. (#2070, fixes #1069, @dayangac)
+- Expand record puns during rename to preserve the untouched field or variable,
+  including qualified and type-annotated puns and cross-file occurrences.
+  (#2065, @rgrinberg)
 - Deduplicate identical rename text edits returned by Merlin recovery.
   (#2064, @rgrinberg)
 - Reject cross-line destruct recovery locations before applying line-local

--- a/ocaml-lsp-server/src/document.ml
+++ b/ocaml-lsp-server/src/document.ml
@@ -141,7 +141,7 @@ module Single_pipeline : sig
   val use_with_config
     :  ?name:string
     -> t
-    -> doc:Text_document.t
+    -> source:Msource.t
     -> config:Mconfig.t
     -> f:(Mpipeline.t -> 'a)
     -> ('a, Exn_with_backtrace.t) result Fiber.t
@@ -150,16 +150,12 @@ end = struct
 
   let create thread = { thread }
 
-  let use_with_config ?name t ~doc ~config ~f =
-    let make_pipeline =
-      let source = Msource.make (Text_document.text doc) in
-      fun () -> Mpipeline.make config source
-    in
+  let use_with_config ?name t ~source ~config ~f =
     let task =
       match
         Lev_fiber.Thread.task t.thread ~f:(fun () ->
           let start = Unix.gettimeofday () in
-          let pipeline = make_pipeline () in
+          let pipeline = Mpipeline.make config source in
           let res = Mpipeline.with_pipeline pipeline (fun () -> f pipeline) in
           let stop = Unix.gettimeofday () in
           res, start, stop)
@@ -190,7 +186,8 @@ end = struct
 
   let use ?name t ~doc ~config ~f =
     let* config = Merlin_config.config config in
-    use_with_config ?name t ~doc ~config ~f
+    let source = Msource.make (Text_document.text doc) in
+    use_with_config ?name t ~source ~config ~f
   ;;
 end
 
@@ -315,7 +312,7 @@ module Merlin = struct
   ;;
 
   let with_configurable_pipeline ?name ~config (t : t) f =
-    Single_pipeline.use_with_config ?name t.pipeline ~doc:t.tdoc ~config ~f
+    Single_pipeline.use_with_config ?name t.pipeline ~source:(source t) ~config ~f
   ;;
 
   let mconfig (t : t) = Merlin_config.config t.merlin_config

--- a/ocaml-lsp-server/src/document.mli
+++ b/ocaml-lsp-server/src/document.mli
@@ -28,6 +28,16 @@ module Single_pipeline : sig
   type t
 
   val create : Lev_fiber.Thread.t -> t
+
+  (** Run a pipeline for a source snapshot on the Merlin worker, outside any
+      other pipeline's state. *)
+  val use_with_config
+    :  ?name:string
+    -> t
+    -> source:Msource.t
+    -> config:Mconfig.t
+    -> f:(Mpipeline.t -> 'a)
+    -> ('a, Exn_with_backtrace.t) result Fiber.t
 end
 
 val make

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -73,6 +73,45 @@ let prepare
         else None))
 ;;
 
+let record_puns_and_fields (parsetree : Mreader.parsetree) =
+  let record_puns = ref [] in
+  let record_fields = ref [] in
+  let iterator =
+    let expr (self : Ast_iterator.iterator) (expr : Parsetree.expression) =
+      (match expr.pexp_desc with
+       | Pexp_record (fields, _) ->
+         List.iter fields ~f:(fun (field, value) ->
+           if Loc.compare field.loc value.pexp_loc = 0
+           then record_puns := field.loc :: !record_puns)
+       | _ -> ());
+      Ast_iterator.default_iterator.expr self expr
+    in
+    let pat (self : Ast_iterator.iterator) (pat : Parsetree.pattern) =
+      (match pat.ppat_desc with
+       | Ppat_record (fields, _) ->
+         List.iter fields ~f:(fun (field, value) ->
+           if Loc.compare field.loc value.ppat_loc = 0
+           then record_puns := field.loc :: !record_puns)
+       | _ -> ());
+      Ast_iterator.default_iterator.pat self pat
+    in
+    let label_declaration
+          (self : Ast_iterator.iterator)
+          (declaration : Parsetree.label_declaration)
+      =
+      record_fields := declaration.pld_name.loc :: !record_fields;
+      Ast_iterator.default_iterator.label_declaration self declaration
+    in
+    { Ast_iterator.default_iterator with expr; pat; label_declaration }
+  in
+  (match parsetree with
+   | `Implementation structure -> iterator.structure iterator structure
+   | `Interface signature -> iterator.signature iterator signature);
+  !record_puns, !record_fields
+;;
+
+let same_range left right = Lsp.Range.compare (Range.of_loc left) (Range.of_loc right) = 0
+
 let rename (state : State.t) { RenameParams.textDocument = { uri }; position; newName; _ }
   =
   let doc = Document_store.get state.store uri in
@@ -82,9 +121,11 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
     let command =
       Query_protocol.Occurrences (`Ident_at (Position.logical position), `Renaming)
     in
-    let+ occurrences, _desync =
-      Document.Merlin.dispatch_exn ~name:"rename" merlin command
+    let+ (occurrences, _desync), parsetree =
+      Document.Merlin.with_pipeline_exn ~name:"rename" merlin (fun pipeline ->
+        Query_commands.dispatch pipeline command, Mpipeline.reader_parsetree pipeline)
     in
+    let record_puns, record_fields = record_puns_and_fields parsetree in
     let locs =
       List.filter_map occurrences ~f:(fun (occurrence : Query_protocol.occurrence) ->
         match occurrence.is_stale with
@@ -103,6 +144,11 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
           in
           Map.add_multi acc ~key:uri ~data:loc)
     in
+    let renames_record_field =
+      Map.exists locs ~f:(fun locs ->
+        List.exists locs ~f:(fun loc ->
+          List.exists record_fields ~f:(fun field -> same_range loc field)))
+    in
     let edits =
       Map.mapi locs ~f:(fun ~key:doc_uri ~data:locs ->
         let source =
@@ -115,7 +161,27 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
         in
         List.map locs ~f:(fun loc ->
           let range = identifier_range source loc in
-          let edit = TextEdit.create ~range ~newText:newName in
+          let edit =
+            if List.exists record_puns ~f:(fun pun -> same_range loc pun)
+            then
+              if renames_record_field
+              then (
+                let source_text = Msource.text source in
+                let (`Offset start_offset) =
+                  Msource.get_offset source (Position.logical range.start)
+                in
+                let (`Offset end_offset) =
+                  Msource.get_offset source (Position.logical range.end_)
+                in
+                let old_name =
+                  String.sub source_text ~pos:start_offset ~len:(end_offset - start_offset)
+                in
+                TextEdit.create ~range ~newText:(newName ^ " = " ^ old_name))
+              else (
+                let range = { range with start = range.end_ } in
+                TextEdit.create ~range ~newText:(" = " ^ newName))
+            else TextEdit.create ~range ~newText:newName
+          in
           let start_position = edit.range.start in
           match start_position with
           | { character = 0; _ } -> edit
@@ -126,7 +192,6 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
             (* [index = 0] if we pass [`Logical (1, 0)], but we handle the case
                  when [character = 0] in a separate matching branch *);
             let source_txt = Msource.text source in
-            (* TODO: handle record field puning *)
             (match source_txt.[index - 1] with
              | '~' (* the occurrence is a named argument *)
              | '?' (* is an optional argument *) ->

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -78,55 +78,176 @@ let prepare
         else None))
 ;;
 
-let workspace_edit_of_locations ~document_changes ~documents ~new_name locations =
+(* In a qualified pun such as [{ M.x }], Merlin reports [M.x] as the variable
+   occurrence but only [x] as the record-field occurrence. *)
+type record_pun =
+  { variable : Range.t
+  ; field : Range.t
+  ; end_ : Position.t (* Includes any type constraint or coercion. *)
+  }
+
+type file_occurrences =
+  { source : Msource.t
+  ; version : int option
+  ; ranges : Range.t list
+  ; record_puns : record_pun list
+  ; has_field_occurrence : bool
+  }
+
+let record_puns_and_fields (parsetree : Mreader.parsetree) =
+  let record_puns = ref [] in
+  let record_fields = ref [] in
+  let field_name_range (field : Longident.t Loc.loc) =
+    let name = Longident.last field.txt in
+    let loc = field.loc in
+    let loc_start =
+      { loc.loc_end with pos_cnum = loc.loc_end.pos_cnum - String.length name }
+    in
+    Range.of_loc { loc with loc_start }
+  in
+  let add_field (field : Longident.t Loc.loc) =
+    record_fields := field_name_range field :: !record_fields
+  in
+  let add_pun (field : Longident.t Loc.loc) ~value_loc =
+    let pun =
+      { variable = Range.of_loc field.loc
+      ; field = field_name_range field
+      ; end_ = (Range.of_loc value_loc).end_
+      }
+    in
+    record_puns := pun :: !record_puns;
+    match field.txt with
+    | Longident.Lident _ -> ()
+    | _ -> record_fields := pun.field :: !record_fields
+  in
+  (* A constrained pun wraps its synthetic identifier. Compare the identifier's
+     location, but keep the annotation in the range used to expand the pun. *)
+  let rec expression_location (value : Parsetree.expression) =
+    match value.pexp_desc with
+    | Pexp_constraint (value, _) | Pexp_coerce (value, _, _) -> expression_location value
+    | _ -> value.pexp_loc
+  in
+  let rec pattern_location (value : Parsetree.pattern) =
+    match value.ppat_desc with
+    | Ppat_constraint (value, _) -> pattern_location value
+    | _ -> value.ppat_loc
+  in
+  let iterator =
+    let expr (self : Ast_iterator.iterator) (expr : Parsetree.expression) =
+      (match expr.pexp_desc with
+       | Pexp_record (fields, _) ->
+         List.iter fields ~f:(fun (field, value) ->
+           if Loc.compare field.loc (expression_location value) = 0
+           then add_pun field ~value_loc:value.pexp_loc
+           else add_field field)
+       | Pexp_field (_, field) | Pexp_setfield (_, field, _) -> add_field field
+       | _ -> ());
+      Ast_iterator.default_iterator.expr self expr
+    in
+    let pat (self : Ast_iterator.iterator) (pat : Parsetree.pattern) =
+      (match pat.ppat_desc with
+       | Ppat_record (fields, _) ->
+         List.iter fields ~f:(fun (field, value) ->
+           if Loc.compare field.loc (pattern_location value) = 0
+           then add_pun field ~value_loc:value.ppat_loc
+           else add_field field)
+       | _ -> ());
+      Ast_iterator.default_iterator.pat self pat
+    in
+    let label_declaration
+          (self : Ast_iterator.iterator)
+          (declaration : Parsetree.label_declaration)
+      =
+      record_fields := Range.of_loc declaration.pld_name.loc :: !record_fields;
+      Ast_iterator.default_iterator.label_declaration self declaration
+    in
+    { Ast_iterator.default_iterator with expr; pat; label_declaration }
+  in
+  (match parsetree with
+   | `Implementation structure -> iterator.structure iterator structure
+   | `Interface signature -> iterator.signature iterator signature);
+  !record_puns, !record_fields
+;;
+
+let same_range left right = Lsp.Range.compare left right = 0
+
+let workspace_edit ~document_changes ~new_name files =
+  let renames_record_field =
+    List.exists files ~f:(fun (_, file) -> file.has_field_occurrence)
+  in
   let edits =
-    List.fold_left
-      locations
-      ~init:(Map.empty (module Uri))
-      ~f:(fun acc (uri, range) -> Map.add_multi acc ~key:uri ~data:range)
-    |> Map.mapi ~f:(fun ~key:doc_uri ~data:ranges ->
-      let source =
-        match Map.find documents doc_uri with
-        | Some document -> Document.source document
-        | None ->
-          let source_path = Uri.to_path doc_uri in
-          In_channel.with_open_text source_path In_channel.input_all |> Msource.make
-      in
-      List.map ranges ~f:(fun range ->
-        let edit =
+    List.map files ~f:(fun (uri, file) ->
+      let source = file.source in
+      let edits =
+        List.concat_map file.ranges ~f:(fun range ->
           let range = identifier_range source range in
-          TextEdit.create ~range ~newText:new_name
-        in
-        match edit.range.start with
-        | { character = 0; _ } -> edit
-        | pos ->
-          let (`Offset index) =
-            let mpos = Position.logical pos in
-            Msource.get_offset source mpos
+          let pun =
+            List.find file.record_puns ~f:(fun pun ->
+              let pun_range = if renames_record_field then pun.field else pun.variable in
+              same_range range pun_range)
           in
-          assert (index > 0)
-          (* [index = 0] if we pass [`Logical (1, 0)], but we handle the case
-              when [character = 0] in a separate matching branch *);
-          let source_txt = Msource.text source in
-          (* TODO: handle record field puning *)
-          (match source_txt.[index - 1] with
-           | '~' (* the occurrence is a named argument *)
-           | '?' (* is an optional argument *) ->
-             let empty_range_at_occur_end =
-               let occur_end_pos = edit.range.end_ in
-               { edit.range with start = occur_end_pos }
-             in
-             TextEdit.create ~range:empty_range_at_occur_end ~newText:(":" ^ new_name)
-           | _ -> edit))
-      |> List.stable_dedup ~compare:compare_text_edit)
+          match pun with
+          | Some pun ->
+            let variable =
+              if not renames_record_field
+              then new_name
+              else (
+                let (`Offset start_offset) =
+                  Msource.get_offset source (Position.logical range.start)
+                in
+                let (`Offset end_offset) =
+                  Msource.get_offset source (Position.logical range.end_)
+                in
+                String.sub
+                  (Msource.text source)
+                  ~pos:start_offset
+                  ~len:(end_offset - start_offset))
+            in
+            (* Insert after any annotation, without replacing its source text. *)
+            let expansion =
+              TextEdit.create
+                ~range:{ Range.start = pun.end_; end_ = pun.end_ }
+                ~newText:(" = " ^ variable)
+            in
+            if renames_record_field
+            then [ TextEdit.create ~range ~newText:new_name; expansion ]
+            else [ expansion ]
+          | None ->
+            let edit = TextEdit.create ~range ~newText:new_name in
+            let edit =
+              match range.start with
+              | { character = 0; _ } -> edit
+              | pos ->
+                let (`Offset index) =
+                  let mpos = Position.logical pos in
+                  Msource.get_offset source mpos
+                in
+                assert (index > 0)
+                (* [index = 0] if we pass [`Logical (1, 0)], but we handle the case
+                 when [character = 0] in a separate matching branch *);
+                let source_txt = Msource.text source in
+                (match source_txt.[index - 1] with
+                 | '~' (* the occurrence is a named argument *)
+                 | '?' (* is an optional argument *) ->
+                   let empty_range_at_occur_end =
+                     let occur_end_pos = edit.range.end_ in
+                     { edit.range with start = occur_end_pos }
+                   in
+                   TextEdit.create
+                     ~range:empty_range_at_occur_end
+                     ~newText:(":" ^ new_name)
+                 | _ -> edit)
+            in
+            [ edit ])
+        |> List.stable_dedup ~compare:compare_text_edit
+      in
+      uri, file.version, edits)
   in
   if document_changes
   then (
     let documentChanges =
-      Map.to_alist edits
-      |> List.map ~f:(fun (uri, edits) ->
+      List.map edits ~f:(fun (uri, version, edits) ->
         let textDocument =
-          let version = Map.find documents uri |> Option.map ~f:Document.version in
           OptionalVersionedTextDocumentIdentifier.create ~uri ?version ()
         in
         let edits = List.map edits ~f:(fun e -> `TextEdit e) in
@@ -134,7 +255,7 @@ let workspace_edit_of_locations ~document_changes ~documents ~new_name locations
     in
     WorkspaceEdit.create ~documentChanges ())
   else (
-    let changes = Map.to_alist edits in
+    let changes = List.map edits ~f:(fun (uri, _, edits) -> uri, edits) in
     WorkspaceEdit.create ~changes ())
 ;;
 
@@ -154,8 +275,11 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
     let command =
       Query_protocol.Occurrences (`Ident_at (Position.logical position), `Renaming)
     in
-    let+ occurrences, _desync =
-      Document.Merlin.dispatch_exn ~name:"rename" merlin command
+    let* (occurrences, _desync), request_records =
+      Document.Merlin.with_pipeline_exn ~name:"rename" merlin (fun pipeline ->
+        let occurrences = Query_commands.dispatch pipeline command in
+        let records = Mpipeline.reader_parsetree pipeline |> record_puns_and_fields in
+        occurrences, records)
     in
     let locations =
       List.filter_map occurrences ~f:(fun (occurrence : Query_protocol.occurrence) ->
@@ -170,8 +294,60 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
           in
           Some (uri, Range.of_loc loc))
     in
+    (* Capture every source and version before yielding. Parsing and edits must
+       use the same snapshots, including for documents other than the request. *)
+    let files =
+      List.fold_left
+        locations
+        ~init:(Map.empty (module Uri))
+        ~f:(fun files (uri, range) -> Map.add_multi files ~key:uri ~data:range)
+      |> Map.to_alist
+      |> List.map ~f:(fun (uri, ranges) ->
+        let document = Map.find documents uri in
+        let source =
+          match document with
+          | Some document -> Document.source document
+          | None ->
+            In_channel.with_open_text (Uri.to_path uri) In_channel.input_all
+            |> Msource.make
+        in
+        let version = Option.map document ~f:Document.version in
+        uri, source, version, ranges)
+    in
+    let+ files =
+      Fiber.parallel_map files ~f:(fun (file_uri, source, version, ranges) ->
+        let+ record_puns, fields =
+          (* The request's pipeline has already read its parsetree. Other files
+             get separate pipelines; never nest compiler states on the worker. *)
+          if Uri.equal uri file_uri
+          then Fiber.return request_records
+          else
+            let* config =
+              let handle = Merlin_config.DB.get state.merlin_config file_uri in
+              Fiber.finalize
+                (fun () -> Merlin_config.config handle)
+                ~finally:(fun () -> Merlin_config.destroy handle)
+            in
+            let+ result =
+              Document.Single_pipeline.use_with_config
+                ~name:"rename-record-puns"
+                state.merlin
+                ~source
+                ~config
+                ~f:(fun pipeline ->
+                  Mpipeline.reader_parsetree pipeline |> record_puns_and_fields)
+            in
+            match result with
+            | Ok result -> result
+            | Error exn -> Exn_with_backtrace.reraise exn
+        in
+        let has_field_occurrence =
+          List.exists ranges ~f:(fun range -> List.exists fields ~f:(same_range range))
+        in
+        file_uri, { source; version; ranges; record_puns; has_field_occurrence })
+    in
     let document_changes =
       Capabilities.workspace_edit_document_changes (State.client_capabilities state)
     in
-    workspace_edit_of_locations ~document_changes ~documents ~new_name:newName locations
+    workspace_edit ~document_changes ~new_name:newName files
 ;;

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -183,7 +183,7 @@ let b = (^*$) 1
     |}]
 ;;
 
-let%expect_test "rename record-punned variable also renames the field" =
+let%expect_test "rename record-punned expression variable preserves the field" =
   let source =
     {ocaml|type t = { x : int }
 let f x = { x }
@@ -199,7 +199,77 @@ let f x = { x }
       "changes": {
         "file:///test.ml": [
           {
+            "newText": " = y",
+            "range": {
+              "end": { "character": 13, "line": 1 },
+              "start": { "character": 13, "line": 1 }
+            }
+          },
+          {
             "newText": "y",
+            "range": {
+              "end": { "character": 7, "line": 1 },
+              "start": { "character": 6, "line": 1 }
+            }
+          }
+        ]
+      }
+    }
+    |}]
+;;
+
+let%expect_test "rename record-punned pattern variable preserves the field" =
+  let source =
+    {ocaml|type t = { x : int }
+let get { x } = x
+|ocaml}
+  in
+  run source (fun client ->
+    let* response = rename ~newName:"y" client (Position.create ~line:1 ~character:10) in
+    print_workspace_edit response;
+    Fiber.return ());
+  [%expect
+    {|
+    {
+      "changes": {
+        "file:///test.ml": [
+          {
+            "newText": "y",
+            "range": {
+              "end": { "character": 17, "line": 1 },
+              "start": { "character": 16, "line": 1 }
+            }
+          },
+          {
+            "newText": " = y",
+            "range": {
+              "end": { "character": 11, "line": 1 },
+              "start": { "character": 11, "line": 1 }
+            }
+          }
+        ]
+      }
+    }
+    |}]
+;;
+
+let%expect_test "rename record field preserves a punned variable" =
+  let source =
+    {ocaml|type t = { x : int }
+let f x = { x }
+|ocaml}
+  in
+  run source (fun client ->
+    let* response = rename ~newName:"y" client (Position.create ~line:0 ~character:11) in
+    print_workspace_edit response;
+    Fiber.return ());
+  [%expect
+    {|
+    {
+      "changes": {
+        "file:///test.ml": [
+          {
+            "newText": "y = x",
             "range": {
               "end": { "character": 13, "line": 1 },
               "start": { "character": 12, "line": 1 }
@@ -208,8 +278,8 @@ let f x = { x }
           {
             "newText": "y",
             "range": {
-              "end": { "character": 7, "line": 1 },
-              "start": { "character": 6, "line": 1 }
+              "end": { "character": 12, "line": 0 },
+              "start": { "character": 11, "line": 0 }
             }
           }
         ]

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -189,7 +189,7 @@ let b = (^*$) 1
     |}]
 ;;
 
-let%expect_test "rename record-punned variable also renames the field" =
+let%expect_test "rename record-punned expression variable preserves the field" =
   test_rename
     ~newName:"y"
     {ocaml|type t = { x : int }
@@ -198,11 +198,11 @@ let f $x = { x }
   [%expect
     {|
     type t = { x : int }
-    let f y = { y }
+    let f y = { x = y }
     |}]
 ;;
 
-let%expect_test "rename record-punned pattern variable also renames the field" =
+let%expect_test "rename record-punned pattern variable preserves the field" =
   test_rename
     ~newName:"y"
     {ocaml|type t = { x : int }
@@ -211,11 +211,11 @@ let get { $x } = x
   [%expect
     {|
     type t = { x : int }
-    let get { y } = y
+    let get { x = y } = y
     |}]
 ;;
 
-let%expect_test "rename record field also renames a punned variable" =
+let%expect_test "rename record field preserves a punned variable" =
   test_rename
     ~newName:"y"
     {ocaml|type t = { $x : int }
@@ -224,7 +224,7 @@ let f x = { x }
   [%expect
     {|
     type t = { y : int }
-    let f x = { y }
+    let f x = { y = x }
     |}]
 ;;
 
@@ -497,7 +497,7 @@ let%expect_test "rename a symbol across open and closed files" =
     |}]
 ;;
 
-let%expect_test "rename cross-file record-punned variable also renames field" =
+let%expect_test "rename cross-file record-punned variable preserves field" =
   test_project_rename
     ~newName:"renamed"
     ~request_file:"lib.ml"
@@ -519,11 +519,11 @@ let result : t = { value }
     let renamed = 1
     main.ml:
     open Lib
-    let result : t = { renamed }
+    let result : t = { value = renamed }
     |}]
 ;;
 
-let%expect_test "rename cross-file punned record field also renames variable" =
+let%expect_test "rename cross-file punned record field preserves variable" =
   test_project_rename
     ~newName:"renamed"
     ~request_file:"lib.ml"
@@ -545,11 +545,11 @@ let result : t = { value }
     let value = 1
     main.ml:
     open Lib
-    let result : t = { renamed }
+    let result : t = { renamed = value }
     |}]
 ;;
 
-let%expect_test "rename field without local declaration also renames punned variable" =
+let%expect_test "rename field without local declaration preserves punned variable" =
   test_project_rename
     ~newName:"renamed"
     ~request_file:"main.ml"
@@ -570,11 +570,11 @@ let punned : t = { value }
     open Lib
     let value = 1
     let explicit : t = { renamed = 2 }
-    let punned : t = { renamed }
+    let punned : t = { renamed = value }
     |}]
 ;;
 
-let%expect_test "rename qualified record-punned variable also renames field" =
+let%expect_test "rename qualified record-punned variable preserves field" =
   test_rename
     ~newName:"y"
     {ocaml|module M = struct type t = { x : int } end
@@ -583,11 +583,11 @@ let f $x : M.t = { M.x }
   [%expect
     {|
     module M = struct type t = { x : int } end
-    let f y : M.t = { y }
+    let f y : M.t = { M.x = y }
     |}]
 ;;
 
-let%expect_test "rename qualified punned field also renames variable" =
+let%expect_test "rename qualified punned field preserves variable" =
   test_rename
     ~newName:"y"
     {ocaml|module M = struct type t = { $x : int } end
@@ -598,7 +598,7 @@ let value : M.t = { M.x }
     {|
     module M = struct type t = { y : int } end
     let x = 1
-    let value : M.t = { M.y }
+    let value : M.t = { M.y = x }
     |}]
 ;;
 
@@ -643,7 +643,7 @@ let f $x =
     {|
     type t = { x : int }
     let f y =
-      ({ y : int }, { y :> int }, { y : int :> int }, { x : int = y })
+      ({ x : int = y }, { x :> int = y }, { x : int :> int = y }, { x : int = y })
     |}]
 ;;
 
@@ -658,7 +658,7 @@ let f x =
     {|
     type t = { y : int }
     let f x =
-      ({ y : int }, { y :> int }, { y : int :> int }, { y : int = x })
+      ({ y : int = x }, { y :> int = x }, { y : int :> int = x }, { y : int = x })
     |}]
 ;;
 
@@ -671,7 +671,7 @@ let f { x : int } { x : int = explicit } = $x, explicit
   [%expect
     {|
     type t = { x : int }
-    let f { y : int } { x : int = explicit } = y, explicit
+    let f { x : int = y } { x : int = explicit } = y, explicit
     |}]
 ;;
 
@@ -684,7 +684,7 @@ let f { x : int } { x : int = explicit } = x, explicit
   [%expect
     {|
     type t = { y : int }
-    let f { y : int } { y : int = explicit } = x, explicit
+    let f { y : int = x } { y : int = explicit } = x, explicit
     |}]
 ;;
 
@@ -698,8 +698,8 @@ let f $x = { M.x (* keep *) :
   [%expect
     {|
     module M = struct type t = { x : int } end
-    let f y = { y (* keep *) :
-      int }
+    let f y = { M.x (* keep *) :
+      int = y }
     |}]
 ;;
 
@@ -714,11 +714,24 @@ let f x = { M.x (* keep *) :
     {|
     module M = struct type t = { y : int } end
     let f x = { M.y (* keep *) :
-      int }
+      int = x }
     |}]
 ;;
 
-let%expect_test "rename qualified pattern-punned variable with and without a constraint" =
+let%expect_test "rename qualified pattern-punned variable preserves field" =
+  test_rename
+    ~newName:"y"
+    {ocaml|module M = struct type t = { x : int } end
+let f { M.x } = $x
+|ocaml};
+  [%expect
+    {|
+    module M = struct type t = { x : int } end
+    let f { M.x = y } = y
+    |}]
+;;
+
+let%expect_test "rename qualified constrained pattern-punned variable" =
   test_rename
     ~newName:"y"
     {ocaml|module M = struct type t = { x : int } end
@@ -728,7 +741,7 @@ let g { M.x } = x
   [%expect
     {|
     module M = struct type t = { x : int } end
-    let f { y : int } = y
+    let f { M.x : int = y } = y
     let g { M.x } = x
     |}]
 ;;
@@ -743,8 +756,8 @@ let g { M.x } = x
   [%expect
     {|
     module M = struct type t = { y : int } end
-    let f { M.y : int } = x
-    let g { M.y } = x
+    let f { M.y : int = x } = x
+    let g { M.y = x } = x
     |}]
 ;;
 


### PR DESCRIPTION
Expand record puns when renaming a variable or record field, preserving the untouched side. Cover expressions, patterns, qualified puns, type constraints and coercions, and cross-file occurrences. Insert the explicit assignment after any annotation without rewriting its text, preserving qualifiers, comments, and formatting.

Analyze recovered parsetrees against the same source snapshots used for edits. Keep ranges, versions, and pun metadata together per file. Reuse the request's existing Merlin pipeline; analyze other files separately on the worker and finalize their temporary configuration handles, including on failure.

Regression tests were merged separately in #2200.
