### PR TITLE
test(code-actions): expose inferred-intf action on a complete interface

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
@@ -93,6 +93,55 @@ val f : t -> t
     |}]
 ;;
 
+let%expect_test "no inferred interface when the interface is complete" =
+  let impl_source =
+    {ocaml|
+type t = Foo of int | Bar of bool
+let f (x : t) = x
+|ocaml}
+  in
+  let uri = DocumentUri.of_path "foo.ml" in
+  let prep client = Test.open_document ~client ~uri ~source:impl_source () in
+  let intf_source =
+    {ocaml|
+type t = Foo of int | Bar of bool
+val f : t -> t
+|ocaml}
+  in
+  let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
+  print_code_actions
+    intf_source
+    range
+    ~prep
+    ~path:"foo.mli"
+    ~filter:(find_action "inferred_intf");
+  [%expect
+    {|
+    Code actions:
+    {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": { "character": 0, "line": 0 },
+                  "start": { "character": 0, "line": 0 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "inferred_intf",
+      "title": "Insert inferred interface"
+    }
+    |}]
+;;
+
 let%expect_test "update-signatures adds new function args" =
   let impl_source =
     {ocaml|


### PR DESCRIPTION
The inferred-intf code action is gated only on the document being an
interface and on the implementation opening successfully. It never checks
whether anything is actually left to insert.

Existing tests cover an empty .mli and a partially populated one. Add a
test for a .mli that already declares everything the .ml exports. The
test fails: the action is still offered.