### PR TITLE
test(e2e): tolerate fake Dune RPC client disconnects

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_rpc_fake.ml
@@ -158,6 +158,7 @@ let start ?(diagnostics = fun _root -> []) ?(progress = []) name =
   let pid =
     match Unix.fork () with
     | 0 ->
+      Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
       let connection, _ = Unix.accept listener in
       Unix.close listener;
       (match serve connection ~diagnostics ~progress with


### PR DESCRIPTION
The fake Dune RPC server already treats socket errors as normal shutdown, but the default `SIGPIPE` behavior could kill the forked child before a failed response write raised `Sys_error`. This intermittently made otherwise successful E2E tests fail during teardown with `fake Dune RPC server failed: signal -8`.

Ignore `SIGPIPE` in the child so disconnect races follow the existing graceful socket-error path.
