### PR TITLE
test(code-actions): reproduce destruct-line missing cases after module-type with

### DIFF
--- a/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
@@ -222,3 +222,30 @@ let%test_unit "record updates without a case are ignored" =
     None
     (find_case "match { r with value = A } with" ~position:0)
 ;;
+
+let%test_unit "module-type with in the scrutinee hides the outer case" =
+  (* Buggy behavior: the first empty-stack [with] is treated as the match [with],
+     so module-type constraints make the real case invisible. *)
+  check_equal
+    "case after module-type with"
+    None
+    (find_case "match (module M : S with type t = int) with | Pack _ -> _" ~position:0);
+  check_equal
+    "case after module type of with"
+    None
+    (find_case
+       "match (module M : module type of N with type t = int) with | Pack _ -> _"
+       ~position:0);
+  check_equal
+    "case after module-type with containing bars"
+    None
+    (find_case
+       "match (module M : S with type t = [ `A | `B ]) with | Pack _ -> _"
+       ~position:0);
+  check_equal
+    "case after anonymous module with struct/end"
+    None
+    (find_case
+       "match (module struct type u = int end : S with type u = int) with | Pack _ -> _"
+       ~position:0)
+;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -438,6 +438,23 @@ let f r = match (match { r with value = A } with | A -> B | B -> C | C -> A) wit
     |}]
 ;;
 
+let%expect_test "destruct-line finds a case after a module-type with" =
+  let source =
+    {ocaml|
+type t = A | B | C
+module type S = sig type u end
+module M : S with type u = int = struct type u = int end
+let f (x : t) = match (x, (module M : S with type u = int)) with | A, _ -> _
+|ocaml}
+  in
+  let range = range ~start_line:4 ~start_character:16 ~end_line:4 ~end_character:21 in
+  print_code_actions
+    source
+    range
+    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  [%expect {| No code actions |}]
+;;
+
 let%expect_test "destruct-line returns UTF-16 edit ranges" =
   let source =
     {ocaml|


### PR DESCRIPTION
Module-type constraints in a match scrutinee use `with`, and the current
destruct-line case search treats the first empty-stack `with` as the match
arm. When that token belongs to `S with type ...`, the real case is ignored
and the action is not offered.

These tests lock in the current buggy behavior.
