### PR TITLE
fix(tests): close client before terminating server

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -237,7 +237,9 @@ let start_dune ?build_dir root runtime_dir =
 ;;
 
 let stop_abruptly client pid =
-  let+ () = Client.stop client in
+  let* () = Client.stop client in
+  (* Close the write side before killing the server so pending replies cannot hit EPIPE. *)
+  let+ () = Client.close client in
   terminate_process pid
 ;;
 


### PR DESCRIPTION
The Dune RPC test cleanup stopped reading from the client and then terminated `ocamllsp` while detached client handlers could still be sending replies. In the promotion-diagnostic test, a pending `client/registerCapability` response could therefore write to a closed pipe and terminate the inline-test runner with `SIGPIPE`.

Close the client transport before terminating the server so pending replies cannot hit `EPIPE`.
