### PR TITLE
test(lsp): cover workspace symbol list discrimination

### DIFF
--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -159,3 +159,27 @@ let%expect_test "workspace symbol and nullable results" =
     rename null: rejected
     |}]
 ;;
+
+let%expect_test "workspace symbol decoding inspects every result" =
+  let workspace_symbols =
+    `List
+      [ `Assoc
+          [ "kind", `Int 12
+          ; "location", Location.yojson_of_t protocol_location
+          ; "name", `String "resolved"
+          ]
+      ; `Assoc
+          [ "data", `String "symbol-id"
+          ; "kind", `Int 12
+          ; "location", `Assoc [ "uri", DocumentUri.yojson_of_t protocol_uri ]
+          ; "name", `String "unresolved"
+          ]
+      ]
+  in
+  check_response
+    "workspace symbols"
+    (Client_request.E
+       (Client_request.WorkspaceSymbol (WorkspaceSymbolParams.create ~query:"value" ())))
+    workspace_symbols;
+  [%expect {| workspace symbols: rejected |}]
+;;


### PR DESCRIPTION
Adds a request-result contract case where a valid `WorkspaceSymbol[]` starts with an item whose full location makes it indistinguishable from `SymbolInformation`, while a later unresolved item carries `data` and a URI-only location.

The current decoder examines only the first item, chooses `SymbolInformation[]`, and rejects the later item. This records the failure before the decoder fix. The response shape is allowed by the [LSP 3.18 workspace symbol specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_symbol).
