### PR TITLE
fix(inlay-hints): constrain results to request range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Return only inlay hints within the range requested by the client. (#2155,
+  @rgrinberg)
 - Return document symbol kinds the client supports, falling back to
   `Constructor` and `Class` when it does not advertise the newer kinds.
   (#2122, fixes #2121, @dayangac)

--- a/ocaml-lsp-server/src/inlay_hints.ml
+++ b/ocaml-lsp-server/src/inlay_hints.ml
@@ -58,7 +58,9 @@ let compute (state : State.t) { InlayHintParams.range; textDocument = { uri }; _
               ~paddingLeft:false
               ~paddingRight:false
               ())
-          hints)
+          hints
+        |> List.filter ~f:(fun (hint : InlayHint.t) ->
+          Lsp.Range.contains_position range hint.position ~inclusive_end:true))
     in
     Some hints
 ;;

--- a/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
+++ b/ocaml-lsp-server/test/e2e-new/inlay_hints.ml
@@ -122,7 +122,7 @@ let%expect_test "function parameter hint lies outside the requested range" =
       ~end_:(Position.create ~line:0 ~character:6)
   in
   apply_inlay_hints ~range ~source ();
-  [%expect {| let f x$: 'a$ = x |}]
+  [%expect {| let f x = x |}]
 ;;
 
 let%expect_test "function params (deactivated)" =


### PR DESCRIPTION
Constrains `textDocument/inlayHint` responses to the range requested by the client.

Merlin can return hints whose insertion positions fall outside the query range, as reproduced in #2039. The server now filters converted LSP hints before returning them, preventing viewport-scoped requests from receiving unrelated hints.
