### PR TITLE
test(dune): cover disabled progress reporting

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -89,6 +89,7 @@
     dune_diagnostics
     dune_formatting
     dune_nested_root
+    dune_progress
     dune_progress_lifecycle
     dune_promotion_disconnect
     dune_promotion_execute

--- a/ocaml-lsp-server/test/e2e-new/dune_progress.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_progress.ml
@@ -1,0 +1,99 @@
+open Test.Import
+open Dune_rpc_test
+
+let normalize_error (params : LogMessageParams.t) =
+  let message =
+    if
+      String.is_substring
+        params.message
+        ~substring:"Invalid_argument(\"progress reporting is not supported\")"
+    then "Invalid_argument(\"progress reporting is not supported\")"
+    else params.message
+  in
+  { params with message }
+;;
+
+let%expect_test "Dune remains connected when work-done progress is unsupported" =
+  let project = create_project "no-progress" in
+  Fun.protect
+    ~finally:(fun () -> destroy_project project)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       let capabilities = ClientCapabilities.create () in
+       run ~capabilities ~trace:Verbose project events ~f:(fun client _workspace ->
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         (* Synchronize with a real Dune progress update before triggering the
+            build result used by the rest of the assertion. *)
+         let* () = Signal.wait (Events.dune_progress events.dune) in
+         Test.write_file project.gate "";
+         let* diagnostic =
+           Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic
+         in
+         let* echo = Client.request client (DebugEcho { message = "still connected" }) in
+         let progress_creations = Mailbox.take_pending events.progress_creations in
+         let progress_notifications =
+           Mailbox.take_pending (Events.progress events.dune)
+         in
+         stop_dune project;
+         let* cleared =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri diagnostic.uri params && no_dune_diagnostic params)
+         in
+         let* () = Lev_fiber.Timer.sleepf 0.05 in
+         let errors =
+           Mailbox.take_pending (Events.errors events.dune) |> List.map ~f:normalize_error
+         in
+         print_payload
+           project
+           "Dune diagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t diagnostic);
+         print_payload
+           project
+           "Dune diagnostics after disconnect:"
+           (PublishDiagnosticsParams.yojson_of_t cleared);
+         print_payloads project "Dune errors:" LogMessageParams.yojson_of_t errors;
+         print_payloads
+           project
+           "progress creations:"
+           WorkDoneProgressCreateParams.yojson_of_t
+           progress_creations;
+         print_payloads
+           project
+           "progress notifications:"
+           (ProgressParams.yojson_of_t Lsp.Progress.yojson_of_t)
+           progress_notifications;
+         Printf.printf "echo: %s\n" echo.message;
+         Fiber.return ()));
+  [%expect
+    {|
+    Dune diagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    Dune diagnostics after disconnect:
+    { "diagnostics": [], "uri": "<document-uri>" }
+    Dune errors:
+    [
+      {
+        "message": "Invalid_argument(\"progress reporting is not supported\")",
+        "type": 1
+      }
+    ]
+    progress creations:
+    []
+    progress notifications:
+    []
+    echo: still connected
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -74,7 +74,9 @@ module Events = struct
 
   type t =
     { dune_ready : Signal.t
+    ; dune_progress : Signal.t
     ; multiple_instances : Signal.t
+    ; errors : LogMessageParams.t Mailbox.t
     ; progress : Lsp.Progress.t ProgressParams.t Mailbox.t
     ; mutable diagnostics : PublishDiagnosticsParams.t list
     ; mutable diagnostic_waiter : diagnostic_waiter option
@@ -82,7 +84,9 @@ module Events = struct
 
   let create () =
     { dune_ready = Signal.create ()
+    ; dune_progress = Signal.create ()
     ; multiple_instances = Signal.create ()
+    ; errors = Mailbox.create ()
     ; progress = Mailbox.create ()
     ; diagnostics = []
     ; diagnostic_waiter = None
@@ -90,7 +94,9 @@ module Events = struct
   ;;
 
   let dune_ready t = t.dune_ready
+  let dune_progress t = t.dune_progress
   let multiple_instances t = t.multiple_instances
+  let errors t = t.errors
   let progress t = t.progress
 
   let rec take_matching ~f rev_prefix = function
@@ -137,6 +143,9 @@ module Events = struct
       Signal.notify t.dune_ready
     | LogMessage { message; _ } when String.is_substring message ~substring:" ignores " ->
       Signal.notify t.multiple_instances
+    | LogMessage ({ type_ = Error; _ } as params) -> Mailbox.push t.errors params
+    | LogTrace { message; _ } when String.is_prefix message ~prefix:"Dune build " ->
+      Signal.notify t.dune_progress
     | WorkDoneProgress progress -> Mailbox.push t.progress progress
     | _ -> Fiber.return ()
   ;;
@@ -349,7 +358,7 @@ let destroy_project project =
   ignore (Sys.command ("rm -rf -- " ^ Filename.quote project.temp) : int)
 ;;
 
-let run_with_workspace ?capabilities ~root ~runtime_dir events ~f =
+let run_with_workspace ?capabilities ?trace ~root ~runtime_dir events ~f =
   let ocamllsp_stderr = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
   Fun.protect
     ~finally:(fun () -> Unix.close ocamllsp_stderr)
@@ -370,6 +379,7 @@ let run_with_workspace ?capabilities ~root ~runtime_dir events ~f =
          ~stderr:ocamllsp_stderr
          ~capabilities
          ~workspaceFolders:(Some [ workspace ])
+         ?trace
          ~on_spawn:(fun pid -> server_pid := Some pid)
        @@ fun client ->
        Fiber.finalize
@@ -377,7 +387,7 @@ let run_with_workspace ?capabilities ~root ~runtime_dir events ~f =
          ~finally:(fun () -> stop_abruptly client (Option.value_exn !server_pid)))
 ;;
 
-let run ?workspace_root ?capabilities project events ~f =
+let run ?workspace_root ?capabilities ?trace project events ~f =
   let root = Option.value workspace_root ~default:project.root in
-  run_with_workspace ~root ~runtime_dir:project.runtime_dir ?capabilities events ~f
+  run_with_workspace ~root ~runtime_dir:project.runtime_dir ?capabilities ?trace events ~f
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -17,7 +17,9 @@ module Events : sig
   type t
 
   val dune_ready : t -> Signal.t
+  val dune_progress : t -> Signal.t
   val multiple_instances : t -> Signal.t
+  val errors : t -> LogMessageParams.t Mailbox.t
   val progress : t -> Lsp.Progress.t ProgressParams.t Mailbox.t
 
   val wait_for_diagnostics
@@ -67,6 +69,7 @@ val print_payloads : project -> string -> ('a -> Yojson.Safe.t) -> 'a list -> un
 
 val run_with_workspace
   :  ?capabilities:ClientCapabilities.t
+  -> ?trace:TraceValue.t
   -> root:string
   -> runtime_dir:string
   -> Lifecycle_events.t
@@ -76,6 +79,7 @@ val run_with_workspace
 val run
   :  ?workspace_root:string
   -> ?capabilities:ClientCapabilities.t
+  -> ?trace:TraceValue.t
   -> project
   -> Lifecycle_events.t
   -> f:(unit Client.t -> WorkspaceFolder.t -> 'a Fiber.t)


### PR DESCRIPTION
Add end-to-end regression coverage for LSP clients that omit work-done progress support.

The test synchronizes with a real Dune progress update and snapshots the resulting internal Dune error, complete diagnostic lifecycle, absence of progress messages, and continued responsiveness of the language server.
