### PR TITLE
refactor(lsp): add Position logical conversions

### DIFF
--- a/lsp/src/position.ml
+++ b/lsp/src/position.ml
@@ -11,3 +11,5 @@ let compare t { line; character } =
 
 let min x y = if compare x y <= 0 then x else y
 let max x y = if compare x y >= 0 then x else y
+let to_logical t = t.line + 1, t.character
+let of_logical ~line ~character = create ~line:(line - 1) ~character

--- a/lsp/src/position.mli
+++ b/lsp/src/position.mli
@@ -6,3 +6,11 @@ val is_zero : t -> bool
 val compare : t -> t -> int
 val min : t -> t -> t
 val max : t -> t -> t
+
+(** [to_logical t] converts the 0-based position to a 1-based line
+    convention: [(line + 1, character)]. *)
+val to_logical : t -> int * int
+
+(** [of_logical ~line ~character] converts a position with a 1-based line and a
+    0-based character back to a regular position. *)
+val of_logical : line:int -> character:int -> t

--- a/lsp/test/position_tests.ml
+++ b/lsp/test/position_tests.ml
@@ -1,0 +1,20 @@
+open Lsp.Types
+module Position = Lsp.Position
+
+let%expect_test "logical position conversions round-trip" =
+  let position = Position.create ~line:2 ~character:3 in
+  let line, character = Position.to_logical position in
+  Printf.printf
+    "to_logical (%d, %d) -> (%d, %d)\n"
+    position.line
+    position.character
+    line
+    character;
+  let back = Position.of_logical ~line ~character in
+  Printf.printf "of_logical -> (%d, %d)\n" back.line back.character;
+  [%expect
+    {|
+    to_logical (2, 3) -> (3, 3)
+    of_logical -> (2, 3)
+    |}]
+;;

--- a/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct_line.ml
@@ -278,7 +278,7 @@ let statement_of_code ~prefix_len code range =
 
 let statement_at_offset doc source offset =
   let (`Logical (line, character)) = Msource.get_logical source (`Offset offset) in
-  let position = Position.create ~line:(line - 1) ~character in
+  let position = Position.of_logical ~line ~character in
   let range = Range.create ~start:position ~end_:position in
   statement_of_code ~prefix_len:character (get_line doc range) range
 ;;

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -306,7 +306,7 @@ let clamp_range_to_source source ({ Range.start; end_ } : Range.t) =
   let clamp position =
     let offset = Msource.get_offset source (Position.logical position) in
     let (`Logical (line, character)) = Msource.get_logical source offset in
-    Position.create ~line:(line - 1) ~character
+    Position.of_logical ~line ~character
   in
   Range.create ~start:(clamp start) ~end_:(clamp end_)
 ;;

--- a/ocaml-lsp-server/src/position.ml
+++ b/ocaml-lsp-server/src/position.ml
@@ -31,7 +31,6 @@ let of_lexical_position (lex_position : Lexing.position) : t option =
 ;;
 
 let logical position =
-  let line = position.line + 1 in
-  let col = position.character in
-  `Logical (line, col)
+  let line, character = to_logical position in
+  `Logical (line, character)
 ;;

--- a/ocaml-lsp-server/src/rename.ml
+++ b/ocaml-lsp-server/src/rename.ml
@@ -3,7 +3,7 @@ open Fiber.O
 
 let position_of_offset source offset =
   let (`Logical (line, character)) = Msource.get_logical source (`Offset offset) in
-  Position.create ~line:(line - 1) ~character
+  Position.of_logical ~line ~character
 ;;
 
 let compare_text_edit (a : TextEdit.t) (b : TextEdit.t) =


### PR DESCRIPTION
Move the 0-based ↔ 1-based line conversion used when talking to Merlin into `Lsp.Position` as `to_logical` / `of_logical`.

The server's `Position.logical` wrapper and the hand-written `line - 1` conversions now go through these helpers. Server call sites keep using the local `Position` module, which already includes `Lsp.Position`.
