### PR TITLE
fix(lsp): accept nullable code lens results

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -13,7 +13,7 @@ type _ t =
   | TextDocumentCompletion :
       CompletionParams.t
       -> [ `CompletionList of CompletionList.t | `List of CompletionItem.t list ] option t
-  | TextDocumentCodeLens : CodeLensParams.t -> CodeLens.t list t
+  | TextDocumentCodeLens : CodeLensParams.t -> CodeLens.t list option t
   | InlayHint : InlayHintParams.t -> InlayHint.t list option t
   | InlayHintResolve : InlayHint.t -> InlayHint.t t
   | TextDocumentDiagnostic : DocumentDiagnosticParams.t -> DocumentDiagnosticReport.t t
@@ -157,7 +157,8 @@ let yojson_of_result (type a) (req : a t) (result : a) =
   | TextDocumentImplementation _, result ->
     Json.Option.yojson_of_t Locations.yojson_of_t result
   | TextDocumentCompletion _, result -> yojson_of_Completion result
-  | TextDocumentCodeLens _, result -> Json.To.list CodeLens.yojson_of_t result
+  | TextDocumentCodeLens _, result ->
+    Json.Option.yojson_of_t (Json.To.list CodeLens.yojson_of_t) result
   | TextDocumentCodeLensResolve _, result -> CodeLens.yojson_of_t result
   | TextDocumentPrepareCallHierarchy _, result ->
     Json.Option.yojson_of_t (Json.To.list CallHierarchyItem.yojson_of_t) result
@@ -568,7 +569,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
          ; (fun json -> `List (list_of_yojson CompletionItem.t_of_yojson json))
          ])
       json
-  | TextDocumentCodeLens _ -> list_of_yojson CodeLens.t_of_yojson json
+  | TextDocumentCodeLens _ -> option_of_yojson (list_of_yojson CodeLens.t_of_yojson) json
   | TextDocumentCodeLensResolve _ -> CodeLens.t_of_yojson json
   | TextDocumentPrepareCallHierarchy _ ->
     option_of_yojson (list_of_yojson CallHierarchyItem.t_of_yojson) json

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -13,7 +13,7 @@ type _ t =
   | TextDocumentCompletion :
       CompletionParams.t
       -> [ `CompletionList of CompletionList.t | `List of CompletionItem.t list ] option t
-  | TextDocumentCodeLens : CodeLensParams.t -> CodeLens.t list t
+  | TextDocumentCodeLens : CodeLensParams.t -> CodeLens.t list option t
   | InlayHint : InlayHintParams.t -> InlayHint.t list option t
   | InlayHintResolve : InlayHint.t -> InlayHint.t t
   | TextDocumentDiagnostic : DocumentDiagnosticParams.t -> DocumentDiagnosticReport.t t

--- a/lsp/src/server_request.ml
+++ b/lsp/src/server_request.ml
@@ -3,7 +3,7 @@ open Types
 
 type _ t =
   | WorkspaceApplyEdit : ApplyWorkspaceEditParams.t -> ApplyWorkspaceEditResult.t t
-  | WorkspaceFolders : WorkspaceFolder.t list t
+  | WorkspaceFolders : WorkspaceFolder.t list option t
   | WorkspaceConfiguration : ConfigurationParams.t -> Json.t list t
   | ClientRegisterCapability : RegistrationParams.t -> unit t
   | ClientUnregisterCapability : UnregistrationParams.t -> unit t
@@ -112,7 +112,8 @@ let of_jsonrpc (r : Jsonrpc.Request.t) : (packed, string) Result.t =
 let yojson_of_result (type a) (t : a t) (r : a) : Json.t =
   match t, r with
   | WorkspaceApplyEdit _, r -> ApplyWorkspaceEditResult.yojson_of_t r
-  | WorkspaceFolders, r -> Json.Conv.yojson_of_list WorkspaceFolder.yojson_of_t r
+  | WorkspaceFolders, r ->
+    Json.Option.yojson_of_t (Json.To.list WorkspaceFolder.yojson_of_t) r
   | WorkspaceConfiguration _, r -> Json.Conv.yojson_of_list (fun x -> x) r
   | ClientRegisterCapability _, () -> `Null
   | ClientUnregisterCapability _, () -> `Null
@@ -133,7 +134,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
   let open Json.Conv in
   match t with
   | WorkspaceApplyEdit _ -> ApplyWorkspaceEditResult.t_of_yojson json
-  | WorkspaceFolders -> list_of_yojson WorkspaceFolder.t_of_yojson json
+  | WorkspaceFolders -> option_of_yojson (list_of_yojson WorkspaceFolder.t_of_yojson) json
   | WorkspaceConfiguration _ -> list_of_yojson (fun x -> x) json
   | ClientRegisterCapability _ -> unit_of_yojson json
   | ClientUnregisterCapability _ -> unit_of_yojson json

--- a/lsp/src/server_request.mli
+++ b/lsp/src/server_request.mli
@@ -3,7 +3,7 @@ open Types
 
 type _ t =
   | WorkspaceApplyEdit : ApplyWorkspaceEditParams.t -> ApplyWorkspaceEditResult.t t
-  | WorkspaceFolders : WorkspaceFolder.t list t
+  | WorkspaceFolders : WorkspaceFolder.t list option t
   | WorkspaceConfiguration : ConfigurationParams.t -> Json.t list t
   | ClientRegisterCapability : RegistrationParams.t -> unit t
   | ClientUnregisterCapability : UnregistrationParams.t -> unit t

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -175,7 +175,7 @@ let%expect_test "workspace folders result is nullable" =
     "workspace folders null"
     (Server_request.response_of_json Server_request.WorkspaceFolders)
     `Null;
-  [%expect {| workspace folders null: rejected |}]
+  [%expect {| workspace folders null: accepted |}]
 ;;
 
 let%expect_test "workspace symbol decoding inspects every result" =

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -167,7 +167,7 @@ let%expect_test "code lens result is nullable" =
        (Client_request.TextDocumentCodeLens
           (CodeLensParams.create ~textDocument:protocol_document ())))
     `Null;
-  [%expect {| code lens null: rejected |}]
+  [%expect {| code lens null: accepted |}]
 ;;
 
 let%expect_test "workspace folders result is nullable" =

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -709,8 +709,12 @@ let on_request
   | TextDocumentCodeLens req ->
     (match state.configuration.data.codelens with
      | Some { enable = true; for_nested_bindings } ->
-       later (text_document_lens ~for_nested_bindings) req
-     | _ -> now [])
+       later
+         (fun state req ->
+            let+ result = text_document_lens ~for_nested_bindings state req in
+            Some result)
+         req
+     | _ -> now (Some []))
   | TextDocumentHighlight req -> later highlight req
   | DocumentSymbol { textDocument = { uri }; _ } -> later document_symbol uri
   | TextDocumentDeclaration { textDocument = { uri }; position; _ } ->

--- a/ocaml-lsp-server/test/e2e-new/code_lens.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_lens.ml
@@ -1,10 +1,13 @@
 open Test.Import
 
 let codelens client textDocument =
-  Client.request
-    client
-    (TextDocumentCodeLens
-       { textDocument; workDoneToken = None; partialResultToken = None })
+  let+ result =
+    Client.request
+      client
+      (TextDocumentCodeLens
+         { textDocument; workDoneToken = None; partialResultToken = None })
+  in
+  Option.value_exn result
 ;;
 
 let json_of_codelens cs = `List (List.map ~f:CodeLens.yojson_of_t cs)

--- a/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_change_config.ml
@@ -1,10 +1,13 @@
 open Test.Import
 
 let codelens client textDocument =
-  Client.request
-    client
-    (TextDocumentCodeLens
-       { textDocument; workDoneToken = None; partialResultToken = None })
+  let+ result =
+    Client.request
+      client
+      (TextDocumentCodeLens
+         { textDocument; workDoneToken = None; partialResultToken = None })
+  in
+  Option.value_exn result
 ;;
 
 let%expect_test "can add the first workspace folder after initialization" =


### PR DESCRIPTION
Aligns `textDocument/codeLens` with its nullable LSP result contract, following the regression test merged in #2150.

The client codec now accepts and emits [`CodeLens[] | null`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeLens). Existing server results remain arrays on the wire.
