### PR TITLE
fix(code-actions): ignore nested with when finding destruct-line cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@
   (#2076, @rgrinberg)
 - Avoid unregistering promotion code actions when clearing the last promotion
   for an already open document. (#2075, @rgrinberg)
+- Find destruct-line cases after module-type constraints in match scrutinees.
+  (#2072, @rgrinberg)
 - Keep Dune RPC registry polling responsive while connected instances are
   running. (#1919, @rgrinberg)
 - Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -31,11 +31,16 @@ module Search = struct
   ;;
 
   let find_case code ~start next =
-    (* The stack tracks the innermost open constructs: [`Match] for a nested
-     [match]/[try] and [`Brace] for a record-update brace. A [with] closes the
-     innermost [`Match]; a [with] above a [`Brace] belongs to the record
-     update; and a [with] with an empty stack belongs to the [match] we started
-     from, whose first case (if any) immediately follows. *)
+    (* The stack tracks the innermost open constructs:
+       - [`Match] for a nested [match]/[try]
+       - [`Brace] for a record-update brace
+       - [`End] for [begin]/[struct]/[sig]/[object]
+       [paren_depth] tracks [(] nesting so module-type constraints such as
+       [(module M : S with type t = _)] do not look like the outer match [with].
+       A [with] closes the innermost [`Match]; a [with] above another stack frame
+       belongs to that construct; a [with] inside parentheses is ignored; and a
+       [with] with an empty stack at depth 0 belongs to the [match] we started
+       from, whose first case (if any) immediately follows. *)
     (* The search is bounded to a few lines after the [match] to avoid lexing the
      rest of the file when the [match] has no cases yet. *)
     let max_lines = 100 in
@@ -50,27 +55,36 @@ module Search = struct
       prev_end := token.end_;
       !lines <= max_lines
     in
-    let rec loop stack =
+    let rec loop stack paren_depth =
       match next () with
       | None -> None
       | Some token when not (budget_ok token) -> None
-      | Some { kind = MATCH | TRY; _ } -> loop (`Match :: stack)
-      | Some { kind = LBRACE; _ } -> loop (`Brace :: stack)
+      | Some { kind = MATCH | TRY; _ } -> loop (`Match :: stack) paren_depth
+      | Some { kind = LBRACE; _ } -> loop (`Brace :: stack) paren_depth
+      | Some { kind = BEGIN | STRUCT | SIG | OBJECT; _ } ->
+        loop (`End :: stack) paren_depth
       | Some { kind = RBRACE; _ } ->
         (match stack with
-         | `Brace :: rest -> loop rest
-         | _ -> loop stack)
+         | `Brace :: rest -> loop rest paren_depth
+         | _ -> loop stack paren_depth)
+      | Some { kind = END; _ } ->
+        (match stack with
+         | `End :: rest -> loop rest paren_depth
+         | _ -> loop stack paren_depth)
+      | Some { kind = LPAREN; _ } -> loop stack (paren_depth + 1)
+      | Some { kind = RPAREN; _ } -> loop stack (max 0 (paren_depth - 1))
       | Some { kind = WITH; _ } ->
         (match stack with
-         | `Match :: rest -> loop rest
-         | `Brace :: _ -> loop stack
+         | `Match :: rest -> loop rest paren_depth
+         | [] when paren_depth > 0 -> loop stack paren_depth
          | [] ->
            (match next () with
             | Some ({ kind = BAR; start; _ } as token) when budget_ok token -> Some start
-            | None | Some _ -> None))
-      | Some _ -> loop stack
+            | None | Some _ -> None)
+         | _ -> loop stack paren_depth)
+      | Some _ -> loop stack paren_depth
     in
-    loop []
+    loop [] 0
   ;;
 
   let find code ~position =

--- a/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/destruct_line_quickcheck_tests.ml
@@ -80,6 +80,9 @@ type expression =
   | Nested_try
   | Nested_match_with_record
   | Nested_try_with_record
+  | Module_type_with
+  | Module_type_of_with
+  | Module_struct_with
   | Array_literal
   | Raw_string
   | String_literal
@@ -119,6 +122,9 @@ let check_existing_case
     | Nested_try -> "(try A with | _ -> A)"
     | Nested_match_with_record -> "(match { r with a = b } with | A -> B)"
     | Nested_try_with_record -> "(try { r with a = b } with | _ -> c)"
+    | Module_type_with -> "(module M : S with type t = int)"
+    | Module_type_of_with -> "(module M : module type of N with type t = int)"
+    | Module_struct_with -> "(module struct type u = int end : S with type u = int)"
     | Array_literal -> "[| 1; 2 |]"
     | Raw_string -> "{| with | |}"
     | String_literal -> "f \"with |\""
@@ -223,29 +229,27 @@ let%test_unit "record updates without a case are ignored" =
     (find_case "match { r with value = A } with" ~position:0)
 ;;
 
-let%test_unit "module-type with in the scrutinee hides the outer case" =
-  (* Buggy behavior: the first empty-stack [with] is treated as the match [with],
-     so module-type constraints make the real case invisible. *)
+let%test_unit "module-type with in the scrutinee does not hide the outer case" =
+  let before_case = "match (module M : S with type t = int) with " in
   check_equal
     "case after module-type with"
-    None
-    (find_case "match (module M : S with type t = int) with | Pack _ -> _" ~position:0);
+    (Some (String.length before_case))
+    (find_case (before_case ^ "| Pack _ -> _") ~position:0);
+  let before_case = "match (module M : module type of N with type t = int) with " in
   check_equal
     "case after module type of with"
-    None
-    (find_case
-       "match (module M : module type of N with type t = int) with | Pack _ -> _"
-       ~position:0);
+    (Some (String.length before_case))
+    (find_case (before_case ^ "| Pack _ -> _") ~position:0);
+  let before_case = "match (module M : S with type t = [ `A | `B ]) with " in
   check_equal
     "case after module-type with containing bars"
-    None
-    (find_case
-       "match (module M : S with type t = [ `A | `B ]) with | Pack _ -> _"
-       ~position:0);
+    (Some (String.length before_case))
+    (find_case (before_case ^ "| Pack _ -> _") ~position:0);
+  let before_case =
+    "match (module struct type u = int end : S with type u = int) with "
+  in
   check_equal
     "case after anonymous module with struct/end"
-    None
-    (find_case
-       "match (module struct type u = int end : S with type u = int) with | Pack _ -> _"
-       ~position:0)
+    (Some (String.length before_case))
+    (find_case (before_case ^ "| Pack _ -> _") ~position:0)
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -452,7 +452,31 @@ let f (x : t) = match (x, (module M : S with type u = int)) with | A, _ -> _
     source
     range
     ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
-  [%expect {| No code actions |}]
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "\n                                                                 | (B -> _\n                                                                 | C), _ -> _",
+                "range": {
+                  "end": { "character": 76, "line": 4 },
+                  "start": { "character": 76, "line": 4 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "destruct-line (enumerate cases, use existing match)",
+      "title": "Destruct-line (enumerate cases, use existing match)"
+    }
+    |}]
 ;;
 
 let%expect_test "destruct-line returns UTF-16 edit ranges" =

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -304,20 +304,21 @@ let f r = $match$ (match { r with value = A } with | A -> B | B -> C | C -> A) w
 ;;
 
 let%expect_test "destruct-line finds a case after a module-type with" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
 module type S = sig type u end
 module M : S with type u = int = struct type u = int end
-let f (x : t) = match (x, (module M : S with type u = int)) with | A, _ -> _
-|ocaml}
-  in
-  let range = range ~start_line:4 ~start_character:16 ~end_line:4 ~end_character:21 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
-  [%expect {| No code actions |}]
+let f (x : t) = $match$ (x, (module M : S with type u = int)) with | A, _ -> _
+|ocaml};
+  [%expect
+    {|
+    type t = A | B | C
+    module type S = sig type u end
+    module M : S with type u = int = struct type u = int end
+    let f (x : t) = match (x, (module M : S with type u = int)) with | A, _ -> _
+                                                                     | ((B | C), _) -> _
+    |}]
 ;;
 
 let%expect_test "destruct-line returns UTF-16 edit ranges" =


### PR DESCRIPTION
Track parentheses and end-delimited constructs while scanning for the first match case so module-type constraints such as `S with type t = _` are not mistaken for the outer match `with`.

With the formatter fix from #2194 now merged, the newly available action preserves nested or-patterns rather than producing invalid cases.
