### PR TITLE
test(code-actions): reject unused text in alert payloads

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_mark_remove.ml
@@ -337,3 +337,56 @@ type t =
 
      | B |}]
 ;;
+
+let%expect_test "deprecated alert text is not an unused diagnostic" =
+  let source =
+    {ocaml|module M = struct let x = 1 end [@@deprecated "do not use: unused open"]
+open M
+let y = x
+|ocaml}
+  in
+  let published_diagnostics = Fiber.Ivar.create () in
+  let handler =
+    Client.Handler.make
+      ~on_notification:(fun _ -> function
+         | PublishDiagnostics diagnostics ->
+           let* filled = Fiber.Ivar.peek published_diagnostics in
+           (match filled with
+            | Some _ -> Fiber.return ()
+            | None -> Fiber.Ivar.fill published_diagnostics diagnostics)
+         | _ -> Fiber.return ())
+      ()
+  in
+  Test.run_initialized ~handler (fun client ->
+    let* () = Test.open_document ~client ~uri:Helpers.uri ~source () in
+    let* { PublishDiagnosticsParams.diagnostics; _ } =
+      Fiber.Ivar.read published_diagnostics
+    in
+    let diagnostic =
+      List.find_exn diagnostics ~f:(fun (diagnostic : Diagnostic.t) ->
+        let message =
+          match diagnostic.message with
+          | `String message -> message
+          | `MarkupContent { value; _ } -> value
+        in
+        String.is_prefix message ~prefix:"Alert deprecated")
+    in
+    let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
+    let context =
+      CodeActionContext.create
+        ~diagnostics:[ diagnostic ]
+        ~only:[ CodeActionKind.QuickFix ]
+        ()
+    in
+    let params =
+      CodeActionParams.create ~textDocument ~range:diagnostic.range ~context ()
+    in
+    let* response = Client.request client (CodeAction params) in
+    Code_actions.print_code_action_result
+      ~filter:(function
+        | `CodeAction { title; _ } -> String.equal title "Remove unused open"
+        | `Command _ -> false)
+      response;
+    Test.shutdown_client client);
+  [%expect {| No code actions |}]
+;;


### PR DESCRIPTION
Prevent unused-code quick fixes from treating user-controlled alert payloads as compiler warnings.

The test captures the real diagnostic published for a deprecated module whose message contains `do not use: unused open`, then verifies that no “Remove unused open” action is offered. The current line-anchored matcher rejects this message, while the unanchored matcher proposed in #2117 would delete only the module name and leave a bare `open`.

This can be merged before #2117 so its matcher fix preserves the distinction between warning descriptions and arbitrary diagnostic text.
