### PR TITLE
fix(document-symbol): respect the client's supported symbol kinds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 ## Fixes
 
+- Return document symbol kinds the client supports, falling back to
+  `Constructor` and `Class` when it does not advertise the newer kinds.
+  (#2122, fixes #2121, @dayangac)
 - Tag unused and deprecated values in diagnostics, so clients can grey them out
   or strike them through. (#2110, fixes #2109, @dayangac)
 - Honor client support for deprecation tags in workspace-symbol results.

--- a/lsp/src/capabilities.ml
+++ b/lsp/src/capabilities.ml
@@ -56,6 +56,11 @@ let document_symbol_tag_support (t : t) =
     map ds.tagSupport (fun tag_support -> tag_support.valueSet))
 ;;
 
+let document_symbol_kind_support (t : t) =
+  Option.bind (document_symbol t) (fun ds ->
+    Option.bind ds.symbolKind (fun symbol_kind -> symbol_kind.valueSet))
+;;
+
 (* Signature help *)
 
 let signature_help (t : t) = Option.bind t.textDocument (fun td -> td.signatureHelp)

--- a/lsp/src/capabilities.mli
+++ b/lsp/src/capabilities.mli
@@ -36,6 +36,11 @@ val document_symbol_hierarchical_support : t -> bool
 (** The set of document symbol tags the client supports. *)
 val document_symbol_tag_support : t -> SymbolTag.t list option
 
+(** The set of document symbol kinds the client supports. When absent, the
+    client only supports the kinds from the initial version of the protocol,
+    [File] to [Array]. *)
+val document_symbol_kind_support : t -> SymbolKind.t list option
+
 (* Signature help *)
 
 (** Whether the client supports offset-based parameter labels. *)

--- a/ocaml-lsp-server/src/document_symbol.ml
+++ b/ocaml-lsp-server/src/document_symbol.ml
@@ -12,7 +12,22 @@ let symbol_kind_of_outline_kind = function
   | `Method -> Method
 ;;
 
-let rec items_to_symbols ~supports_deprecated_tag items =
+(* An absent [symbolKind.valueSet] means the client only supports the kinds from
+   the initial version of the protocol, so fall back to one of those. *)
+let supported_symbol_kind supported kind =
+  match supported with
+  | None -> kind
+  | Some supported ->
+    if List.mem supported kind ~equal:Poly.equal
+    then kind
+    else (
+      match kind with
+      | SymbolKind.EnumMember -> SymbolKind.Constructor
+      | TypeParameter -> Class
+      | kind -> kind)
+;;
+
+let rec items_to_symbols ~supports_deprecated_tag ~supported_kinds items =
   List.rev_map
     ~f:
       (fun
@@ -42,12 +57,15 @@ let rec items_to_symbols ~supports_deprecated_tag items =
       in
       DocumentSymbol.create
         ~name:outline_name
-        ~kind:(symbol_kind_of_outline_kind outline_kind)
+        ~kind:
+          (supported_symbol_kind
+             supported_kinds
+             (symbol_kind_of_outline_kind outline_kind))
         ~range
         ~selectionRange
         ?deprecated
         ?tags
-        ~children:(items_to_symbols ~supports_deprecated_tag children)
+        ~children:(items_to_symbols ~supports_deprecated_tag ~supported_kinds children)
         ())
     items
 ;;
@@ -70,7 +88,8 @@ let run (client_capabilities : ClientCapabilities.t) doc uri =
             ~tag:Deprecated
             ~equal:(fun SymbolTag.Deprecated Deprecated -> true))
     in
-    let symbols = items_to_symbols ~supports_deprecated_tag outline in
+    let supported_kinds = Capabilities.document_symbol_kind_support client_capabilities in
+    let symbols = items_to_symbols ~supports_deprecated_tag ~supported_kinds outline in
     (match Capabilities.document_symbol_hierarchical_support client_capabilities with
      | true -> Some (`DocumentSymbol symbols)
      | false ->

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -979,7 +979,7 @@ let%expect_test "symbol kinds are restricted to those the client supports" =
         "children": [
           {
             "children": [],
-            "kind": 22,
+            "kind": 9,
             "name": "A",
             "range": {
               "end": { "character": 10, "line": 0 },
@@ -992,7 +992,7 @@ let%expect_test "symbol kinds are restricted to those the client supports" =
           },
           {
             "children": [],
-            "kind": 22,
+            "kind": 9,
             "name": "B",
             "range": {
               "end": { "character": 14, "line": 0 },
@@ -1004,7 +1004,7 @@ let%expect_test "symbol kinds are restricted to those the client supports" =
             }
           }
         ],
-        "kind": 26,
+        "kind": 5,
         "name": "t",
         "range": {
           "end": { "character": 14, "line": 0 },
@@ -1017,7 +1017,7 @@ let%expect_test "symbol kinds are restricted to those the client supports" =
       },
       {
         "children": [],
-        "kind": 22,
+        "kind": 9,
         "name": "E",
         "range": {
           "end": { "character": 11, "line": 1 },

--- a/ocaml-lsp-server/test/e2e-new/document_symbol.ml
+++ b/ocaml-lsp-server/test/e2e-new/document_symbol.ml
@@ -928,3 +928,106 @@ let
     ghost overlapping first line: range=((0, 41), (2, 1)) selection=((0, 41), (2, 1))
     |}]
 ;;
+
+let%expect_test "symbol kinds are restricted to those the client supports" =
+  let source = "type t = A | B\nexception E\n" in
+  let capabilities =
+    let symbolKind =
+      (* The kinds from the initial version of the protocol, File to Array. *)
+      ClientSymbolKindOptions.create
+        ~valueSet:
+          [ SymbolKind.File
+          ; Module
+          ; Namespace
+          ; Package
+          ; Class
+          ; Method
+          ; Property
+          ; Field
+          ; Constructor
+          ; Enum
+          ; Interface
+          ; Function
+          ; Variable
+          ; Constant
+          ; String
+          ; Number
+          ; Boolean
+          ; Array
+          ]
+        ()
+    in
+    let documentSymbol =
+      DocumentSymbolClientCapabilities.create
+        ~hierarchicalDocumentSymbolSupport:true
+        ~symbolKind
+        ()
+    in
+    let textDocument = TextDocumentClientCapabilities.create ~documentSymbol () in
+    ClientCapabilities.create ~textDocument ()
+  in
+  let request client =
+    let open Fiber.O in
+    let+ response = Util.call_document_symbol client in
+    print_result response
+  in
+  Helpers.test ~capabilities source request;
+  [%expect
+    {|
+    [
+      {
+        "children": [
+          {
+            "children": [],
+            "kind": 22,
+            "name": "A",
+            "range": {
+              "end": { "character": 10, "line": 0 },
+              "start": { "character": 9, "line": 0 }
+            },
+            "selectionRange": {
+              "end": { "character": 10, "line": 0 },
+              "start": { "character": 9, "line": 0 }
+            }
+          },
+          {
+            "children": [],
+            "kind": 22,
+            "name": "B",
+            "range": {
+              "end": { "character": 14, "line": 0 },
+              "start": { "character": 11, "line": 0 }
+            },
+            "selectionRange": {
+              "end": { "character": 14, "line": 0 },
+              "start": { "character": 13, "line": 0 }
+            }
+          }
+        ],
+        "kind": 26,
+        "name": "t",
+        "range": {
+          "end": { "character": 14, "line": 0 },
+          "start": { "character": 0, "line": 0 }
+        },
+        "selectionRange": {
+          "end": { "character": 6, "line": 0 },
+          "start": { "character": 5, "line": 0 }
+        }
+      },
+      {
+        "children": [],
+        "kind": 22,
+        "name": "E",
+        "range": {
+          "end": { "character": 11, "line": 1 },
+          "start": { "character": 0, "line": 1 }
+        },
+        "selectionRange": {
+          "end": { "character": 11, "line": 1 },
+          "start": { "character": 10, "line": 1 }
+        }
+      }
+    ]
+    |}]
+;;


### PR DESCRIPTION
Constructors, exceptions and labels were returned as `EnumMember` and types as
`TypeParameter`, regardless of `textDocument.documentSymbol.symbolKind`. A
client that does not advertise the capability supports only the kinds from the
initial version of the protocol, `File` to `Array`, and neither of those is in
that set.

Fall back to `Constructor` and `Class` for such clients, mirroring what
completions already do through `Capabilities.completion_item_kind_support`.

The first commit adds a test for a client advertising only the original kinds
and records the current output; the second adds the capability accessor and the
fallback.

Fixes #2121.
