### PR TITLE
fix(code-actions): hide inferred-intf action when nothing is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Stop offering the inferred-interface code action when the interface already
+  declares everything the implementation exports. (#2096, fixes #347, @dayangac)
 - Unregister Dune promotion code actions when an RPC instance finishes.
   (#2076, @rgrinberg)
 - Avoid unregistering promotion code actions when clearing the last promotion

--- a/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inferred_intf.ml
@@ -23,6 +23,9 @@ let code_action (state : State.t) doc (params : CodeActionParams.t) =
     let* intf = Inference.infer_intf state doc in
     (match intf with
      | None -> Fiber.return None
+     (* Nothing is missing from the interface, so the action would insert an
+        empty edit. Check before formatting to also skip the ocamlformat rpc. *)
+     | Some intf when String.is_empty (String.strip intf) -> Fiber.return None
      | Some intf ->
        let+ formatted_intf =
          Ocamlformat_rpc.format_type state.ocamlformat_rpc ~typ:intf

--- a/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
@@ -115,31 +115,7 @@ val f : t -> t
     ~prep
     ~path:"foo.mli"
     ~filter:(find_action "inferred_intf");
-  [%expect
-    {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "",
-                "range": {
-                  "end": { "character": 0, "line": 0 },
-                  "start": { "character": 0, "line": 0 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "inferred_intf",
-      "title": "Insert inferred interface"
-    }
-    |}]
+  [%expect {| No code actions |}]
 ;;
 
 let%expect_test "update-signatures adds new function args" =


### PR DESCRIPTION
The action was offered whenever the document was an interface, even when
the implementation exported nothing the interface did not already
declare. In that case the inferred signature is empty, so the action
appeared in the menu and applied an edit that changed nothing.

Skip the action when the inferred signature is blank. Checking before the
ocamlformat round-trip also avoids an rpc call that cannot change the
outcome.