### PR TITLE
docs(changes): record construct completion range fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Keep construct-completion text edits on the request line when Merlin recovery
+  returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.
   (#2055, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal


### PR DESCRIPTION
Add the missing `CHANGES.md` entry for the construct-completion range fix merged in #2034.