### PR TITLE
refactor(lsp): add Lsp.Document_symbol protocol helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,7 +135,7 @@
     in {
       overlays.default = (final: prev: {
         ocamlPackages = prev.ocamlPackages.overrideScope
-          (oself: osuper: with oself; makeLocalPackages final);
+          (oself: osuper: makeLocalPackages final);
       });
     } // (flake-utils.lib.eachDefaultSystem (system:
       let

--- a/lsp/src/document_symbol.ml
+++ b/lsp/src/document_symbol.ml
@@ -1,0 +1,27 @@
+open Import
+
+open struct
+  open Types
+  module DocumentSymbol = DocumentSymbol
+  module SymbolInformation = SymbolInformation
+  module Location = Location
+end
+
+let rec flatten ~uri ?containerName (symbols : DocumentSymbol.t list) =
+  List.concat_map symbols ~f:(fun (symbol : DocumentSymbol.t) ->
+    let symbol_information =
+      SymbolInformation.create
+        ?containerName
+        ~kind:symbol.kind
+        ~location:{ Location.range = symbol.range; uri }
+        ~name:symbol.name
+        ?deprecated:symbol.deprecated
+        ?tags:symbol.tags
+        ()
+    in
+    let children =
+      Option.value symbol.children ~default:[]
+      |> flatten ~uri ?containerName:(Some symbol.name)
+    in
+    symbol_information :: children)
+;;

--- a/lsp/src/document_symbol.mli
+++ b/lsp/src/document_symbol.mli
@@ -1,0 +1,18 @@
+open Import
+open Types
+
+(** Helpers for the [textDocument/documentSymbol] request.
+
+    The hierarchical [DocumentSymbol] representation is the protocol's native
+    shape, but clients without [hierarchicalDocumentSymbolSupport] require the
+    flat [SymbolInformation] representation instead. *)
+
+(** [flatten ~uri ?containerName symbols] converts a hierarchical symbol tree
+    into a flat [SymbolInformation] list in depth-first order. Each symbol's
+    name becomes the [containerName] of its children; [deprecated] and [tags]
+    are preserved. *)
+val flatten
+  :  uri:DocumentUri.t
+  -> ?containerName:string
+  -> DocumentSymbol.t list
+  -> SymbolInformation.t list

--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -1,6 +1,7 @@
 module Progress = Progress
 module Position = Position
 module Range = Range
+module Document_symbol = Document_symbol
 module Client_notification = Client_notification
 module Client_request = Client_request
 module Experimental = Experimental

--- a/lsp/src/range.ml
+++ b/lsp/src/range.ml
@@ -28,6 +28,13 @@ let intersection x y =
   if Position.compare start end_ < 0 then Some { start; end_ } else None
 ;;
 
+let normalize_selection_range (range : t) ~(selection : t) =
+  let selection_is_valid = Position.compare selection.start selection.end_ <= 0 in
+  if selection_is_valid && contains range selection
+  then selection
+  else Option.value (intersection range selection) ~default:range
+;;
+
 let overlaps x y ~touching =
   if touching
   then Position.compare x.start y.end_ <= 0 && Position.compare y.start x.end_ <= 0

--- a/lsp/src/range.mli
+++ b/lsp/src/range.mli
@@ -20,6 +20,13 @@ val contains_position : t -> Position.t -> inclusive_end:bool -> bool
     intersection. *)
 val intersection : t -> t -> t option
 
+(** [normalize_selection_range range ~selection] returns a selection range
+    that satisfies the specification requirement that the selection is
+    contained in [range]. Valid selections are preserved, non-empty overlaps
+    are clipped to the intersection, and reversed, touching, or disjoint
+    selections fall back to [range]. *)
+val normalize_selection_range : t -> selection:t -> t
+
 (** Whether two ranges overlap. With [touching] set, ranges that share only a
     boundary are also considered to overlap. *)
 val overlaps : t -> t -> touching:bool -> bool

--- a/lsp/test/document_symbol_tests.ml
+++ b/lsp/test/document_symbol_tests.ml
@@ -1,0 +1,127 @@
+open Lsp.Types
+module Position = Lsp.Position
+module Range = Lsp.Range
+
+let range start_line start_character end_line end_character =
+  let start = Position.create ~line:start_line ~character:start_character in
+  let end_ = Position.create ~line:end_line ~character:end_character in
+  Range.create ~start ~end_
+;;
+
+let print_symbols symbols =
+  let json = `List (List.map SymbolInformation.yojson_of_t symbols) in
+  Yojson.Safe.pretty_to_string json |> print_endline
+;;
+
+let%expect_test "normalize document-symbol selection ranges" =
+  let full_range = range 1 2 3 8 in
+  let print label selection =
+    let normalized =
+      match selection with
+      | None -> full_range
+      | Some selection -> Lsp.Range.normalize_selection_range full_range ~selection
+    in
+    Printf.printf "%s: %s\n" label (Range.to_string normalized)
+  in
+  print "contained" (Some (range 1 4 2 6));
+  print "contained empty" (Some (range 2 4 2 4));
+  print "overlap before" (Some (range 0 9 1 5));
+  print "overlap after" (Some (range 3 4 4 1));
+  print "enclosing" (Some (range 0 0 4 0));
+  print "touch before" (Some (range 0 0 1 2));
+  print "touch after" (Some (range 3 8 4 0));
+  print "disjoint before" (Some (range 0 0 1 1));
+  print "disjoint after" (Some (range 3 9 4 0));
+  print "ghost" None;
+  print "reversed" (Some (range 2 6 2 4));
+  [%expect
+    {|
+    contained: ((1, 4), (2, 6))
+    contained empty: ((2, 4), (2, 4))
+    overlap before: ((1, 2), (1, 5))
+    overlap after: ((3, 4), (3, 8))
+    enclosing: ((1, 2), (3, 8))
+    touch before: ((1, 2), (3, 8))
+    touch after: ((1, 2), (3, 8))
+    disjoint before: ((1, 2), (3, 8))
+    disjoint after: ((1, 2), (3, 8))
+    ghost: ((1, 2), (3, 8))
+    reversed: ((1, 2), (3, 8))
+    |}]
+;;
+
+let%expect_test "flatten document symbols preserves hierarchy and tags" =
+  let symbol ?children ?deprecated ?tags ~name ~kind ~range () =
+    DocumentSymbol.create
+      ?children
+      ?deprecated
+      ?tags
+      ~name
+      ~kind
+      ~range
+      ~selectionRange:range
+      ()
+  in
+  let uri = Lsp.Uri.of_path "/workspace/test.ml" in
+  let symbols =
+    [ symbol
+        ~name:"M"
+        ~kind:SymbolKind.Module
+        ~range:(range 0 0 10 0)
+        ~children:
+          [ symbol
+              ~name:"x"
+              ~kind:SymbolKind.Variable
+              ~range:(range 1 0 1 1)
+              ~deprecated:true
+              ~tags:[ SymbolTag.Deprecated ]
+              ()
+          ; symbol ~name:"f" ~kind:SymbolKind.Function ~range:(range 2 0 2 5) ()
+          ]
+        ()
+    ]
+  in
+  Lsp.Document_symbol.flatten ~uri symbols |> print_symbols;
+  [%expect
+    {|
+    [
+      {
+        "kind": 2,
+        "location": {
+          "range": {
+            "end": { "character": 0, "line": 10 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "uri": "file:///workspace/test.ml"
+        },
+        "name": "M"
+      },
+      {
+        "containerName": "M",
+        "deprecated": true,
+        "kind": 13,
+        "location": {
+          "range": {
+            "end": { "character": 1, "line": 1 },
+            "start": { "character": 0, "line": 1 }
+          },
+          "uri": "file:///workspace/test.ml"
+        },
+        "name": "x",
+        "tags": [ 1 ]
+      },
+      {
+        "containerName": "M",
+        "kind": 12,
+        "location": {
+          "range": {
+            "end": { "character": 5, "line": 2 },
+            "start": { "character": 0, "line": 2 }
+          },
+          "uri": "file:///workspace/test.ml"
+        },
+        "name": "f"
+      }
+    ]
+    |}]
+;;

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -12,17 +12,6 @@ let symbol_kind_of_outline_kind = function
   | `Method -> Method
 ;;
 
-let normalize_selection_range ~(range : Range.t) = function
-  | None -> range
-  | Some (selection_range : Range.t) ->
-    let selection_is_valid =
-      Lsp.Position.compare selection_range.start selection_range.end_ <= 0
-    in
-    if selection_is_valid && Range.contains range selection_range
-    then selection_range
-    else Option.value (Range.intersection range selection_range) ~default:range
-;;
-
 let rec items_to_symbols ~supports_deprecated_tag items =
   List.rev_map
     ~f:
@@ -40,7 +29,9 @@ let rec items_to_symbols ~supports_deprecated_tag items =
          Preserve valid selections, clip non-empty overlaps, and fall back to
          [range] for ghost, invalid, touching, or disjoint selections. *)
       let selectionRange =
-        normalize_selection_range ~range (Range.of_loc_opt selection)
+        match Range.of_loc_opt selection with
+        | None -> range
+        | Some selection -> Lsp.Range.normalize_selection_range range ~selection
       in
       let { Deprecation.deprecated; tags } =
         Deprecation.create
@@ -59,27 +50,6 @@ let rec items_to_symbols ~supports_deprecated_tag items =
         ~children:(items_to_symbols ~supports_deprecated_tag children)
         ())
     items
-;;
-
-let rec flatten_document_symbols ~uri ~container_name (symbols : DocumentSymbol.t list) =
-  List.concat_map symbols ~f:(fun symbol ->
-    let symbol_information =
-      SymbolInformation.create
-        ?containerName:container_name
-        ~kind:symbol.kind
-        ~location:{ range = symbol.range; uri }
-        ~name:symbol.name
-        ?deprecated:symbol.deprecated
-        ?tags:symbol.tags
-        ()
-    in
-    let children =
-      flatten_document_symbols
-        ~uri
-        ~container_name:(Some symbol.name)
-        (Option.value symbol.children ~default:[])
-    in
-    symbol_information :: children)
 ;;
 
 let run (client_capabilities : ClientCapabilities.t) doc uri =
@@ -116,6 +86,6 @@ let run (client_capabilities : ClientCapabilities.t) doc uri =
      with
      | true -> Some (`DocumentSymbol symbols)
      | false ->
-       let flattened = flatten_document_symbols ~uri ~container_name:None symbols in
+       let flattened = Lsp.Document_symbol.flatten ~uri symbols in
        Some (`SymbolInformation flattened))
 ;;

--- a/ocaml-lsp-server/src/document_symbol.mli
+++ b/ocaml-lsp-server/src/document_symbol.mli
@@ -1,7 +1,5 @@
 open Import
 
-val normalize_selection_range : range:Range.t -> Range.t option -> Range.t
-
 val run
   :  ClientCapabilities.t
   -> Document.t

--- a/ocaml-lsp-server/test/ocaml_lsp_tests.ml
+++ b/ocaml-lsp-server/test/ocaml_lsp_tests.ml
@@ -74,48 +74,6 @@ let%expect_test "document-symbol selection range relationships" =
     |}]
 ;;
 
-let%expect_test "normalize document-symbol selection ranges" =
-  let range start_line start_character end_line end_character =
-    let start = Position.create ~line:start_line ~character:start_character in
-    let end_ = Position.create ~line:end_line ~character:end_character in
-    Range.create ~start ~end_
-  in
-  let full_range = range 1 2 3 8 in
-  let print label selection_range =
-    let normalized =
-      Ocaml_lsp_server.Testing.Document_symbol.normalize_selection_range
-        ~range:full_range
-        selection_range
-    in
-    Printf.printf "%s: %s\n" label (Range.to_string normalized)
-  in
-  print "contained" (Some (range 1 4 2 6));
-  print "contained empty" (Some (range 2 4 2 4));
-  print "overlap before" (Some (range 0 9 1 5));
-  print "overlap after" (Some (range 3 4 4 1));
-  print "enclosing" (Some (range 0 0 4 0));
-  print "touch before" (Some (range 0 0 1 2));
-  print "touch after" (Some (range 3 8 4 0));
-  print "disjoint before" (Some (range 0 0 1 1));
-  print "disjoint after" (Some (range 3 9 4 0));
-  print "ghost" None;
-  print "reversed" (Some (range 2 6 2 4));
-  [%expect
-    {|
-    contained: ((1, 4), (2, 6))
-    contained empty: ((2, 4), (2, 4))
-    overlap before: ((1, 2), (1, 5))
-    overlap after: ((3, 4), (3, 8))
-    enclosing: ((1, 2), (3, 8))
-    touch before: ((1, 2), (3, 8))
-    touch after: ((1, 2), (3, 8))
-    disjoint before: ((1, 2), (3, 8))
-    disjoint after: ((1, 2), (3, 8))
-    ghost: ((1, 2), (3, 8))
-    reversed: ((1, 2), (3, 8))
-    |}]
-;;
-
 let%expect_test "diagnostic message equality ignores insignificant whitespace" =
   let test left right =
     let relation =


### PR DESCRIPTION
Move the generic parts of the server's document-symbol handling into a new
Lsp.Document_symbol module: selection-range normalization (the spec requires
the selection to be contained in the symbol range) and flattening the
hierarchical DocumentSymbol tree into SymbolInformation for clients without
hierarchicalDocumentSymbolSupport.

The server keeps the OCaml outline-to-symbol mapping and the capability-driven
response selection; the flatten and normalize tests move to lsp/test.