### PR TITLE
feat(formatting): support ocp-indent as a formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Support `ocp-indent` as an alternative for document and range formatting.
+  (#2148, @rgrinberg)
 - Support `textDocument/onTypeFormatting` through the optional, persistent
   `ocp-indent-rpc` helper. (#1986, @rgrinberg)
 - Report Dune RPC, build progress, and Merlin configuration process activity

--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ $ make install
 ### Additional package installations
 
 - Install [ocamlformat](https://github.com/ocaml-ppx/ocamlformat#installation)
-  package if you want source file formatting support.
-
-  Note: To have source file formatting support in your project, there needs to
-  be an `.ocamlformat` file present in your project's root directory.
+  or [ocp-indent](https://github.com/OCamlPro/ocp-indent) if you want source file
+  formatting support. Configuration discovery walks from the document's
+  directory up to its containing workspace root, and the closest formatter
+  configuration wins. If a directory contains both `.ocamlformat` and
+  `.ocp-indent`, OCaml-LSP selects `ocamlformat`. With neither configuration, it
+  prefers `ocamlformat` when available and otherwise falls back to `ocp-indent`.
+  Unlike `ocamlformat`, `ocp-indent` only adjusts indentation.
 
 - OCaml-LSP also uses a program called `ocamlformat-rpc` to format code that is
   either generated or displayed by OCaml-LSP, e.g., when you hover over a module

--- a/dune-project
+++ b/dune-project
@@ -71,6 +71,7 @@ possible and does not make any assumptions about IO.
   (ppx_expect (and (>= v0.17.0) :with-test))
   (ppx_sexp_conv (and (>= v0.17.0) :with-test))
   (ocamlformat (and :with-test (= 0.29.0)))
+  (ocp-indent :with-test)
   (ocamlc-loc (>= 3.7.0))
   (pp (>= 1.1.2))
   (csexp (>= 1.5))

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,7 @@
                     p.ppx_expect
                     p.ppx_sexp_conv
                     p.ppx_yojson_conv
+                    p.ocp-indent
                     ocaml-index
                     ocp-indent-rpc
                     (ocamlformat pkgs)

--- a/lsp/src/workspaces.ml
+++ b/lsp/src/workspaces.ml
@@ -72,3 +72,35 @@ let workspace_folders { root_uri; root_path; workspace_folders } =
            ~name:(Filename.basename cwd)
        ])
 ;;
+
+let normalize_directory path =
+  let path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path else path
+  in
+  (* [Filename.dirname] treats the final path component as a basename, even when
+     [path] has a trailing separator. Appending [.] marks [path] as a directory;
+     taking its dirname then strips trailing separators while preserving roots. *)
+  Filename.concat path Filename.current_dir_name |> Filename.dirname
+;;
+
+let equal_path =
+  if Sys.win32
+  then fun x y -> String.equal (String.lowercase_ascii x) (String.lowercase_ascii y)
+  else String.equal
+;;
+
+let find_workspace_folder t uri =
+  let roots =
+    workspace_folders t
+    |> List.map ~f:(fun (folder : WorkspaceFolder.t) ->
+      normalize_directory (DocumentUri.to_path folder.uri), folder)
+  in
+  let rec loop directory =
+    match List.find_opt roots ~f:(fun (root, _) -> equal_path root directory) with
+    | Some (_, folder) -> Some folder
+    | None ->
+      let parent = Filename.dirname directory in
+      if equal_path parent directory then None else loop parent
+  in
+  DocumentUri.to_path uri |> Filename.dirname |> normalize_directory |> loop
+;;

--- a/lsp/src/workspaces.mli
+++ b/lsp/src/workspaces.mli
@@ -6,3 +6,6 @@ type t
 val create : InitializeParams.t -> t
 val on_change : t -> DidChangeWorkspaceFoldersParams.t -> t
 val workspace_folders : t -> WorkspaceFolder.t list
+
+(** Return the innermost workspace folder containing the document. *)
+val find_workspace_folder : t -> DocumentUri.t -> WorkspaceFolder.t option

--- a/lsp/test/workspaces_tests.ml
+++ b/lsp/test/workspaces_tests.ml
@@ -45,6 +45,32 @@ let%expect_test "workspace folders are updated" =
     |}]
 ;;
 
+let%expect_test "find the innermost workspace containing a document" =
+  let workspaces =
+    Workspaces.create
+      (initialize
+         ~workspaceFolders:(Some [ folder "/workspace"; folder "/workspace/nested" ])
+         ())
+  in
+  let print path =
+    match Workspaces.find_workspace_folder workspaces (Uri.of_path path) with
+    | None -> print_endline "none"
+    | Some folder ->
+      WorkspaceFolder.yojson_of_t folder
+      |> Yojson.Safe.pretty_to_string ~std:false
+      |> print_endline
+  in
+  print "/workspace/file.ml";
+  print "/workspace/nested/lib/file.ml";
+  print "/workspace-other/file.ml";
+  [%expect
+    {|
+    { "name": "workspace", "uri": "file:///workspace" }
+    { "name": "nested", "uri": "file:///workspace/nested" }
+    none
+    |}]
+;;
+
 let%expect_test "workspace folder fallbacks" =
   let root_uri = Uri.of_path "/workspace/root-uri" in
   let root_uri_workspaces = Workspaces.create (initialize ~rootUri:root_uri ()) in

--- a/ocaml-lsp-server.opam
+++ b/ocaml-lsp-server.opam
@@ -43,6 +43,7 @@ depends: [
   "ppx_expect" {>= "v0.17.0" & with-test}
   "ppx_sexp_conv" {>= "v0.17.0" & with-test}
   "ocamlformat" {with-test & = "0.29.0"}
+  "ocp-indent" {with-test}
   "ocamlc-loc" {>= "3.7.0"}
   "pp" {>= "1.1.2"}
   "csexp" {>= "1.5"}

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -381,20 +381,29 @@ module Formatter = struct
       Some (Diff.edit ~from:(Document.Dune.text doc) ~to_)
   ;;
 
+  let workspace_root rpc doc =
+    let state : State.t = Server.state rpc in
+    Workspaces.find_workspace_folder (State.workspaces state) (Document.uri doc)
+    |> Option.map ~f:(fun (folder : WorkspaceFolder.t) -> folder.uri)
+  ;;
+
   let run rpc doc =
     match Document.kind doc with
-    | `Merlin merlin -> run_ocamlformat rpc (Ocamlformat.run merlin)
+    | `Merlin merlin ->
+      let workspace_root = workspace_root rpc doc in
+      run_ocamlformat rpc (Ocamlformat.run ~workspace_root merlin)
     | `Other ->
       (match Document.dune doc with
-       | Some dune -> run_dune rpc dune
-       | None -> Fiber.return None)
+       | None -> Fiber.return None
+       | Some dune -> run_dune rpc dune)
   ;;
 
   let run_on_range rpc doc range =
     match Document.syntax doc with
     | Dune | Cram -> Fiber.return None
     | Ocaml | Reason | Mlx | Ocamllex | Menhir ->
-      run_ocamlformat rpc (Ocamlformat.run_on_range doc range)
+      let workspace_root = workspace_root rpc doc in
+      Ocamlformat.run_on_range ~workspace_root doc range |> run_ocamlformat rpc
   ;;
 end
 

--- a/ocaml-lsp-server/src/ocamlformat.ml
+++ b/ocaml-lsp-server/src/ocamlformat.ml
@@ -100,9 +100,11 @@ let message = function
 type formatter =
   | Reason of Document.Kind.t
   | Ocaml of Uri.t
+  | Ocp_indent of Uri.t
   | Mlx of Uri.t
 
 let args = function
+  | Ocp_indent _ -> []
   | Ocaml uri ->
     let name = Uri.to_path uri in
     let flag =
@@ -123,6 +125,7 @@ let args = function
 let binary_name t =
   match t with
   | Ocaml _ -> "ocamlformat"
+  | Ocp_indent _ -> "ocp-indent"
   | Mlx _ -> "ocamlformat-mlx"
   | Reason _ -> "refmt"
 ;;
@@ -147,6 +150,70 @@ let formatter doc =
           | `Other -> failwith "unable to format non merlin document"))
 ;;
 
+type configured_formatter =
+  | Configured_ocamlformat
+  | Configured_ocp_indent
+  | Not_configured
+
+let normalize_directory path =
+  let path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path else path
+  in
+  (* [Filename.dirname] treats the final path component as a basename, even when
+     [path] has a trailing separator. Appending [.] marks [path] as a directory;
+     taking its dirname then strips trailing separators while preserving roots. *)
+  Filename.concat path Filename.current_dir_name |> Filename.dirname
+;;
+
+let equal_path =
+  if Sys.win32
+  then fun x y -> String.equal (String.lowercase x) (String.lowercase y)
+  else String.equal
+;;
+
+let configured_formatter ~workspace_root uri =
+  let workspace_root =
+    Option.map workspace_root ~f:(fun uri -> Uri.to_path uri |> normalize_directory)
+  in
+  let rec loop directory =
+    if Sys.file_exists (Filename.concat directory ".ocamlformat")
+    then Configured_ocamlformat
+    else if Sys.file_exists (Filename.concat directory ".ocp-indent")
+    then Configured_ocp_indent
+    else (
+      match workspace_root with
+      | None -> Not_configured
+      | Some workspace_root when equal_path workspace_root directory -> Not_configured
+      | Some _ ->
+        let parent = Filename.dirname directory in
+        if equal_path parent directory then Not_configured else loop parent)
+  in
+  Uri.to_path uri |> Filename.dirname |> normalize_directory |> loop
+;;
+
+let document_formatter ~workspace_root doc =
+  let open Result.O in
+  let+ formatter = formatter doc in
+  match formatter with
+  | Reason _ | Ocp_indent _ | Mlx _ -> formatter
+  | Ocaml uri ->
+    (match configured_formatter ~workspace_root uri with
+     | Configured_ocp_indent -> Ocp_indent uri
+     | Configured_ocamlformat -> formatter
+     | Not_configured ->
+       (match Bin.which "ocamlformat" with
+        | Some _ -> formatter
+        | None ->
+          (match Bin.which "ocp-indent" with
+           | Some _ -> Ocp_indent uri
+           | None -> formatter)))
+;;
+
+let working_directory = function
+  | Ocp_indent uri -> Spawn.Working_dir.Path (Uri.to_path uri |> Filename.dirname)
+  | Reason _ | Ocaml _ | Mlx _ -> Spawn.Working_dir.Inherit
+;;
+
 let exec ?cwd cancel refmt args stdin =
   let+ res, cancel = run_command ?cwd cancel refmt stdin args in
   match cancel with
@@ -159,19 +226,19 @@ let exec ?cwd cancel refmt args stdin =
      | _ -> Result.Error (Unexpected_result { message = res.stderr }))
 ;;
 
-let run merlin cancel : (TextEdit.t list, error) result Fiber.t =
+let run ~workspace_root merlin cancel : (TextEdit.t list, error) result Fiber.t =
   let doc = Document.Merlin.to_doc merlin in
   let res =
     let open Result.O in
-    let* formatter = formatter doc in
+    let* formatter = document_formatter ~workspace_root doc in
     let args = args formatter in
     let+ binary = binary formatter in
-    binary, args, Document.source doc |> Msource.text
+    binary, args, Document.source doc |> Msource.text, formatter
   in
   match res with
   | Error e -> Fiber.return (Error e)
-  | Ok (binary, args, contents) ->
-    exec cancel binary args contents
+  | Ok (binary, args, contents, formatter) ->
+    exec ~cwd:(working_directory formatter) cancel binary args contents
     |> Fiber.map
          ~f:(Result.map ~f:(fun { stdout = to_; _ } -> Diff.edit ~from:contents ~to_))
 ;;
@@ -191,19 +258,19 @@ let compute_modified_margin binary cancel offset formatter =
     |> Fiber.map ~f:(fun res ->
       let margin =
         match res with
+        | Error _ -> default
         | Ok { stderr = config; _ } ->
-          config
-          |> String.split_lines
+          String.split_lines config
           |> List.find_map ~f:(fun line ->
             match String.chop_prefix line ~prefix:"margin=" with
             | None -> None
             | Some margin ->
               String.split margin ~on:' ' |> List.hd |> Option.bind ~f:Int.of_string_opt)
           |> Option.value ~default
-        | Error _ -> default
       in
       let margin = margin - offset in
       "--margin=" ^ Int.to_string margin)
+  | Ocp_indent _ -> assert false
   | Reason _ ->
     let margin =
       Sys.getenv_opt "REFMT_PRINT_WIDTH"
@@ -252,8 +319,10 @@ let format_snippet ~start ~stop ~padding formatter binary cancel contents =
     |> String.strip ~drop:(( = ) ' ')
   in
   let open Fiber.O in
-  let* margin = compute_modified_margin binary cancel padding formatter in
-  let args = margin :: args in
+  let* args =
+    let+ margin = compute_modified_margin binary cancel padding formatter in
+    margin :: args
+  in
   let++ { stdout = formatted; _ } = exec cancel binary args to_format in
   let formatted =
     (* if the return is unchanged, don't insert extra padding *)
@@ -262,19 +331,50 @@ let format_snippet ~start ~stop ~padding formatter binary cancel contents =
   prefix ^ formatted ^ suffix
 ;;
 
-let run_on_range doc range cancel : (TextEdit.t list, error) result Fiber.t =
-  let res =
-    let open Result.O in
-    let* formatter = range_formatter doc in
-    let+ binary = binary formatter in
-    binary, formatter
-  in
-  match res with
+let run_ocp_indent_on_range doc uri (range : Range.t) cancel =
+  let formatter = Ocp_indent uri in
+  match binary formatter with
   | Error e -> Fiber.return (Error e)
-  | Ok (binary, formatter) ->
+  | Ok binary ->
     let contents = Document.source doc |> Msource.text in
-    let start, stop = Text_document.absolute_range (Document.text_document doc) range in
-    let padding = range.start.character in
-    let++ to_ = format_snippet formatter binary cancel ~start ~stop ~padding contents in
-    Diff.edit ~from:contents ~to_
+    let args =
+      (* TODO: [--lines] formats complete boundary lines, so a range starting or
+         ending mid-line can produce edits outside the requested LSP range. Clamp
+         the edits or avoid formatting boundary indentation outside the range. *)
+      let last_line =
+        if range.end_.character = 0 && range.end_.line > range.start.line
+        then range.end_.line
+        else range.end_.line + 1
+      in
+      let first_line = range.start.line + 1 in
+      [ sprintf "--lines=%d-%d" first_line last_line ]
+    in
+    exec ~cwd:(working_directory formatter) cancel binary args contents
+    |> Fiber.map
+         ~f:(Result.map ~f:(fun { stdout = to_; _ } -> Diff.edit ~from:contents ~to_))
+;;
+
+let run_on_range ~workspace_root doc range cancel
+  : (TextEdit.t list, error) result Fiber.t
+  =
+  match document_formatter ~workspace_root doc with
+  | Ok (Ocp_indent uri) -> run_ocp_indent_on_range doc uri range cancel
+  | Error _ | Ok (Reason _ | Ocaml _ | Mlx _) ->
+    (match
+       let open Result.O in
+       let* formatter = range_formatter doc in
+       let+ binary = binary formatter in
+       binary, formatter
+     with
+     | Error e -> Fiber.return (Error e)
+     | Ok (binary, formatter) ->
+       let contents = Document.source doc |> Msource.text in
+       let++ to_ =
+         let padding = range.start.character in
+         let start, stop =
+           Text_document.absolute_range (Document.text_document doc) range
+         in
+         format_snippet formatter binary cancel ~start ~stop ~padding contents
+       in
+       Diff.edit ~from:contents ~to_)
 ;;

--- a/ocaml-lsp-server/src/ocamlformat.mli
+++ b/ocaml-lsp-server/src/ocamlformat.mli
@@ -1,7 +1,11 @@
 (** Generic formatting facility for OCaml and Reason sources.
 
     Relies on [ocamlformat] for OCaml, [ocamlformat-mlx] for OCaml.mlx, and
-    [refmt] for Reason. *)
+    [refmt] for Reason. For OCaml files, the closest [.ocamlformat] or
+    [.ocp-indent] between the document and its workspace root selects the
+    formatter. [ocamlformat] wins when both files are in the same directory. If
+    neither is configured, [ocp-indent] is the fallback when [ocamlformat] is
+    missing. *)
 
 open Import
 
@@ -14,12 +18,14 @@ type error =
 val message : error -> string
 
 val run
-  :  Document.Merlin.t
+  :  workspace_root:Uri.t option
+  -> Document.Merlin.t
   -> Fiber.Cancel.t option
   -> (TextEdit.t list, error) result Fiber.t
 
 val run_on_range
-  :  Document.t
+  :  workspace_root:Uri.t option
+  -> Document.t
   -> Range.t
   -> Fiber.Cancel.t option
   -> (TextEdit.t list, error) result Fiber.t

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -12,6 +12,7 @@
   (deps
    %{bin:ocaml-index}
    %{bin:ocamlformat-rpc}
+   %{bin:ocp-indent}
    %{bin:ocp-indent-rpc}
    for_ppx.ml
    for_pp.ml

--- a/ocaml-lsp-server/test/e2e-new/formatting.ml
+++ b/ocaml-lsp-server/test/e2e-new/formatting.ml
@@ -32,9 +32,15 @@ let write_formatter bin_dir name =
   Test.write_file
     path
     (Printf.sprintf
-       "#!/bin/sh\ncat >/dev/null\nprintf '%%s\\n' 'let selected = \"%s\"'\n"
+       "#!/bin/sh\n\
+        while IFS= read -r line; do :; done\n\
+        printf '%%s\\n' 'let selected = \"%s\"'\n"
        name);
   Unix.chmod path 0o700
+;;
+
+let workspace_folder path =
+  WorkspaceFolder.create ~uri:(DocumentUri.of_path path) ~name:(Filename.basename path)
 ;;
 
 let make_request textDocument =
@@ -101,11 +107,19 @@ let print_request_error = function
     Fiber.return ()
 ;;
 
-let test_formatter_failure ~path_env source =
+let test_formatter_failure
+      ?(path = "/workspace/format_failure.ml")
+      ?workspace_root
+      ~path_env
+      source
+  =
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
-  Test.run_initialized ~handler ~extra_env:[ "PATH=" ^ path_env ]
+  let workspaceFolders =
+    Option.map workspace_root ~f:(fun root -> [ workspace_folder root ])
+  in
+  Test.run_initialized ~handler ~extra_env:[ "PATH=" ^ path_env ] ~workspaceFolders
   @@ fun client ->
-  let uri = DocumentUri.of_path "/workspace/format_failure.ml" in
+  let uri = DocumentUri.of_path path in
   let* () = Test.open_document ~client ~uri ~source () in
   let textDocument = TextDocumentIdentifier.create ~uri in
   let* result =
@@ -124,6 +138,19 @@ let%expect_test "reports a missing ocamlformat executable" =
     |}]
 ;;
 
+let%expect_test "reports a missing configured ocp-indent executable" =
+  let dir = Test.temp_dir "ocamllsp-no-ocp-indent-" in
+  Test.write_file (Filename.concat dir ".ocp-indent") "base=4\n";
+  let empty_path = Filename.concat dir "bin" in
+  Unix.mkdir empty_path 0o700;
+  let path = Filename.concat dir "format_failure.ml" in
+  test_formatter_failure ~path ~workspace_root:dir ~path_env:empty_path "let  x=1";
+  [%expect
+    {|
+    code=InvalidRequest message=Unable to find ocp-indent binary. You need to install ocp-indent manually to use the formatting feature.
+    |}]
+;;
+
 let%expect_test "reports a nonzero ocamlformat exit" =
   let failing_path = Test.temp_dir "ocamllsp-failing-ocamlformat-" in
   let formatter = Filename.concat failing_path "ocamlformat" in
@@ -138,8 +165,49 @@ let%expect_test "reports a nonzero ocamlformat exit" =
   [%expect {| code=InternalError message=formatter exploded |}]
 ;;
 
-let%expect_test "selects a formatter from project configuration" =
-  let dir = Test.temp_dir "ocamllsp-formatter-selection-" in
+let%expect_test "falls back to ocp-indent when ocamlformat is unavailable" =
+  let dir = Test.temp_dir "ocamllsp-ocp-indent-fallback-" in
+  let bin_dir = Filename.concat dir "bin" in
+  Unix.mkdir bin_dir 0o700;
+  write_formatter bin_dir "ocp-indent";
+  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
+  Test.run_initialized
+    ~handler
+    ~extra_env:[ "PATH=" ^ bin_dir ]
+    (fun client ->
+       let uri =
+         let path = Filename.concat dir "test.ml" in
+         DocumentUri.of_path path
+       in
+       let* () =
+         let source = "let selected = \"source\"\n" in
+         Test.open_document ~client ~uri ~source ()
+       in
+       let* response =
+         let textDocument = TextDocumentIdentifier.create ~uri in
+         Client.request client (make_request textDocument)
+       in
+       print_formatting_textedits response;
+       Test.exit_client client);
+  [%expect
+    {|
+    [
+      {
+        "newText": "let selected = \"ocp-indent\"\n",
+        "range": {
+          "end": { "character": 0, "line": 1 },
+          "start": { "character": 0, "line": 0 }
+        }
+      }
+    ]
+    |}]
+;;
+
+let%expect_test "selects a formatter from workspace configuration" =
+  let outer = Test.temp_dir "ocamllsp-formatter-selection-" in
+  Test.write_file (Filename.concat outer ".ocp-indent") "base=4\n";
+  let dir = Filename.concat outer "workspace" in
+  Unix.mkdir dir 0o700;
   let bin_dir = Filename.concat dir "bin" in
   Unix.mkdir bin_dir 0o700;
   write_formatter bin_dir "ocamlformat";
@@ -151,13 +219,24 @@ let%expect_test "selects a formatter from project configuration" =
       Test.write_file (Filename.concat project config) "base=4\n");
     Filename.concat project "test.ml"
   in
+  let unconfigured = project "unconfigured" [] in
   let ocp_indent = project "ocp-indent" [ ".ocp-indent" ] in
+  let closer_ocp_indent =
+    let parent = Filename.concat dir "closer-ocp-indent" in
+    Unix.mkdir parent 0o700;
+    Test.write_file (Filename.concat parent ".ocamlformat") "profile=default\n";
+    let child = Filename.concat parent "child" in
+    Unix.mkdir child 0o700;
+    Test.write_file (Filename.concat child ".ocp-indent") "base=4\n";
+    Filename.concat child "test.ml"
+  in
   let both = project "both" [ ".ocp-indent"; ".ocamlformat" ] in
   let source = "let selected = \\\"source\\\"\n" in
   let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
   let path = Sys.getenv_opt "PATH" |> Option.value ~default:"" in
   Test.run_initialized
     ~handler
+    ~workspaceFolders:(Some [ workspace_folder dir ])
     ~extra_env:[ "PATH=" ^ bin_dir ^ ":" ^ path ]
     (fun client ->
        let format label path =
@@ -168,7 +247,9 @@ let%expect_test "selects a formatter from project configuration" =
          let+ response = Client.request client (make_request textDocument) in
          print_formatting_textedits response
        in
+       let* () = format "configuration outside workspace:" unconfigured in
        let* () = format "only .ocp-indent:" ocp_indent in
+       let* () = format "closer .ocp-indent than .ocamlformat:" closer_ocp_indent in
        print_endline "range with only .ocp-indent:";
        let uri = DocumentUri.of_path ocp_indent in
        let textDocument = TextDocumentIdentifier.create ~uri in
@@ -179,7 +260,7 @@ let%expect_test "selects a formatter from project configuration" =
        Client.notification client Exit);
   [%expect
     {|
-    only .ocp-indent:
+    configuration outside workspace:
     [
       {
         "newText": "let selected = \"ocamlformat\"\n",
@@ -189,10 +270,30 @@ let%expect_test "selects a formatter from project configuration" =
         }
       }
     ]
+    only .ocp-indent:
+    [
+      {
+        "newText": "let selected = \"ocp-indent\"\n",
+        "range": {
+          "end": { "character": 0, "line": 1 },
+          "start": { "character": 0, "line": 0 }
+        }
+      }
+    ]
+    closer .ocp-indent than .ocamlformat:
+    [
+      {
+        "newText": "let selected = \"ocp-indent\"\n",
+        "range": {
+          "end": { "character": 0, "line": 1 },
+          "start": { "character": 0, "line": 0 }
+        }
+      }
+    ]
     range with only .ocp-indent:
     [
       {
-        "newText": "let selected = \"ocamlformat\"\n",
+        "newText": "let selected = \"ocp-indent\"\n",
         "range": {
           "end": { "character": 0, "line": 1 },
           "start": { "character": 0, "line": 0 }
@@ -206,6 +307,76 @@ let%expect_test "selects a formatter from project configuration" =
         "range": {
           "end": { "character": 0, "line": 1 },
           "start": { "character": 0, "line": 0 }
+        }
+      }
+    ]
+    |}]
+;;
+
+let%expect_test "ocp-indent formats documents and ranges" =
+  let dir = Test.temp_dir "ocamllsp-ocp-indent-formatting-" in
+  Test.write_file (Filename.concat dir ".ocp-indent") "base=4\n";
+  let handler = Client.Handler.make ~on_notification:(fun _ _ -> Fiber.return ()) () in
+  Test.run_initialized
+    ~handler
+    ~workspaceFolders:(Some [ workspace_folder dir ])
+    (fun client ->
+       let uri =
+         let path = Filename.concat dir "test.ml" in
+         DocumentUri.of_path path
+       in
+       let* () =
+         let source =
+           "let f () =\nprint_endline \"f\"\nlet g () =\nprint_endline \"g\"\n"
+         in
+         Test.open_document ~client ~uri ~source ()
+       in
+       let textDocument = TextDocumentIdentifier.create ~uri in
+       let* response = Client.request client (make_request textDocument) in
+       print_endline "document:";
+       print_formatting_textedits response;
+       let* response =
+         let request =
+           let range =
+             Range.create
+               ~start:(Position.create ~line:1 ~character:0)
+               ~end_:(Position.create ~line:2 ~character:0)
+           in
+           let options = FormattingOptions.create ~tabSize:2 ~insertSpaces:true () in
+           Lsp.Client_request.TextDocumentRangeFormatting
+             (DocumentRangeFormattingParams.create ~textDocument ~range ~options ())
+         in
+         Client.request client request
+       in
+       print_endline "range:";
+       print_formatting_textedits response;
+       Test.exit_client client);
+  [%expect
+    {|
+    document:
+    [
+      {
+        "newText": "    print_endline \"f\"\n",
+        "range": {
+          "end": { "character": 0, "line": 2 },
+          "start": { "character": 0, "line": 1 }
+        }
+      },
+      {
+        "newText": "    print_endline \"g\"\n",
+        "range": {
+          "end": { "character": 0, "line": 4 },
+          "start": { "character": 0, "line": 3 }
+        }
+      }
+    ]
+    range:
+    [
+      {
+        "newText": "    print_endline \"f\"\n",
+        "range": {
+          "end": { "character": 0, "line": 2 },
+          "start": { "character": 0, "line": 1 }
         }
       }
     ]


### PR DESCRIPTION
Allow document and range formatting to use `ocp-indent`. Formatter configuration is discovered from the document directory up to its containing workspace root, and the closest directory containing `.ocamlformat` or `.ocp-indent` selects the formatter. If both files occur in that directory, `ocamlformat` wins. Configuration files above the workspace root are ignored. With neither formatter configured, OCaml-LSP continues to prefer `ocamlformat` and falls back to an installed `ocp-indent` when necessary.

`ocp-indent` runs from the document directory so it can discover project configuration, and range formatting is translated to its line-based interface. The formatter-selection, proximity, workspace-boundary, fallback, missing-binary, document, and range behavior is covered end to end.
