### PR TITLE
fix(folding-range): respect client folding range capabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 ## Fixes
 
+- Respect the client's folding range capabilities: omit character positions for
+  `lineFoldingOnly` clients, omit unsupported folding range kinds, and honor
+  `rangeLimit`. (#2099, fixes #911, @dayangac)
 - Return no location instead of failing the request when a definition,
   declaration or type definition cannot be found, so clients that request them
   eagerly no longer surface spurious errors. (#2100, fixes #1161, @dayangac)

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -1,17 +1,51 @@
 open Import
 open Fiber.O
 
-let folding_range { Range.start; end_ } =
+type client_config =
+  { line_folding_only : bool
+  ; supported_kinds : FoldingRangeKind.t list option
+  ; range_limit : int option
+  }
+
+let client_config (state : State.t) =
+  match
+    let open Option.O in
+    let* text_document = (State.client_capabilities state).textDocument in
+    text_document.foldingRange
+  with
+  | None -> { line_folding_only = false; supported_kinds = None; range_limit = None }
+  | Some { lineFoldingOnly; foldingRangeKind; rangeLimit; _ } ->
+    { line_folding_only = Option.value lineFoldingOnly ~default:false
+    ; supported_kinds = Option.bind foldingRangeKind ~f:(fun kind -> kind.valueSet)
+    ; range_limit = rangeLimit
+    }
+;;
+
+let folding_range config { Range.start; end_ } =
+  (* Clients that only fold whole lines ignore the character positions. *)
+  let startCharacter, endCharacter =
+    if config.line_folding_only
+    then None, None
+    else Some start.character, Some end_.character
+  in
+  let kind =
+    match config.supported_kinds with
+    | None -> Some FoldingRangeKind.Region
+    | Some kinds ->
+      Option.some_if
+        (List.mem kinds FoldingRangeKind.Region ~equal:Poly.equal)
+        FoldingRangeKind.Region
+  in
   FoldingRange.create
     ~startLine:start.line
-    ~startCharacter:start.character
+    ?startCharacter
     ~endLine:end_.line
-    ~endCharacter:end_.character
-    ~kind:Region
+    ?endCharacter
+    ?kind
     ()
 ;;
 
-let fold_over_parsetree (parsetree : Mreader.parsetree) =
+let fold_over_parsetree config (parsetree : Mreader.parsetree) =
   let ranges = ref [] in
   let push (range : Range.t) =
     if not (Range.is_single_line range) (* don't fold a single line *)
@@ -286,7 +320,7 @@ let fold_over_parsetree (parsetree : Mreader.parsetree) =
     | `Interface signature -> iterator.signature iterator signature
     | `Implementation structure -> iterator.structure iterator structure
   in
-  List.rev_map !ranges ~f:folding_range
+  List.rev_map !ranges ~f:(folding_range config)
 ;;
 
 let compute (state : State.t) (params : FoldingRangeParams.t) =
@@ -295,10 +329,17 @@ let compute (state : State.t) (params : FoldingRangeParams.t) =
     match Document.kind doc with
     | `Other -> Fiber.return None
     | `Merlin m ->
+      let config = client_config state in
       let+ ranges =
         Document.Merlin.with_pipeline_exn ~name:"folding range" m (fun pipeline ->
           let parsetree = Mpipeline.reader_parsetree pipeline in
-          fold_over_parsetree parsetree)
+          fold_over_parsetree config parsetree)
+      in
+      let ranges =
+        (* [rangeLimit] is a hint, so returning fewer ranges is allowed. *)
+        match config.range_limit with
+        | Some limit when limit < List.length ranges -> List.take ranges limit
+        | Some _ | None -> ranges
       in
       Some ranges)
 ;;

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -231,6 +231,7 @@ include struct
   module ExecuteCommandOptions = ExecuteCommandOptions
   module ExecuteCommandParams = ExecuteCommandParams
   module FoldingRange = FoldingRange
+  module FoldingRangeKind = FoldingRangeKind
   module FoldingRangeParams = FoldingRangeParams
   module Hover = Hover
   module HoverParams = HoverParams

--- a/ocaml-lsp-server/test/e2e-new/folding_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/folding_range.ml
@@ -1547,20 +1547,8 @@ let%expect_test "line folding only omits character positions" =
   [%expect
     {|
     [
-      {
-        "endCharacter": 4,
-        "endLine": 3,
-        "kind": "region",
-        "startCharacter": 0,
-        "startLine": 0
-      },
-      {
-        "endCharacter": 4,
-        "endLine": 8,
-        "kind": "region",
-        "startCharacter": 0,
-        "startLine": 5
-      }
+      { "endLine": 3, "kind": "region", "startLine": 0 },
+      { "endLine": 8, "kind": "region", "startLine": 5 }
     ]
     |}]
 ;;
@@ -1575,20 +1563,8 @@ let%expect_test "omits unsupported folding range kinds" =
   [%expect
     {|
     [
-      {
-        "endCharacter": 4,
-        "endLine": 3,
-        "kind": "region",
-        "startCharacter": 0,
-        "startLine": 0
-      },
-      {
-        "endCharacter": 4,
-        "endLine": 8,
-        "kind": "region",
-        "startCharacter": 0,
-        "startLine": 5
-      }
+      { "endCharacter": 4, "endLine": 3, "startCharacter": 0, "startLine": 0 },
+      { "endCharacter": 4, "endLine": 8, "startCharacter": 0, "startLine": 5 }
     ]
     |}]
 ;;
@@ -1604,13 +1580,6 @@ let%expect_test "respects the client's folding range limit" =
         "kind": "region",
         "startCharacter": 0,
         "startLine": 0
-      },
-      {
-        "endCharacter": 4,
-        "endLine": 8,
-        "kind": "region",
-        "startCharacter": 0,
-        "startLine": 5
       }
     ]
     |}]

--- a/ocaml-lsp-server/test/e2e-new/folding_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/folding_range.ml
@@ -9,13 +9,25 @@ let folding_range client =
 
 let print_folding_ranges = Test.print_option_list ~none:"null" FoldingRange.yojson_of_t
 
-let test source =
+let test ?capabilities source =
   let req client =
     let* response = folding_range client in
     print_folding_ranges response;
     Fiber.return ()
   in
-  Helpers.test source req
+  Helpers.test ?capabilities source req
+;;
+
+let folding_range_capabilities ?foldingRangeKind ?lineFoldingOnly ?rangeLimit () =
+  let foldingRange =
+    FoldingRangeClientCapabilities.create
+      ?foldingRangeKind
+      ?lineFoldingOnly
+      ?rangeLimit
+      ()
+  in
+  let textDocument = TextDocumentClientCapabilities.create ~foldingRange () in
+  ClientCapabilities.create ~textDocument ()
 ;;
 
 let%expect_test "returns folding ranges for `let`" =
@@ -1511,6 +1523,94 @@ else
         "kind": "region",
         "startCharacter": 2,
         "startLine": 10
+      }
+    ]
+    |}]
+;;
+
+let capability_test_source =
+  {folding_range|let a =
+  let b = 1
+  in
+  ()
+
+let c =
+  let d = 2
+  in
+  ()|folding_range}
+;;
+
+let%expect_test "line folding only omits character positions" =
+  test
+    ~capabilities:(folding_range_capabilities ~lineFoldingOnly:true ())
+    capability_test_source;
+  [%expect
+    {|
+    [
+      {
+        "endCharacter": 4,
+        "endLine": 3,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 0
+      },
+      {
+        "endCharacter": 4,
+        "endLine": 8,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 5
+      }
+    ]
+    |}]
+;;
+
+let%expect_test "omits unsupported folding range kinds" =
+  let foldingRangeKind =
+    ClientFoldingRangeKindOptions.create ~valueSet:[ FoldingRangeKind.Comment ] ()
+  in
+  test
+    ~capabilities:(folding_range_capabilities ~foldingRangeKind ())
+    capability_test_source;
+  [%expect
+    {|
+    [
+      {
+        "endCharacter": 4,
+        "endLine": 3,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 0
+      },
+      {
+        "endCharacter": 4,
+        "endLine": 8,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 5
+      }
+    ]
+    |}]
+;;
+
+let%expect_test "respects the client's folding range limit" =
+  test ~capabilities:(folding_range_capabilities ~rangeLimit:1 ()) capability_test_source;
+  [%expect
+    {|
+    [
+      {
+        "endCharacter": 4,
+        "endLine": 3,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 0
+      },
+      {
+        "endCharacter": 4,
+        "endLine": 8,
+        "kind": "region",
+        "startCharacter": 0,
+        "startLine": 5
       }
     ]
     |}]


### PR DESCRIPTION
Folding ranges were always built with character positions and a `Region` kind,
and the full list was always returned, without consulting the client's
`FoldingRangeClientCapabilities`. `foldingRangeProvider` is advertised
unconditionally, and `compute` already had `State.t` in scope.

Omit the character positions when the client sets `lineFoldingOnly`, omit the
kind when `Region` is absent from `foldingRangeKind.valueSet`, and truncate the
result to `rangeLimit`.

These fields are hints rather than hard requirements, so this is about not
sending data the client has said it will ignore, in line with the recent
capability-negotiation work.

`import.ml` gains one line: `Import` re-exports LSP types selectively and
`FoldingRangeKind` was not among them.

Each commit passes on its own: the test commit records the current output, and
the fix commit updates it. No other expectation in the suite changed.

Fixes #911.
