### PR TITLE
refactor(lsp): move code-action kind filtering

### DIFF
--- a/lsp/src/code_action.ml
+++ b/lsp/src/code_action.ml
@@ -1,0 +1,18 @@
+open Import
+open Types
+
+let kind_to_string kind =
+  match CodeActionKind.yojson_of_t kind with
+  | `String kind -> kind
+  | _ -> assert false
+;;
+
+let kind_is_requested only kind =
+  match only with
+  | None -> true
+  | Some only ->
+    let kind = kind_to_string kind in
+    List.exists only ~f:(fun requested ->
+      let requested = kind_to_string requested in
+      String.equal requested kind || String.is_prefix kind ~prefix:(requested ^ "."))
+;;

--- a/lsp/src/code_action.mli
+++ b/lsp/src/code_action.mli
@@ -1,0 +1,5 @@
+open Types
+
+(** [kind_is_requested only kind] reports whether [kind] is selected by the
+    optional hierarchical code-action kind filter [only]. *)
+val kind_is_requested : CodeActionKind.t list option -> CodeActionKind.t -> bool

--- a/lsp/src/lsp.ml
+++ b/lsp/src/lsp.ml
@@ -4,6 +4,7 @@ module Range = Range
 module Document_symbol = Document_symbol
 module Client_notification = Client_notification
 module Client_request = Client_request
+module Code_action = Code_action
 module Experimental = Experimental
 module Extension = Extension
 module Header = Header

--- a/lsp/test/code_action_tests.ml
+++ b/lsp/test/code_action_tests.ml
@@ -1,0 +1,29 @@
+open Lsp.Types
+
+let print only kind =
+  print_endline (Bool.to_string (Lsp.Code_action.kind_is_requested only kind))
+;;
+
+let%expect_test "code action kind filters" =
+  print None CodeActionKind.QuickFix;
+  print (Some [ CodeActionKind.Refactor ]) CodeActionKind.RefactorExtract;
+  print (Some [ CodeActionKind.Refactor ]) CodeActionKind.QuickFix;
+  print
+    (Some [ CodeActionKind.Other "ocaml.switch" ])
+    (CodeActionKind.Other "ocaml.switch");
+  print
+    (Some [ CodeActionKind.Other "ocaml.switch" ])
+    (CodeActionKind.Other "ocaml.switch.foo");
+  print
+    (Some [ CodeActionKind.Other "ocaml.switch" ])
+    (CodeActionKind.Other "ocaml.switcheroo");
+  [%expect
+    {|
+    true
+    true
+    false
+    true
+    true
+    false
+    |}]
+;;

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -40,7 +40,7 @@ let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
   let enabled_actions =
     List.filter
       ~f:(fun (action : Code_action.t) ->
-        Code_action.kind_is_requested params.context.only action.kind)
+        Lsp.Code_action.kind_is_requested params.context.only action.kind)
       [ Action_destruct_line.t ~dispatch:destruct_dispatch state
       ; Action_destruct.t ~dispatch:destruct_dispatch state
       ; Action_update_signature.t state
@@ -109,7 +109,7 @@ let compute server (params : CodeActionParams.t) =
     let store = state.store in
     Document_store.get_opt store uri
   in
-  let kind_is_requested = Code_action.kind_is_requested params.context.only in
+  let kind_is_requested = Lsp.Code_action.kind_is_requested params.context.only in
   let dune_actions =
     if kind_is_requested CodeActionKind.QuickFix
     then Dune.code_actions (State.dune state) params.textDocument.uri

--- a/ocaml-lsp-server/src/code_actions/action_jump.ml
+++ b/ocaml-lsp-server/src/code_actions/action_jump.ml
@@ -65,7 +65,7 @@ let code_actions
   =
   let targets =
     List.filter targets ~f:(fun target ->
-      Code_action.kind_is_requested params.context.only (kind target))
+      Lsp.Code_action.kind_is_requested params.context.only (kind target))
   in
   match Document.kind doc, targets with
   | `Merlin merlin, _ :: _ when available capabilities ->

--- a/ocaml-lsp-server/src/code_actions/code_action.ml
+++ b/ocaml-lsp-server/src/code_actions/code_action.ml
@@ -17,21 +17,6 @@ type t =
 let batchable kind run = { kind; run = `Batchable run }
 let non_batchable kind run = { kind; run = `Non_batchable run }
 
-let kind_is_requested only kind =
-  match only with
-  | None -> true
-  | Some only ->
-    let to_string kind =
-      match CodeActionKind.yojson_of_t kind with
-      | `String kind -> kind
-      | _ -> assert false
-    in
-    let kind = to_string kind in
-    List.exists only ~f:(fun requested ->
-      let requested = to_string requested in
-      String.equal requested kind || String.is_prefix kind ~prefix:(requested ^ "."))
-;;
-
 let source_text doc (loc : Loc.t) =
   let open Option.O in
   let source = Document.source doc in

--- a/ocaml-lsp-server/src/code_actions/code_action.mli
+++ b/ocaml-lsp-server/src/code_actions/code_action.mli
@@ -23,7 +23,4 @@ val non_batchable
   -> (Document.t -> CodeActionParams.t -> CodeAction.t option Fiber.t)
   -> t
 
-(** Whether [kind] is included by the requested code action kinds. *)
-val kind_is_requested : CodeActionKind.t list option -> CodeActionKind.t -> bool
-
 val source_text : Document.t -> Loc.t -> string option


### PR DESCRIPTION
Depends on #2108.

Move hierarchical code-action kind matching into Lsp.Code_action so it can be reused by LSP servers. Keep the server's existing action API while delegating filtering to the shared helper, and add expect coverage for exact, hierarchical, custom, and unmatched kinds.