### PR TITLE
test(lsp): expose dropped trailing newlines in edit ranges

### DIFF
--- a/lsp/test/range_tests.ml
+++ b/lsp/test/range_tests.ml
@@ -9,23 +9,21 @@ let resize newText =
   Range.resize_for_edit edit
 ;;
 
-let%expect_test "resize_for_edit preserves trailing newlines" =
-  print_endline (Range.to_string (resize "x\n"));
-  print_endline (Range.to_string (resize ""));
-  print_endline (Range.to_string (resize "x"));
-  print_endline (Range.to_string (resize "ab\ncd"));
-  print_endline (Range.to_string (resize "a\nb\n"));
-  print_endline (Range.to_string (resize "ab\n\n"));
-  print_endline (Range.to_string (resize "\n"));
+let print_resize newText =
+  Printf.printf "%S -> %s\n" newText (Range.to_string (resize newText))
+;;
+
+let%expect_test "resize_for_edit drops trailing newlines" =
+  List.iter print_resize [ "x\n"; ""; "x"; "ab\ncd"; "a\nb\n"; "ab\n\n"; "\n" ];
   [%expect
     {|
-    ((2, 5), (2, 6))
-    ((2, 5), (2, 5))
-    ((2, 5), (2, 6))
-    ((2, 5), (3, 2))
-    ((2, 5), (3, 1))
-    ((2, 5), (3, 0))
-    ((2, 5), (2, 5))
+    "x\n" -> ((2, 5), (2, 6))
+    "" -> ((2, 5), (2, 5))
+    "x" -> ((2, 5), (2, 6))
+    "ab\ncd" -> ((2, 5), (3, 2))
+    "a\nb\n" -> ((2, 5), (3, 1))
+    "ab\n\n" -> ((2, 5), (3, 0))
+    "\n" -> ((2, 5), (2, 5))
     |}]
 ;;
 


### PR DESCRIPTION
Make the `resize_for_edit` regression output identify each replacement string alongside its computed range. This exposes the current trailing-newline bug directly: for example, `"x\n"` is treated like `"x"`, and the final newline in `"a\nb\n"` does not advance the end position.

This is test-only and preserves the currently observed results; the fix is intentionally separate.
