### PR TITLE
fix(dune): retain promotions for instance finalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Unregister Dune promotion code actions when an RPC instance finishes.
+  (#2076, @rgrinberg)
 - Avoid unregistering promotion code actions when clearing the last promotion
   for an already open document. (#2075, @rgrinberg)
 - Keep Dune RPC registry polling responsive while connected instances are

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -159,7 +159,7 @@ end = struct
     | Idle
     | Connected of Lev_fiber_csexp.Session.t * Drpc.Where.t
     | Running of running
-    | Finished
+    | Finished of Drpc.Diagnostic.Promotion.t Map.M(String).t
 
   type t =
     { config : config
@@ -169,13 +169,14 @@ end = struct
 
   let client t =
     match t.state with
-    | Connected _ | Idle | Finished -> None
+    | Connected _ | Idle | Finished _ -> None
     | Running r -> r.client
   ;;
 
   let promotions t =
     match t.state with
-    | Connected _ | Idle | Finished -> Map.empty (module String)
+    | Connected _ | Idle -> Map.empty (module String)
+    | Finished promotions -> promotions
     | Running r -> r.promotions
   ;;
 
@@ -448,7 +449,7 @@ end = struct
           in
           t.config.log ~type_:Error ~message
       in
-      t.state <- Finished;
+      t.state <- Finished (Map.empty (module String));
       Error ()
     | Ok session ->
       let message =
@@ -494,7 +495,6 @@ end = struct
     let* () =
       Fiber.all_concurrently_unit
         [ (let* () = Chan.run chan in
-           t.state <- Finished;
            Diagnostics.disconnect diagnostics running.diagnostics_id;
            let* () = Diagnostics.send diagnostics `All in
            Fiber.Ivar.fill finish ())
@@ -540,6 +540,8 @@ end = struct
              Fiber.all_concurrently_unit [ progress; diagnostics; Fiber.Ivar.read finish ]))
         ]
     in
+    (* Snapshot after both fibers finish so finalization sees the last promotion set. *)
+    t.state <- Finished running.promotions;
     Progress.end_build_if_running progress
   ;;
 
@@ -561,7 +563,7 @@ end = struct
        | Error _ ->
          Jsonrpc.Response.Error.(
            raise (make ~message:"dune failed to format" ~code:InternalError ())))
-    | Connected _ | Idle | Finished | Running _ -> assert false
+    | Connected _ | Idle | Finished _ | Running _ -> assert false
   ;;
 end
 

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
@@ -12,12 +12,13 @@ let%expect_test "promotion registrations when Dune disconnects" =
          Test.write_file project.gate "";
          let* initial = Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic in
          let* registration = Mailbox.wait events.registrations in
+         let promotion_cleanup = Mailbox.wait events.unregistrations in
          stop_dune project;
          let* cleared =
            Events.wait_for_diagnostics events.dune ~f:(fun params ->
              for_uri initial.uri params && no_dune_diagnostic params)
          in
-         let* () = Lev_fiber.Timer.sleepf 0.02 in
+         let* unregistration = promotion_cleanup in
          print_payload
            project
            "initial textDocument/publishDiagnostics:"
@@ -34,7 +35,7 @@ let%expect_test "promotion registrations when Dune disconnects" =
            project
            "client/unregisterCapability after Dune disconnects:"
            UnregistrationParams.yojson_of_t
-           (Mailbox.take_pending events.unregistrations);
+           (unregistration :: Mailbox.take_pending events.unregistrations);
          Fiber.return ()));
   [%expect
     {|
@@ -71,6 +72,15 @@ let%expect_test "promotion registrations when Dune disconnects" =
     textDocument/publishDiagnostics after Dune disconnects:
     { "diagnostics": [], "uri": "<document-uri>" }
     client/unregisterCapability after Dune disconnects:
-    []
+    [
+      {
+        "unregisterations": [
+          {
+            "id": "ocamllsp-promote/<document-uri>",
+            "method": "textDocument/codeAction"
+          }
+        ]
+      }
+    ]
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -32,8 +32,10 @@ let%expect_test "connected Dune does not process workspace removal" =
            Events.wait_for_diagnostics events.dune ~f:(fun params ->
              for_uri initial.uri params && no_dune_diagnostic params)
          in
+         let promotion_cleanup = Mailbox.wait events.unregistrations in
          let* () = Client.notification client (ChangeWorkspaceFolders params) in
          let* cleared = diagnostics_after_removal in
+         let* unregistration = promotion_cleanup in
          print_payloads
            project
            "textDocument/publishDiagnostics after workspace removal:"
@@ -43,7 +45,7 @@ let%expect_test "connected Dune does not process workspace removal" =
            project
            "client/unregisterCapability after workspace removal:"
            UnregistrationParams.yojson_of_t
-           (Mailbox.take_pending events.unregistrations);
+           (unregistration :: Mailbox.take_pending events.unregistrations);
          Fiber.return ()));
   [%expect
     {|
@@ -87,6 +89,15 @@ let%expect_test "connected Dune does not process workspace removal" =
     textDocument/publishDiagnostics after workspace removal:
     [ { "diagnostics": [], "uri": "<document-uri>" } ]
     client/unregisterCapability after workspace removal:
-    []
+    [
+      {
+        "unregisterations": [
+          {
+            "id": "ocamllsp-promote/<document-uri>",
+            "method": "textDocument/codeAction"
+          }
+        ]
+      }
+    ]
     |}]
 ;;


### PR DESCRIPTION
When a Dune RPC instance finishes, keep its final promotion set on
`Finished` only after both instance fibers complete. Finalization can then
unregister promotion code actions exactly once on disconnect and workspace
removal.