### PR TITLE
test(code-actions): cover the create-counterpart client capabilities

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -7,13 +7,13 @@ let range ~start_line ~start_character ~end_line ~end_character =
   Range.create ~start ~end_
 ;;
 
-let iter_code_actions ?prep ?path ?(diagnostics = []) ?only ~source range =
+let iter_code_actions ?prep ?path ?capabilities ?(diagnostics = []) ?only ~source range =
   let makeRequest textDocument =
     let context = CodeActionContext.create ~diagnostics ?only () in
     Lsp.Client_request.CodeAction
       (CodeActionParams.create ~textDocument ~range ~context ())
   in
-  iter_lsp_response ?prep ?path ~language_id:"ocaml" ~makeRequest ~source
+  iter_lsp_response ?prep ?path ?capabilities ~language_id:"ocaml" ~makeRequest ~source
 ;;
 
 let print_code_action_result ?(filter = fun _ -> true) = function
@@ -40,6 +40,7 @@ let print_code_actions
       ?(diagnostics = [])
       ?only
       ?filter
+      ?capabilities
       source
       range
   =
@@ -48,6 +49,7 @@ let print_code_actions
     ~path
     ~diagnostics
     ?only
+    ?capabilities
     ~source
     range
     (print_code_action_result ?filter)

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -10,6 +10,7 @@ val range
 val iter_code_actions
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string
+  -> ?capabilities:ClientCapabilities.t
   -> ?diagnostics:Diagnostic.t list
   -> ?only:CodeActionKind.t list
   -> source:string
@@ -28,6 +29,7 @@ val print_code_actions
   -> ?diagnostics:Diagnostic.t list
   -> ?only:CodeActionKind.t list
   -> ?filter:([ `Command of Command.t | `CodeAction of CodeAction.t ] -> bool)
+  -> ?capabilities:ClientCapabilities.t
   -> string
   -> Range.t
   -> unit

--- a/ocaml-lsp-server/test/e2e-new/code_actions_annotations.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_annotations.ml
@@ -463,3 +463,66 @@ let my_fun x y : int = 1
   print_code_actions source range ~filter:find_remove_annotation_action;
   [%expect {| No code actions |}]
 ;;
+
+let capabilities_with_create_file =
+  let window =
+    let showDocument = ShowDocumentClientCapabilities.create ~support:true in
+    WindowClientCapabilities.create ~showDocument ()
+  in
+  let workspace =
+    let workspaceEdit =
+      WorkspaceEditClientCapabilities.create
+        ~documentChanges:true
+        ~resourceOperations:[ ResourceOperationKind.Create ]
+        ()
+    in
+    WorkspaceClientCapabilities.create ~workspaceEdit ()
+  in
+  ClientCapabilities.create ~window ~workspace ()
+;;
+
+let%expect_test "create counterpart action, client supports resource operations" =
+  let range = range ~start_line:0 ~start_character:4 ~end_line:0 ~end_character:5 in
+  print_code_actions
+    ~capabilities:capabilities_with_create_file
+    ~filter:(find_action "switch")
+    "let x = 1\n"
+    range;
+  [%expect
+    {|
+    Code actions:
+    {
+      "command": {
+        "arguments": [ "file:///foo.mli" ],
+        "command": "ocamllsp/open-related-source",
+        "title": "Create foo.mli"
+      },
+      "edit": {
+        "documentChanges": [ { "kind": "create", "uri": "file:///foo.mli" } ]
+      },
+      "kind": "switch",
+      "title": "Create foo.mli"
+    }
+    |}]
+;;
+
+let%expect_test "create counterpart action, client lacks resource operations" =
+  let range = range ~start_line:0 ~start_character:4 ~end_line:0 ~end_character:5 in
+  print_code_actions ~filter:(find_action "switch") "let x = 1\n" range;
+  [%expect
+    {|
+    Code actions:
+    {
+      "command": {
+        "arguments": [ "file:///foo.mli" ],
+        "command": "ocamllsp/open-related-source",
+        "title": "Create foo.mli"
+      },
+      "edit": {
+        "documentChanges": [ { "kind": "create", "uri": "file:///foo.mli" } ]
+      },
+      "kind": "switch",
+      "title": "Create foo.mli"
+    }
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.ml
@@ -42,6 +42,7 @@ let open_document_with_client ~prep ~path ~source client =
 let iter_lsp_response_internal
       ?(prep = fun _ -> Fiber.return ())
       ?(path = "foo.ml")
+      ?(capabilities = capabilities_with_show_document)
       ~language_id
       ~makeRequest
       ~source
@@ -50,9 +51,7 @@ let iter_lsp_response_internal
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
   Test.run ~handler
   @@ fun client ->
-  let run_client () =
-    Test.start_client ~capabilities:capabilities_with_show_document client
-  in
+  let run_client () = Test.start_client ~capabilities client in
   let request () =
     let* (_ : InitializeResult.t) = Client.initialized client in
     let uri = DocumentUri.of_path path in
@@ -75,8 +74,15 @@ let iter_lsp_response_internal
   Fiber.fork_and_join_unit run_client (fun () -> Fiber.finalize request ~finally:shutdown)
 ;;
 
-let iter_lsp_response ?prep ?path ~language_id ~makeRequest ~source k =
-  iter_lsp_response_internal ?prep ?path ~language_id ~makeRequest ~source (function
+let iter_lsp_response ?prep ?path ?capabilities ~language_id ~makeRequest ~source k =
+  iter_lsp_response_internal
+    ?prep
+    ?path
+    ?capabilities
+    ~language_id
+    ~makeRequest
+    ~source
+    (function
     | Ok response ->
       k response;
       Fiber.return ()

--- a/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
+++ b/ocaml-lsp-server/test/e2e-new/lsp_helpers.mli
@@ -8,6 +8,7 @@ val change_config : client:'a Client.t -> DidChangeConfigurationParams.t -> unit
 val iter_lsp_response
   :  ?prep:(unit Client.t -> unit Fiber.t)
   -> ?path:string
+  -> ?capabilities:ClientCapabilities.t
   -> language_id:string
   -> makeRequest:(TextDocumentIdentifier.t -> 'a Client.out_request)
   -> source:string


### PR DESCRIPTION
Nothing exercised a client that can apply a `CreateFile` resource operation: the
code action tests advertise only `window.showDocument`.

Add a test for a client advertising `workspaceEdit.documentChanges` with the
create resource operation, and one for a client advertising neither, and thread
the capabilities through the code action test helpers.

Both currently receive the same action, including the `CreateFile` edit that a
client without the capability cannot apply. #2115 changes the second case.

Refs #2114.
