### PR TITLE
test(dune): cover reconnecting cleaned-up instances

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_promotion_disconnect.ml
@@ -36,6 +36,20 @@ let%expect_test "promotion registrations when Dune disconnects" =
            "client/unregisterCapability after Dune disconnects:"
            UnregistrationParams.yojson_of_t
            (unregistration :: Mailbox.take_pending events.unregistrations);
+         restart_dune project;
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         let* reconnected =
+           Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic
+         in
+         let* reregistration = Mailbox.wait events.registrations in
+         print_payload
+           project
+           "textDocument/publishDiagnostics after Dune reconnects:"
+           (PublishDiagnosticsParams.yojson_of_t reconnected);
+         print_payload
+           project
+           "client/registerCapability after Dune reconnects:"
+           (RegistrationParams.yojson_of_t reregistration);
          Fiber.return ()));
   [%expect
     {|
@@ -82,5 +96,35 @@ let%expect_test "promotion registrations when Dune disconnects" =
         ]
       }
     ]
+    textDocument/publishDiagnostics after Dune reconnects:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    client/registerCapability after Dune reconnects:
+    {
+      "registrations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction",
+          "registerOptions": {
+            "codeActionKinds": [ "quickfix" ],
+            "documentSelector": [
+              { "language": null, "scheme": null, "pattern": "<document-path>" }
+            ]
+          }
+        }
+      ]
+    }
     |}]
 ;;

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.ml
@@ -388,6 +388,16 @@ let stop_dune project =
   stop_process pid
 ;;
 
+let restart_dune project =
+  assert (Option.is_none project.dune_pid);
+  let dune_pid = start_dune project.root project.runtime_dir in
+  match wait_for_rpc_registration project.runtime_dir dune_pid with
+  | () -> project.dune_pid <- Some dune_pid
+  | exception exn ->
+    stop_process dune_pid;
+    raise exn
+;;
+
 let destroy_project project =
   Option.iter project.dune_pid ~f:stop_process;
   ignore (Sys.command ("rm -rf -- " ^ Filename.quote project.temp) : int)

--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_test.mli
@@ -67,6 +67,7 @@ val wait_for_rpc_registration : string -> int -> unit
 val stop_process : int -> unit
 val create_project : string -> project
 val stop_dune : project -> unit
+val restart_dune : project -> unit
 val destroy_project : project -> unit
 val print_payload : project -> string -> Yojson.Safe.t -> unit
 val print_payloads : project -> string -> ('a -> Yojson.Safe.t) -> 'a list -> unit

--- a/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_workspace_removal.ml
@@ -1,7 +1,7 @@
 open Test.Import
 open Dune_rpc_test
 
-let%expect_test "connected Dune does not process workspace removal" =
+let%expect_test "connected Dune cleans up after workspace removal" =
   let project = create_project "ws" in
   let events = Lifecycle_events.create () in
   Fun.protect
@@ -46,6 +46,28 @@ let%expect_test "connected Dune does not process workspace removal" =
            "client/unregisterCapability after workspace removal:"
            UnregistrationParams.yojson_of_t
            (unregistration :: Mailbox.take_pending events.unregistrations);
+         let event =
+           WorkspaceFoldersChangeEvent.create ~added:[ workspace ] ~removed:[]
+         in
+         let params = DidChangeWorkspaceFoldersParams.create ~event in
+         print_payload
+           project
+           "client workspace/didChangeWorkspaceFolders re-addition:"
+           (DidChangeWorkspaceFoldersParams.yojson_of_t params);
+         let* () = Client.notification client (ChangeWorkspaceFolders params) in
+         let* () = Signal.wait (Events.dune_ready events.dune) in
+         let* reconnected =
+           Events.wait_for_diagnostics events.dune ~f:has_dune_diagnostic
+         in
+         let* reregistration = Mailbox.wait events.registrations in
+         print_payload
+           project
+           "textDocument/publishDiagnostics after workspace re-addition:"
+           (PublishDiagnosticsParams.yojson_of_t reconnected);
+         print_payload
+           project
+           "client/registerCapability after workspace re-addition:"
+           (RegistrationParams.yojson_of_t reregistration);
          Fiber.return ()));
   [%expect
     {|
@@ -99,5 +121,42 @@ let%expect_test "connected Dune does not process workspace removal" =
         ]
       }
     ]
+    client workspace/didChangeWorkspaceFolders re-addition:
+    {
+      "event": {
+        "added": [ { "name": "dune-rpc", "uri": "<workspace-uri>" } ],
+        "removed": []
+      }
+    }
+    textDocument/publishDiagnostics after workspace re-addition:
+    {
+      "diagnostics": [
+        {
+          "message": "--- expected.ml\n+++ actual.ml\n@@ -1 +1 @@\n-let answer = 0\n+let answer = 42\n\\ No newline at end of file",
+          "range": {
+            "end": { "character": 0, "line": 0 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<document-uri>"
+    }
+    client/registerCapability after workspace re-addition:
+    {
+      "registrations": [
+        {
+          "id": "ocamllsp-promote/<document-uri>",
+          "method": "textDocument/codeAction",
+          "registerOptions": {
+            "codeActionKinds": [ "quickfix" ],
+            "documentSelector": [
+              { "language": null, "scheme": null, "pattern": "<document-path>" }
+            ]
+          }
+        }
+      ]
+    }
     |}]
 ;;


### PR DESCRIPTION
Existing lifecycle tests verify that Dune diagnostics and promotion registrations are cleaned up after a disconnect or workspace removal. Extend them through the recovery path to verify that restarting Dune or re-adding the workspace reconnects, republishes promotion diagnostics, and restores the dynamic code-action registration.

This ensures instance cleanup is reversible rather than leaving the workspace permanently disconnected.
