### PR TITLE
test(e2e): add fake Dune RPC server for blackbox tests

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -88,6 +88,7 @@
     dune_diagnostic_aggregation
     dune_diagnostic_conversion
     dune_diagnostics
+    dune_fake_diagnostics
     dune_formatting
     dune_nested_root
     dune_progress

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -17,6 +17,7 @@
    (package ocaml-lsp-server)))
  (libraries
   unix
+  csexp
   stdune
   dune-rpc
   fiber

--- a/ocaml-lsp-server/test/e2e-new/dune_fake_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_fake_diagnostics.ml
@@ -1,0 +1,205 @@
+open Test.Import
+open Dune_rpc_test
+module D = Dune_rpc.Private.Diagnostic
+module Fake = Dune_rpc_fake
+
+let capabilities =
+  let publishDiagnostics = PublishDiagnosticsClientCapabilities.create () in
+  let textDocument = TextDocumentClientCapabilities.create ~publishDiagnostics () in
+  let window = WindowClientCapabilities.create ~workDoneProgress:true () in
+  ClientCapabilities.create ~textDocument ~window ()
+;;
+
+let position ~fname ~line ~character =
+  let open Lexing in
+  { pos_fname = fname; pos_lnum = line; pos_bol = 0; pos_cnum = character }
+;;
+
+let fake_diagnostic ~fname ~diagnostic_id ~diagnostic_message ~line ~start_char ~end_char =
+  let open D in
+  let diagnostic_loc =
+    let start = position ~fname ~line ~character:start_char in
+    let stop = position ~fname ~line ~character:end_char in
+    Stdune.Lexbuf.Loc.{ start; stop }
+  in
+  { targets = []
+  ; id = Id.create diagnostic_id
+  ; message = Stdune.Pp.text diagnostic_message
+  ; loc = Some diagnostic_loc
+  ; severity = Some Error
+  ; promotion = []
+  ; directory = None
+  ; related = []
+  }
+;;
+
+let source_uri fake = Uri.of_path (Filename.concat (Fake.root fake) "main.ml")
+
+let print_publication fake label params =
+  print_endline label;
+  PublishDiagnosticsParams.yojson_of_t params
+  |> fun json ->
+  (* The workspace root is a randomized temp directory; keep it out of the
+     expected output. *)
+  let root_uri = Uri.to_string (Uri.of_path (Fake.root fake)) in
+  let json =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.map fields ~f:(fun (name, value) ->
+           let rec sanitize = function
+             | `String s ->
+               `String (String.substr_replace_all s ~pattern:root_uri ~with_:"<root>")
+             | `Assoc fields -> `Assoc (List.map fields ~f:(fun (n, v) -> n, sanitize v))
+             | `List values -> `List (List.map values ~f:sanitize)
+             | json -> json
+           in
+           name, sanitize value))
+    | json -> json
+  in
+  Test.print_result json
+;;
+
+let%expect_test
+    "keep Dune and Merlin diagnostics with different messages at the same range"
+  =
+  let fake =
+    Fake.start "different" ~diagnostics:(fun root ->
+      let source = Filename.concat root "main.ml" in
+      [ [ D.Event.Add
+            (fake_diagnostic
+               ~fname:source
+               ~diagnostic_id:1
+               ~diagnostic_message:"dune says wrong"
+               ~line:1
+               ~start_char:21
+               ~end_char:22)
+        ]
+      ])
+  in
+  Fun.protect
+    ~finally:(fun () -> Fake.stop fake)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run_with_workspace
+         ~capabilities
+         ~root:(Fake.root fake)
+         ~runtime_dir:(Fake.runtime_dir fake)
+         events
+         ~f:(fun client _workspace ->
+           let uri = source_uri fake in
+           let* () = open_document client ~uri ~text:"let value : string = 1\n" in
+           let+ merged =
+             Events.wait_for_diagnostics events.dune ~f:(fun params ->
+               for_uri uri params
+               && List.exists params.diagnostics ~f:(fun (d : Diagnostic.t) ->
+                 Option.equal String.equal d.source (Some "dune"))
+               && List.exists params.diagnostics ~f:(fun (d : Diagnostic.t) ->
+                 Option.equal String.equal d.source (Some "ocamllsp")))
+           in
+           print_publication fake "merged:" merged));
+  [%expect
+    {|
+    merged:
+    {
+      "diagnostics": [
+        {
+          "message": "No config found for file main.ml. Try calling 'dune build'.",
+          "range": {
+            "end": { "character": 0, "line": 1 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "ocamllsp"
+        },
+        {
+          "message": "dune says\nwrong",
+          "range": {
+            "end": { "character": 22, "line": 0 },
+            "start": { "character": 21, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        },
+        {
+          "message": "The constant 1 has type int but an expression was expected of type string",
+          "range": {
+            "end": { "character": 22, "line": 0 },
+            "start": { "character": 21, "line": 0 }
+          },
+          "severity": 1,
+          "source": "ocamllsp"
+        }
+      ],
+      "uri": "<root>/main.ml"
+    }
+    |}]
+;;
+
+let%expect_test "removes a Dune diagnostic published earlier" =
+  let fake =
+    Fake.start "removal" ~diagnostics:(fun root ->
+      let source = Filename.concat root "main.ml" in
+      [ [ D.Event.Add
+            (fake_diagnostic
+               ~fname:source
+               ~diagnostic_id:1
+               ~diagnostic_message:"transient dune error"
+               ~line:1
+               ~start_char:0
+               ~end_char:3)
+        ]
+      ; [ D.Event.Remove
+            (fake_diagnostic
+               ~fname:source
+               ~diagnostic_id:1
+               ~diagnostic_message:""
+               ~line:1
+               ~start_char:0
+               ~end_char:3)
+        ]
+      ])
+  in
+  Fun.protect
+    ~finally:(fun () -> Fake.stop fake)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run_with_workspace
+         ~capabilities
+         ~root:(Fake.root fake)
+         ~runtime_dir:(Fake.runtime_dir fake)
+         events
+         ~f:(fun client _workspace ->
+           let uri = source_uri fake in
+           let* () = open_document client ~uri ~text:"let value = 1\n" in
+           let* published =
+             Events.wait_for_diagnostics events.dune ~f:(fun params ->
+               for_uri uri params && has_dune_diagnostic params)
+           in
+           print_publication fake "with dune diagnostic:" published;
+           let+ cleared =
+             Events.wait_for_diagnostics events.dune ~f:(fun params ->
+               for_uri uri params && no_dune_diagnostic params)
+           in
+           print_publication fake "after removal:" cleared));
+  [%expect
+    {|
+    with dune diagnostic:
+    {
+      "diagnostics": [
+        {
+          "message": "transient dune\nerror",
+          "range": {
+            "end": { "character": 3, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<root>/main.ml"
+    }
+    after removal:
+    { "diagnostics": [], "uri": "<root>/main.ml" }
+    |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.ml
@@ -1,0 +1,197 @@
+open Test.Import
+module Rpc = Dune_rpc.Private
+
+type t =
+  { root : string
+  ; runtime_dir : string
+  ; pid : int
+  }
+
+let root t = t.root
+let runtime_dir t = t.runtime_dir
+
+let mkdir path =
+  match Unix.mkdir path 0o700 with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+;;
+
+let register runtime_dir dune =
+  let env variable =
+    if String.equal variable "XDG_RUNTIME_DIR"
+    then Some runtime_dir
+    else Sys.getenv_opt variable
+  in
+  let config = Rpc.Registry.Config.create (Xdg.create ~env ()) in
+  let watch_dir = Rpc.Registry.Config.watch_dir config in
+  mkdir (Filename.dirname watch_dir);
+  mkdir watch_dir;
+  let (`Caller_should_write file) = Rpc.Registry.Config.register config dune in
+  Test.write_file file.path file.contents
+;;
+
+let read_packet input ~version =
+  match Csexp.input_opt input with
+  | Error message -> failwith message
+  | Ok None -> None
+  | Ok (Some sexp) ->
+    (match Rpc.Conv.of_sexp Rpc.Packet.sexp ~version sexp with
+     | Ok packet -> Some packet
+     | Error error -> Rpc.Conv.dyn_of_error error |> Dyn.to_string |> failwith)
+;;
+
+let write_packet output packet =
+  Rpc.Conv.to_sexp Rpc.Packet.sexp packet |> Csexp.to_channel output;
+  flush output
+;;
+
+let response
+      (type request response)
+      (decl : (request, response) Rpc.Decl.Request.t)
+      ~version
+      (value : response)
+  =
+  match
+    List.find decl.generations ~f:(fun (generation, _) -> Int.equal generation version)
+  with
+  | None -> failwith "unsupported fake Dune RPC response version"
+  | Some (_, Rpc.Decl.Generation.T conversion) ->
+    Rpc.Conv.to_sexp conversion.resp (conversion.downgrade_resp value)
+;;
+
+let selected_version menu method_ =
+  let name = Rpc.Method.Name.to_string method_ in
+  match List.Assoc.find menu name ~equal:String.equal with
+  | Some version -> version
+  | None -> failwith ("Dune RPC method was not negotiated: " ^ name)
+;;
+
+let serve connection ~diagnostics ~progress =
+  let input = Unix.in_channel_of_descr connection in
+  let output = Unix.out_channel_of_descr connection in
+  let latest = Rpc.Version.latest in
+  let initialize_id, initialize =
+    match read_packet input ~version:latest with
+    | Some (Rpc.Packet.Request (id, call)) ->
+      (match Rpc.Initialize.Request.of_call call ~version:latest with
+       | Ok initialize -> id, initialize
+       | Error _ -> failwith "invalid Dune RPC initialize request")
+    | Some _ | None -> failwith "expected Dune RPC initialize request"
+  in
+  write_packet
+    output
+    (Rpc.Packet.Response
+       ( initialize_id
+       , Ok (Rpc.Initialize.Response.create () |> Rpc.Initialize.Response.to_response) ));
+  let dune_version = Rpc.Initialize.Request.dune_version initialize in
+  let menu_id, offered =
+    match read_packet input ~version:dune_version with
+    | Some (Rpc.Packet.Request (id, call)) ->
+      (match Rpc.Version_negotiation.Request.of_call call ~version:dune_version with
+       | Ok (Rpc.Version_negotiation.Request.Menu offered) -> id, offered
+       | Error _ -> failwith "invalid Dune RPC version negotiation request")
+    | Some _ | None -> failwith "expected Dune RPC version negotiation request"
+  in
+  let selected =
+    List.map offered ~f:(fun (method_, versions) ->
+      let version = List.fold_left versions ~init:0 ~f:Int.max in
+      method_, version)
+  in
+  write_packet
+    output
+    (Rpc.Packet.Response
+       ( menu_id
+       , Ok
+           (Rpc.Version_negotiation.Response.create selected
+            |> Rpc.Version_negotiation.Response.to_response) ));
+  let menu =
+    List.map selected ~f:(fun (method_, version) ->
+      Rpc.Method.Name.to_string method_, version)
+  in
+  let diagnostic_decl = Rpc.Procedures.Poll.poll Rpc.Procedures.Poll.diagnostic in
+  let progress_decl = Rpc.Procedures.Poll.poll Rpc.Procedures.Poll.progress in
+  let diagnostics = ref diagnostics in
+  let progress = ref progress in
+  let next queue =
+    match !queue with
+    | [] -> None
+    | value :: rest ->
+      queue := rest;
+      Some value
+  in
+  let rec loop () =
+    match read_packet input ~version:dune_version with
+    | None -> ()
+    | Some (Rpc.Packet.Notification _) -> loop ()
+    | Some (Rpc.Packet.Response _) -> failwith "unexpected response from Dune RPC client"
+    | Some (Rpc.Packet.Request (id, call)) ->
+      if Rpc.Method.Name.equal call.method_ diagnostic_decl.decl.method_
+      then (
+        let version = selected_version menu call.method_ in
+        let payload = response diagnostic_decl ~version (next diagnostics) in
+        write_packet output (Rpc.Packet.Response (id, Ok payload));
+        loop ())
+      else if Rpc.Method.Name.equal call.method_ progress_decl.decl.method_
+      then (
+        let version = selected_version menu call.method_ in
+        let payload = response progress_decl ~version (next progress) in
+        write_packet output (Rpc.Packet.Response (id, Ok payload));
+        loop ())
+      else
+        failwith ("unexpected Dune RPC request: " ^ Rpc.Method.Name.to_string call.method_)
+  in
+  loop ()
+;;
+
+let start ?(diagnostics = fun _root -> []) ?(progress = []) name =
+  let temp = Test.temp_dir ("ocamllsp-fake-dune-" ^ name ^ "-") in
+  let root = Filename.concat temp "workspace" in
+  let runtime_dir = Filename.concat temp "runtime" in
+  mkdir root;
+  mkdir runtime_dir;
+  Test.write_file (Filename.concat root "dune-project") "(lang dune 3.18)\n";
+  let socket_path = Filename.concat temp "rpc.sock" in
+  let listener = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Unix.bind listener (Unix.ADDR_UNIX socket_path);
+  Unix.listen listener 1;
+  let diagnostics = diagnostics root in
+  let pid =
+    match Unix.fork () with
+    | 0 ->
+      let connection, _ = Unix.accept listener in
+      Unix.close listener;
+      (match serve connection ~diagnostics ~progress with
+       | () ->
+         Unix.close connection;
+         Unix._exit 0
+       | exception Sys_error _ ->
+         Unix.close connection;
+         Unix._exit 0
+       | exception exn ->
+         Format.eprintf "fake Dune RPC server: %s@." (Printexc.to_string exn);
+         Unix.close connection;
+         Unix._exit 2)
+    | pid -> pid
+  in
+  Unix.close listener;
+  let dune = Rpc.Registry.Dune.create ~where:(`Unix socket_path) ~root ~pid in
+  register runtime_dir dune;
+  { root; runtime_dir; pid }
+;;
+
+let stop t =
+  (match Unix.kill t.pid Sys.sigterm with
+   | () -> ()
+   | exception Unix.Unix_error (Unix.ESRCH, _, _) -> ());
+  match Test.waitpid t.pid with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WSIGNALED signal when signal = Sys.sigterm -> ()
+  | status ->
+    failwith
+      (Printf.sprintf
+         "fake Dune RPC server failed: %s"
+         (match status with
+          | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+          | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+          | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal))
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.mli
@@ -1,0 +1,13 @@
+open Test.Import
+
+type t
+
+val start
+  :  ?diagnostics:(string -> Dune_rpc.Private.Diagnostic.Event.t list list)
+  -> ?progress:Dune_rpc.Private.Progress.t list
+  -> string
+  -> t
+
+val root : t -> string
+val runtime_dir : t -> string
+val stop : t -> unit


### PR DESCRIPTION
Add a fake Dune RPC server for the black-box e2e tests.

The server registers itself in the Dune RPC registry and speaks the
initialize / version-negotiation / diagnostic / progress protocol, so tests
can drive the server's Dune integration deterministically without a real
`dune build -w` process. A `diagnostics` callback lets each test script the
diagnostic events (add/remove) that the server reports.

Used by the upcoming Dune diagnostics coverage tests.
