### PR TITLE
fix(lsp): preserve trailing newlines in edit ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Preserve trailing newlines when computing post-edit ranges. (#2159,
+  @rgrinberg)
 - Return only inlay hints within the range requested by the client. (#2155,
   @rgrinberg)
 - Return document symbol kinds the client supports, falling back to

--- a/lsp/src/range.ml
+++ b/lsp/src/range.ml
@@ -47,27 +47,18 @@ let first_line =
   { start; end_ }
 ;;
 
-let split_lines t =
-  let lines = String.split_on_char ~sep:'\n' t in
-  match List.last lines with
-  | Some "" -> List.rev lines |> List.tl |> List.rev
-  | _ -> lines
-;;
-
 let resize_for_edit { Types.TextEdit.range; newText } =
-  match split_lines newText with
-  | [] -> { range with end_ = range.start }
-  | several_lines ->
-    let end_ =
-      let start = range.start in
-      let line = start.line + List.length several_lines - 1 in
-      let character =
-        let last_line_len = List.last_exn several_lines |> String.length in
-        if line = start.line then start.character + last_line_len else last_line_len
-      in
-      { Position.line; character }
+  let end_ =
+    let lines = String.split_on_char ~sep:'\n' newText in
+    let start = range.start in
+    let line = start.line + List.length lines - 1 in
+    let character =
+      let last_line_len = List.last_exn lines |> String.length in
+      if line = start.line then start.character + last_line_len else last_line_len
     in
-    { range with end_ }
+    { Position.line; character }
+  in
+  { range with end_ }
 ;;
 
 let to_string t =

--- a/lsp/test/range_tests.ml
+++ b/lsp/test/range_tests.ml
@@ -13,17 +13,17 @@ let print_resize newText =
   Printf.printf "%S -> %s\n" newText (Range.to_string (resize newText))
 ;;
 
-let%expect_test "resize_for_edit drops trailing newlines" =
+let%expect_test "resize_for_edit preserves trailing newlines" =
   List.iter print_resize [ "x\n"; ""; "x"; "ab\ncd"; "a\nb\n"; "ab\n\n"; "\n" ];
   [%expect
     {|
-    "x\n" -> ((2, 5), (2, 6))
+    "x\n" -> ((2, 5), (3, 0))
     "" -> ((2, 5), (2, 5))
     "x" -> ((2, 5), (2, 6))
     "ab\ncd" -> ((2, 5), (3, 2))
-    "a\nb\n" -> ((2, 5), (3, 1))
-    "ab\n\n" -> ((2, 5), (3, 0))
-    "\n" -> ((2, 5), (2, 5))
+    "a\nb\n" -> ((2, 5), (4, 0))
+    "ab\n\n" -> ((2, 5), (4, 0))
+    "\n" -> ((2, 5), (3, 0))
     |}]
 ;;
 


### PR DESCRIPTION
`Range.resize_for_edit` discarded the terminal empty segment when replacement text ended with a newline. As a result, ranges for replacements such as `"x\n"` ended on the previous line and did not select the full inserted text.

Preserve that segment so every trailing newline advances the resulting end position to the next line. This fixes the behavior exposed by #2158.
