### PR TITLE
test(e2e): run preprocessor fixtures outside the checkout

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/preprocessor_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/preprocessor_helpers.ml
@@ -7,13 +7,17 @@ type project =
 
 let setup ~name ~fixture ~dune_file =
   let project_root = Sys.getenv "DUNE_PROJECT_ROOT" in
-  let dir = Test.temp_dir ~temp_dir:project_root ("ocamllsp-" ^ name ^ "-") in
+  (* Create the temp project outside the checkout: dune refuses to treat a
+     directory under a hidden path (e.g. [.scratch]) as a project root, which
+     breaks both [dune build] and the server's [dune ocaml-merlin] config
+     discovery. *)
+  let dir = Test.temp_dir ("ocamllsp-" ^ name ^ "-") in
   let path = Filename.concat dir (name ^ ".ml") in
   let fixture = Filename.concat project_root fixture in
   Test.write_file path (Fs_io.read_file fixture |> Result.ok_exn);
   Test.write_file (Filename.concat dir "dune-project") "(lang dune 3.24)\n";
   Test.write_file (Filename.concat dir "dune") dune_file;
-  Test.run_command ~cwd:dir "dune build @check";
+  Test.run_command ~cwd:dir "dune build --root . @check";
   { path; uri = DocumentUri.of_path path }
 ;;
 


### PR DESCRIPTION
Create the temp preprocessor project in the system temp directory instead of
under the checkout root, and build it with `--root .`.

Dune refuses to treat a directory under a hidden path (such as `.scratch`)
as a project root, which broke both `dune build` and the server's
`dune ocaml-merlin` config discovery for the fixture project in nested
checkouts.
