### PR TITLE
fix(code-actions): hide inferred-intf action when nothing is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Stop offering the inferred-interface code action when the interface already
+  declares everything the implementation exports. (#2088, fixes #347, @dayangac)
 - Unregister Dune promotion code actions when an RPC instance finishes.
   (#2076, @rgrinberg)
 - Avoid unregistering promotion code actions when clearing the last promotion

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -23,6 +23,9 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
     let* intf = Inference.infer_intf state doc in
     (match intf with
      | None -> Fiber.return None
+     (* Nothing is missing from the interface, so the action would insert an
+        empty edit. Check before formatting to also skip the ocamlformat rpc. *)
+     | Some intf when String.is_empty (String.strip intf) -> Fiber.return None
      | Some intf ->
        let+ formatted_intf =
          Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ:intf

--- a/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
@@ -93,6 +93,31 @@ val f : t -> t
     |}]
 ;;
 
+let%expect_test "no inferred interface when the interface is complete" =
+  let impl_source =
+    {ocaml|
+type t = Foo of int | Bar of bool
+let f (x : t) = x
+|ocaml}
+  in
+  let uri = DocumentUri.of_path "foo.ml" in
+  let prep client = Test.open_document ~client ~uri ~source:impl_source () in
+  let intf_source =
+    {ocaml|
+type t = Foo of int | Bar of bool
+val f : t -> t
+|ocaml}
+  in
+  let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
+  print_code_actions
+    intf_source
+    range
+    ~prep
+    ~path:"foo.mli"
+    ~filter:(find_action "inferred_intf");
+  [%expect {| No code actions |}]
+;;
+
 let%expect_test "update-signatures adds new function args" =
   let impl_source =
     {ocaml|


### PR DESCRIPTION
The inferred-interface code action was gated only on the document being an
interface and on the implementation opening successfully. It never checked
whether anything was left to insert, so on a `.mli` that already declares
everything the `.ml` exports the action still appeared in the menu and applied
an edit whose `newText` was empty.

Skip the action when the inferred signature is blank. Checking before the
ocamlformat round-trip also avoids an rpc call that cannot change the outcome.

Note this is a different code path from #2051, which made the
`ocamllsp/inferIntf` custom request reject interface documents. The code action
goes through `Inference.infer_intf` and was unaffected.

Existing tests covered an empty `.mli` and a partially populated one; the new
test covers a complete one.

Fixes #347.
