### PR TITLE
fix(lsp): accept nullable workspace folder results

### DIFF
--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -3,7 +3,7 @@ open Types
 
 type _ t =
   | WorkspaceApplyEdit : ApplyWorkspaceEditParams.t -> ApplyWorkspaceEditResult.t t
-  | WorkspaceFolders : WorkspaceFolder.t list t
+  | WorkspaceFolders : WorkspaceFolder.t list option t
   | WorkspaceConfiguration : ConfigurationParams.t -> Json.t list t
   | ClientRegisterCapability : RegistrationParams.t -> unit t
   | ClientUnregisterCapability : UnregistrationParams.t -> unit t
@@ -112,7 +112,8 @@ let of_jsonrpc (r : Jsonrpc.Request.t) : (packed, string) Result.t =
 let yojson_of_result (type a) (t : a t) (r : a) : Json.t =
   match t, r with
   | WorkspaceApplyEdit _, r -> ApplyWorkspaceEditResult.yojson_of_t r
-  | WorkspaceFolders, r -> Json.Conv.yojson_of_list WorkspaceFolder.yojson_of_t r
+  | WorkspaceFolders, r ->
+    Json.Option.yojson_of_t (Json.To.list WorkspaceFolder.yojson_of_t) r
   | WorkspaceConfiguration _, r -> Json.Conv.yojson_of_list (fun x -> x) r
   | ClientRegisterCapability _, () -> `Null
   | ClientUnregisterCapability _, () -> `Null
@@ -133,7 +134,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   let open Json.Conv in
   match t with
   | WorkspaceApplyEdit _ -> ApplyWorkspaceEditResult.t_of_yojson json
-  | WorkspaceFolders -> list_of_yojson WorkspaceFolder.t_of_yojson json
+  | WorkspaceFolders -> option_of_yojson (list_of_yojson WorkspaceFolder.t_of_yojson) json
   | WorkspaceConfiguration _ -> list_of_yojson (fun x -> x) json
   | ClientRegisterCapability _ -> unit_of_yojson json
   | ClientUnregisterCapability _ -> unit_of_yojson json

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -3,7 +3,7 @@ open Types
 
 type _ t =
   | WorkspaceApplyEdit : ApplyWorkspaceEditParams.t -> ApplyWorkspaceEditResult.t t
-  | WorkspaceFolders : WorkspaceFolder.t list t
+  | WorkspaceFolders : WorkspaceFolder.t list option t
   | WorkspaceConfiguration : ConfigurationParams.t -> Json.t list t
   | ClientRegisterCapability : RegistrationParams.t -> unit t
   | ClientUnregisterCapability : UnregistrationParams.t -> unit t

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -175,7 +175,7 @@ let%expect_test "workspace folders result is nullable" =
     "workspace folders null"
     (Server_request.response_of_json Server_request.WorkspaceFolders)
     `Null;
-  [%expect {| workspace folders null: rejected |}]
+  [%expect {| workspace folders null: accepted |}]
 ;;
 
 let%expect_test "workspace symbol decoding inspects every result" =


### PR DESCRIPTION
Aligns `workspace/workspaceFolders` with its nullable LSP result contract, following the regression test merged in #2150.

The server-request codec now accepts and emits [`WorkspaceFolder[] | null`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_workspaceFolders). Existing server results remain arrays on the wire.
