### PR TITLE
test(diagnostics): cover raw and structured related information

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -442,3 +442,102 @@ let%expect_test "different diagnostics, including holes, sorted by range" =
     }
     |}]
 ;;
+
+let related_information_capabilities =
+  let publishDiagnostics =
+    PublishDiagnosticsClientCapabilities.create ~relatedInformation:true ()
+  in
+  let textDocument = TextDocumentClientCapabilities.create ~publishDiagnostics () in
+  ClientCapabilities.create ~textDocument ()
+;;
+
+let%expect_test "related information from raw locations in the message" =
+  let source =
+    {ocaml|module X : sig
+  val x : unit
+end = struct
+  let x = 123
+end
+|ocaml}
+  in
+  test ~capabilities:related_information_capabilities source;
+  [%expect
+    {|
+    textDocument/publishDiagnostics
+    {
+      "diagnostics": [
+        {
+          "message": "Signature mismatch:\nModules do not match:\n  sig val x : int end\nis not included in\n  sig val x : unit end\nValues do not match: val x : int is not included in val x : unit\nThe type int is not compatible with the type unit",
+          "range": {
+            "end": { "character": 3, "line": 4 },
+            "start": { "character": 6, "line": 2 }
+          },
+          "relatedInformation": [
+            {
+              "location": {
+                "range": {
+                  "end": { "character": 14, "line": 2 },
+                  "start": { "character": 2, "line": 2 }
+                },
+                "uri": "file:///test.ml"
+              },
+              "message": "Expected declaration"
+            },
+            {
+              "location": {
+                "range": {
+                  "end": { "character": 7, "line": 4 },
+                  "start": { "character": 6, "line": 4 }
+                },
+                "uri": "file:///test.ml"
+              },
+              "message": "Actual declaration"
+            }
+          ],
+          "severity": 1,
+          "source": "ocamllsp"
+        }
+      ],
+      "uri": "file:///test.ml"
+    }
+    |}]
+;;
+
+let%expect_test "related information for structured sub-errors" =
+  let source =
+    {ocaml|let f x = x + 1
+let () = f 1 2
+|ocaml}
+  in
+  test ~capabilities:related_information_capabilities source;
+  [%expect
+    {|
+    textDocument/publishDiagnostics
+    {
+      "diagnostics": [
+        {
+          "message": "The function f has type int -> int\nIt is applied to too many arguments",
+          "range": {
+            "end": { "character": 14, "line": 1 },
+            "start": { "character": 9, "line": 1 }
+          },
+          "relatedInformation": [
+            {
+              "location": {
+                "range": {
+                  "end": { "character": 14, "line": 1 },
+                  "start": { "character": 13, "line": 1 }
+                },
+                "uri": "file:///test.ml"
+              },
+              "message": "This extra argument is not expected."
+            }
+          ],
+          "severity": 1,
+          "source": "ocamllsp"
+        }
+      ],
+      "uri": "file:///test.ml"
+    }
+    |}]
+;;


### PR DESCRIPTION
Cover both related-information paths of Merlin diagnostics:

- raw locations: a signature mismatch whose sub-locations appear in the
  message text is parsed into structured `relatedInformation` (with the
  `relatedInformation` client capability);
- structured sub-errors: the "extra argument" error, one of the few errors
  where Merlin populates structured sub-locations.
