### PR TITLE
fix(lsp): accept workspace symbol result variants

### DIFF
--- a/lsp/src/client_request.ml
+++ b/lsp/src/client_request.ml
@@ -2,6 +2,11 @@ open! Import
 open Types
 open Extension
 
+type workspace_symbol_result =
+  [ `SymbolInformation of SymbolInformation.t list
+  | `WorkspaceSymbol of WorkspaceSymbol.t list
+  ]
+
 type _ t =
   | Shutdown : unit t
   | Initialize : InitializeParams.t -> InitializeResult.t t
@@ -50,7 +55,7 @@ type _ t =
          ]
            option
            t
-  | WorkspaceSymbol : WorkspaceSymbolParams.t -> SymbolInformation.t list option t
+  | WorkspaceSymbol : WorkspaceSymbolParams.t -> workspace_symbol_result option t
   | WorkspaceSymbolResolve : WorkspaceSymbol.t -> WorkspaceSymbol.t t
   | DebugEcho : DebugEcho.Params.t -> DebugEcho.Result.t t
   | DebugTextDocumentGet :
@@ -110,6 +115,28 @@ type _ t =
       ; params : Jsonrpc.Structured.t option
       }
       -> Json.t t
+
+let yojson_of_workspace_symbol_result (result : workspace_symbol_result) : Json.t =
+  match result with
+  | `SymbolInformation symbols -> Json.To.list SymbolInformation.yojson_of_t symbols
+  | `WorkspaceSymbol symbols -> Json.To.list WorkspaceSymbol.yojson_of_t symbols
+;;
+
+let workspace_symbol_result_of_yojson json : workspace_symbol_result =
+  let is_workspace_symbol = function
+    | `Assoc fields ->
+      Option.is_some (List.assoc_opt "data" fields)
+      ||
+        (match List.assoc_opt "location" fields with
+        | Some (`Assoc location) -> Option.is_none (List.assoc_opt "range" location)
+        | _ -> false)
+    | _ -> false
+  in
+  match json with
+  | `List symbols when List.exists symbols ~f:is_workspace_symbol ->
+    `WorkspaceSymbol (Json.Of.list WorkspaceSymbol.t_of_yojson json)
+  | _ -> `SymbolInformation (Json.Of.list SymbolInformation.t_of_yojson json)
+;;
 
 let yojson_of_DocumentSymbol ds : Json.t =
   Json.Option.yojson_of_t
@@ -197,7 +224,7 @@ let yojson_of_result (type a) (req : a t) (result : a) =
     Json.Option.yojson_of_t (Json.To.list DocumentLink.yojson_of_t) result
   | TextDocumentLinkResolve _, result -> DocumentLink.yojson_of_t result
   | WorkspaceSymbol _, result ->
-    Json.Option.yojson_of_t (Json.To.list SymbolInformation.yojson_of_t) result
+    Json.Option.yojson_of_t yojson_of_workspace_symbol_result result
   | TextDocumentColorPresentation _, result ->
     Json.To.list ColorPresentation.yojson_of_t result
   | TextDocumentColor _, result -> Json.To.list ColorInformation.yojson_of_t result
@@ -593,8 +620,7 @@ let response_of_json (type a) (t : a t) (json : Json.t) : a =
              `SymbolInformation (list_of_yojson SymbolInformation.t_of_yojson json))
          ])
       json
-  | WorkspaceSymbol _ ->
-    option_of_yojson (list_of_yojson SymbolInformation.t_of_yojson) json
+  | WorkspaceSymbol _ -> option_of_yojson workspace_symbol_result_of_yojson json
   | DebugEcho _ -> DebugEcho.Result.t_of_yojson json
   | DebugTextDocumentGet _ -> DebugTextDocumentGet.Result.t_of_yojson json
   | TextDocumentReferences _ ->

--- a/lsp/src/client_request.mli
+++ b/lsp/src/client_request.mli
@@ -2,6 +2,11 @@ open! Import
 open Types
 open Extension
 
+type workspace_symbol_result =
+  [ `SymbolInformation of SymbolInformation.t list
+  | `WorkspaceSymbol of WorkspaceSymbol.t list
+  ]
+
 type _ t =
   | Shutdown : unit t
   | Initialize : InitializeParams.t -> InitializeResult.t t
@@ -50,7 +55,7 @@ type _ t =
          ]
            option
            t
-  | WorkspaceSymbol : WorkspaceSymbolParams.t -> SymbolInformation.t list option t
+  | WorkspaceSymbol : WorkspaceSymbolParams.t -> workspace_symbol_result option t
   | WorkspaceSymbolResolve : WorkspaceSymbol.t -> WorkspaceSymbol.t t
   | DebugEcho : DebugEcho.Params.t -> DebugEcho.Result.t t
   | DebugTextDocumentGet :

--- a/lsp/test/request_result_contract_tests.ml
+++ b/lsp/test/request_result_contract_tests.ml
@@ -145,7 +145,7 @@ let%expect_test "workspace symbol and nullable results" =
     `Null;
   [%expect
     {|
-    workspace symbol: rejected
+    workspace symbol: accepted
     signature help null: accepted
     selection range null: accepted
     rename null: accepted
@@ -170,6 +170,36 @@ let%expect_test "workspace folders result is nullable" =
   [%expect {| workspace folders null: accepted |}]
 ;;
 
+let%expect_test "workspace symbol result preserves resolvable fields" =
+  let workspace_symbol =
+    `List
+      [ `Assoc
+          [ "data", `String "symbol-id"
+          ; "kind", `Int 12
+          ; "location", `Assoc [ "uri", DocumentUri.yojson_of_t protocol_uri ]
+          ; "name", `String "value"
+          ]
+      ]
+  in
+  round_trip_response
+    "workspace symbol"
+    (Client_request.E
+       (Client_request.WorkspaceSymbol (WorkspaceSymbolParams.create ~query:"value" ())))
+    workspace_symbol;
+  [%expect
+    {|
+    workspace symbol:
+    [
+      {
+        "data": "symbol-id",
+        "kind": 12,
+        "location": { "uri": "file:///workspace/test.ml" },
+        "name": "value"
+      }
+    ]
+    |}]
+;;
+
 let%expect_test "workspace symbol decoding inspects every result" =
   let workspace_symbols =
     `List
@@ -191,5 +221,5 @@ let%expect_test "workspace symbol decoding inspects every result" =
     (Client_request.E
        (Client_request.WorkspaceSymbol (WorkspaceSymbolParams.create ~query:"value" ())))
     workspace_symbols;
-  [%expect {| workspace symbols: rejected |}]
+  [%expect {| workspace symbols: accepted |}]
 ;;

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -630,7 +630,12 @@ let on_request
      | Some doc -> now (Some (Msource.text (Document.source doc))))
   | DebugEcho params -> now params
   | Shutdown -> Fiber.return (Reply.now (), state)
-  | WorkspaceSymbol req -> later (fun state () -> Workspace_symbol.run state req) ()
+  | WorkspaceSymbol req ->
+    later
+      (fun state () ->
+         Workspace_symbol.run state req
+         >>| Option.map ~f:(fun symbols -> `SymbolInformation symbols))
+      ()
   | CodeActionResolve ca -> later (fun state () -> Code_actions.resolve state ca) ()
   | ExecuteCommand command ->
     if String.equal command.command Merlin_config_command.command_name

--- a/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
+++ b/ocaml-lsp-server/test/e2e-new/workspace_symbol_test_helpers.ml
@@ -84,7 +84,7 @@ let a_bin_main_ml =
   {workspace_symbol|let main_y = Lib.lib_x
 ;;
 
-let () = 
+let () =
   let main_z = "test" in
 
 print_endline (main_z);;
@@ -246,6 +246,10 @@ let print_symbols workspaces symbols =
 
 let workspace_symbol client query =
   Client.request client (WorkspaceSymbol (WorkspaceSymbolParams.create ~query ()))
+  >>| function
+  | None -> None
+  | Some (`SymbolInformation symbols) -> Some symbols
+  | Some (`WorkspaceSymbol _) -> failwith "unexpected resolvable workspace symbols"
 ;;
 
 let run ?on_notification ?capabilities workspaces f =


### PR DESCRIPTION
Aligns `workspace/symbol` decoding with the LSP result variants: legacy `SymbolInformation[]` responses and resolvable `WorkspaceSymbol[]` responses.

The decoder inspects every result element before selecting a representation, so a later URI-only or data-bearing workspace symbol is not misclassified from the first legacy-compatible element. The server continues emitting its existing `SymbolInformation[]` shape. The mixed-order regression is covered by #2149.
