### PR TITLE
fix(dune): ignore progress when the client disables it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@
   @rgrinberg)
 - Use each document's current version in multi-file rename edits. (#1958, @rgrinberg)
 - Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
+- Do not report Dune build progress when the client disables work-done progress.
+  (#2082, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)

--- a/ocaml-lsp-server/src/progress.ml
+++ b/ocaml-lsp-server/src/progress.ml
@@ -59,7 +59,7 @@ let start_build (t : enabled) =
 let build_progress t (progress : Drpc.Progress.t) =
   Fiber.of_thunk (fun () ->
     match t with
-    | Disabled -> invalid_arg "progress reporting is not supported"
+    | Disabled -> Fiber.return ()
     | Enabled ({ token; report_progress; _ } as t) ->
       (match progress with
        | Success -> end_build t ~message:"Build finished"

--- a/ocaml-lsp-server/test/e2e-new/dune_progress.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_progress.ml
@@ -84,12 +84,7 @@ let%expect_test "Dune remains connected when work-done progress is unsupported" 
     Dune diagnostics after disconnect:
     { "diagnostics": [], "uri": "<document-uri>" }
     Dune errors:
-    [
-      {
-        "message": "Invalid_argument(\"progress reporting is not supported\")",
-        "type": 1
-      }
-    ]
+    []
     progress creations:
     []
     progress notifications:


### PR DESCRIPTION
Clients that omit work-done progress support currently cause each Dune progress update to raise an internal error.

Treat disabled progress reporting as a no-op while preserving Dune build bookkeeping. The regression coverage added in #2077 now verifies that no progress messages are sent to the client and no internal Dune error is reported.
