### PR TITLE
fix(dune): reconcile promotions by diagnostic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,8 @@
 - Do not report Dune build progress when the client disables work-done progress.
   (#2082, @rgrinberg)
 - Reject malformed Dune promotion commands. (#2084, @rgrinberg)
+- Keep Dune promotion registrations balanced when diagnostics share a source.
+  (#2089, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@
 - Do not report Dune build progress when the client disables work-done progress.
   (#2082, @rgrinberg)
 - Reject malformed Dune promotion commands. (#2084, @rgrinberg)
+- Keep Dune promotion registrations balanced when diagnostics share a source.
+  (#2089, @rgrinberg)
 - Reject negative JSON-RPC `Content-Length` headers. (#1873, @rgrinberg)
 - Report unsupported LSP request methods as unavailable instead of internal
   server errors. (#1862, @rgrinberg)

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -27,6 +27,74 @@ module For_diff = struct
   let diagnostic_data t = fst view_promotion_capability, yojson_of_t t
 end
 
+module Promotion_tracker = struct
+  module Diagnostic_id = struct
+    module T = struct
+      include Drpc.Diagnostic.Id
+
+      let compare_ordering = compare
+      let compare left right = Ordering.to_int (compare_ordering left right)
+      let sexp_of_t = Sexplib0.Sexp_conv.sexp_of_opaque
+    end
+
+    include T
+    include Comparator.Make (T)
+  end
+
+  type t = { by_diagnostic : Drpc.Diagnostic.Promotion.t list Map.M(Diagnostic_id).t }
+
+  type event =
+    | Add of Drpc.Diagnostic.Promotion.t list
+    | Remove
+
+  let empty = { by_diagnostic = Map.empty (module Diagnostic_id) }
+
+  let active t =
+    (* Dune's promote RPC identifies a promotion only by [in_source] and chooses
+       between candidates itself. Until it can select a specific [in_build],
+       keep one representative per source for the single code action. Once the
+       API can distinguish candidates, expose each one as a separate action. *)
+    Map.fold
+      t.by_diagnostic
+      ~init:(Map.empty (module String))
+      ~f:(fun ~key:_ ~data:promotions active ->
+        List.fold_left promotions ~init:active ~f:(fun active promotion ->
+          Map.set
+            active
+            ~key:(Drpc.Diagnostic.Promotion.in_source promotion)
+            ~data:promotion))
+  ;;
+
+  let update t ~id event =
+    let by_diagnostic =
+      match event with
+      | Add promotions -> Map.set t.by_diagnostic ~key:id ~data:promotions
+      | Remove -> Map.remove t.by_diagnostic id
+    in
+    { by_diagnostic }
+  ;;
+
+  let diff previous current =
+    let previous = active previous in
+    let current = active current in
+    let add, remove =
+      Map.fold_symmetric_diff
+        previous
+        current
+        (* A different representative for an existing source does not change its
+           dynamic registration. *)
+        ~data_equal:(fun _ _ -> true)
+        ~init:([], [])
+        ~f:(fun (add, remove) (_, change) ->
+          match change with
+          | `Left promotion -> add, promotion :: remove
+          | `Right promotion -> promotion :: add, remove
+          | `Unequal _ -> assert false)
+    in
+    List.rev add, List.rev remove
+  ;;
+end
+
 module Chan : sig
   type t
 
@@ -151,14 +219,14 @@ end = struct
     ; diagnostics_id : Diagnostics.Dune.t
     ; id : Id.t
     ; mutable client : Client.t option
-    ; mutable promotions : Drpc.Diagnostic.Promotion.t Map.M(String).t
+    ; mutable promotions : Promotion_tracker.t
     }
 
   type state =
     | Idle
     | Connected of Lev_fiber_csexp.Session.t * Drpc.Where.t
     | Running of running
-    | Finished of Drpc.Diagnostic.Promotion.t Map.M(String).t
+    | Finished of Promotion_tracker.t
 
   type t =
     { config : config
@@ -175,8 +243,8 @@ end = struct
   let promotions t =
     match t.state with
     | Connected _ | Idle -> Map.empty (module String)
-    | Finished promotions -> promotions
-    | Running r -> r.promotions
+    | Finished promotions -> Promotion_tracker.active promotions
+    | Running r -> Promotion_tracker.active r.promotions
   ;;
 
   let source t = t.source
@@ -339,60 +407,40 @@ end = struct
   let diagnostic_loop t client config (running : running) diagnostics =
     let* res = Client.poll client Drpc.Sub.diagnostic in
     let send_diagnostics evs =
-      let promotions, add, remove =
+      let previous = running.promotions in
+      let promotions =
         List.fold_left
           evs
-          ~init:(running.promotions, [], [])
-          ~f:(fun (promotions, add, remove) (ev : Drpc.Diagnostic.Event.t) ->
-            let diagnostic =
-              match ev with
-              | Add x -> x
-              | Remove x -> x
+          ~init:previous
+          ~f:(fun promotions (ev : Drpc.Diagnostic.Event.t) ->
+            let id =
+              let diagnostic =
+                match ev with
+                | Add diagnostic | Remove diagnostic -> diagnostic
+              in
+              Drpc.Diagnostic.id diagnostic
             in
-            let id = Drpc.Diagnostic.id diagnostic in
-            let promotion = Drpc.Diagnostic.promotion diagnostic in
-            match ev with
-            | Remove _ ->
-              let promotions, requests =
-                List.fold_left
-                  promotion
-                  ~init:(promotions, [])
-                  ~f:(fun (ps, acc) promotion ->
-                    let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match Map.find ps source with
-                    | Some _ -> Map.remove ps source, promotion :: acc
-                    | None ->
-                      Log.log ~section:"warning" (fun () ->
-                        Log.msg
-                          "removing non existant promotion"
-                          [ ( "promotion"
-                            , `String (Drpc.Diagnostic.Promotion.in_source promotion) )
-                          ]);
-                      ps, acc)
-              in
-              Diagnostics.remove diagnostics (`Dune (running.diagnostics_id, id));
-              promotions, add, requests :: remove
-            | Add d ->
-              let promotions, requests =
-                List.fold_left
-                  promotion
-                  ~init:(promotions, [])
-                  ~f:(fun (ps, acc) promotion ->
-                    let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match Map.find ps source with
-                    | Some _ ->
-                      (* TODO it should not be possible to offer more than one
-                         promotion for a file in dune *)
-                      assert false
-                    | None -> Map.add_exn ps ~key:source ~data:promotion, promotion :: acc)
-              in
-              let uri, diagnostic = lsp_of_dune t d in
-              Diagnostics.set
-                diagnostics
-                (`Dune (running.diagnostics_id, id, uri, diagnostic));
-              promotions, requests :: add, remove)
+            let promotions =
+              Promotion_tracker.update
+                promotions
+                ~id
+                (match ev with
+                 | Add diagnostic ->
+                   Promotion_tracker.Add (Drpc.Diagnostic.promotion diagnostic)
+                 | Remove _ -> Remove)
+            in
+            (match ev with
+             | Remove _ ->
+               Diagnostics.remove diagnostics (`Dune (running.diagnostics_id, id))
+             | Add diagnostic ->
+               let uri, diagnostic = lsp_of_dune t diagnostic in
+               Diagnostics.set
+                 diagnostics
+                 (`Dune (running.diagnostics_id, id, uri, diagnostic)));
+            promotions)
       in
-      promotions, List.concat add, List.concat remove
+      let add, remove = Promotion_tracker.diff previous promotions in
+      promotions, add, remove
     in
     match res with
     | Error v -> raise (Drpc.Version_error.E v)
@@ -474,7 +522,7 @@ end = struct
           in
           t.config.log ~type_:Error ~message
       in
-      t.state <- Finished (Map.empty (module String));
+      t.state <- Finished Promotion_tracker.empty;
       Error ()
     | Ok session ->
       let message =
@@ -507,7 +555,7 @@ end = struct
     let running =
       { chan
       ; finish
-      ; promotions = Map.empty (module String)
+      ; promotions = Promotion_tracker.empty
       ; client = None
       ; diagnostics_id = Diagnostics.Dune.gen (Pid.of_int (Registry.Dune.pid source))
       ; id = Id.gen ()

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -27,6 +27,58 @@ module For_diff = struct
   let diagnostic_data t = fst view_promotion_capability, yojson_of_t t
 end
 
+module Promotion_tracker = struct
+  type t =
+    { by_diagnostic : (Drpc.Diagnostic.Id.t * Drpc.Diagnostic.Promotion.t list) list
+    ; active : Drpc.Diagnostic.Promotion.t Map.M(String).t
+    }
+
+  type event =
+    | Add of Drpc.Diagnostic.Promotion.t list
+    | Remove
+
+  let empty = { by_diagnostic = []; active = Map.empty (module String) }
+  let active t = t.active
+  let equal_id left right = Ordering.to_int (Drpc.Diagnostic.Id.compare left right) = 0
+
+  let changed
+        ~(from : Drpc.Diagnostic.Promotion.t Map.M(String).t)
+        ~(to_ : Drpc.Diagnostic.Promotion.t Map.M(String).t)
+    =
+    Map.to_alist from
+    |> List.filter_map ~f:(fun (source, promotion) ->
+      Option.some_if (not (Map.mem to_ source)) promotion)
+  ;;
+
+  let update t ~id event =
+    let by_diagnostic =
+      List.filter t.by_diagnostic ~f:(fun (other, _) -> not (equal_id id other))
+    in
+    let by_diagnostic =
+      match event with
+      | Add promotions -> (id, promotions) :: by_diagnostic
+      | Remove -> by_diagnostic
+    in
+    let active =
+      List.fold_right
+        by_diagnostic
+        ~init:(Map.empty (module String))
+        ~f:(fun (_, promotions) active ->
+          List.fold_left promotions ~init:active ~f:(fun active promotion ->
+            Map.set
+              active
+              ~key:(Drpc.Diagnostic.Promotion.in_source promotion)
+              ~data:promotion))
+    in
+    { by_diagnostic; active }
+  ;;
+
+  let diff previous current =
+    ( changed ~from:current.active ~to_:previous.active
+    , changed ~from:previous.active ~to_:current.active )
+  ;;
+end
+
 module Chan : sig
   type t
 
@@ -151,16 +203,14 @@ end = struct
     ; diagnostics_id : Diagnostics.Dune.t
     ; id : Id.t
     ; mutable client : Client.t option
-    ; mutable promotions :
-        (* TODO we need to clean these up in the finalizer *)
-        Drpc.Diagnostic.Promotion.t Map.M(String).t
+    ; mutable promotions : Promotion_tracker.t
     }
 
   type state =
     | Idle
     | Connected of Lev_fiber_csexp.Session.t * Drpc.Where.t
     | Running of running
-    | Finished of Drpc.Diagnostic.Promotion.t Map.M(String).t
+    | Finished of Promotion_tracker.t
 
   type t =
     { config : config
@@ -177,8 +227,8 @@ end = struct
   let promotions t =
     match t.state with
     | Connected _ | Idle -> Map.empty (module String)
-    | Finished promotions -> promotions
-    | Running r -> r.promotions
+    | Finished promotions -> Promotion_tracker.active promotions
+    | Running r -> Promotion_tracker.active r.promotions
   ;;
 
   let source t = t.source
@@ -341,60 +391,38 @@ end = struct
   let diagnostic_loop t client config (running : running) diagnostics =
     let* res = Client.poll client Drpc.Sub.diagnostic in
     let send_diagnostics evs =
-      let promotions, add, remove =
+      let previous = running.promotions in
+      let promotions =
         List.fold_left
           evs
-          ~init:(running.promotions, [], [])
-          ~f:(fun (promotions, add, remove) (ev : Drpc.Diagnostic.Event.t) ->
+          ~init:previous
+          ~f:(fun promotions (ev : Drpc.Diagnostic.Event.t) ->
             let diagnostic =
               match ev with
-              | Add x -> x
-              | Remove x -> x
+              | Add diagnostic | Remove diagnostic -> diagnostic
             in
             let id = Drpc.Diagnostic.id diagnostic in
-            let promotion = Drpc.Diagnostic.promotion diagnostic in
-            match ev with
-            | Remove _ ->
-              let promotions, requests =
-                List.fold_left
-                  promotion
-                  ~init:(promotions, [])
-                  ~f:(fun (ps, acc) promotion ->
-                    let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match Map.find ps source with
-                    | Some _ -> Map.remove ps source, promotion :: acc
-                    | None ->
-                      Log.log ~section:"warning" (fun () ->
-                        Log.msg
-                          "removing non existant promotion"
-                          [ ( "promotion"
-                            , `String (Drpc.Diagnostic.Promotion.in_source promotion) )
-                          ]);
-                      ps, acc)
-              in
-              Diagnostics.remove diagnostics (`Dune (running.diagnostics_id, id));
-              promotions, add, requests :: remove
-            | Add d ->
-              let promotions, requests =
-                List.fold_left
-                  promotion
-                  ~init:(promotions, [])
-                  ~f:(fun (ps, acc) promotion ->
-                    let source = Drpc.Diagnostic.Promotion.in_source promotion in
-                    match Map.find ps source with
-                    | Some _ ->
-                      (* TODO it should not be possible to offer more than one
-                         promotion for a file in dune *)
-                      assert false
-                    | None -> Map.add_exn ps ~key:source ~data:promotion, promotion :: acc)
-              in
-              let uri, diagnostic = lsp_of_dune t d in
-              Diagnostics.set
-                diagnostics
-                (`Dune (running.diagnostics_id, id, uri, diagnostic));
-              promotions, requests :: add, remove)
+            let promotions =
+              Promotion_tracker.update
+                promotions
+                ~id
+                (match ev with
+                 | Add diagnostic ->
+                   Promotion_tracker.Add (Drpc.Diagnostic.promotion diagnostic)
+                 | Remove _ -> Promotion_tracker.Remove)
+            in
+            (match ev with
+             | Remove _ ->
+               Diagnostics.remove diagnostics (`Dune (running.diagnostics_id, id))
+             | Add diagnostic ->
+               let uri, diagnostic = lsp_of_dune t diagnostic in
+               Diagnostics.set
+                 diagnostics
+                 (`Dune (running.diagnostics_id, id, uri, diagnostic)));
+            promotions)
       in
-      promotions, List.concat add, List.concat remove
+      let add, remove = Promotion_tracker.diff previous promotions in
+      promotions, add, remove
     in
     match res with
     | Error v -> raise (Drpc.Version_error.E v)
@@ -476,7 +504,7 @@ end = struct
           in
           t.config.log ~type_:Error ~message
       in
-      t.state <- Finished (Map.empty (module String));
+      t.state <- Finished Promotion_tracker.empty;
       Error ()
     | Ok session ->
       let message =
@@ -509,7 +537,7 @@ end = struct
     let running =
       { chan
       ; finish
-      ; promotions = Map.empty (module String)
+      ; promotions = Promotion_tracker.empty
       ; client = None
       ; diagnostics_id = Diagnostics.Dune.gen (Pid.of_int (Registry.Dune.pid source))
       ; id = Id.gen ()

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
@@ -32,15 +32,41 @@ let dune_file ~left_ready ~right_ready ~gate =
     gate
 ;;
 
-let normalize_error (params : LogMessageParams.t) =
-  let message =
-    if
-      String.is_substring params.message ~substring:"Assert_failure"
-      || String.is_substring params.message ~substring:"Assertion failed"
-    then "promotion registration assertion failed"
-    else params.message
+let diagnostic_message (diagnostic : Diagnostic.t) =
+  match diagnostic.message with
+  | `String message -> message
+  | `MarkupContent { value; _ } -> value
+;;
+
+let dune_diagnostics params =
+  let params = only_dune_diagnostics params in
+  let diagnostics =
+    List.sort params.diagnostics ~compare:(fun left right ->
+      String.compare (diagnostic_message left) (diagnostic_message right))
   in
-  { params with message }
+  { params with diagnostics }
+;;
+
+let dune_diagnostic_count params =
+  let params = dune_diagnostics params in
+  List.length params.diagnostics
+;;
+
+let promotion_actions client uri =
+  let position = Position.create ~line:0 ~character:0 in
+  let range = Range.create ~start:position ~end_:position in
+  let textDocument = TextDocumentIdentifier.create ~uri in
+  let context =
+    CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.QuickFix ] ()
+  in
+  let params = CodeActionParams.create ~textDocument ~range ~context () in
+  let+ actions = Client.request client (CodeAction params) in
+  Option.value actions ~default:[]
+  |> List.filter_map ~f:(function
+    | `CodeAction (action : CodeAction.t)
+      when Option.exists action.command ~f:(fun command ->
+             String.equal command.command "dune/promote") -> Some action
+    | `CodeAction _ | `Command _ -> None)
 ;;
 
 let%expect_test "duplicate shared-source promotions do not hang the server" =
@@ -76,19 +102,92 @@ let%expect_test "duplicate shared-source promotions do not hang the server" =
          let* () = Signal.wait (Events.dune_ready events.dune) in
          let* () = Signal.wait (Events.dune_progress events.dune) in
          Test.write_file project.gate "";
-         let* error = Mailbox.wait (Events.errors events.dune) in
+         let uri = Uri.of_path project.expected in
+         let* diagnostics =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri uri params && dune_diagnostic_count params = 2)
+         in
+         let* registration = Mailbox.wait events.registrations in
+         let* promotions = promotion_actions client uri in
+         let registrations = registration :: Mailbox.take_pending events.registrations in
+         let errors = Mailbox.take_pending (Events.errors events.dune) in
          let* echo = Client.request client (DebugEcho { message = "still alive" }) in
+         print_payload
+           project
+           "Dune diagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t (dune_diagnostics diagnostics));
+         print_payloads project "Dune errors:" LogMessageParams.yojson_of_t errors;
          print_payloads
            project
-           "Dune errors:"
-           LogMessageParams.yojson_of_t
-           [ normalize_error error ];
+           "registrations:"
+           RegistrationParams.yojson_of_t
+           registrations;
+         print_payloads project "promotions:" CodeAction.yojson_of_t promotions;
          Printf.printf "echo: %s\n" echo.message;
          Fiber.return ()));
   [%expect
     {|
+    Dune diagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ left.actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 1",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        },
+        {
+          "message": "--- expected.ml\n+++ right.actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 2",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
     Dune errors:
-    [ { "message": "promotion registration assertion failed", "type": 1 } ]
+    []
+    registrations:
+    [
+      {
+        "registrations": [
+          {
+            "id": "ocamllsp-promote/<document-uri>",
+            "method": "textDocument/codeAction",
+            "registerOptions": {
+              "codeActionKinds": [ "quickfix" ],
+              "documentSelector": [
+                {
+                  "language": null,
+                  "scheme": null,
+                  "pattern": "<document-path>"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+    promotions:
+    [
+      {
+        "command": {
+          "arguments": [
+            { "dune": "<workspace-path>", "in_source": "<document-path>" }
+          ],
+          "command": "dune/promote",
+          "title": "Promote"
+        },
+        "kind": "quickfix",
+        "title": "Promote"
+      }
+    ]
     echo: still alive
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
@@ -32,15 +32,44 @@ let dune_file ~left_ready ~right_ready ~gate =
     gate
 ;;
 
-let normalize_error (params : LogMessageParams.t) =
-  let message =
-    if
-      String.is_substring params.message ~substring:"Assert_failure"
-      || String.is_substring params.message ~substring:"Assertion failed"
-    then "promotion registration assertion failed"
-    else params.message
+let dune_diagnostics params =
+  let params = only_dune_diagnostics params in
+  let diagnostics =
+    let diagnostic_message (diagnostic : Diagnostic.t) =
+      match diagnostic.message with
+      | `String message -> message
+      | `MarkupContent { value; _ } -> value
+    in
+    List.sort params.diagnostics ~compare:(fun left right ->
+      String.compare (diagnostic_message left) (diagnostic_message right))
   in
-  { params with message }
+  { params with diagnostics }
+;;
+
+let dune_diagnostic_count params =
+  let params = dune_diagnostics params in
+  List.length params.diagnostics
+;;
+
+let promotion_actions client uri =
+  let params =
+    let range =
+      let position = Position.create ~line:0 ~character:0 in
+      Range.create ~start:position ~end_:position
+    in
+    let textDocument = TextDocumentIdentifier.create ~uri in
+    let context =
+      CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.QuickFix ] ()
+    in
+    CodeActionParams.create ~textDocument ~range ~context ()
+  in
+  Client.request client (CodeAction params)
+  >>| Option.value ~default:[]
+  >>| List.filter_map ~f:(function
+    | `CodeAction (action : CodeAction.t)
+      when Option.exists action.command ~f:(fun command ->
+             String.equal command.command "dune/promote") -> Some action
+    | `CodeAction _ | `Command _ -> None)
 ;;
 
 let%expect_test "duplicate shared-source promotions do not hang the server" =
@@ -76,19 +105,92 @@ let%expect_test "duplicate shared-source promotions do not hang the server" =
          let* () = Signal.wait (Events.dune_ready events.dune) in
          let* () = Signal.wait (Events.dune_progress events.dune) in
          Test.write_file project.gate "";
-         let* error = Mailbox.wait (Events.errors events.dune) in
+         let uri = Uri.of_path project.expected in
+         let* diagnostics =
+           Events.wait_for_diagnostics events.dune ~f:(fun params ->
+             for_uri uri params && dune_diagnostic_count params = 2)
+         in
+         let* registration = Mailbox.wait events.registrations in
+         let* promotions = promotion_actions client uri in
+         let registrations = registration :: Mailbox.take_pending events.registrations in
+         let errors = Mailbox.take_pending (Events.errors events.dune) in
          let* echo = Client.request client (DebugEcho { message = "still alive" }) in
+         print_payload
+           project
+           "Dune diagnostics:"
+           (PublishDiagnosticsParams.yojson_of_t (dune_diagnostics diagnostics));
+         print_payloads project "Dune errors:" LogMessageParams.yojson_of_t errors;
          print_payloads
            project
-           "Dune errors:"
-           LogMessageParams.yojson_of_t
-           [ normalize_error error ];
+           "registrations:"
+           RegistrationParams.yojson_of_t
+           registrations;
+         print_payloads project "promotions:" CodeAction.yojson_of_t promotions;
          Printf.printf "echo: %s\n" echo.message;
          Fiber.return ()));
   [%expect
     {|
+    Dune diagnostics:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ left.actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 1",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        },
+        {
+          "message": "--- expected.ml\n+++ right.actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 2",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
     Dune errors:
-    [ { "message": "promotion registration assertion failed", "type": 1 } ]
+    []
+    registrations:
+    [
+      {
+        "registrations": [
+          {
+            "id": "ocamllsp-promote/<document-uri>",
+            "method": "textDocument/codeAction",
+            "registerOptions": {
+              "codeActionKinds": [ "quickfix" ],
+              "documentSelector": [
+                {
+                  "language": null,
+                  "scheme": null,
+                  "pattern": "<document-path>"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+    promotions:
+    [
+      {
+        "command": {
+          "arguments": [
+            { "dune": "<workspace-path>", "in_source": "<document-path>" }
+          ],
+          "command": "dune/promote",
+          "title": "Promote"
+        },
+        "kind": "quickfix",
+        "title": "Promote"
+      }
+    ]
     echo: still alive
     |}]
 ;;


### PR DESCRIPTION
Dune attaches promotion metadata to individual diagnostics, but the server currently stores promotions only in a map keyed by source path. When two rules produce diagnostics that promote the same source, inserting the second promotion hits an assertion, aborts the whole diagnostic batch, and disconnects that Dune instance. #2087 records the resulting missing diagnostics, registration, and code action.

Introduce a promotion tracker that retains promotions by diagnostic identity while deriving the active source-path map used by code actions and cleanup. Each diagnostic batch is applied to the tracker first, then its previous and final active source sets are compared. A capability is registered when the first diagnostic for a source appears and unregistered only when the last one disappears, avoiding duplicate registrations and premature unregistration when diagnostics overlap.

With this reconciliation, both diagnostics are published without internal errors while the client receives one balanced promotion registration and one promotion code action.
