### PR TITLE
dev(nix): use packaged ocaml-index

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,32 @@
         "type": "github"
       }
     },
+    "ocaml-overlays": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785162195,
+        "narHash": "sha256-GxdCHR9GJ1jyhNSjrFaOlOG0E7ibBNOBg8BITVnRfYg=",
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "rev": "cb48a30a71cbd88e44c8aa85d59f59832b53e4b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "merlin": "merlin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "ocaml-overlays": "ocaml-overlays"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs";
+    ocaml-overlays = {
+      url = "github:nix-ocaml/nix-overlays";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     merlin = {
       url = "github:ocaml/merlin";
       flake = false;
@@ -100,14 +104,6 @@
             }
           );
 
-          ocaml-index = buildDunePackage {
-            pname = "ocaml-index";
-            src = pkgs.ocamlPackages.merlin-lib.src;
-            version = pkgs.ocamlPackages.merlin-lib.version;
-            doCheck = false;
-            propagatedBuildInputs = [ pkgs.ocamlPackages.merlin-lib ];
-          };
-
           ocp-indent-rpc =
             with pkgs.ocamlPackages;
             buildDunePackage (
@@ -190,7 +186,10 @@
     // (flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgsWithoutOverlays = (import nixpkgs { inherit system; });
+        pkgsWithoutOverlays = import nixpkgs {
+          inherit system;
+          overlays = [ inputs.ocaml-overlays.overlays.default ];
+        };
         # The project uses Dune language 3.24, which is newer than the Dune in
         # the current Nixpkgs snapshot.
         # 3.24.1 ships an inverted RPC registry mtime skip (ocaml/dune#15630).
@@ -243,7 +242,7 @@
           nixpkgs.mkShell {
             buildInputs = [
               nixpkgs.ocamlPackages.utop
-              localPackages.ocaml-index
+              nixpkgs.ocamlPackages.ocaml-index
             ];
             inputsFrom = builtins.map (x: x.overrideAttrs (p: n: { doCheck = true; })) (
               builtins.attrValues localPackages
@@ -282,7 +281,7 @@
               base_quickcheck
               ppx_expect
               ppx_sexp_conv
-              checkPackages.ocaml-index
+              ocaml-index
               (ocamlformat checkPkgs)
             ];
             # Keep Dune RPC Unix socket paths below the platform limit.


### PR DESCRIPTION
Use the `ocaml-index` package provided by the nix-ocaml overlay instead of rebuilding it locally from Merlin's source tree. The overlay follows this flake's nixpkgs input and is shared by the development and check shells, removing the bespoke package definition while keeping both environments supplied with `ocaml-index`.
