### PR TITLE
fix(document-store): only unregister closed promotion docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Avoid unregistering promotion code actions when clearing the last promotion
+  for an already open document. (#2075, @rgrinberg)
 - Keep Dune RPC registry polling responsive while connected instances are
   running. (#1919, @rgrinberg)
 - Fix the build on FreeBSD, where `statfs(2)` is declared in `<sys/mount.h>`

--- a/ocaml-lsp-server/src/document_store.ml
+++ b/ocaml-lsp-server/src/document_store.ml
@@ -28,10 +28,9 @@ type semantic_tokens_cache =
     to O and to register while transitioning from X to O. *)
 
 type doc =
-  { (* invariant: if [document <> None], then no promotions are active *)
-    document : Document.t option
-  ; (* the number of associated promotions. when this is 0, we may unsubscribe
-       from code actions *)
+  { document : Document.t option
+  ; (* promotion refcount. dynamic registration is needed only while the
+       document is closed and this count is positive *)
     promotions : int
   ; mutable semantic_tokens_cache : semantic_tokens_cache option
   }
@@ -163,8 +162,8 @@ let unregister_promotions t uris =
     | None -> false
     | Some doc ->
       doc := { !doc with promotions = !doc.promotions - 1 };
-      let unsubscribe = !doc.promotions = 0 in
-      if unsubscribe && !doc.document = None then Hashtbl.remove t.db uri;
+      let unsubscribe = !doc.promotions = 0 && !doc.document = None in
+      if unsubscribe then Hashtbl.remove t.db uri;
       unsubscribe)
   |> unregister_request t
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_open.ml
@@ -21,6 +21,8 @@ let%expect_test "promotion removal while its document is open" =
            Events.wait_for_diagnostics events.dune ~f:(fun params ->
              for_uri initial.uri params && no_dune_diagnostic params)
          in
+         (* Negative check: with the document open, clearing the last promotion
+            must not emit another unregister. Drain the registration pool. *)
          let* () = Lev_fiber.Timer.sleepf 0.01 in
          print_payload
            project
@@ -88,15 +90,6 @@ let%expect_test "promotion removal while its document is open" =
     Dune diagnostics after removing the promotion:
     { "diagnostics": [], "uri": "<document-uri>" }
     client/unregisterCapability after removing the promotion:
-    [
-      {
-        "unregisterations": [
-          {
-            "id": "ocamllsp-promote/<document-uri>",
-            "method": "textDocument/codeAction"
-          }
-        ]
-      }
-    ]
+    []
     |}]
 ;;


### PR DESCRIPTION
When the last Dune promotion for a file is cleared, only send
`client/unregisterCapability` if that document is still closed. Open
documents already dropped the dynamic registration on `didOpen`, so a
second unregister was spurious.