### PR TITLE
fix(server): enable function param inlay hints without configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@
 - Preserve deprecation status in workspace-symbol results. (#2044, @rgrinberg)
 - Render empty odoc tables in hover documentation without raising an internal
   error. (#2038, @rgrinberg)
+- Enable function parameter inlay hints when the client sends no configuration.
+  (#2097, fixes #1371, @dayangac)
 - Respect client support for signature-help parameter-label offsets. (#2009,
   @rgrinberg)
 - Keep Merlin diagnostic ranges within document bounds. (#2008, @rgrinberg)

--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -62,7 +62,7 @@ interface config {
 
     /**
     * Enable/Disable Inlay Hints for function params
-    * @default false
+    * @default true
     * @since 1.23
     */
     hintFunctionParams : boolean

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -950,7 +950,7 @@ let default =
       Some
         { hint_pattern_variables = false
         ; hint_let_bindings = false
-        ; hint_function_params = false
+        ; hint_function_params = true
         }
   ; dune_diagnostics = Some { enable = true }
   ; syntax_documentation = Some { enable = false }

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -123,5 +123,6 @@ let%expect_test "function params (deactivated)" =
 let%expect_test "function params (no configuration sent)" =
   let source = "let f a b c d = (a + b, c ^ string_of_bool d)" in
   apply_inlay_hints ~configure:false ~source ();
-  [%expect {| let f a b c d = (a + b, c ^ string_of_bool d) |}]
+  [%expect
+    {| let f a$: int$ b$: int$ c$: string$ d$: bool$ = (a + b, c ^ string_of_bool d) |}]
 ;;


### PR DESCRIPTION
`b7faaf23` (#1517) made function parameter inlay hints default to enabled,
but only changed the `[@default true]` used when deserializing an
`inlayHints` object. `Config_data.default`, which applies when the client
sends no configuration at all, still had `hint_function_params = false`.

Clients that never send `workspace/didChangeConfiguration` therefore saw
no function parameter hints, while clients sending even an empty
`inlayHints` object saw them. `config.md` also documented the pre-#1517
default.

Set `hint_function_params = true` in `Config_data.default`, update
`config.md`, and update the test from #2095 to expect hints when no
configuration is sent.

Fixes #1371.
