### PR TITLE
fix(diagnostics): tag unused and deprecated values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ## Fixes
 
+- Tag unused and deprecated values in diagnostics, so clients can grey them out
+  or strike them through. (#2110, fixes #2109, @dayangac)
 - Respect the client's folding range capabilities: omit character positions for
   `lineFoldingOnly` clients, omit unsupported folding range kinds, and honor
   `rangeLimit`. (#2099, fixes #911, @dayangac)

--- a/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
+++ b/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
@@ -1,8 +1,15 @@
 open Import
 
-let is_unused_var_warning s =
-  String.is_prefix s ~prefix:"Error (warning 26)"
-  || String.is_prefix s ~prefix:"Error (warning 27)"
+(* Merlin renders a warning as "Warning 26: ..." and, when warnings are fatal,
+   as "Error (warning 26): ...". Alerts follow the same pair of shapes. *)
+let is_warning s ~number =
+  String.is_prefix s ~prefix:(sprintf "Warning %d" number)
+  || String.is_prefix s ~prefix:(sprintf "Error (warning %d)" number)
 ;;
 
-let is_deprecated_warning s = String.is_prefix s ~prefix:"Error (alert deprecated)"
+let is_unused_var_warning s = is_warning s ~number:26 || is_warning s ~number:27
+
+let is_deprecated_warning s =
+  String.is_prefix s ~prefix:"Alert deprecated"
+  || String.is_prefix s ~prefix:"Error (alert deprecated)"
+;;

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -122,7 +122,8 @@ let%expect_test "unused values have diagnostic tags" =
             "start": { "character": 6, "line": 1 }
           },
           "severity": 2,
-          "source": "ocamllsp"
+          "source": "ocamllsp",
+          "tags": [ 1 ]
         }
       ],
       "uri": "file:///test.ml"
@@ -154,7 +155,8 @@ let () = ignore X.x
             "start": { "character": 16, "line": 6 }
           },
           "severity": 2,
-          "source": "ocamllsp"
+          "source": "ocamllsp",
+          "tags": [ 2 ]
         }
       ],
       "uri": "file:///test.ml"

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -5,7 +5,7 @@ let print_diagnostics params =
   PublishDiagnosticsParams.yojson_of_t params |> Test.print_result
 ;;
 
-let test ?(print = print_diagnostics) source =
+let test ?(print = print_diagnostics) ?capabilities source =
   let diagnostics = Fiber.Ivar.create () in
   let handler =
     Client.Handler.make
@@ -18,7 +18,7 @@ let test ?(print = print_diagnostics) source =
          | _ -> Fiber.return ())
       ()
   in
-  Test.run_initialized ~handler (fun client ->
+  Test.run_initialized ~handler ?capabilities (fun client ->
     let textDocument =
       TextDocumentItem.create
         ~uri:Helpers.uri
@@ -92,6 +92,16 @@ let%expect_test "has related diagnostics" =
     |}]
 ;;
 
+let tag_capabilities =
+  let tagSupport =
+    ClientDiagnosticsTagOptions.create
+      ~valueSet:[ DiagnosticTag.Unnecessary; DiagnosticTag.Deprecated ]
+  in
+  let publishDiagnostics = PublishDiagnosticsClientCapabilities.create ~tagSupport () in
+  let textDocument = TextDocumentClientCapabilities.create ~publishDiagnostics () in
+  ClientCapabilities.create ~textDocument ()
+;;
+
 let%expect_test "unused values have diagnostic tags" =
   let source =
     {ocaml|let () =
@@ -99,7 +109,7 @@ let%expect_test "unused values have diagnostic tags" =
   ()
 |ocaml}
   in
-  test source;
+  test ~capabilities:tag_capabilities source;
   [%expect
     {|
     textDocument/publishDiagnostics
@@ -131,7 +141,7 @@ end
 let () = ignore X.x
 |ocaml}
   in
-  test source;
+  test ~capabilities:tag_capabilities source;
   [%expect
     {|
     textDocument/publishDiagnostics


### PR DESCRIPTION
The diagnostic tag was selected by matching the message against
`Error (warning 26)` and `Error (alert deprecated)`, which Merlin only produces
when warnings are fatal. Normally it emits `Warning 26: ...` and
`Alert deprecated: ...`, so no tag was ever attached and clients could not grey
out unused values or strike through deprecated ones.

Match both renderings.

The tag path was untested: no test advertised `publishDiagnostics.tagSupport`,
so tags were dropped before the message was inspected, and the two tests named
after diagnostic tags passed while asserting output with none. The first commit
advertises the capability and leaves the expectations unchanged, which is what
makes the gap visible.

Fixes #2109.
