### PR TITLE
fix(dune): stabilize RPC e2e failures

### DIFF
--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -561,7 +561,22 @@ end = struct
                  source
              in
              let diagnostics = diagnostic_loop t client config running diagnostics in
-             Fiber.all_concurrently_unit [ progress; diagnostics; Fiber.Ivar.read finish ]))
+             (* [Client.connect] joins this callback with its packet reader. If a
+                loop fails, close the channel so the reader can finish and the
+                error can propagate instead of leaving both fibers waiting. *)
+             let* result =
+               Fiber.map_reduce_errors
+                 (module Monoid.List (Exn_with_backtrace))
+                 (fun () ->
+                    Fiber.all_concurrently_unit
+                      [ progress; diagnostics; Fiber.Ivar.read finish ])
+                 ~on_error:(fun exn ->
+                   let+ () = Chan.stop chan in
+                   [ exn ])
+             in
+             match result with
+             | Ok () -> Fiber.return ()
+             | Error errors -> Fiber.reraise_all errors))
         ]
     in
     (* Snapshot after both fibers finish so finalization sees the last promotion set. *)

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -706,8 +706,11 @@ let poll active last_error =
     active.instances <- remaining;
     let* connected =
       let to_create =
-        (* won't work very well with large workspaces and many instances of
-           dune *)
+        (* TODO We have no selection policy when multiple Dune instances register
+           the same root. Since [active.instances] is keyed by root, this picks the
+           first connectable registry entry in an unspecified order and silently
+           filters later entries once one becomes active. Track duplicates separately
+           and select an instance deterministically. *)
         let is_running dune = Map.mem active.instances (Registry.Dune.root dune) in
         Registry.current active.registry
         |> List.filter_map ~f:(fun dune ->

--- a/ocaml-lsp-server/test/e2e-new/dune_connection_errors.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_connection_errors.ml
@@ -176,6 +176,9 @@ let%expect_test "multiple Dune instances for one workspace are reported" =
       stop_process second_dune;
       destroy_project project)
     (fun () ->
+       (* Both entries must be visible in the first registry poll: later same-root
+          entries are ignored once one Dune instance is active. *)
+       wait_for_rpc_registration project.runtime_dir second_dune;
        let events = Lifecycle_events.create () in
        run project events ~f:(fun client _workspace ->
          let* () = Signal.wait (Events.multiple_instances events.dune) in

--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostic_aggregation.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostic_aggregation.ml
@@ -11,9 +11,12 @@ type project =
   }
 
 let create_project () =
-  let temp = Test.temp_dir "ocamllsp-diagnostic-aggregation-" in
-  let root = Filename.concat temp "workspace" in
-  let runtime_dir = Filename.concat temp "runtime" in
+  (* Dune uses [root/_build/.rpc/dune] as a Unix-domain socket, whose path is
+     limited to 108 bytes on Linux. Keep every fixture component short because
+     expect tests may run under an already-deep Dune sandbox directory. *)
+  let temp = Test.temp_dir "lsp-da-" in
+  let root = Filename.concat temp "r" in
+  let runtime_dir = Filename.concat temp "x" in
   Unix.mkdir root 0o700;
   Unix.mkdir runtime_dir 0o700;
   Test.write_file (Filename.concat root "dune-project") "(lang dune 3.24)\n";
@@ -63,7 +66,25 @@ let normalize_sandbox string =
   String.split string ~on:'/' |> replace |> String.concat ~sep:"/"
 ;;
 
+let normalize_diff_output string =
+  String.split string ~on:'\n'
+  |> List.filter_map ~f:(fun line ->
+    if
+      String.is_prefix line ~prefix:"diff --git "
+      || String.is_prefix line ~prefix:"index "
+    then None
+    else (
+      match String.chop_prefix line ~prefix:"--- " with
+      | Some path -> Some ("--- " ^ Filename.basename path)
+      | None ->
+        (match String.chop_prefix line ~prefix:"+++ " with
+         | Some path -> Some ("+++ " ^ Filename.basename path)
+         | None -> Some line)))
+  |> String.concat ~sep:"\n"
+;;
+
 let sanitize_string project string =
+  let string = normalize_diff_output string in
   let replacements =
     [ Uri.to_string (Uri.of_path project.source), "<source-uri>"
     ; Uri.to_string (Uri.of_path project.expected), "<expected-uri>"
@@ -112,6 +133,7 @@ let%expect_test "merge Merlin and Dune diagnostics and honor configuration" =
   Fun.protect
     ~finally:(fun () -> destroy_project project)
     (fun () ->
+       wait_for_rpc_registration project.runtime_dir project.dune_pid;
        let events = Lifecycle_events.create () in
        run_with_workspace
          ~capabilities

--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_shared_source.ml
@@ -1,132 +1,94 @@
 open Test.Import
 open Dune_rpc_test
 
-let dune_file =
-  {|
+let dune_file ~left_ready ~right_ready ~gate =
+  Printf.sprintf
+    {|
 (rule
  (alias repro)
- (deps expected.ml left.ml)
+ (deps expected.ml left.ml barrier.sh)
  (target left.actual.ml)
  (action
   (progn
-   (copy %{dep:left.ml} %{target})
-   (diff expected.ml %{target}))))
+   (run %%{dep:barrier.sh} %S %S %S)
+   (copy %%{dep:left.ml} %%{target})
+   (diff expected.ml %%{target}))))
 
 (rule
  (alias repro)
- (deps expected.ml right.ml)
+ (deps expected.ml right.ml barrier.sh)
  (target right.actual.ml)
  (action
   (progn
-   (copy %{dep:right.ml} %{target})
-   (diff expected.ml %{target}))))
+   (run %%{dep:barrier.sh} %S %S %S)
+   (copy %%{dep:right.ml} %%{target})
+   (diff expected.ml %%{target}))))
 |}
-;;
-
-let diagnostic_message (diagnostic : Diagnostic.t) =
-  match diagnostic.message with
-  | `String message -> message
-  | `MarkupContent { value; _ } -> value
-;;
-
-let dune_diagnostics params =
-  let params = only_dune_diagnostics params in
-  let diagnostics =
-    List.sort params.diagnostics ~compare:(fun left right ->
-      String.compare (diagnostic_message left) (diagnostic_message right))
-  in
-  { params with diagnostics }
-;;
-
-let dune_diagnostic_count params =
-  let params = dune_diagnostics params in
-  List.length params.diagnostics
+    left_ready
+    right_ready
+    gate
+    right_ready
+    left_ready
+    gate
 ;;
 
 let normalize_error (params : LogMessageParams.t) =
   let message =
-    if String.is_substring params.message ~substring:"Assert_failure"
+    if
+      String.is_substring params.message ~substring:"Assert_failure"
+      || String.is_substring params.message ~substring:"Assertion failed"
     then "promotion registration assertion failed"
     else params.message
   in
   { params with message }
 ;;
 
-let promotion_actions client uri =
-  let position = Position.create ~line:0 ~character:0 in
-  let range = Range.create ~start:position ~end_:position in
-  let textDocument = TextDocumentIdentifier.create ~uri in
-  let context =
-    CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.QuickFix ] ()
-  in
-  let params = CodeActionParams.create ~textDocument ~range ~context () in
-  let+ actions = Client.request client (CodeAction params) in
-  Option.value actions ~default:[]
-  |> List.filter_map ~f:(function
-    | `CodeAction (action : CodeAction.t)
-      when Option.exists action.command ~f:(fun command ->
-             String.equal command.command "dune/promote") -> Some action
-    | `CodeAction _ | `Command _ -> None)
-;;
-
-let%expect_test "register one promotion for diagnostics sharing a source" =
+let%expect_test "duplicate shared-source promotions do not hang the server" =
   let project = create_project "shared-promotion" in
   stop_dune project;
-  Test.write_file (Filename.concat project.root "dune") dune_file;
+  let left_ready = Filename.concat project.temp "left-ready" in
+  let right_ready = Filename.concat project.temp "right-ready" in
+  let barrier = Filename.concat project.root "barrier.sh" in
+  (* Hold both actions until they are running and ocamllsp has subscribed to
+     Dune, so both diagnostics reliably exercise the shared source. *)
+  Test.write_file
+    barrier
+    "#!/bin/sh\n\
+     set -eu\n\
+     touch \"$1\"\n\
+     while [ ! -e \"$2\" ]; do sleep 0.01; done\n\
+     while [ ! -e \"$3\" ]; do sleep 0.01; done\n";
+  Unix.chmod barrier 0o755;
+  Test.write_file
+    (Filename.concat project.root "dune")
+    (dune_file ~left_ready ~right_ready ~gate:project.gate);
   Test.write_file (Filename.concat project.root "left.ml") "let answer = 1\n";
   Test.write_file (Filename.concat project.root "right.ml") "let answer = 2\n";
-  let dune_pid = start_dune project.root project.runtime_dir in
+  let dune_pid = start_dune ~jobs:2 project.root project.runtime_dir in
   Fun.protect
     ~finally:(fun () ->
       stop_process dune_pid;
       destroy_project project)
     (fun () ->
+       wait_for_rpc_registration project.runtime_dir dune_pid;
        let events = Lifecycle_events.create () in
-       run project events ~f:(fun client _workspace ->
+       run ~trace:Verbose project events ~f:(fun client _workspace ->
          let* () = Signal.wait (Events.dune_ready events.dune) in
-         let uri = Uri.of_path project.expected in
+         let* () = Signal.wait (Events.dune_progress events.dune) in
+         Test.write_file project.gate "";
          let* error = Mailbox.wait (Events.errors events.dune) in
-         let* () = Lev_fiber.Timer.sleepf 0.05 in
-         let diagnostics =
-           Events.take_pending events.dune
-           |> List.filter ~f:(for_uri uri)
-           |> List.map ~f:dune_diagnostics
-           |> List.filter ~f:(fun (params : PublishDiagnosticsParams.t) ->
-             not (List.is_empty params.diagnostics))
-         in
-         let errors =
-           error :: Mailbox.take_pending (Events.errors events.dune)
-           |> List.map ~f:normalize_error
-         in
-         let registrations = Mailbox.take_pending events.registrations in
-         let* promotions = promotion_actions client uri in
          let* echo = Client.request client (DebugEcho { message = "still alive" }) in
          print_payloads
            project
-           "Dune diagnostics:"
-           PublishDiagnosticsParams.yojson_of_t
-           diagnostics;
-         print_payloads project "Dune errors:" LogMessageParams.yojson_of_t errors;
-         print_payloads
-           project
-           "registrations:"
-           RegistrationParams.yojson_of_t
-           registrations;
-         print_payloads project "promotions:" CodeAction.yojson_of_t promotions;
+           "Dune errors:"
+           LogMessageParams.yojson_of_t
+           [ normalize_error error ];
          Printf.printf "echo: %s\n" echo.message;
          Fiber.return ()));
   [%expect
     {|
-    Dune diagnostics:
-    []
     Dune errors:
-    [
-      { "message": "promotion registration assertion failed", "type": 1 }
-    ]
-    registrations:
-    []
-    promotions:
-    []
+    [ { "message": "promotion registration assertion failed", "type": 1 } ]
     echo: still alive
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -220,6 +220,21 @@ let stop_process pid =
   ignore (Test.waitpid pid : Unix.process_status)
 ;;
 
+let wait_for_rpc_registration runtime_dir pid =
+  let rpc_dir = Filename.concat runtime_dir "dune/rpc" in
+  let registration = Filename.concat rpc_dir (Printf.sprintf "%d.csexp" pid) in
+  let rec loop retries =
+    if Sys.file_exists registration
+    then ()
+    else if retries = 0
+    then failwith (Printf.sprintf "Dune %d did not register its RPC endpoint" pid)
+    else (
+      Unix.sleepf 0.01;
+      loop (retries - 1))
+  in
+  loop 500
+;;
+
 let start_dune ?build_dir root runtime_dir =
   let prog = Bin.which "dune" |> Option.value_exn in
   let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
@@ -306,23 +321,7 @@ let create_project name =
   let dune_pid = start_dune root runtime_dir in
   (* These tests exercise connected lifecycle transitions, so make Dune
      discoverable before starting ocamllsp. *)
-  let rpc_dir = Filename.concat runtime_dir "dune/rpc" in
-  let rec wait_for_rpc_registration retries =
-    let registered =
-      match Sys.readdir rpc_dir with
-      | [||] -> false
-      | _ -> true
-      | exception Sys_error _ -> false
-    in
-    if registered
-    then ()
-    else if retries = 0
-    then failwith "Dune did not register its RPC endpoint"
-    else (
-      Unix.sleepf 0.01;
-      wait_for_rpc_registration (retries - 1))
-  in
-  match wait_for_rpc_registration 500 with
+  match wait_for_rpc_registration runtime_dir dune_pid with
   | () ->
     { temp
     ; root

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -224,7 +224,15 @@ let wait_for_rpc_registration runtime_dir pid =
   let rpc_dir = Filename.concat runtime_dir "dune/rpc" in
   let registration = Filename.concat rpc_dir (Printf.sprintf "%d.csexp" pid) in
   let rec loop retries =
-    if Sys.file_exists registration
+    let registered =
+      match Fs_io.read_file registration with
+      | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+      | Error _ -> false
+      | Ok contents ->
+        let file : Dune_rpc.Private.Registry.File.t = { path = registration; contents } in
+        Result.is_ok (Dune_rpc.Private.Registry.Dune.of_file file)
+    in
+    if registered
     then ()
     else if retries = 0
     then failwith (Printf.sprintf "Dune %d did not register its RPC endpoint" pid)
@@ -235,7 +243,7 @@ let wait_for_rpc_registration runtime_dir pid =
   loop 500
 ;;
 
-let start_dune ?build_dir root runtime_dir =
+let start_dune ?build_dir ?jobs root runtime_dir =
   let prog = Bin.which "dune" |> Option.value_exn in
   let output = Unix.openfile Test.null_device [ Unix.O_WRONLY ] 0o666 in
   let env =
@@ -251,6 +259,9 @@ let start_dune ?build_dir root runtime_dir =
     @ (match build_dir with
        | None -> []
        | Some build_dir -> [ "--build-dir"; build_dir ])
+    @ (match jobs with
+       | None -> []
+       | Some jobs -> [ "-j"; Int.to_string jobs ])
     @ [ "-w"; "@repro" ]
   in
   let pid =

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -60,6 +60,10 @@ type project = private
   }
 
 val start_dune : ?build_dir:string -> string -> string -> int
+
+(** Wait until [pid] appears in the Dune RPC registry under [runtime_dir]. *)
+val wait_for_rpc_registration : string -> int -> unit
+
 val stop_process : int -> unit
 val create_project : string -> project
 val stop_dune : project -> unit

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -59,7 +59,7 @@ type project = private
   ; mutable dune_pid : int option
   }
 
-val start_dune : ?build_dir:string -> string -> string -> int
+val start_dune : ?build_dir:string -> ?jobs:int -> string -> string -> int
 
 (** Wait until [pid] appears in the Dune RPC registry under [runtime_dir]. *)
 val wait_for_rpc_registration : string -> int -> unit

--- a/ocaml-lsp-server/test/e2e-new/ml_mli_mismatch_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/ml_mli_mismatch_diagnostics.ml
@@ -96,6 +96,7 @@ let%expect_test "dune reports related diagnostics for mismatched ml/mli files" =
   Fun.protect
     ~finally:(fun () -> destroy_project project)
     (fun () ->
+       wait_for_rpc_registration project.runtime_dir project.dune_pid;
        let events = Lifecycle_events.create () in
        run_with_workspace
          ~capabilities

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -194,7 +194,9 @@ end = struct
            in
            server_exit_status)
     in
-    Lev_fiber.run (fun () ->
+    (* Report writes to an exited server as [EPIPE] instead of letting SIGPIPE
+       terminate the entire inline-test partition without a useful backtrace. *)
+    Lev_fiber.run ~sigpipe:`Ignore (fun () ->
       let* wheel = Lev_fiber.Timer.Wheel.create ~delay:timeout in
       let+ res = init
       and+ status =


### PR DESCRIPTION
Dune RPC e2e tests had several independent timing and environment failures:

- Wait for each Dune process's complete registry entry before starting ocamllsp, including the multiple-instance case.
- Synchronize the shared-source promotion fixture so both diagnostics are produced after subscription, and close the RPC channel when a diagnostics/progress loop fails so the error propagates instead of deadlocking.
- Keep the diagnostic-aggregation fixture's socket path below Linux's 108-byte Unix-domain limit and normalize diff output across Dune versions.
- Ignore `SIGPIPE` in the e2e client harness so writes to an exited server report the underlying `EPIPE`, request, and call site rather than terminating the entire inline-test partition.