### PR TITLE
refactor(lsp): move Range.resize_for_edit into Lsp.Range

### DIFF
--- a/lsp/src/import.ml
+++ b/lsp/src/import.ml
@@ -1,4 +1,19 @@
-module List = Stdlib.ListLabels
+module List = struct
+  include Stdlib.ListLabels
+
+  let rec last = function
+    | [] -> None
+    | [ x ] -> Some x
+    | _ :: xs -> last xs
+  ;;
+
+  let rec last_exn = function
+    | [] -> invalid_arg "List.last_exn"
+    | [ x ] -> x
+    | _ :: xs -> last_exn xs
+  ;;
+end
+
 module Option = Stdlib.Option
 module Array = Stdlib.ArrayLabels
 module Bytes = Stdlib.BytesLabels

--- a/lsp/src/range.ml
+++ b/lsp/src/range.ml
@@ -40,6 +40,29 @@ let first_line =
   { start; end_ }
 ;;
 
+let split_lines t =
+  let lines = String.split_on_char ~sep:'\n' t in
+  match List.last lines with
+  | Some "" -> List.rev lines |> List.tl |> List.rev
+  | _ -> lines
+;;
+
+let resize_for_edit { Types.TextEdit.range; newText } =
+  match split_lines newText with
+  | [] -> { range with end_ = range.start }
+  | several_lines ->
+    let end_ =
+      let start = range.start in
+      let line = start.line + List.length several_lines - 1 in
+      let character =
+        let last_line_len = List.last_exn several_lines |> String.length in
+        if line = start.line then start.character + last_line_len else last_line_len
+      in
+      { Position.line; character }
+    in
+    { range with end_ }
+;;
+
 let to_string t =
   Printf.sprintf
     "((%d, %d), (%d, %d))"

--- a/lsp/src/range.mli
+++ b/lsp/src/range.mli
@@ -25,4 +25,11 @@ val intersection : t -> t -> t option
 val overlaps : t -> t -> touching:bool -> bool
 
 val first_line : t
+
+(** [resize_for_edit edit] returns the range of the text after [edit] has been
+    applied: the range's start is unchanged and the end is moved to the end of
+    the inserted text. This is the range that must be replaced to undo the
+    edit. *)
+val resize_for_edit : Types.TextEdit.t -> t
+
 val to_string : t -> string

--- a/lsp/test/range_tests.ml
+++ b/lsp/test/range_tests.ml
@@ -1,0 +1,35 @@
+open Lsp.Types
+module Position = Lsp.Position
+module Range = Lsp.Range
+
+let resize newText =
+  let start = Position.create ~line:2 ~character:5 in
+  let range = Range.create ~start ~end_:start in
+  let edit = TextEdit.create ~range ~newText in
+  Range.resize_for_edit edit
+;;
+
+let%expect_test "resize_for_edit preserves trailing newlines" =
+  print_endline (Range.to_string (resize "x\n"));
+  print_endline (Range.to_string (resize ""));
+  print_endline (Range.to_string (resize "x"));
+  print_endline (Range.to_string (resize "ab\ncd"));
+  print_endline (Range.to_string (resize "a\nb\n"));
+  print_endline (Range.to_string (resize "ab\n\n"));
+  print_endline (Range.to_string (resize "\n"));
+  [%expect
+    {|
+    ((2, 5), (2, 6))
+    ((2, 5), (2, 5))
+    ((2, 5), (2, 6))
+    ((2, 5), (3, 2))
+    ((2, 5), (3, 1))
+    ((2, 5), (3, 0))
+    ((2, 5), (2, 5))
+    |}]
+;;
+
+let%expect_test "resize_for_edit uses UTF-16 character units" =
+  print_endline (Range.to_string (resize "😀"));
+  [%expect {| ((2, 5), (2, 9)) |}]
+;;

--- a/ocaml-lsp-server/src/range.ml
+++ b/ocaml-lsp-server/src/range.ml
@@ -13,22 +13,4 @@ let of_loc_opt (loc : Loc.t) : t option =
 ;;
 
 let of_loc (loc : Loc.t) : t = of_loc_opt loc |> Option.value ~default:first_line
-
-let resize_for_edit { TextEdit.range; newText } =
-  let lines = String.split_lines newText in
-  match lines with
-  | [] -> { range with end_ = range.start }
-  | several_lines ->
-    let end_ =
-      let start = range.start in
-      let line = start.line + List.length several_lines - 1 in
-      let character =
-        let last_line_len = List.last_exn several_lines |> String.length in
-        if line = start.line then start.character + last_line_len else last_line_len
-      in
-      { Position.line; character }
-    in
-    { range with end_ }
-;;
-
 let contains_loc loc pos = contains_position (of_loc loc) pos ~inclusive_end:true

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -14,24 +14,6 @@ let%expect_test "convert an LSP position to a Merlin logical position" =
   [%expect {| LSP position (2, 3) -> Merlin logical position (3, 3) |}]
 ;;
 
-let%expect_test "replacement ranges preserve trailing newlines" =
-  let start = Position.create ~line:2 ~character:5 in
-  let range = Range.create ~start ~end_:start in
-  let edit = TextEdit.create ~range ~newText:"x\n" in
-  let range = Ocaml_lsp_server.Testing.Range.resize_for_edit edit in
-  print_endline (Range.to_string range);
-  [%expect {| ((2, 5), (2, 6)) |}]
-;;
-
-let%expect_test "replacement ranges use UTF-16 character units" =
-  let start = Position.create ~line:2 ~character:5 in
-  let range = Range.create ~start ~end_:start in
-  let edit = TextEdit.create ~range ~newText:"😀" in
-  let range = Ocaml_lsp_server.Testing.Range.resize_for_edit edit in
-  print_endline (Range.to_string range);
-  [%expect {| ((2, 5), (2, 9)) |}]
-;;
-
 let%expect_test "document-symbol selection range relationships" =
   let range start_line start_character end_line end_character =
     let start = Position.create ~line:start_line ~character:start_character in


### PR DESCRIPTION
Move `Range.resize_for_edit` from the server into `Lsp.Range`. The range covered by a `TextEdit` after application is protocol-adjacent text math, useful for undoing or chaining edits, so it belongs in the shared library rather than ocamllsp.

The server keeps using it through its existing `Range` include. The replacement-range tests move to `lsp/test`.
