### PR TITLE
test(workspace-symbol): reproduce dropped deprecation tags

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol.ml
@@ -78,6 +78,39 @@ let%expect_test "reports deprecated workspace symbols" =
     |}]
 ;;
 
+let%expect_test "reproduces dropped workspace symbol deprecation tags" =
+  let workspace_a, _workspace_b = setup_workspaces () in
+  Test.write_file
+    (Filename.concat workspace_a.path "lib/LibTypes.mli")
+    (a_lib_types_mli ^ "\nval deprecated_value : int [@@deprecated]\n");
+  build_project workspace_a;
+  let capabilities =
+    let tagSupport = ClientSymbolTagOptions.create ~valueSet:[ SymbolTag.Deprecated ] in
+    let symbol = WorkspaceSymbolClientCapabilities.create ~tagSupport () in
+    let workspace = WorkspaceClientCapabilities.create ~symbol () in
+    ClientCapabilities.create ~workspace ()
+  in
+  run ~capabilities [ workspace_a ] (fun client ->
+    let* symbols = workspace_symbol client "deprecated_value" in
+    (match symbols with
+     | Some [ symbol ] ->
+       let deprecated =
+         Option.value_map symbol.deprecated ~default:"missing" ~f:Bool.to_string
+       in
+       let tags =
+         Option.value_map symbol.tags ~default:"missing" ~f:(fun _ -> "present")
+       in
+       Printf.printf "name: %s\ndeprecated: %s\ntags: %s\n" symbol.name deprecated tags
+     | _ -> print_endline "expected exactly one symbol");
+    Fiber.return ());
+  [%expect
+    {|
+    name: deprecated_value
+    deprecated: true
+    tags: missing
+    |}]
+;;
+
 let%expect_test "returns filtered symbols from workspace" =
   let workspace_a, _workspace_b = setup_workspaces () in
   build_project workspace_a;

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
@@ -248,12 +248,12 @@ let workspace_symbol client query =
   Client.request client (WorkspaceSymbol (WorkspaceSymbolParams.create ~query ()))
 ;;
 
-let run ?on_notification workspaces f =
+let run ?on_notification ?capabilities workspaces f =
   let handler = Client.Handler.make ?on_notification () in
   let workspaceFolders =
     Some (List.map workspaces ~f:(fun workspace -> workspace.folder))
   in
-  Test.run_initialized ~handler ~workspaceFolders (fun client ->
+  Test.run_initialized ~handler ?capabilities ~workspaceFolders (fun client ->
     let* () = f client in
     Test.shutdown_client client)
 ;;


### PR DESCRIPTION
Add an end-to-end regression test for workspace-symbol deprecation output when the client advertises `SymbolTag.Deprecated`. The test captures the current legacy-field response and is intended to precede the implementation fix.