### PR TITLE
test(inlay-hints): cover function params default with no configuration

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -6,6 +6,7 @@ let apply_inlay_hints
       ?(hint_pattern_variables = false)
       ?(hint_let_bindings = false)
       ?hint_function_params
+      ?(configure = true)
       ~source
       ()
   =
@@ -34,10 +35,13 @@ let apply_inlay_hints
     | None -> []
     | Some hint_function_params -> [ "hintFunctionParams", `Bool hint_function_params ]
   in
+  let settings =
+    if configure then Some (`Assoc [ "inlayHints", `Assoc regular_config ]) else None
+  in
   let inlay_hints =
     Test.run_request
       ~prep:(fun client -> Test.open_document ~client ~uri ~source ())
-      ~settings:(`Assoc [ "inlayHints", `Assoc regular_config ])
+      ?settings
       (InlayHint request)
   in
   match inlay_hints with
@@ -113,5 +117,11 @@ let%expect_test "function params" =
 let%expect_test "function params (deactivated)" =
   let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
   apply_inlay_hints ~hint_function_params:false ~source ();
+  [%expect {| let f a b c d = (a + b, c ^ string_of_bool d) |}]
+;;
+
+let%expect_test "function params (no configuration sent)" =
+  let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
+  apply_inlay_hints ~configure:false ~source ();
   [%expect {| let f a b c d = (a + b, c ^ string_of_bool d) |}]
 ;;


### PR DESCRIPTION
The inlay hint test helper always sends a workspace configuration, so no
test exercised the path where the client sends none. That path uses
`Config_data.default`, which currently disables function parameter hints
even though the ppx `[@default true]` on `hint_function_params` enables
them whenever an `inlayHints` object is deserialized.

Add a `configure` flag to the helper and a test for that path. The test
documents the current behavior: without configuration, function
parameter hints are absent. It should be updated to expect hints once
the default is fixed (#2013).

Refs #1371.
