### PR TITLE
fix(dune): reject malformed promotion commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@
 - Handle zero-work Dune build progress updates. (#1896, @rgrinberg)
 - Do not report Dune build progress when the client disables work-done progress.
   (#2082, @rgrinberg)
+- Reject malformed Dune promotion commands. (#2084, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -892,16 +892,27 @@ module Promote = struct
 
   let name = "dune/promote"
 
-  let run t (command : ExecuteCommandParams.t) =
+  let input arguments =
+    let invalid () =
+      Jsonrpc.Response.Error.raise
+        (Jsonrpc.Response.Error.make
+           ~code:InvalidParams
+           ~message:"invalid Dune promotion arguments"
+           ())
+    in
+    match arguments with
+    | Some [ arg ] ->
+      (match Input.t_of_yojson arg with
+       | promote -> promote
+       | exception Json.Conv.Of_yojson_error _ -> invalid ())
+    | _ -> invalid ()
+  ;;
+
+  let run t (promote : Input.t) =
     Fiber.of_thunk (fun () ->
       match !t with
       | Closed -> Fiber.return ()
       | Active active ->
-        let promote =
-          match command.arguments with
-          | Some [ arg ] -> Input.t_of_yojson arg
-          | _ -> assert false
-        in
         (match Map.find active.instances promote.dune with
          | None ->
            let message = sprintf "dune %S already disconected" promote.dune in
@@ -964,7 +975,8 @@ let on_command t (cmd : ExecuteCommandParams.t) =
     then
       Jsonrpc.Response.Error.raise
         (Jsonrpc.Response.Error.make ~code:InvalidRequest ~message:"invalid command" ());
-    let* () = Promote.run t cmd in
+    let promote = Promote.input cmd.arguments in
+    let* () = Promote.run t promote in
     Fiber.return `Null)
 ;;
 

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_execute.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_execute.ml
@@ -104,10 +104,10 @@ let%expect_test "request and execute a Dune promotion" =
     }
     promoted contents: "let answer = 42"
     missing promotion request: ignored RPC error
-    missing arguments (InternalError): uncaught exception
-    extra arguments (InternalError): uncaught exception
-    null argument (InternalError): uncaught exception
-    incomplete argument (InternalError): uncaught exception
+    missing arguments (InvalidParams): invalid Dune promotion arguments
+    extra arguments (InvalidParams): invalid Dune promotion arguments
+    null argument (InvalidParams): invalid Dune promotion arguments
+    incomplete argument (InvalidParams): invalid Dune promotion arguments
     invalid command (InvalidRequest): invalid command
     |}]
 ;;


### PR DESCRIPTION
Malformed `dune/promote` payloads currently reach assertions or JSON decoder exceptions and surface as generic internal errors, as captured by #2083.

Decode promotion arguments before command dispatch and map invalid shapes or payloads to a stable `InvalidParams` response. The snapshots now assert that behavior for missing, extra, null, and incomplete arguments.
