### PR TITLE
test(definition): cover requests on non-Merlin documents

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/definition.ml
+++ b/ocaml-lsp-server/test/e2e-new/definition.ml
@@ -84,3 +84,34 @@ let () =
     ]
     |}]
 ;;
+
+let%expect_test "definition on a non-Merlin document returns null" =
+  (Test.run_initialized
+   @@ fun client ->
+   let uri = DocumentUri.of_path "test.t" in
+   let text =
+     TextDocumentItem.create
+       ~uri
+       ~languageId:(LanguageKind.Other "cram")
+       ~version:0
+       ~text:"  $ echo hello\n"
+   in
+   let* () =
+     Client.notification
+       client
+       (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument:text))
+   in
+   let textDocument = TextDocumentIdentifier.create ~uri in
+   let* response =
+     Client.request
+       client
+       (TextDocumentDefinition
+          (DefinitionParams.create
+             ~textDocument
+             ~position:(Position.create ~line:0 ~character:8)
+             ()))
+   in
+   print_locations response;
+   Test.shutdown_client client);
+  [%expect {| [] |}]
+;;


### PR DESCRIPTION
Cover the non-Merlin document path of the definition request.

A definition request on a cram document must return `null` rather than
erroring. Uses `Test.run_initialized` + `Test.shutdown_client` because the
`Helpers.test` teardown waits for diagnostics, which non-Merlin documents
never produce.
