### PR TITLE
fix(semantic-highlighting): classify module names the iterator missed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 - Respect the client's folding range capabilities: omit character positions for
   `lineFoldingOnly` clients, omit unsupported folding range kinds, and honor
   `rangeLimit`. (#2099, fixes #911, @dayangac)
+- Classify module names in `with` constraints and in signature `open`s in
+  semantic highlighting. (#2098, fixes #808, @dayangac)
 - Return no location instead of failing the request when a definition,
   declaration or type definition cannot be found, so clients that request them
   eagerly no longer surface spurious errors. (#2100, fixes #1161, @dayangac)

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -897,6 +897,18 @@ end = struct
     | `Default_iterator -> Ast_iterator.default_iterator.module_expr self me
   ;;
 
+  (* An open in a structure reaches [module_expr], but one in a signature is an
+     [open_description], which the default iterator does not route through any
+     overridden method. *)
+  let open_description
+        (self : Ast_iterator.iterator)
+        ({ popen_expr; popen_attributes; popen_override = _; popen_loc = _ } :
+          Parsetree.open_description)
+    =
+    lident popen_expr Token_type.module_ ();
+    self.attributes self popen_attributes
+  ;;
+
   let module_type_declaration
         (self : Ast_iterator.iterator)
         ({ pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc = _ } :
@@ -972,6 +984,21 @@ end = struct
     | `Default_iterator -> Ast_iterator.default_iterator.module_type self mt
   ;;
 
+  (* [Pmty_with] is left to the default iterator, which dispatches each
+     constraint here. Without this the constrained names receive no token. *)
+  let with_constraint (self : Ast_iterator.iterator) (wc : Parsetree.with_constraint) =
+    match wc with
+    | Pwith_type (l, td) | Pwith_typesubst (l, td) ->
+      lident l (Token_type.of_builtin Type) ();
+      self.type_declaration self td
+    | Pwith_module (l, l') | Pwith_modsubst (l, l') ->
+      lident l Token_type.module_ ();
+      lident l' Token_type.module_ ()
+    | Pwith_modtype (l, mt) | Pwith_modtypesubst (l, mt) ->
+      lident l Token_type.module_type ();
+      self.module_type self mt
+  ;;
+
   (* TODO: *)
   let attribute _self _attr = ()
 
@@ -995,6 +1022,8 @@ end = struct
     ; value_description
     ; module_type
     ; module_declaration
+    ; with_constraint
+    ; open_description
     }
   ;;
 

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -1516,7 +1516,7 @@ module type T = S with module M = N
     {|
     module type <interface|-0>S</0> = sig module <namespace|definition-1>M</1> : sig type <type|definition-2>t</2> end end
     module <namespace|definition-3>N</3> = struct type <type|definition-4>t</4> = <type|-5>int</5> end
-    module type <interface|-6>T</6> = <interface|-7>S</7> with module M = N
+    module type <interface|-6>T</6> = <interface|-7>S</7> with module <namespace|-8>M</8> = <namespace|-9>N</9>
     |}]
 ;;
 
@@ -1534,8 +1534,8 @@ end
     {|
     module <namespace|definition-0>M</0> = struct type <type|definition-1>t</1> = <type|-2>int</2> end
     module type <interface|-3>S</3> = sig
-      open M
-      val <variable|definition-4>x</4> : <type|-5>t</5>
+      open <namespace|-4>M</4>
+      val <variable|definition-5>x</5> : <type|-6>t</6>
     end
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
+++ b/ocaml-lsp-server/test/e2e-new/semantic_hl_tests.ml
@@ -1503,3 +1503,39 @@ let ((*comment*)) = ()
     let <variable|-2>x</2> = ((* comment *))
     let ((*comment*)) = () |}]
 ;;
+
+let%expect_test "module type with constraints" =
+  test_semantic_tokens_full
+  @@ String.strip
+       {|
+module type S = sig module M : sig type t end end
+module N = struct type t = int end
+module type T = S with module M = N
+      |};
+  [%expect
+    {|
+    module type <interface|-0>S</0> = sig module <namespace|definition-1>M</1> : sig type <type|definition-2>t</2> end end
+    module <namespace|definition-3>N</3> = struct type <type|definition-4>t</4> = <type|-5>int</5> end
+    module type <interface|-6>T</6> = <interface|-7>S</7> with module M = N
+    |}]
+;;
+
+let%expect_test "open in a signature" =
+  test_semantic_tokens_full
+  @@ String.strip
+       {|
+module M = struct type t = int end
+module type S = sig
+  open M
+  val x : t
+end
+      |};
+  [%expect
+    {|
+    module <namespace|definition-0>M</0> = struct type <type|definition-1>t</1> = <type|-2>int</2> end
+    module type <interface|-3>S</3> = sig
+      open M
+      val <variable|definition-4>x</4> : <type|-5>t</5>
+    end
+    |}]
+;;


### PR DESCRIPTION
Two module names receive no semantic token.

`Pmty_with` is left to the default iterator, which dispatches each constraint to
`with_constraint`. That method was not overridden, so in `S with module M = N`
neither `M` nor `N` was classified.

An `open` in a structure reaches `module_expr` and its `Pmod_ident` case emits a
token, but an `open` in a signature is an `open_description`, which was not
overridden either.

Override both. Each commit passes on its own: the test commit records the
current output, the fix commit updates it. No other expectation changed.

Fixes #808.
