### PR TITLE
fix(lev): include <sys/mount.h> for statfs on FreeBSD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`
+  rather than `<sys/statfs.h>`. (#2070, fixes #1069, @dayangac)
 - Keep construct-completion text edits on the request line when Merlin recovery
   returns a multiline location. (#2034, @rgrinberg)
 - Advertise Dune promotion code actions using their returned `quickfix` kind.

--- a/submodules/lev/lev/vendor/ev.c
+++ b/submodules/lev/lev/vendor/ev.c
@@ -507,7 +507,12 @@
 #endif
 
 #if EV_USE_INOTIFY
-# include <sys/statfs.h>
+/* FreeBSD defines statfs(2) in <sys/mount.h> */
+# ifdef __FreeBSD__
+#  include <sys/mount.h>
+# else
+#  include <sys/statfs.h>
+# endif
 # include <sys/inotify.h>
 /* some very old inotify.h headers don't have IN_DONT_FOLLOW */
 # ifndef IN_DONT_FOLLOW


### PR DESCRIPTION
The vendored libev includes `<sys/statfs.h>` unconditionally under
`EV_USE_INOTIFY`, but FreeBSD declares `statfs(2)` in `<sys/mount.h>`, so the
build fails there.

This applies the same guard as upstream lev `10f615ef`, byte for byte, so the
next subrepo sync is a no-op for this hunk. Non-FreeBSD platforms take the
unchanged `<sys/statfs.h>` branch.

A full `git subrepo pull` would also pick this up, but that is 17 commits across
16 files including a libev update, which is a much larger change than this needs.

Fixes #1069.
