### PR TITLE
fix(diagnostics): convert related location lines to LSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Convert related locations parsed from Merlin diagnostic messages to zero-based
+  LSP line numbers. (#2163, fixes #2145, @rgrinberg)
 - Preserve trailing newlines when computing post-edit ranges. (#2159,
   @rgrinberg)
 - Return only inlay hints within the range requested by the client. (#2155,

--- a/ocaml-lsp-server/src/diagnostics.ml
+++ b/ocaml-lsp-server/src/diagnostics.ml
@@ -293,8 +293,8 @@ let extract_related_errors uri raw_message =
                 | None -> 1, 1
                 | Some (x, y) -> x, y
               in
-              ( Position.create ~line:line_start ~character:char_start
-              , Position.create ~line:line_end ~character:char_end )
+              ( Position.of_logical ~line:line_start ~character:char_start
+              , Position.of_logical ~line:line_end ~character:char_end )
             in
             let range = Range.create ~start ~end_ in
             Location.create ~range ~uri

--- a/ocaml-lsp-server/test/e2e-new/diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/diagnostics.ml
@@ -476,8 +476,8 @@ end
             {
               "location": {
                 "range": {
-                  "end": { "character": 14, "line": 2 },
-                  "start": { "character": 2, "line": 2 }
+                  "end": { "character": 14, "line": 1 },
+                  "start": { "character": 2, "line": 1 }
                 },
                 "uri": "file:///test.ml"
               },
@@ -486,8 +486,8 @@ end
             {
               "location": {
                 "range": {
-                  "end": { "character": 7, "line": 4 },
-                  "start": { "character": 6, "line": 4 }
+                  "end": { "character": 7, "line": 3 },
+                  "start": { "character": 6, "line": 3 }
                 },
                 "uri": "file:///test.ml"
               },


### PR DESCRIPTION
Merlin diagnostics can encode related locations in formatted compiler messages. `Ocamlc_loc.parse_raw` retains the compiler's one-based line numbers, but the conversion passed them unchanged to zero-based LSP positions.

Convert parsed lines with `Position.of_logical` and update the regression expectations.

Fixes #2145.
