### PR TITLE
fix(hover): resolve constructors and exceptions at their declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   `rangeLimit`. (#2099, fixes #911, @dayangac)
 - Classify module names in `with` constraints and in signature `open`s in
   semantic highlighting. (#2098, fixes #808, @dayangac)
+- Report a type when hovering a variant constructor or an exception where it is
+  declared. (#2102, fixes #1300, @dayangac)
 - Return no location instead of failing the request when a definition,
   declaration or type definition cannot be found, so clients that request them
   eagerly no longer surface spurious errors. (#2100, fixes #1161, @dayangac)

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -124,6 +124,22 @@ let hover_at_cursor parsetree (`Logical (cursor_line, cursor_col)) =
   let typ (_ : Ast_iterator.iterator) (typ : Parsetree.core_type) =
     if is_at_cursor typ.ptyp_loc then result := Some `Type_enclosing
   in
+  (* Hover a variant constructor where it is declared *)
+  let constructor_declaration
+        (self : Ast_iterator.iterator)
+        (decl : Parsetree.constructor_declaration)
+    =
+    if is_at_cursor decl.pcd_name.loc then result := Some `Type_enclosing;
+    Ast_iterator.default_iterator.constructor_declaration self decl
+  in
+  (* Hover an exception, or a type extension constructor, where it is declared *)
+  let extension_constructor
+        (self : Ast_iterator.iterator)
+        (ext : Parsetree.extension_constructor)
+    =
+    if is_at_cursor ext.pext_name.loc then result := Some `Type_enclosing;
+    Ast_iterator.default_iterator.extension_constructor self ext
+  in
   (* Hover a type declaration *)
   let type_declaration (self : Ast_iterator.iterator) (decl : Parsetree.type_declaration) =
     if is_at_cursor decl.ptype_name.loc
@@ -244,6 +260,8 @@ let hover_at_cursor parsetree (`Logical (cursor_line, cursor_col)) =
     ; expr
     ; typ
     ; type_declaration
+    ; constructor_declaration
+    ; extension_constructor
     ; value_description
     ; module_expr
     ; module_type

--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -356,8 +356,20 @@ let use = Exn 1
     ];
   [%expect
     {|
-    no hover response
-    no hover response
+    {
+      "contents": { "kind": "plaintext", "value": "int -> exn" },
+      "range": {
+        "end": { "character": 13, "line": 0 },
+        "start": { "character": 10, "line": 0 }
+      }
+    }
+    {
+      "contents": { "kind": "plaintext", "value": "string -> t" },
+      "range": {
+        "end": { "character": 10, "line": 1 },
+        "start": { "character": 9, "line": 1 }
+      }
+    }
     {
       "contents": { "kind": "plaintext", "value": "int -> exn" },
       "range": {

--- a/ocaml-lsp-server/test/e2e-new/hover.ml
+++ b/ocaml-lsp-server/test/e2e-new/hover.ml
@@ -340,3 +340,30 @@ let f (o : <  g : int -> unit >) = o#g 4
     }
     |}]
 ;;
+
+let%expect_test "hover on constructor and exception declarations" =
+  let source =
+    {ocaml|exception Exn of int
+type t = A of string
+let use = Exn 1
+|ocaml}
+  in
+  Hover_helpers.test_hover
+    source
+    [ Position.create ~line:0 ~character:11
+    ; Position.create ~line:1 ~character:10
+    ; Position.create ~line:2 ~character:11
+    ];
+  [%expect
+    {|
+    no hover response
+    no hover response
+    {
+      "contents": { "kind": "plaintext", "value": "int -> exn" },
+      "range": {
+        "end": { "character": 13, "line": 2 },
+        "start": { "character": 10, "line": 2 }
+      }
+    }
+    |}]
+;;


### PR DESCRIPTION
The hover iterator overrides `type_declaration` and `value_description` but
neither `constructor_declaration` nor `extension_constructor`, so hovering a
variant constructor or an exception where it is declared produced no response,
while the same name at a use site resolved.

Override both, so the declaration site reports the constructor type.

The issue title refers to the type being rendered as a functor. That rendering
is already gone; what remains at the same cursor position is no response at all,
which is what this fixes.

Fixes #1300.
