### PR TITLE
fix(code-actions): match the diagnostic messages ocamllsp emits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 ## Fixes
 
+- Offer the unused-code quick fixes again: they matched diagnostic messages the
+  server does not emit, and marking an unused `open!` produced `open!!`.
+  (#2117, fixes #2116, @dayangac)
 - Tag unused and deprecated values in diagnostics, so clients can grey them out
   or strike them through. (#2110, fixes #2109, @dayangac)
 - Respect the client's folding range capabilities: omit character positions for

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 - Return document symbol kinds the client supports, falling back to
   `Constructor` and `Class` when it does not advertise the newer kinds.
   (#2122, fixes #2121, @dayangac)
+- Offer the unused-code quick fixes again: they matched diagnostic messages the
+  server does not emit, and marking an unused `open!` produced `open!!`.
+  (#2117, fixes #2116, @dayangac)
 - Tag unused and deprecated values in diagnostics, so clients can grey them out
   or strike them through. (#2110, fixes #2109, @dayangac)
 - Honor client support for deprecation tags in workspace-symbol results.

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -1,20 +1,21 @@
 open Import
 open Option.O
 
+(* Merlin prefixes the description with the warning number, as in
+   "Warning 33: unused open B.", and uses "Error (warning 33 [unused-open]): ..."
+   when warnings are fatal. Match the description anywhere in the message rather
+   than anchoring it.
+
+   [unused open!] precedes [unused open] because [Re] keeps the first matching
+   alternative, and an [open!] diagnostic must not be marked as an [open]. *)
 let diagnostic_regex, diagnostic_regex_marks =
   let msgs =
-    ( Re.mark
-        (Re.alt
-           [ Re.str "Error (warning 26)"
-           ; Re.str "Error (warning 27)"
-           ; Re.str "unused value"
-           ])
-    , `Value )
-    :: ([ "unused open", `Open
-        ; "unused open!", `Open_bang
+    (Re.mark (Re.alt [ Re.str "unused value"; Re.str "unused variable" ]), `Value)
+    :: ([ "unused open!", `Open_bang
+        ; "unused open", `Open
         ; "unused type", `Type
-        ; "unused constructor", `Constructor
         ; "unused extension constructor", `Extension
+        ; "unused constructor", `Constructor
         ; "this match case is unused", `Case
         ; "unused for-loop index", `For_loop_index
         ; "unused rec flag", `Rec
@@ -22,9 +23,7 @@ let diagnostic_regex, diagnostic_regex_marks =
         ]
         |> List.map ~f:(fun (msg, kind) -> Re.mark (Re.str msg), kind))
   in
-  let regex =
-    Re.compile (Re.seq [ Re.bol; Re.alt (List.map ~f:(fun ((_, r), _) -> r) msgs) ])
-  in
+  let regex = Re.compile (Re.alt (List.map ~f:(fun ((_, r), _) -> r) msgs)) in
   let marks = List.map ~f:(fun ((m, _), k) -> m, k) msgs in
   regex, marks
 ;;

--- a/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
+++ b/ocaml-lsp-server/src/code_actions/action_mark_remove_unused.ml
@@ -1,20 +1,34 @@
 open Import
 open Option.O
 
-let diagnostic_regex, diagnostic_regex_marks =
+(* Merlin warning descriptions are prefixed with a warning number. Classify
+   those diagnostics by number so arbitrary diagnostic text cannot be mistaken
+   for an unused warning. Dune diagnostics have bare descriptions, so retain the
+   textual fallback only for diagnostics whose source is Dune. *)
+let warning_kinds =
+  [ 11, `Case
+  ; 26, `Value
+  ; 27, `Value
+  ; 32, `Value
+  ; 33, `Open
+  ; 34, `Type
+  ; 35, `For_loop_index
+  ; 37, `Constructor
+  ; 38, `Extension
+  ; 39, `Rec
+  ; 60, `Module
+  ; 66, `Open_bang
+  ]
+;;
+
+let dune_diagnostic_regex, dune_diagnostic_regex_marks =
   let msgs =
-    ( Re.mark
-        (Re.alt
-           [ Re.str "Error (warning 26)"
-           ; Re.str "Error (warning 27)"
-           ; Re.str "unused value"
-           ])
-    , `Value )
-    :: ([ "unused open", `Open
-        ; "unused open!", `Open_bang
+    (Re.mark (Re.alt [ Re.str "unused value"; Re.str "unused variable" ]), `Value)
+    :: ([ "unused open!", `Open_bang
+        ; "unused open", `Open
         ; "unused type", `Type
-        ; "unused constructor", `Constructor
         ; "unused extension constructor", `Extension
+        ; "unused constructor", `Constructor
         ; "this match case is unused", `Case
         ; "unused for-loop index", `For_loop_index
         ; "unused rec flag", `Rec
@@ -29,25 +43,37 @@ let diagnostic_regex, diagnostic_regex_marks =
   regex, marks
 ;;
 
+let dune_diagnostic_kind message =
+  let* group = Re.exec_opt dune_diagnostic_regex message in
+  List.find_map dune_diagnostic_regex_marks ~f:(fun (mark, kind) ->
+    Option.some_if (Re.Mark.test group mark) kind)
+;;
+
 let find_unused_diagnostic pos ds =
-  let open Option.O in
   List.filter ds ~f:(fun (d : Diagnostic.t) ->
     Range.contains_position d.range pos ~inclusive_end:true)
   |> List.find_map ~f:(fun (d : Diagnostic.t) ->
-    let* group =
-      let message =
-        match d.message with
-        | `String m -> m
-        | `MarkupContent { value = m; _ } ->
-          (* TODO: this is wrong *)
-          m
-      in
-      Re.exec_opt diagnostic_regex message
+    let message =
+      match d.message with
+      | `String message -> message
+      | `MarkupContent { value = message; _ } ->
+        (* TODO: this is wrong *)
+        message
     in
-    let+ kind =
-      List.find_map diagnostic_regex_marks ~f:(fun (m, k) ->
-        Option.some_if (Re.Mark.test group m) k)
+    let kind =
+      match
+        List.find_map warning_kinds ~f:(fun (number, kind) ->
+          Option.some_if (Diagnostic_util.is_warning message ~number) kind)
+      with
+      | Some kind -> Some kind
+      | None ->
+        (match d.source with
+         | Some source
+           when String.equal source "dune" || String.is_prefix source ~prefix:"dune (pid="
+           -> dune_diagnostic_kind message
+         | None | Some _ -> None)
     in
+    let+ kind = kind in
     kind, d)
 ;;
 

--- a/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
+++ b/ocaml-lsp-server/src/code_actions/diagnostic_util.ml
@@ -1,10 +1,15 @@
 open Import
 
 (* Merlin renders a warning as "Warning 26: ..." and, when warnings are fatal,
-   as "Error (warning 26): ...". Alerts follow the same pair of shapes. *)
+   as "Error (warning 26 [unused-var]): ..."; older renderings omit the warning
+   name. Alerts follow the same pair of shapes. *)
 let is_warning s ~number =
-  String.is_prefix s ~prefix:(sprintf "Warning %d" number)
-  || String.is_prefix s ~prefix:(sprintf "Error (warning %d)" number)
+  [ sprintf "Warning %d:" number
+  ; sprintf "Warning %d [" number
+  ; sprintf "Error (warning %d)" number
+  ; sprintf "Error (warning %d " number
+  ]
+  |> List.exists ~f:(fun prefix -> String.is_prefix s ~prefix)
 ;;
 
 let is_unused_var_warning s = is_warning s ~number:26 || is_warning s ~number:27

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -11,22 +11,32 @@ let run_test ~title ~message source =
 ;;
 
 let mark_test = function
-  | `Value -> run_test ~title:"Mark as unused" ~message:"unused value"
-  | `Open -> run_test ~title:"Replace with open!" ~message:"unused open"
+  | `Value -> run_test ~title:"Mark as unused" ~message:"Warning 26: unused variable x."
+  | `Open ->
+    run_test
+      ~title:"Replace with open!"
+      ~message:"Error (warning 33 [unused-open]): unused open B."
   | `For_loop_index ->
-    run_test ~title:"Mark for-loop index as unused" ~message:"unused for-loop index"
+    run_test
+      ~title:"Mark for-loop index as unused"
+      ~message:"Warning 35: unused for-loop index i."
 ;;
 
 let remove_test = function
-  | `Value -> run_test ~title:"Remove unused" ~message:"unused value"
-  | `Open -> run_test ~title:"Remove unused open" ~message:"unused open"
-  | `Open_bang -> run_test ~title:"Remove unused open!" ~message:"unused open!"
-  | `Type -> run_test ~title:"Remove unused type" ~message:"unused type"
-  | `Module -> run_test ~title:"Remove unused module" ~message:"unused module"
-  | `Case -> run_test ~title:"Remove unused case" ~message:"this match case is unused"
-  | `Rec -> run_test ~title:"Remove unused rec" ~message:"unused rec flag"
+  | `Value -> run_test ~title:"Remove unused" ~message:"Warning 26: unused variable x."
+  | `Open -> run_test ~title:"Remove unused open" ~message:"Warning 33: unused open B."
+  | `Open_bang ->
+    run_test ~title:"Remove unused open!" ~message:"Warning 66: unused open! B."
+  | `Type -> run_test ~title:"Remove unused type" ~message:"Warning 34: unused type t."
+  | `Module ->
+    run_test ~title:"Remove unused module" ~message:"Warning 60: unused module M."
+  | `Case ->
+    run_test ~title:"Remove unused case" ~message:"Warning 11: this match case is unused."
+  | `Rec -> run_test ~title:"Remove unused rec" ~message:"Warning 39: unused rec flag."
   | `Constructor ->
-    run_test ~title:"Remove unused constructor" ~message:"unused constructor"
+    run_test
+      ~title:"Remove unused constructor"
+      ~message:"Warning 37: unused constructor A."
 ;;
 
 let%expect_test "mark value in let" =
@@ -37,11 +47,7 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect
-    {|
-    let f =
-      let _x = 1 in
-      0 |}]
+  [%expect {| |}]
 ;;
 
 (* todo *)
@@ -53,11 +59,7 @@ let $f$ =
   let x = 1 in
   0
 |};
-  [%expect
-    {|
-    let _f =
-      let x = 1 in
-      0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "mark value in match" =
@@ -67,10 +69,7 @@ let%expect_test "mark value in match" =
 let f = function
   | $x$ -> 0
 |};
-  [%expect
-    {|
-    let f = function
-      | _x -> 0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove value in let" =
@@ -81,10 +80,7 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect
-    {|
-    let f =
-      0 |}]
+  [%expect {| |}]
 ;;
 
 (* todo *)
@@ -104,7 +100,7 @@ let%expect_test "mark open" =
     {|
 $open M$
 |};
-  [%expect {| open! M |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "mark for loop index" =
@@ -116,12 +112,7 @@ let () =
     ()
   done
 |};
-  [%expect
-    {|
-    let () =
-      for _i = 0 to 10 do
-        ()
-      done |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove open" =
@@ -131,7 +122,7 @@ let%expect_test "remove open" =
 open A
 $open B$
 |};
-  [%expect {| open A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove open!" =
@@ -150,7 +141,7 @@ let%expect_test "remove type" =
 $type t = int$
 type s = bool
 |};
-  [%expect {| type s = bool |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove module" =
@@ -160,7 +151,7 @@ let%expect_test "remove module" =
 $module A = struct end$
 module B = struct end
 |};
-  [%expect {| module B = struct end |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove case" =
@@ -171,10 +162,7 @@ let f = function
  | 0 -> 0
  | $0 -> 1$
 |};
-  [%expect
-    {|
-    let f = function
-     | 0 -> 0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove case after Unicode" =
@@ -187,7 +175,11 @@ let f = function
 |}
   in
   let diagnostics =
-    [ Diagnostic.create ~message:(`String "this match case is unused") ~range () ]
+    [ Diagnostic.create
+        ~message:(`String "Warning 11: this match case is unused.")
+        ~range
+        ()
+    ]
   in
   Code_actions.print_code_actions
     ~diagnostics
@@ -197,39 +189,7 @@ let f = function
     source
     range;
   [%expect
-    {|
-    Code actions:
-    {
-      "diagnostics": [
-        {
-          "message": "this match case is unused",
-          "range": {
-            "end": { "character": 12, "line": 3 },
-            "start": { "character": 3, "line": 3 }
-          }
-        }
-      ],
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "",
-                "range": {
-                  "end": { "character": 12, "line": 3 },
-                  "start": { "character": 1, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": true,
-      "kind": "quickfix",
-      "title": "Remove unused case"
-    }
-    |}]
+    {| No code actions |}]
 ;;
 
 let%expect_test "remove rec flag after Unicode" =
@@ -240,7 +200,7 @@ let café = let rec $f$ = 0 in f
 |}
   in
   let diagnostics =
-    [ Diagnostic.create ~message:(`String "unused rec flag") ~range () ]
+    [ Diagnostic.create ~message:(`String "Warning 39: unused rec flag.") ~range () ]
   in
   Code_actions.print_code_actions
     ~diagnostics
@@ -250,39 +210,7 @@ let café = let rec $f$ = 0 in f
     source
     range;
   [%expect
-    {|
-    Code actions:
-    {
-      "diagnostics": [
-        {
-          "message": "unused rec flag",
-          "range": {
-            "end": { "character": 20, "line": 1 },
-            "start": { "character": 19, "line": 1 }
-          }
-        }
-      ],
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "",
-                "range": {
-                  "end": { "character": 18, "line": 1 },
-                  "start": { "character": 15, "line": 1 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "quickfix",
-      "title": "Remove unused rec"
-    }
-    |}]
+    {| No code actions |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -291,7 +219,7 @@ let%expect_test "remove constructor" =
     {|
 type t = A $| B$
 |};
-  [%expect {| type t = A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -302,10 +230,7 @@ type t =
   | A
  $| B$
 |};
-  [%expect
-    {|
-    type t =
-      | A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -316,11 +241,7 @@ type t =
  $| A$
  | B
 |};
-  [%expect
-    {|
-    type t =
-
-     | B |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -331,11 +252,7 @@ type t =
  $A$
  | B
 |};
-  [%expect
-    {|
-    type t =
-
-     | B |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "deprecated alert text is not an unused diagnostic" =

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -44,7 +44,12 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f =
+      let _x = 1 in
+      0
+    |}]
 ;;
 
 (* todo *)
@@ -56,7 +61,12 @@ let $f$ =
   let x = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let _f =
+      let x = 1 in
+      0
+    |}]
 ;;
 
 let%expect_test "mark value in match" =
@@ -66,7 +76,11 @@ let%expect_test "mark value in match" =
 let f = function
   | $x$ -> 0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f = function
+      | _x -> 0
+    |}]
 ;;
 
 let%expect_test "remove value in let" =
@@ -77,7 +91,11 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f =
+      0
+    |}]
 ;;
 
 (* todo *)
@@ -97,7 +115,7 @@ let%expect_test "mark open" =
     {|
 $open M$
 |};
-  [%expect {| |}]
+  [%expect {| open! M |}]
 ;;
 
 let%expect_test "mark for loop index" =
@@ -109,7 +127,13 @@ let () =
     ()
   done
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let () =
+      for _i = 0 to 10 do
+        ()
+      done
+    |}]
 ;;
 
 let%expect_test "remove open" =
@@ -119,7 +143,7 @@ let%expect_test "remove open" =
 open A
 $open B$
 |};
-  [%expect {| |}]
+  [%expect {| open A |}]
 ;;
 
 let%expect_test "remove open!" =
@@ -128,7 +152,8 @@ let%expect_test "remove open!" =
     {|
 open A
 $open! B$
-|}
+|};
+  [%expect {| open A |}]
 ;;
 
 let%expect_test "remove type" =
@@ -138,7 +163,7 @@ let%expect_test "remove type" =
 $type t = int$
 type s = bool
 |};
-  [%expect {| |}]
+  [%expect {| type s = bool |}]
 ;;
 
 let%expect_test "remove module" =
@@ -148,7 +173,7 @@ let%expect_test "remove module" =
 $module A = struct end$
 module B = struct end
 |};
-  [%expect {| |}]
+  [%expect {| module B = struct end |}]
 ;;
 
 let%expect_test "remove case" =
@@ -159,7 +184,11 @@ let f = function
  | 0 -> 0
  | $0 -> 1$
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f = function
+     | 0 -> 0
+    |}]
 ;;
 
 let%expect_test "remove case after Unicode" =
@@ -276,7 +305,7 @@ let%expect_test "remove constructor" =
     {|
 type t = A $| B$
 |};
-  [%expect {| |}]
+  [%expect {| type t = A |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -287,7 +316,11 @@ type t =
   | A
  $| B$
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+      | A
+    |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -298,7 +331,12 @@ type t =
  $| A$
  | B
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+
+     | B
+    |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -309,5 +347,10 @@ type t =
  $A$
  | B
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+
+     | B
+    |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -1,9 +1,9 @@
 open Test.Import
 
-let run_test ~title ~message source =
-  let src, range = Code_actions.parse_selection source in
+let run_test ?source ~title ~message source_text =
+  let src, range = Code_actions.parse_selection source_text in
   Code_actions.apply_code_action
-    ~diagnostics:[ Diagnostic.create ~message:(`String message) ~range () ]
+    ~diagnostics:[ Diagnostic.create ~message:(`String message) ~range ?source () ]
     title
     src
     range
@@ -47,7 +47,12 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f =
+      let _x = 1 in
+      0
+    |}]
 ;;
 
 (* todo *)
@@ -59,7 +64,12 @@ let $f$ =
   let x = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let _f =
+      let x = 1 in
+      0
+    |}]
 ;;
 
 let%expect_test "mark value in match" =
@@ -69,7 +79,11 @@ let%expect_test "mark value in match" =
 let f = function
   | $x$ -> 0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f = function
+      | _x -> 0
+    |}]
 ;;
 
 let%expect_test "remove value in let" =
@@ -80,7 +94,11 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f =
+      0
+    |}]
 ;;
 
 (* todo *)
@@ -100,7 +118,18 @@ let%expect_test "mark open" =
     {|
 $open M$
 |};
-  [%expect {| |}]
+  [%expect {| open! M |}]
+;;
+
+let%expect_test "mark open reported by Dune" =
+  run_test
+    ~source:"dune (pid=123)"
+    ~title:"Replace with open!"
+    ~message:"unused open"
+    {|
+$open M$
+|};
+  [%expect {| open! M |}]
 ;;
 
 let%expect_test "mark for loop index" =
@@ -112,7 +141,13 @@ let () =
     ()
   done
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let () =
+      for _i = 0 to 10 do
+        ()
+      done
+    |}]
 ;;
 
 let%expect_test "remove open" =
@@ -122,7 +157,7 @@ let%expect_test "remove open" =
 open A
 $open B$
 |};
-  [%expect {| |}]
+  [%expect {| open A |}]
 ;;
 
 let%expect_test "remove open!" =
@@ -131,7 +166,8 @@ let%expect_test "remove open!" =
     {|
 open A
 $open! B$
-|}
+|};
+  [%expect {| open A |}]
 ;;
 
 let%expect_test "remove type" =
@@ -141,7 +177,7 @@ let%expect_test "remove type" =
 $type t = int$
 type s = bool
 |};
-  [%expect {| |}]
+  [%expect {| type s = bool |}]
 ;;
 
 let%expect_test "remove module" =
@@ -151,7 +187,7 @@ let%expect_test "remove module" =
 $module A = struct end$
 module B = struct end
 |};
-  [%expect {| |}]
+  [%expect {| module B = struct end |}]
 ;;
 
 let%expect_test "remove case" =
@@ -162,7 +198,11 @@ let f = function
  | 0 -> 0
  | $0 -> 1$
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    let f = function
+     | 0 -> 0
+    |}]
 ;;
 
 let%expect_test "remove case after Unicode" =
@@ -189,7 +229,39 @@ let f = function
     source
     range;
   [%expect
-    {| No code actions |}]
+    {|
+    Code actions:
+    {
+      "diagnostics": [
+        {
+          "message": "Warning 11: this match case is unused.",
+          "range": {
+            "end": { "character": 12, "line": 3 },
+            "start": { "character": 3, "line": 3 }
+          }
+        }
+      ],
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": { "character": 12, "line": 3 },
+                  "start": { "character": 1, "line": 3 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": true,
+      "kind": "quickfix",
+      "title": "Remove unused case"
+    }
+    |}]
 ;;
 
 let%expect_test "remove rec flag after Unicode" =
@@ -210,7 +282,39 @@ let café = let rec $f$ = 0 in f
     source
     range;
   [%expect
-    {| No code actions |}]
+    {|
+    Code actions:
+    {
+      "diagnostics": [
+        {
+          "message": "Warning 39: unused rec flag.",
+          "range": {
+            "end": { "character": 20, "line": 1 },
+            "start": { "character": 19, "line": 1 }
+          }
+        }
+      ],
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": { "character": 18, "line": 1 },
+                  "start": { "character": 15, "line": 1 }
+                }
+              }
+            ],
+            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
+          }
+        ]
+      },
+      "isPreferred": false,
+      "kind": "quickfix",
+      "title": "Remove unused rec"
+    }
+    |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -219,7 +323,7 @@ let%expect_test "remove constructor" =
     {|
 type t = A $| B$
 |};
-  [%expect {| |}]
+  [%expect {| type t = A |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -230,7 +334,11 @@ type t =
   | A
  $| B$
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+      | A
+    |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -241,7 +349,12 @@ type t =
  $| A$
  | B
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+
+     | B
+    |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -252,7 +365,12 @@ type t =
  $A$
  | B
 |};
-  [%expect {| |}]
+  [%expect
+    {|
+    type t =
+
+     | B
+    |}]
 ;;
 
 let%expect_test "deprecated alert text is not an unused diagnostic" =

--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -11,22 +11,29 @@ let run_test ~title ~message source =
 ;;
 
 let mark_test = function
-  | `Value -> run_test ~title:"Mark as unused" ~message:"unused value"
-  | `Open -> run_test ~title:"Replace with open!" ~message:"unused open"
+  | `Value -> run_test ~title:"Mark as unused" ~message:"Warning 26: unused variable x."
+  | `Open -> run_test ~title:"Replace with open!" ~message:"Warning 33: unused open B."
   | `For_loop_index ->
-    run_test ~title:"Mark for-loop index as unused" ~message:"unused for-loop index"
+    run_test
+      ~title:"Mark for-loop index as unused"
+      ~message:"Warning 35: unused for-loop index i."
 ;;
 
 let remove_test = function
-  | `Value -> run_test ~title:"Remove unused" ~message:"unused value"
-  | `Open -> run_test ~title:"Remove unused open" ~message:"unused open"
-  | `Open_bang -> run_test ~title:"Remove unused open!" ~message:"unused open!"
-  | `Type -> run_test ~title:"Remove unused type" ~message:"unused type"
-  | `Module -> run_test ~title:"Remove unused module" ~message:"unused module"
-  | `Case -> run_test ~title:"Remove unused case" ~message:"this match case is unused"
-  | `Rec -> run_test ~title:"Remove unused rec" ~message:"unused rec flag"
+  | `Value -> run_test ~title:"Remove unused" ~message:"Warning 26: unused variable x."
+  | `Open -> run_test ~title:"Remove unused open" ~message:"Warning 33: unused open B."
+  | `Open_bang ->
+    run_test ~title:"Remove unused open!" ~message:"Warning 66: unused open! B."
+  | `Type -> run_test ~title:"Remove unused type" ~message:"Warning 34: unused type t."
+  | `Module ->
+    run_test ~title:"Remove unused module" ~message:"Warning 60: unused module M."
+  | `Case ->
+    run_test ~title:"Remove unused case" ~message:"Warning 11: this match case is unused."
+  | `Rec -> run_test ~title:"Remove unused rec" ~message:"Warning 39: unused rec flag."
   | `Constructor ->
-    run_test ~title:"Remove unused constructor" ~message:"unused constructor"
+    run_test
+      ~title:"Remove unused constructor"
+      ~message:"Warning 37: unused constructor A."
 ;;
 
 let%expect_test "mark value in let" =
@@ -37,11 +44,7 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect
-    {|
-    let f =
-      let _x = 1 in
-      0 |}]
+  [%expect {| |}]
 ;;
 
 (* todo *)
@@ -53,11 +56,7 @@ let $f$ =
   let x = 1 in
   0
 |};
-  [%expect
-    {|
-    let _f =
-      let x = 1 in
-      0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "mark value in match" =
@@ -67,10 +66,7 @@ let%expect_test "mark value in match" =
 let f = function
   | $x$ -> 0
 |};
-  [%expect
-    {|
-    let f = function
-      | _x -> 0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove value in let" =
@@ -81,10 +77,7 @@ let f =
   let $x$ = 1 in
   0
 |};
-  [%expect
-    {|
-    let f =
-      0 |}]
+  [%expect {| |}]
 ;;
 
 (* todo *)
@@ -104,7 +97,7 @@ let%expect_test "mark open" =
     {|
 $open M$
 |};
-  [%expect {| open! M |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "mark for loop index" =
@@ -116,12 +109,7 @@ let () =
     ()
   done
 |};
-  [%expect
-    {|
-    let () =
-      for _i = 0 to 10 do
-        ()
-      done |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove open" =
@@ -131,7 +119,7 @@ let%expect_test "remove open" =
 open A
 $open B$
 |};
-  [%expect {| open A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove open!" =
@@ -150,7 +138,7 @@ let%expect_test "remove type" =
 $type t = int$
 type s = bool
 |};
-  [%expect {| type s = bool |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove module" =
@@ -160,7 +148,7 @@ let%expect_test "remove module" =
 $module A = struct end$
 module B = struct end
 |};
-  [%expect {| module B = struct end |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove case" =
@@ -171,10 +159,7 @@ let f = function
  | 0 -> 0
  | $0 -> 1$
 |};
-  [%expect
-    {|
-    let f = function
-     | 0 -> 0 |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove case after Unicode" =
@@ -291,7 +276,7 @@ let%expect_test "remove constructor" =
     {|
 type t = A $| B$
 |};
-  [%expect {| type t = A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -302,10 +287,7 @@ type t =
   | A
  $| B$
 |};
-  [%expect
-    {|
-    type t =
-      | A |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -316,11 +298,7 @@ type t =
  $| A$
  | B
 |};
-  [%expect
-    {|
-    type t =
-
-     | B |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "remove constructor" =
@@ -331,9 +309,5 @@ type t =
  $A$
  | B
 |};
-  [%expect
-    {|
-    type t =
-
-     | B |}]
+  [%expect {| |}]
 ;;


### PR DESCRIPTION
The unused-code quick fixes treated every diagnostic as though it used Dune’s bare descriptions. Merlin instead publishes messages such as `Warning 33: unused open B.`, so most actions were unavailable; fatal unused-variable diagnostics were the main exception.

Classify Merlin diagnostics by warning number, supporting both regular and fatal renderings. Keep the textual fallback for Dune diagnostics only when their source identifies Dune. Warning 66 is distinct from warning 33, preventing `open!` from being turned into `open!!`.

Restricting bare-description matching to Dune also prevents arbitrary alert payloads from triggering destructive unused-code actions, preserving the regression test added in #2141.

Fixes #2116.
