### PR TITLE
fix(definition): log locate failures instead of failing the request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 ## Fixes
 
+- Return no location instead of failing the request when a definition,
+  declaration or type definition cannot be found, so clients that request them
+  eagerly no longer surface spurious errors. (#2100, fixes #1161, @dayangac)
 - Prefer a same-document related location when a Dune diagnostic has an empty
   primary range, such as ml/mli mismatches. (#2093, @rgrinberg)
 - Stop offering the inferred-interface code action when the interface already

--- a/ocaml-lsp-server/src/definition_query.ml
+++ b/ocaml-lsp-server/src/definition_query.ml
@@ -41,16 +41,11 @@ let run kind (state : State.t) ?prefix uri position =
     (match location_of_merlin_loc uri result with
      | Ok s -> Fiber.return s
      | Error err_msg ->
-       let kind =
-         match kind with
-         | `Definition -> "definition"
-         | `Declaration -> "declaration"
-         | `Type_definition -> "type definition"
-       in
-       Jsonrpc.Response.Error.raise
-         (Jsonrpc.Response.Error.make
-            ~code:Jsonrpc.Response.Error.Code.RequestFailed
-            ~message:(sprintf "Request \"Jump to %s\" failed." kind)
-            ~data:(`String (sprintf "Locate: %s" err_msg))
-            ()))
+       (* Merlin reports a failure for ordinary cursor positions, such as a
+          keyword or a name that is already at its definition. Clients request
+          definitions eagerly, so reporting these as request errors surfaces
+          them to the user as spurious failures. *)
+       Log.log ~section:"debug" (fun () ->
+         Log.msg "locate failed" [ "kind", `String name; "error", `String err_msg ]);
+       Fiber.return None)
 ;;

--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -9,21 +9,15 @@ let definition client position =
     (TextDocumentDefinition (DefinitionParams.create ~textDocument ~position ()))
 ;;
 
-let print_definition_error label = function
-  | Error [ { Exn_with_backtrace.exn = Jsonrpc.Response.Error.E error; backtrace = _ } ]
-    ->
-    Printf.printf "%s: %s" label error.message;
-    Option.iter error.data ~f:(fun data ->
-      Printf.printf " (%s)" (Yojson.Safe.to_string data));
-    print_newline ();
+let print_definition_result label = function
+  | Ok locations ->
+    Printf.printf "%s: " label;
+    print_locations locations;
     Fiber.return ()
   | Error errors -> Fiber.reraise_all errors
-  | Ok _ ->
-    Printf.printf "%s unexpectedly succeeded\n" label;
-    Fiber.return ()
 ;;
 
-let%expect_test "reports definition lookup failures without stopping the server" =
+let%expect_test "reports no definition for lookup failures without stopping the server" =
   let source =
     "let origin = 1\n\
      let missing_use = missing\n\
@@ -34,7 +28,7 @@ let%expect_test "reports definition lookup failures without stopping the server"
   let req client =
     let check label position =
       let* result = Fiber.collect_errors (fun () -> definition client position) in
-      print_definition_error label result
+      print_definition_result label result
     in
     let* () = check "at origin" (Position.create ~line:0 ~character:4) in
     let* () = check "missing" (Position.create ~line:1 ~character:18) in
@@ -47,9 +41,9 @@ let%expect_test "reports definition lookup failures without stopping the server"
   Helpers.test source req;
   [%expect
     {|
-    at origin: Request "Jump to definition" failed. ("Locate: Already at definition point")
-    missing: Request "Jump to definition" failed. ("Locate: Not in environment: missing")
-    builtin: Request "Jump to definition" failed. ("Locate: \"int\" is a builtin, it is not possible to jump to its definition")
+    at origin: []
+    missing: []
+    builtin: []
     definition after errors:
     [
       {


### PR DESCRIPTION
Merlin reports a failure for ordinary cursor positions: a keyword, a name
already at its definition, or a builtin type. Each became a `RequestFailed`
response, so clients that request definitions eagerly showed spurious errors.

Log the failure and return no location instead, as suggested on the issue. The
return type already allowed it.

This drops the enriched messages from #1518; they remain in the debug log.

Fixes #1161.
