### PR TITLE
fix(lsp): accept nullable text document results

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -59,7 +59,7 @@ type _ t =
   | TextDocumentReferences : ReferenceParams.t -> Location.t list option t
   | TextDocumentHighlight : DocumentHighlightParams.t -> DocumentHighlight.t list option t
   | TextDocumentFoldingRange : FoldingRangeParams.t -> FoldingRange.t list option t
-  | SignatureHelp : SignatureHelpParams.t -> SignatureHelp.t t
+  | SignatureHelp : SignatureHelpParams.t -> SignatureHelp.t option t
   | CodeAction : CodeActionParams.t -> CodeActionResult.t t
   | CodeActionResolve : CodeAction.t -> CodeAction.t t
   | CompletionItemResolve : CompletionItem.t -> CompletionItem.t t
@@ -182,7 +182,7 @@ let yojson_of_result (type a) (req : a t) (result : a) =
     Json.Option.yojson_of_t (Json.To.list FoldingRange.yojson_of_t) result
   | TextDocumentMoniker _, result ->
     Json.Option.yojson_of_t (Json.To.list Moniker.yojson_of_t) result
-  | SignatureHelp _, result -> SignatureHelp.yojson_of_t result
+  | SignatureHelp _, result -> Json.Option.yojson_of_t SignatureHelp.yojson_of_t result
   | CodeAction _, result -> CodeActionResult.yojson_of_t result
   | CodeActionResolve _, result -> CodeAction.yojson_of_t result
   | CompletionItemResolve _, result -> CompletionItem.yojson_of_t result
@@ -601,7 +601,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
     option_of_yojson (list_of_yojson DocumentHighlight.t_of_yojson) json
   | TextDocumentFoldingRange _ ->
     option_of_yojson (list_of_yojson FoldingRange.t_of_yojson) json
-  | SignatureHelp _ -> SignatureHelp.t_of_yojson json
+  | SignatureHelp _ -> option_of_yojson SignatureHelp.t_of_yojson json
   | CodeAction _ -> CodeActionResult.t_of_yojson json
   | CodeActionResolve _ -> CodeAction.t_of_yojson json
   | CompletionItemResolve _ -> CompletionItem.t_of_yojson json

--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -39,7 +39,7 @@ type _ t =
   | TextDocumentRangesFormatting :
       DocumentRangesFormattingParams.t
       -> TextEdit.t list option t
-  | TextDocumentRename : RenameParams.t -> WorkspaceEdit.t t
+  | TextDocumentRename : RenameParams.t -> WorkspaceEdit.t option t
   | TextDocumentLink : DocumentLinkParams.t -> DocumentLink.t list option t
   | TextDocumentLinkResolve : DocumentLink.t -> DocumentLink.t t
   | TextDocumentMoniker : MonikerParams.t -> Moniker.t list option t
@@ -170,7 +170,8 @@ let yojson_of_result (type a) (req : a t) (result : a) =
     Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
   | TextDocumentRangesFormatting _, result ->
     Json.Option.yojson_of_t (Json.To.list TextEdit.yojson_of_t) result
-  | TextDocumentRename _, result -> WorkspaceEdit.yojson_of_t result
+  | TextDocumentRename _, result ->
+    Json.Option.yojson_of_t WorkspaceEdit.yojson_of_t result
   | DocumentSymbol _, result -> yojson_of_DocumentSymbol result
   | DebugEcho _, result -> DebugEcho.Result.yojson_of_t result
   | DebugTextDocumentGet _, result -> DebugTextDocumentGet.Result.yojson_of_t result
@@ -579,7 +580,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
     option_of_yojson (list_of_yojson TextEdit.t_of_yojson) json
   | TextDocumentRangesFormatting _ ->
     option_of_yojson (list_of_yojson TextEdit.t_of_yojson) json
-  | TextDocumentRename _ -> WorkspaceEdit.t_of_yojson json
+  | TextDocumentRename _ -> option_of_yojson WorkspaceEdit.t_of_yojson json
   | TextDocumentLink _ -> option_of_yojson (list_of_yojson DocumentLink.t_of_yojson) json
   | TextDocumentLinkResolve _ -> DocumentLink.t_of_yojson json
   | TextDocumentMoniker _ -> option_of_yojson (list_of_yojson Moniker.t_of_yojson) json

--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -74,7 +74,7 @@ type _ t =
       ColorPresentationParams.t
       -> ColorPresentation.t list t
   | TextDocumentColor : DocumentColorParams.t -> ColorInformation.t list t
-  | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list t
+  | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list option t
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
   | SemanticTokensFull : SemanticTokensParams.t -> SemanticTokens.t option t
   | SemanticTokensDelta :
@@ -200,7 +200,8 @@ let yojson_of_result (type a) (req : a t) (result : a) =
   | TextDocumentColorPresentation _, result ->
     Json.To.list ColorPresentation.yojson_of_t result
   | TextDocumentColor _, result -> Json.To.list ColorInformation.yojson_of_t result
-  | SelectionRange _, result -> Json.yojson_of_list SelectionRange.yojson_of_t result
+  | SelectionRange _, result ->
+    Json.Option.yojson_of_t (Json.To.list SelectionRange.yojson_of_t) result
   | SemanticTokensFull _, result ->
     Json.Option.yojson_of_t SemanticTokens.yojson_of_t result
   | SemanticTokensDelta _, result -> yojson_of_SemanticTokensDelta result
@@ -613,7 +614,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
     option_of_yojson (list_of_yojson TextEdit.t_of_yojson) json
   | TextDocumentColorPresentation _ -> list_of_yojson ColorPresentation.t_of_yojson json
   | TextDocumentColor _ -> list_of_yojson ColorInformation.t_of_yojson json
-  | SelectionRange _ -> list_of_yojson SelectionRange.t_of_yojson json
+  | SelectionRange _ -> option_of_yojson (list_of_yojson SelectionRange.t_of_yojson) json
   | ExecuteCommand _ -> json
   | SemanticTokensFull _ -> option_of_yojson SemanticTokens.t_of_yojson json
   | SemanticTokensDelta _ ->

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -74,7 +74,7 @@ type _ t =
       ColorPresentationParams.t
       -> ColorPresentation.t list t
   | TextDocumentColor : DocumentColorParams.t -> ColorInformation.t list t
-  | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list t
+  | SelectionRange : SelectionRangeParams.t -> SelectionRange.t list option t
   | ExecuteCommand : ExecuteCommandParams.t -> Json.t t
   | SemanticTokensFull : SemanticTokensParams.t -> SemanticTokens.t option t
   | SemanticTokensDelta :

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -39,7 +39,7 @@ type _ t =
   | TextDocumentRangesFormatting :
       DocumentRangesFormattingParams.t
       -> TextEdit.t list option t
-  | TextDocumentRename : RenameParams.t -> WorkspaceEdit.t t
+  | TextDocumentRename : RenameParams.t -> WorkspaceEdit.t option t
   | TextDocumentLink : DocumentLinkParams.t -> DocumentLink.t list option t
   | TextDocumentLinkResolve : DocumentLink.t -> DocumentLink.t t
   | TextDocumentMoniker : MonikerParams.t -> Moniker.t list option t

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -59,7 +59,7 @@ type _ t =
   | TextDocumentReferences : ReferenceParams.t -> Location.t list option t
   | TextDocumentHighlight : DocumentHighlightParams.t -> DocumentHighlight.t list option t
   | TextDocumentFoldingRange : FoldingRangeParams.t -> FoldingRange.t list option t
-  | SignatureHelp : SignatureHelpParams.t -> SignatureHelp.t t
+  | SignatureHelp : SignatureHelpParams.t -> SignatureHelp.t option t
   | CodeAction : CodeActionParams.t -> CodeActionResult.t t
   | CodeActionResolve : CodeAction.t -> CodeAction.t t
   | CompletionItemResolve : CompletionItem.t -> CompletionItem.t t

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -155,7 +155,7 @@ let%expect_test "workspace symbol and nullable results" =
     {|
     workspace symbol: rejected
     signature help null: accepted
-    selection range null: rejected
+    selection range null: accepted
     rename null: rejected
     |}]
 ;;

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -154,7 +154,7 @@ let%expect_test "workspace symbol and nullable results" =
   [%expect
     {|
     workspace symbol: rejected
-    signature help null: rejected
+    signature help null: accepted
     selection range null: rejected
     rename null: rejected
     |}]

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -156,7 +156,7 @@ let%expect_test "workspace symbol and nullable results" =
     workspace symbol: rejected
     signature help null: accepted
     selection range null: accepted
-    rename null: rejected
+    rename null: accepted
     |}]
 ;;
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -730,7 +730,12 @@ let on_request
          let+ result = Rename.prepare state req in
          Option.map result ~f:(fun range -> `Range range))
       req
-  | TextDocumentRename req -> later Rename.rename req
+  | TextDocumentRename req ->
+    later
+      (fun state req ->
+         let+ result = Rename.rename state req in
+         Some result)
+      req
   | TextDocumentFoldingRange req -> later Folding_range.compute req
   | SignatureHelp req ->
     later

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -732,7 +732,12 @@ let on_request
       req
   | TextDocumentRename req -> later Rename.rename req
   | TextDocumentFoldingRange req -> later Folding_range.compute req
-  | SignatureHelp req -> later Signature_help.run req
+  | SignatureHelp req ->
+    later
+      (fun state req ->
+         let+ result = Signature_help.run state req in
+         Some result)
+      req
   | TextDocumentLinkResolve l -> now l
   | TextDocumentLink _ -> now None
   | WillSaveWaitUntilTextDocument _ -> now None

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -762,7 +762,12 @@ let on_request
             Ocp_indent.format_on_type state.ocp_indent doc position)
          ()
      | _ -> now (Some []))
-  | SelectionRange req -> later selection_range req
+  | SelectionRange req ->
+    later
+      (fun state req ->
+         let+ result = selection_range state req in
+         Some result)
+      req
   | TextDocumentImplementation _ -> Server.not_supported ()
   | SemanticTokensFull p -> later Semantic_highlighting.on_request_full p
   | SemanticTokensDelta p -> later Semantic_highlighting.on_request_full_delta p

--- a/ocaml-lsp-server/test/e2e-new/rename.ml
+++ b/ocaml-lsp-server/test/e2e-new/rename.ml
@@ -15,9 +15,12 @@ let prepare_rename client position =
 
 let rename ?(newName = "new_num") client position =
   let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
-  Client.request
-    client
-    (TextDocumentRename (RenameParams.create ~textDocument ~position ~newName ()))
+  let+ result =
+    Client.request
+      client
+      (TextDocumentRename (RenameParams.create ~textDocument ~position ~newName ()))
+  in
+  Option.value_exn result
 ;;
 
 let print_prepare_rename = function
@@ -432,7 +435,7 @@ let%expect_test "rename a symbol across open and closed files" =
              ~newName:"renamed"
              ()))
    in
-   print_document_changes response;
+   print_document_changes (Option.value_exn response);
    let* () = Client.request client Shutdown in
    Client.stop client);
   Unix.close stderr;

--- a/ocaml-lsp-server/test/e2e-new/selection_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/selection_range.ml
@@ -2,9 +2,12 @@ open Test.Import
 
 let selection_range client positions =
   let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
-  Client.request
-    client
-    (SelectionRange (SelectionRangeParams.create ~textDocument ~positions ()))
+  let+ result =
+    Client.request
+      client
+      (SelectionRange (SelectionRangeParams.create ~textDocument ~positions ()))
+  in
+  Option.value_exn result
 ;;
 
 let print_selection_ranges ranges =

--- a/ocaml-lsp-server/test/e2e-new/signature_help.ml
+++ b/ocaml-lsp-server/test/e2e-new/signature_help.ml
@@ -33,9 +33,12 @@ let capabilities = make_capabilities ~labelOffsetSupport:true ()
 
 let signature_help ?context client position =
   let textDocument = TextDocumentIdentifier.create ~uri:Helpers.uri in
-  Client.request
-    client
-    (SignatureHelp (SignatureHelpParams.create ?context ~textDocument ~position ()))
+  let+ result =
+    Client.request
+      client
+      (SignatureHelp (SignatureHelpParams.create ?context ~textDocument ~position ()))
+  in
+  Option.value_exn result
 ;;
 
 let print_signature_help signature_help =


### PR DESCRIPTION
Aligns three client request codecs with their nullable LSP result contracts:

- `textDocument/signatureHelp` accepts `SignatureHelp | null`.
- `textDocument/selectionRange` accepts `SelectionRange[] | null`.
- `textDocument/rename` accepts `WorkspaceEdit | null`.

Existing server results are wrapped without changing their normal wire output. Each behavior is kept in a separate commit with its corresponding regression expectation.
