### PR TITLE
lsp: add client capability helpers

### DIFF
--- a/lsp/src/capabilities.ml
+++ b/lsp/src/capabilities.ml
@@ -1,0 +1,180 @@
+open Import
+open Types
+
+(* [Option.map] with the option argument first, so that the function's
+     argument type is known while it is typechecked. This is required to
+     resolve record labels of types from [Types], which has an interface. *)
+let map opt f = Option.map f opt
+
+type t = ClientCapabilities.t
+
+(* Completion *)
+
+let completion (t : t) = Option.bind t.textDocument (fun td -> td.completion)
+let completion_item (t : t) = Option.bind (completion t) (fun c -> c.completionItem)
+
+let completion_documentation_format (t : t) =
+  Option.bind (completion_item t) (fun item -> item.documentationFormat)
+;;
+
+let completion_deprecated_support (t : t) =
+  Option.bind (completion_item t) (fun item -> item.deprecatedSupport)
+  |> Option.value ~default:false
+;;
+
+let completion_preselect_support (t : t) =
+  Option.bind (completion_item t) (fun item -> item.preselectSupport)
+  |> Option.value ~default:false
+;;
+
+let completion_resolve_properties (t : t) =
+  Option.bind (completion_item t) (fun item ->
+    map item.resolveSupport (fun resolve -> resolve.properties))
+;;
+
+let completion_tag_support (t : t) =
+  Option.bind (completion_item t) (fun item ->
+    map item.tagSupport (fun tag_support -> tag_support.valueSet))
+;;
+
+let completion_item_kind_support (t : t) =
+  Option.bind (completion t) (fun c ->
+    Option.bind c.completionItemKind (fun kinds -> kinds.valueSet))
+;;
+
+(* Document symbol *)
+
+let document_symbol (t : t) = Option.bind t.textDocument (fun td -> td.documentSymbol)
+
+let document_symbol_hierarchical_support (t : t) =
+  Option.bind (document_symbol t) (fun ds -> ds.hierarchicalDocumentSymbolSupport)
+  |> Option.value ~default:false
+;;
+
+let document_symbol_tag_support (t : t) =
+  Option.bind (document_symbol t) (fun ds ->
+    map ds.tagSupport (fun tag_support -> tag_support.valueSet))
+;;
+
+(* Signature help *)
+
+let signature_help (t : t) = Option.bind t.textDocument (fun td -> td.signatureHelp)
+
+let signature_label_offset_support (t : t) =
+  Option.bind (signature_help t) (fun sh ->
+    Option.bind sh.signatureInformation (fun si ->
+      Option.bind si.parameterInformation (fun pi -> pi.labelOffsetSupport)))
+  |> Option.value ~default:false
+;;
+
+let signature_documentation_format (t : t) =
+  Option.bind (signature_help t) (fun sh ->
+    Option.bind sh.signatureInformation (fun si -> si.documentationFormat))
+;;
+
+(* Hover *)
+
+let hover_content_format (t : t) =
+  Option.bind t.textDocument (fun td -> Option.bind td.hover (fun h -> h.contentFormat))
+;;
+
+(* Code actions *)
+
+let code_action (t : t) = Option.bind t.textDocument (fun td -> td.codeAction)
+
+let code_action_literal_support (t : t) =
+  Option.bind (code_action t) (fun ca -> ca.codeActionLiteralSupport)
+;;
+
+let code_action_data_support (t : t) =
+  Option.bind (code_action t) (fun ca -> ca.dataSupport) |> Option.value ~default:false
+;;
+
+let code_action_resolve_properties (t : t) =
+  Option.bind (code_action t) (fun ca ->
+    map ca.resolveSupport (fun resolve -> resolve.properties))
+;;
+
+(* Semantic tokens *)
+
+let semantic_tokens (t : t) = Option.bind t.textDocument (fun td -> td.semanticTokens)
+
+(* Folding range *)
+
+let folding_range (t : t) = Option.bind t.textDocument (fun td -> td.foldingRange)
+
+let folding_range_line_folding_only (t : t) =
+  Option.bind (folding_range t) (fun fr -> fr.lineFoldingOnly)
+  |> Option.value ~default:false
+;;
+
+let folding_range_kinds (t : t) =
+  Option.bind (folding_range t) (fun fr ->
+    Option.bind fr.foldingRangeKind (fun kinds -> kinds.valueSet))
+;;
+
+let folding_range_limit (t : t) = Option.bind (folding_range t) (fun fr -> fr.rangeLimit)
+
+(* Publish diagnostics *)
+
+let publish_diagnostics (t : t) =
+  Option.bind t.textDocument (fun td -> td.publishDiagnostics)
+;;
+
+let publish_diagnostics_related_information_support (t : t) =
+  Option.bind (publish_diagnostics t) (fun pd -> pd.relatedInformation)
+  |> Option.value ~default:false
+;;
+
+let publish_diagnostics_tag_support (t : t) =
+  Option.bind (publish_diagnostics t) (fun pd ->
+    map pd.tagSupport (fun tag_support -> tag_support.valueSet))
+;;
+
+let publish_diagnostics_data_support (t : t) =
+  Option.bind (publish_diagnostics t) (fun pd -> pd.dataSupport)
+  |> Option.value ~default:false
+;;
+
+(* Text document synchronization *)
+
+let text_document_sync_dynamic_registration (t : t) =
+  Option.bind t.textDocument (fun td ->
+    Option.bind td.synchronization (fun sync -> sync.dynamicRegistration))
+  |> Option.value ~default:false
+;;
+
+(* Workspace *)
+
+let workspace_symbol_tag_support (t : t) =
+  Option.bind t.workspace (fun w ->
+    Option.bind w.symbol (fun symbol ->
+      map symbol.tagSupport (fun tag_support -> tag_support.valueSet)))
+;;
+
+let workspace_edit_document_changes (t : t) =
+  Option.bind t.workspace (fun w ->
+    Option.bind w.workspaceEdit (fun edit -> edit.documentChanges))
+  |> Option.value ~default:false
+;;
+
+(* Window *)
+
+let show_document (t : t) = Option.bind t.window (fun w -> w.showDocument)
+
+let work_done_progress (t : t) =
+  Option.bind t.window (fun w -> w.workDoneProgress) |> Option.value ~default:false
+;;
+
+(* General *)
+
+let position_encodings (t : t) = Option.bind t.general (fun g -> g.positionEncodings)
+
+(* Helpers *)
+
+let supports_markdown = function
+  | Some (MarkupKind.Markdown :: _) -> true
+  | _ -> false
+;;
+
+let supported xs ~tag ~equal = List.exists ~f:(equal tag) xs

--- a/lsp/src/capabilities.mli
+++ b/lsp/src/capabilities.mli
@@ -1,0 +1,123 @@
+(** Accessors for client capabilities.
+
+    The client capability tree is a deep structure of optional records. These
+    functions collapse the navigation into single lookups. Boolean flags
+    follow the convention that an absent capability is treated as [false]. *)
+
+open Types
+
+type t = ClientCapabilities.t
+
+(* Completion *)
+
+(** The formats accepted for completion item documentation. *)
+val completion_documentation_format : t -> MarkupKind.t list option
+
+(** Whether the client supports the deprecated field of completion items. *)
+val completion_deprecated_support : t -> bool
+
+(** Whether the client supports preselecting a completion item. *)
+val completion_preselect_support : t -> bool
+
+(** The properties the client supports resolving for completion items. *)
+val completion_resolve_properties : t -> string list option
+
+(** The set of completion item tags the client supports. *)
+val completion_tag_support : t -> CompletionItemTag.t list option
+
+(** The set of completion item kinds the client supports. *)
+val completion_item_kind_support : t -> CompletionItemKind.t list option
+
+(* Document symbol *)
+
+(** Whether the client supports hierarchical document symbols. *)
+val document_symbol_hierarchical_support : t -> bool
+
+(** The set of document symbol tags the client supports. *)
+val document_symbol_tag_support : t -> SymbolTag.t list option
+
+(* Signature help *)
+
+(** Whether the client supports offset-based parameter labels. *)
+val signature_label_offset_support : t -> bool
+
+(** The formats accepted for signature help documentation. *)
+val signature_documentation_format : t -> MarkupKind.t list option
+
+(* Hover *)
+
+(** The formats accepted for hover contents. *)
+val hover_content_format : t -> MarkupKind.t list option
+
+(* Code actions *)
+
+val code_action_literal_support : t -> ClientCodeActionLiteralOptions.t option
+
+(** Whether the client supports the data field of code actions. *)
+val code_action_data_support : t -> bool
+
+(** The properties the client supports resolving for code actions. *)
+val code_action_resolve_properties : t -> string list option
+
+(* Semantic tokens *)
+
+val semantic_tokens : t -> SemanticTokensClientCapabilities.t option
+
+(* Folding range *)
+
+val folding_range : t -> FoldingRangeClientCapabilities.t option
+
+(** Whether the client supports folding only whole lines. *)
+val folding_range_line_folding_only : t -> bool
+
+(** The set of folding range kinds the client supports. *)
+val folding_range_kinds : t -> FoldingRangeKind.t list option
+
+(** The maximum number of folding ranges the client accepts. *)
+val folding_range_limit : t -> int option
+
+(* Publish diagnostics *)
+
+val publish_diagnostics : t -> PublishDiagnosticsClientCapabilities.t option
+
+(** Whether the client supports related information in diagnostics. *)
+val publish_diagnostics_related_information_support : t -> bool
+
+(** The set of diagnostic tags the client supports. *)
+val publish_diagnostics_tag_support : t -> DiagnosticTag.t list option
+
+(** Whether the client supports the data field of diagnostics. *)
+val publish_diagnostics_data_support : t -> bool
+
+(* Text document synchronization *)
+
+(** Whether the client supports dynamic registration of text document
+    synchronization. *)
+val text_document_sync_dynamic_registration : t -> bool
+
+(* Workspace *)
+
+(** The set of workspace-symbol tags the client supports. *)
+val workspace_symbol_tag_support : t -> SymbolTag.t list option
+
+(** Whether the client supports document changes in workspace edits. *)
+val workspace_edit_document_changes : t -> bool
+
+(* Window *)
+
+val show_document : t -> ShowDocumentClientCapabilities.t option
+
+(** Whether the client supports work done progress. *)
+val work_done_progress : t -> bool
+
+(* General *)
+
+val position_encodings : t -> PositionEncodingKind.t list option
+
+(* Helpers *)
+
+(** Whether Markdown is the client's preferred markup format. *)
+val supports_markdown : MarkupKind.t list option -> bool
+
+(** Whether the client's advertised value set includes [tag]. *)
+val supported : 'a list -> tag:'a -> equal:('a -> 'a -> bool) -> bool

--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -6,6 +6,7 @@ module Client_notification = Client_notification
 module Client_request = Client_request
 module Code_action = Code_action
 module Deprecation = Deprecation
+module Capabilities = Capabilities
 module Experimental = Experimental
 module Extension = Extension
 module Header = Header

--- a/lsp/test/capabilities_tests.ml
+++ b/lsp/test/capabilities_tests.ml
@@ -1,0 +1,75 @@
+open Base
+open Lsp.Types
+
+let capabilities ?folding_range () =
+  let textDocument =
+    TextDocumentClientCapabilities.create ?foldingRange:folding_range ()
+  in
+  ClientCapabilities.create ~textDocument ()
+;;
+
+let print_folding_range (t : ClientCapabilities.t) =
+  let line_folding_only = Lsp.Capabilities.folding_range_line_folding_only t in
+  let kinds =
+    match Lsp.Capabilities.folding_range_kinds t with
+    | None -> "none"
+    | Some kinds ->
+      let kind_to_string = function
+        | FoldingRangeKind.Comment -> "comment"
+        | Imports -> "imports"
+        | Region -> "region"
+        | Other s -> s
+      in
+      kinds |> List.map ~f:kind_to_string |> String.concat ~sep:","
+  in
+  let limit =
+    match Lsp.Capabilities.folding_range_limit t with
+    | None -> "none"
+    | Some limit -> Int.to_string limit
+  in
+  Stdlib.Printf.printf
+    "line_folding_only=%b kinds=%s limit=%s\n"
+    line_folding_only
+    kinds
+    limit
+;;
+
+let%expect_test "folding range capabilities default to no support" =
+  capabilities () |> print_folding_range;
+  capabilities ~folding_range:(FoldingRangeClientCapabilities.create ()) ()
+  |> print_folding_range;
+  [%expect
+    {|
+    line_folding_only=false kinds=none limit=none
+    line_folding_only=false kinds=none limit=none
+    |}]
+;;
+
+let%expect_test "folding range capabilities are read" =
+  let folding_range =
+    FoldingRangeClientCapabilities.create
+      ~lineFoldingOnly:true
+      ~foldingRangeKind:
+        (ClientFoldingRangeKindOptions.create ~valueSet:[ Region; Comment ] ())
+      ~rangeLimit:100
+      ()
+  in
+  capabilities ~folding_range () |> print_folding_range;
+  [%expect
+    {|
+    line_folding_only=true kinds=region,comment limit=100
+    |}]
+;;
+
+let%expect_test "folding range capabilities with absent optional fields" =
+  let folding_range =
+    FoldingRangeClientCapabilities.create
+      ~foldingRangeKind:(ClientFoldingRangeKindOptions.create ())
+      ()
+  in
+  capabilities ~folding_range () |> print_folding_range;
+  [%expect
+    {|
+    line_folding_only=false kinds=none limit=none
+    |}]
+;;

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -26,13 +26,12 @@ module Code_action_error_monoid = struct
 end
 
 let client_can_resolve_edits (state : State.t) =
-  match (State.client_capabilities state).textDocument with
-  | Some
-      { codeAction =
-          Some { dataSupport = Some true; resolveSupport = Some { properties }; _ }
-      ; _
-      } -> List.mem properties "edit" ~equal:String.equal
-  | None | Some _ -> false
+  let capabilities = State.client_capabilities state in
+  Capabilities.code_action_data_support capabilities
+  &&
+  match Capabilities.code_action_resolve_properties capabilities with
+  | Some properties -> List.mem properties "edit" ~equal:String.equal
+  | None -> false
 ;;
 
 let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
@@ -130,11 +129,7 @@ let compute server (params : CodeActionParams.t) =
   match doc with
   | None -> Fiber.return (Reply.now (actions dune_actions), state)
   | Some doc ->
-    let capabilities =
-      let open Option.O in
-      let* window = (State.client_capabilities state).window in
-      window.showDocument
-    in
+    let capabilities = Capabilities.show_document (State.client_capabilities state) in
     let open_related =
       if kind_is_requested Action_open_related.kind
       then Action_open_related.for_uri capabilities doc

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -357,55 +357,35 @@ let complete
     match Document.kind doc with
     | `Other -> Fiber.return None
     | `Merlin merlin ->
-      let completion_capability =
-        let open Option.O in
-        let capabilities = State.client_capabilities state in
-        let* td = capabilities.textDocument in
-        td.completion
-      in
-      let completion_item_capability =
-        let open Option.O in
-        let* completion = completion_capability in
-        completion.completionItem
-      in
+      let capabilities = State.client_capabilities state in
       let resolve =
-        match
-          let open Option.O in
-          let* item = completion_item_capability in
-          item.resolveSupport
-        with
+        match Capabilities.completion_resolve_properties capabilities with
         | None -> false
-        | Some { properties } -> List.mem properties ~equal:String.equal "documentation"
+        | Some properties -> List.mem properties ~equal:String.equal "documentation"
       in
       let supports_deprecated_tag =
-        match
-          let open Option.O in
-          let* item = completion_item_capability in
-          item.tagSupport
-        with
-        | None -> false
-        | Some { valueSet } ->
-          Deprecation.tag_supported
-            valueSet
-            ~tag:Deprecated
-            ~equal:(fun CompletionItemTag.Deprecated Deprecated -> true)
+        Option.value_map
+          (Capabilities.completion_tag_support capabilities)
+          ~default:false
+          ~f:(fun value_set ->
+            Deprecation.tag_supported
+              value_set
+              ~tag:CompletionItemTag.Deprecated
+              ~equal:(fun CompletionItemTag.Deprecated Deprecated -> true))
       in
       let supports_deprecated_field =
         (not supports_deprecated_tag)
-        && Option.value
-             ~default:false
-             (let open Option.O in
-              let* item = completion_item_capability in
-              item.deprecatedSupport)
+        && Capabilities.completion_deprecated_support capabilities
       in
       let supports_enum_member =
-        Option.value
+        Option.value_map
+          (Capabilities.completion_item_kind_support capabilities)
           ~default:false
-          (let open Option.O in
-           let* completion = completion_capability in
-           let* kinds = completion.completionItemKind in
-           let* valueSet = kinds.valueSet in
-           Some (List.mem valueSet CompletionItemKind.EnumMember ~equal:Poly.equal))
+          ~f:(fun value_set ->
+            Capabilities.supported
+              value_set
+              ~tag:CompletionItemKind.EnumMember
+              ~equal:Poly.equal)
       in
       let* should_provide_completions =
         match context with
@@ -442,17 +422,12 @@ let complete
                ~resolve
            else (
              let preselect_first =
-               match
-                 let open Option.O in
-                 let* item = completion_item_capability in
-                 item.preselectSupport
-               with
-               | None | Some false -> fun x -> x
-               | Some true ->
-                 (function
-                   | [] -> []
-                   | ci :: rest ->
-                     { ci with CompletionItem.preselect = Some true } :: rest)
+               if Capabilities.completion_preselect_support capabilities
+               then
+                 function
+                 | [] -> []
+                 | ci :: rest -> { ci with CompletionItem.preselect = Some true } :: rest
+               else fun x -> x
              in
              let+ construct_cmd_resp, compl_by_prefix_resp =
                Document.Merlin.with_pipeline_exn

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -86,19 +86,16 @@ type t =
   }
 
 let create
-      (capabilities : PublishDiagnosticsClientCapabilities.t option)
+      (capabilities : ClientCapabilities.t)
       send
       ~report_dune_diagnostics
       ~shorten_merlin_diagnostics
   =
-  let related_information, tags =
-    match capabilities with
-    | None -> false, []
-    | Some c ->
-      ( Option.value ~default:false c.relatedInformation
-      , (match c.tagSupport with
-         | None -> []
-         | Some { valueSet } -> valueSet) )
+  let related_information =
+    Capabilities.publish_diagnostics_related_information_support capabilities
+  in
+  let tags =
+    Capabilities.publish_diagnostics_tag_support capabilities |> Option.value ~default:[]
   in
   { dune = Hashtbl.create (module Dune)
   ; merlin = Hashtbl.create (module Uri)

--- a/ocaml-lsp-server/src/diagnostics.mli
+++ b/ocaml-lsp-server/src/diagnostics.mli
@@ -6,7 +6,7 @@ val dune_source : string
 type t
 
 val create
-  :  PublishDiagnosticsClientCapabilities.t option
+  :  ClientCapabilities.t
   -> (PublishDiagnosticsParams.t list -> unit Fiber.t)
   -> report_dune_diagnostics:bool
   -> shorten_merlin_diagnostics:bool

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -60,31 +60,18 @@ let run (client_capabilities : ClientCapabilities.t) doc uri =
       Document.Merlin.with_pipeline_exn ~name:"document-symbols" merlin (fun pipeline ->
         Query_commands.dispatch pipeline Query_protocol.Outline)
     in
-    let document_symbol_capabilities =
-      let open Option.O in
-      let* text_document = client_capabilities.textDocument in
-      text_document.documentSymbol
-    in
     let supports_deprecated_tag =
-      Option.value
+      Option.value_map
+        (Capabilities.document_symbol_tag_support client_capabilities)
         ~default:false
-        (let open Option.O in
-         let* document_symbol = document_symbol_capabilities in
-         let* tag_support = document_symbol.tagSupport in
-         Some
-           (Deprecation.tag_supported
-              tag_support.valueSet
-              ~tag:Deprecated
-              ~equal:(fun SymbolTag.Deprecated Deprecated -> true)))
+        ~f:(fun value_set ->
+          Deprecation.tag_supported
+            value_set
+            ~tag:Deprecated
+            ~equal:(fun SymbolTag.Deprecated Deprecated -> true))
     in
     let symbols = items_to_symbols ~supports_deprecated_tag outline in
-    (match
-       Option.value
-         ~default:false
-         (let open Option.O in
-          let* document_symbol = document_symbol_capabilities in
-          document_symbol.hierarchicalDocumentSymbolSupport)
-     with
+    (match Capabilities.document_symbol_hierarchical_support client_capabilities with
      | true -> Some (`DocumentSymbol symbols)
      | false ->
        let flattened = Lsp.Document_symbol.flatten ~uri symbols in

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -829,11 +829,7 @@ let create
   =
   let config =
     let include_promotions =
-      (let open Option.O in
-       let* td = client_capabilities.textDocument in
-       let* diagnostics = td.publishDiagnostics in
-       diagnostics.dataSupport)
-      |> Option.value ~default:false
+      Capabilities.publish_diagnostics_data_support client_capabilities
       && Experimental.bool
            (Experimental.of_opt_json client_capabilities.experimental)
            (fst view_promotion_capability)

--- a/ocaml-lsp-server/src/folding_range.ml
+++ b/ocaml-lsp-server/src/folding_range.ml
@@ -8,17 +8,11 @@ type client_config =
   }
 
 let client_config (state : State.t) =
-  match
-    let open Option.O in
-    let* text_document = (State.client_capabilities state).textDocument in
-    text_document.foldingRange
-  with
-  | None -> { line_folding_only = false; supported_kinds = None; range_limit = None }
-  | Some { lineFoldingOnly; foldingRangeKind; rangeLimit; _ } ->
-    { line_folding_only = Option.value lineFoldingOnly ~default:false
-    ; supported_kinds = Option.bind foldingRangeKind ~f:(fun kind -> kind.valueSet)
-    ; range_limit = rangeLimit
-    }
+  let capabilities = State.client_capabilities state in
+  { line_folding_only = Capabilities.folding_range_line_folding_only capabilities
+  ; supported_kinds = Capabilities.folding_range_kinds capabilities
+  ; range_limit = Capabilities.folding_range_limit capabilities
+  }
 ;;
 
 let folding_range config { Range.start; end_ } =
@@ -33,7 +27,7 @@ let folding_range config { Range.start; end_ } =
     | None -> Some FoldingRangeKind.Region
     | Some kinds ->
       Option.some_if
-        (List.mem kinds FoldingRangeKind.Region ~equal:Poly.equal)
+        (Capabilities.supported kinds ~tag:FoldingRangeKind.Region ~equal:Poly.equal)
         FoldingRangeKind.Region
   in
   FoldingRange.create

--- a/ocaml-lsp-server/src/hover_req.ml
+++ b/ocaml-lsp-server/src/hover_req.ml
@@ -402,9 +402,8 @@ let type_enclosing_hover
     in
     let contents =
       let markdown =
-        let client_capabilities = State.client_capabilities state in
-        ClientCapabilities.markdown_support client_capabilities ~field:(fun td ->
-          Option.map td.hover ~f:(fun h -> h.contentFormat))
+        Capabilities.supports_markdown
+          (Capabilities.hover_content_format (State.client_capabilities state))
       in
       format_type_enclosing ~syntax ~markdown ~typ ~doc:documentation ~syntax_doc
     in

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -182,20 +182,8 @@ end
    listed alphabetically. Try to keep the order. *)
 include struct
   open Lsp.Types
-
-  module ClientCapabilities = struct
-    include ClientCapabilities
-
-    let markdown_support (client_capabilities : ClientCapabilities.t) ~field =
-      match client_capabilities.textDocument with
-      | None -> false
-      | Some td ->
-        (match field td with
-         | Some (Some (MarkupKind.Markdown :: _)) -> true
-         | None | Some None | Some (Some _) -> false)
-    ;;
-  end
-
+  module Capabilities = Lsp.Capabilities
+  module ClientCapabilities = ClientCapabilities
   module CodeAction = CodeAction
   module CodeActionDisabled = CodeActionDisabled
   module CodeActionKind = CodeActionKind

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -20,8 +20,8 @@ let view_metrics server =
 
 let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeResult.t =
   let codeActionProvider =
-    match client_capabilities.textDocument with
-    | Some { codeAction = Some { codeActionLiteralSupport = Some _; _ }; _ } ->
+    match Capabilities.code_action_literal_support client_capabilities with
+    | Some _ ->
       let codeActionKinds =
         [ Action_destruct_line.kind
         ; Action_destruct.kind
@@ -106,11 +106,7 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
     in
     let executeCommandProvider =
       let commands =
-        if
-          Action_open_related.available
-            (let open Option.O in
-             let* window = client_capabilities.window in
-             window.showDocument)
+        if Action_open_related.available (Capabilities.show_document client_capabilities)
         then
           view_metrics_command_name
           :: Action_open_related.command_name
@@ -125,10 +121,9 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
     in
     let semanticTokensProvider =
       let open Option.O in
-      let* text_document = client_capabilities.textDocument in
-      let* semantic_tokens = text_document.semanticTokens in
+      let* semantic_tokens = Capabilities.semantic_tokens client_capabilities in
       let supports_relative =
-        List.mem semantic_tokens.formats Lsp.Types.TokenFormat.Relative ~equal:Poly.equal
+        Capabilities.supported semantic_tokens.formats ~tag:Relative ~equal:Poly.equal
       in
       let* full_request = semantic_tokens.requests.full in
       let* full =
@@ -152,12 +147,13 @@ let initialize_info (client_capabilities : ClientCapabilities.t) : InitializeRes
     in
     let positionEncoding =
       let open Option.O in
-      let* general = client_capabilities.general in
-      let* options = general.positionEncodings in
+      let* options = Capabilities.position_encodings client_capabilities in
       List.find_map
         ([ UTF8; UTF16 ] : PositionEncodingKind.t list)
         ~f:(fun encoding ->
-          Option.some_if (List.mem options ~equal:Poly.equal encoding) encoding)
+          Option.some_if
+            (Capabilities.supported options ~tag:encoding ~equal:Poly.equal)
+            encoding)
     in
     ServerCapabilities.create
       ~textDocumentSync
@@ -237,12 +233,8 @@ let set_diagnostics detached diagnostics doc =
 
 let register_dune_and_cram_text_document_sync server (capabilities : ClientCapabilities.t)
   =
-  match capabilities.textDocument with
-  | Some
-      { TextDocumentClientCapabilities.synchronization =
-          Some { TextDocumentSyncClientCapabilities.dynamicRegistration = Some true; _ }
-      ; _
-      } ->
+  if Capabilities.text_document_sync_dynamic_registration capabilities
+  then (
     let documentSelector =
       [ "cram"; "dune"; "dune-project"; "dune-workspace" ]
       |> List.map ~f:(fun language ->
@@ -258,8 +250,8 @@ let register_dune_and_cram_text_document_sync server (capabilities : ClientCapab
     in
     let registrations = [ make "textDocument/didOpen"; make "textDocument/didClose" ] in
     let params = RegistrationParams.create ~registrations in
-    Server.request server (Server_request.ClientRegisterCapability params)
-  | _ -> Fiber.return ()
+    Server.request server (Server_request.ClientRegisterCapability params))
+  else Fiber.return ()
 ;;
 
 let on_initialize server (ip : InitializeParams.t) =
@@ -275,18 +267,16 @@ let on_initialize server (ip : InitializeParams.t) =
     Diagnostics.create
       ~report_dune_diagnostics
       ~shorten_merlin_diagnostics
-      (let open Option.O in
-       let* td = ip.capabilities.textDocument in
-       td.publishDiagnostics)
+      ip.capabilities
       (function
-        | [] -> Fiber.return ()
-        | diagnostics ->
-          let state = Server.state server in
-          task_if_running state.detached ~f:(fun () ->
-            let batch = Server.Batch.create server in
-            List.iter diagnostics ~f:(fun d ->
-              Server.Batch.notification batch (PublishDiagnostics d));
-            Server.Batch.submit batch))
+      | [] -> Fiber.return ()
+      | diagnostics ->
+        let state = Server.state server in
+        task_if_running state.detached ~f:(fun () ->
+          let batch = Server.Batch.create server in
+          List.iter diagnostics ~f:(fun d ->
+            Server.Batch.notification batch (PublishDiagnostics d));
+          Server.Batch.submit batch))
   in
   let+ dune =
     let progress =
@@ -667,13 +657,9 @@ let on_request
     later
       (fun state () ->
          let markdown =
-           ClientCapabilities.markdown_support
-             (State.client_capabilities state)
-             ~field:(fun d ->
-               let open Option.O in
-               let+ completion = d.completion in
-               let* completion_item = completion.completionItem in
-               completion_item.documentationFormat)
+           Capabilities.supports_markdown
+             (Capabilities.completion_documentation_format
+                (State.client_capabilities state))
          in
          let resolve = Compl.Resolve.of_completion_item ci in
          match resolve with

--- a/ocaml-lsp-server/src/progress.ml
+++ b/ocaml-lsp-server/src/progress.ml
@@ -15,10 +15,9 @@ type t =
   | Enabled of enabled
 
 let create (client_capabilities : ClientCapabilities.t) ~report_progress ~create_task =
-  match client_capabilities.window with
-  | Some { workDoneProgress = Some true; _ } ->
-    Enabled { token = None; build_counter = 0; create_task; report_progress }
-  | _ -> Disabled
+  if Capabilities.work_done_progress client_capabilities
+  then Enabled { token = None; build_counter = 0; create_task; report_progress }
+  else Disabled
 ;;
 
 let end_build (t : enabled) ~message =

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -146,13 +146,7 @@ let rename (state : State.t) { RenameParams.textDocument = { uri }; position; ne
     in
     let workspace_edits =
       let documentChanges =
-        let open Option.O in
-        Option.value
-          ~default:false
-          (let client_capabilities = State.client_capabilities state in
-           let* workspace = client_capabilities.workspace in
-           let* edit = workspace.workspaceEdit in
-           edit.documentChanges)
+        Capabilities.workspace_edit_document_changes (State.client_capabilities state)
       in
       if documentChanges
       then (

--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -1063,12 +1063,10 @@ let compute_encoded_tokens config doc =
 ;;
 
 let client_config state =
-  let semantic_tokens =
-    let open Option.O in
-    let* text_document = (State.client_capabilities state).textDocument in
-    text_document.semanticTokens
-  in
-  Option.value_map semantic_tokens ~default:default_config ~f:create_config
+  Option.value_map
+    (Capabilities.semantic_tokens (State.client_capabilities state))
+    ~default:default_config
+    ~f:create_config
 ;;
 
 (** Contains implementation of a custom request that provides human-readable

--- a/ocaml-lsp-server/src/signature_help.ml
+++ b/ocaml-lsp-server/src/signature_help.ml
@@ -129,15 +129,7 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
        in
        let offset = String.length prefix in
        let supports_parameter_label_offsets =
-         let open Option.O in
-         let support =
-           let* text_document = (State.client_capabilities state).textDocument in
-           let* signature_help = text_document.signatureHelp in
-           let* signature_information = signature_help.signatureInformation in
-           let* parameter_information = signature_information.parameterInformation in
-           parameter_information.labelOffsetSupport
-         in
-         Option.value support ~default:false
+         Capabilities.signature_label_offset_support (State.client_capabilities state)
        in
        let+ doc =
          Document.Merlin.doc_comment
@@ -166,12 +158,9 @@ let run (state : State.t) { SignatureHelpParams.textDocument = { uri }; position
            let open Option.O in
            let+ doc in
            let markdown =
-             ClientCapabilities.markdown_support
-               (State.client_capabilities state)
-               ~field:(fun td ->
-                 let* sh = td.signatureHelp in
-                 let+ si = sh.signatureInformation in
-                 si.documentationFormat)
+             Capabilities.supports_markdown
+               (Capabilities.signature_documentation_format
+                  (State.client_capabilities state))
            in
            format_doc ~markdown ~doc
          in

--- a/ocaml-lsp-server/src/workspace_symbol.ml
+++ b/ocaml-lsp-server/src/workspace_symbol.ml
@@ -381,17 +381,14 @@ let run
 let run (state : State.t) (params : WorkspaceSymbolParams.t) =
   let open Fiber.O in
   let supports_deprecated_tag =
-    Option.value
+    Option.value_map
+      (Capabilities.workspace_symbol_tag_support (State.client_capabilities state))
       ~default:false
-      (let open Option.O in
-       let* workspace = (State.client_capabilities state).workspace in
-       let* symbol = workspace.symbol in
-       let* tag_support = symbol.tagSupport in
-       Some
-         (Deprecation.tag_supported
-            tag_support.valueSet
-            ~tag:Deprecated
-            ~equal:(fun SymbolTag.Deprecated Deprecated -> true)))
+      ~f:(fun value_set ->
+        Deprecation.tag_supported
+          value_set
+          ~tag:Deprecated
+          ~equal:(fun SymbolTag.Deprecated Deprecated -> true))
   in
   let workspaces = Workspaces.workspace_folders (State.workspaces state) in
   let* thread = Lazy_fiber.force state.symbols_thread in


### PR DESCRIPTION
Add a `Lsp.Capabilities` module with accessors that collapse the repetitive navigation of the client capability tree, plus two small helpers:

- `supports_markdown`: whether Markdown is the client's preferred format
- `supported`: membership in a client-advertised value set

Boolean accessors treat an absent capability as false, matching the convention used throughout the server. Migrate the server to these helpers and drop the local `markdown_support` / `tag_supported` wrappers.