### PR TITLE
build(nix): pin dune-rpc registry mtime fix from #15634

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,12 +142,22 @@
         pkgsWithoutOverlays = (import nixpkgs { inherit system; });
         # The project uses Dune language 3.24, which is newer than the Dune in
         # the current Nixpkgs snapshot.
-        duneLatest = pkgsWithoutOverlays.dune_3.overrideAttrs (_: {
-          version = "3.24.1";
+        # 3.24.1 ships an inverted RPC registry mtime skip (ocaml/dune#15630).
+        # ocaml/dune#15634 fixes Poll.poll so clients that race the first
+        # registry write still discover the Dune instance. Pin that fix until
+        # a release includes it. applyPatches so dune-rpc/stdune inherit it too
+        # (overrideAttrs patches only affect the dune package build).
+        duneSrc = pkgsWithoutOverlays.applyPatches {
+          name = "dune-3.24.1+15634-src";
           src = pkgsWithoutOverlays.fetchurl {
             url = "https://github.com/ocaml/dune/releases/download/3.24.1/dune-3.24.1.tbz";
             hash = "sha256-Co6qYt/LlFgCvK+abyAmylIoMz7jkaG97dPnCj8m6iw=";
           };
+          patches = [ ./patches/dune-rpc-registry-mtime-15634.patch ];
+        };
+        duneLatest = pkgsWithoutOverlays.dune_3.overrideAttrs (_: {
+          version = "3.24.1+15634";
+          src = duneSrc;
         });
         ocamlVersionOverlay = ocaml: _final: prev: {
           ocamlPackages = prev.ocaml-ng.${ocaml}.overrideScope (_: osuper: {

--- a/patches/dune-rpc-registry-mtime-15634.patch
+++ b/patches/dune-rpc-registry-mtime-15634.patch
@@ -1,0 +1,19 @@
+diff --git a/otherlibs/dune-rpc/registry.ml b/otherlibs/dune-rpc/registry.ml
+index 7befe9322c3..9db913cdabf 100644
+--- a/otherlibs/dune-rpc/registry.ml
++++ b/otherlibs/dune-rpc/registry.ml
+@@ -169,11 +169,10 @@ struct
+     let** (`Mtime mtime) = IO.stat dir in
+     let skip =
+       match t.last_mtime with
+-      | Some last_mtime -> last_mtime <> mtime
+-      | None ->
+-        t.last_mtime <- Some mtime;
+-        false
++      | Some last_mtime -> last_mtime = mtime
++      | None -> false
+     in
++    t.last_mtime <- Some mtime;
+     if skip
+     then Fiber.return (Ok Refresh.empty)
+     else


### PR DESCRIPTION
Temporary Nix pin for [ocaml/dune#15634](https://github.com/ocaml/dune/pull/15634) until a Dune release ships the fix.

Dune 3.24.1 inverts the RPC registry mtime skip ([ocaml/dune#15630](https://github.com/ocaml/dune/issues/15630)). If ocaml-lsp polls before Dune writes its registry entry, later polls skip forever and the server never connects. That shows up as flaky Dune diagnostics / connection e2e hangs.

The patch is applied with `applyPatches` on the shared Dune source so `dune-rpc` (linked into ocamllsp) gets the fix, not only the `dune` binary.
