### PR TITLE
fix(ocamlformat-rpc): degrade gracefully when the process dies at startup

### DIFF
--- a/ocaml-lsp-server/src/ocamlformat_rpc.ml
+++ b/ocaml-lsp-server/src/ocamlformat_rpc.ml
@@ -219,7 +219,29 @@ let run_rpc ~logger ~bin t =
      | Disabled | Stopped -> Fiber.return ()
      | Running _ -> assert false
      | Waiting_for_init _ ->
-       let* process = Process.create ~logger ~bin () in
+       let* process =
+         let* res = Fiber.collect_errors (fun () -> Process.create ~logger ~bin ()) in
+         match res with
+         | Ok process -> Fiber.return process
+         | Error exns ->
+           (* The ocamlformat-rpc process died or produced invalid output while
+              starting. Report it like a failed negotiation so that hover keeps
+              working with unformatted types instead of failing the request. *)
+           let message =
+             List.map exns ~f:(fun exn -> Printexc.to_string exn.exn)
+             |> String.concat ~sep:"; "
+           in
+           let* () =
+             logger
+               ~type_:MessageType.Error
+               ~message:
+                 (Printf.sprintf
+                    "An error happened when negotiating with the OCamlformat-RPC server: \
+                     %s"
+                    message)
+           in
+           Fiber.return (Error `No_process)
+       in
        let* () = Fiber.Ivar.fill wait_init () in
        (match process with
         | Error `No_process ->


### PR DESCRIPTION
An `ocamlformat-rpc` process that dies or produces garbage during startup
version negotiation used to raise an uncaught exception ("fd closed
unflushed") that failed the hover request with an internal error.

Wrap `Process.create` in `Fiber.collect_errors` and report the failure as an
error `LogMessage`, degrading to unformatted hover types instead of failing
the request. Fixes the reproduction in #2132.
