### PR TITLE
test(lsp): expose nullable request result drift

### DIFF
--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -160,6 +160,16 @@ let%expect_test "workspace symbol and nullable results" =
     |}]
 ;;
 
+let%expect_test "code lens result is nullable" =
+  check_response
+    "code lens null"
+    (Client_request.E
+       (Client_request.TextDocumentCodeLens
+          (CodeLensParams.create ~textDocument:protocol_document ())))
+    `Null;
+  [%expect {| code lens null: rejected |}]
+;;
+
 let%expect_test "workspace symbol decoding inspects every result" =
   let workspace_symbols =
     `List

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -170,6 +170,14 @@ let%expect_test "code lens result is nullable" =
   [%expect {| code lens null: rejected |}]
 ;;
 
+let%expect_test "workspace folders result is nullable" =
+  check_decode
+    "workspace folders null"
+    (Server_request.response_of_json Server_request.WorkspaceFolders)
+    `Null;
+  [%expect {| workspace folders null: rejected |}]
+;;
+
 let%expect_test "workspace symbol decoding inspects every result" =
   let workspace_symbols =
     `List


### PR DESCRIPTION
Adds request-result contract checks showing that valid `null` responses are currently rejected for `textDocument/codeLens` and `workspace/workspaceFolders`.

LSP 3.18 defines these results as [`CodeLens[] | null`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeLens) and [`WorkspaceFolder[] | null`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_workspaceFolders). The snapshots record the existing rejection ahead of the follow-up fixes.
