### PR TITLE
lsp: add Experimental module

### DIFF
--- a/lsp/src/experimental.ml
+++ b/lsp/src/experimental.ml
@@ -1,0 +1,14 @@
+open Import
+
+type t = (string * Json.t) list
+
+let of_opt_json = function
+  | Some (`Assoc fields) -> fields
+  | _ -> []
+;;
+
+let bool t name =
+  match List.assoc_opt name t with
+  | Some (`Bool b) -> b
+  | _ -> false
+;;

--- a/lsp/src/experimental.mli
+++ b/lsp/src/experimental.mli
@@ -1,0 +1,17 @@
+(** Experimental client capabilities.
+
+    The [experimental] field of [InitializeParams] is a free-form object that
+    clients use to advertise non-standard capabilities. This module provides a
+    small interface for querying boolean flags from it. *)
+
+open Import
+
+type t
+
+(** [of_opt_json json] parses the [experimental] field of the initialize
+    request. *)
+val of_opt_json : Json.t option -> t
+
+(** [bool t name] looks up the boolean flag [name]. Flags that are absent or
+    are not booleans are treated as [false]. *)
+val bool : t -> string -> bool

--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -3,6 +3,7 @@ module Position = Position
 module Range = Range
 module Client_notification = Client_notification
 module Client_request = Client_request
+module Experimental = Experimental
 module Extension = Extension
 module Header = Header
 module Import = Import

--- a/ocaml-lsp-server/src/client.ml
+++ b/ocaml-lsp-server/src/client.ml
@@ -15,20 +15,6 @@ let show_document_contents server ~prefix ~suffix contents =
   ()
 ;;
 
-module Experimental_capabilities = struct
-  type t = bool
-
-  let of_opt_json (json : Json.t option) =
-    match json with
-    | Some (`Assoc fields) ->
-      Json.field fields "jumpToNextHole" Json.Conv.bool_of_yojson
-      |> Option.value ~default:false
-    | _ -> false
-  ;;
-
-  let supportsJumpToNextHole t = t
-end
-
 module Vscode = struct
   module Commands = struct
     let triggerSuggest =

--- a/ocaml-lsp-server/src/client.mli
+++ b/ocaml-lsp-server/src/client.mli
@@ -10,15 +10,6 @@ val show_document_contents
   -> string
   -> unit Fiber.t
 
-module Experimental_capabilities : sig
-  (** Module to store experimental client capabilities *)
-
-  type t
-
-  val of_opt_json : Json.t option -> t
-  val supportsJumpToNextHole : t -> bool
-end
-
 module Vscode : sig
   (** A collection of VS Code editor commands.
 

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -58,8 +58,7 @@ let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postpr
   | Ok reply ->
     let reply = postprocess reply in
     let supportsJumpToNextHole =
-      State.experimental_client_capabilities state
-      |> Client.Experimental_capabilities.supportsJumpToNextHole
+      Experimental.bool (State.experimental_client_capabilities state) "jumpToNextHole"
     in
     Some (code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
   | Error

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -466,8 +466,9 @@ let complete
              in
              let construct_completionItems =
                let supportsJumpToNextHole =
-                 State.experimental_client_capabilities state
-                 |> Client.Experimental_capabilities.supportsJumpToNextHole
+                 Experimental.bool
+                   (State.experimental_client_capabilities state)
+                   "jumpToNextHole"
                in
                Complete_with_construct.process_dispatch_resp
                  ~supportsJumpToNextHole

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -834,13 +834,9 @@ let create
        let* diagnostics = td.publishDiagnostics in
        diagnostics.dataSupport)
       |> Option.value ~default:false
-      &&
-      match client_capabilities.experimental with
-      | Some (`Assoc xs) ->
-        (match List.Assoc.find xs (fst view_promotion_capability) ~equal:String.equal with
-         | Some (`Bool b) -> b
-         | _ -> false)
-      | _ -> false
+      && Experimental.bool
+           (Experimental.of_opt_json client_capabilities.experimental)
+           (fst view_promotion_capability)
     in
     { document_store; diagnostics; progress; include_promotions; log; trace }
   in

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -230,6 +230,7 @@ include struct
   module DocumentUri = DocumentUri
   module ExecuteCommandOptions = ExecuteCommandOptions
   module ExecuteCommandParams = ExecuteCommandParams
+  module Experimental = Lsp.Experimental
   module FoldingRange = FoldingRange
   module FoldingRangeParams = FoldingRangeParams
   module Hover = Hover

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -6,7 +6,7 @@ type init =
       { params : InitializeParams.t
       ; workspaces : Workspaces.t
       ; dune : Dune.t
-      ; exp_client_caps : Client.Experimental_capabilities.t
+      ; exp_client_caps : Experimental.t
       ; diagnostics : Diagnostics.t
       ; position_encoding : [ `UTF16 | `UTF8 ]
       }
@@ -109,8 +109,7 @@ let initialize
         ; dune
         ; diagnostics
         ; position_encoding
-        ; exp_client_caps =
-            Client.Experimental_capabilities.of_opt_json params.capabilities.experimental
+        ; exp_client_caps = Experimental.of_opt_json params.capabilities.experimental
         }
   }
 ;;

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -6,7 +6,7 @@ type init =
       { params : InitializeParams.t
       ; workspaces : Workspaces.t
       ; dune : Dune.t
-      ; exp_client_caps : Client.Experimental_capabilities.t
+      ; exp_client_caps : Experimental.t
       ; diagnostics : Diagnostics.t
       ; position_encoding : [ `UTF16 | `UTF8 ]
       }
@@ -69,7 +69,7 @@ val modify_workspaces : t -> f:(Workspaces.t -> Workspaces.t) -> t
 val client_capabilities : t -> ClientCapabilities.t
 
 (** @return experimental client capabilities *)
-val experimental_client_capabilities : t -> Client.Experimental_capabilities.t
+val experimental_client_capabilities : t -> Experimental.t
 
 val diagnostics : t -> Diagnostics.t
 val log_msg : t Server.t -> type_:MessageType.t -> message:string -> unit Fiber.t


### PR DESCRIPTION
Add a small `Lsp.Experimental` interface for querying boolean flags from the free-form `experimental` field of the initialize request.

This replaces the hand-rolled JSON parsing and the `Client.Experimental_capabilities` wrapper in the server. Call sites in state, completion, destruct, and dune now use the shared helper.