### PR TITLE
fix(dune): fall back from empty diagnostic ranges to related locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Prefer a same-document related location when a Dune diagnostic has an empty
+  primary range, such as ml/mli mismatches. (#2093, @rgrinberg)
 - Stop offering the inferred-interface code action when the interface already
   declares everything the implementation exports. (#2096, fixes #347, @dayangac)
 - Unregister Dune promotion code actions when an RPC instance finishes.

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -183,7 +183,7 @@ end = struct
 
   let source t = t.source
 
-  let diagnostic_to_lsp diagnostics ~include_promotions diagnostic =
+  let diagnostic_to_lsp diagnostics ~include_promotions ~uri diagnostic =
     let module D = Drpc.Diagnostic in
     let range_of_loc loc =
       let loc =
@@ -222,6 +222,27 @@ end = struct
                Location.create ~uri ~range
              in
              DiagnosticRelatedInformation.create ~location ~message))
+    in
+    (* OCaml often reports the primary ml/mli mismatch location as a line with no
+       character span. Dune turns that into a zero-width range, which is useless in
+       editors. Prefer the first related location in the same document when that
+       happens. *)
+    let range =
+      let is_empty_range (range : Range.t) =
+        Lsp.Position.compare range.start range.end_ = 0
+      in
+      match is_empty_range range with
+      | false -> range
+      | true ->
+        (match relatedInformation with
+         | None -> range
+         | Some related ->
+           (match
+              List.find related ~f:(fun (related : DiagnosticRelatedInformation.t) ->
+                Uri.equal related.location.uri uri)
+            with
+            | Some related -> related.location.range
+            | None -> range))
     in
     let message = make_message (D.message diagnostic) in
     let tags = Diagnostics.tags_of_message diagnostics ~src:`Dune message in
@@ -274,10 +295,12 @@ end = struct
   ;;
 
   let lsp_of_dune t diagnostic =
-    ( uri_of_dune t diagnostic
+    let uri = uri_of_dune t diagnostic in
+    ( uri
     , diagnostic_to_lsp
         t.config.diagnostics
         ~include_promotions:t.config.include_promotions
+        ~uri
         diagnostic )
   ;;
 

--- a/ocaml-lsp-server/test/e2e-new/ml_mli_mismatch_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/ml_mli_mismatch_diagnostics.ml
@@ -119,8 +119,8 @@ let%expect_test "dune reports related diagnostics for mismatched ml/mli files" =
         {
           "message": "The implementation foo.ml does not match the interface foo.mli: \nValues do not match: val x : int is not included in val x : unit\nThe type int is not compatible with the type unit",
           "range": {
-            "end": { "character": 0, "line": 0 },
-            "start": { "character": 0, "line": 0 }
+            "end": { "character": 5, "line": 0 },
+            "start": { "character": 4, "line": 0 }
           },
           "relatedInformation": [
             {


### PR DESCRIPTION
When OCaml reports an ml/mli mismatch, the primary diagnostic location is often
only a line with no character span. Dune turns that into a zero-width range
(`0:0`), which is useless in editors.

If a Dune diagnostic range is empty, fall back to the first related location in
the same document (for example the "Actual declaration" span).
