### PR TITLE
fix(references): honor includeDeclaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Exclude symbol declarations from reference results when requested by the
+  client. (#2164, @rgrinberg)
 - Convert related locations parsed from Merlin diagnostic messages to zero-based
   LSP line numbers. (#2163, fixes #2145, @rgrinberg)
 - Preserve trailing newlines when computing post-edit ranges. (#2159,

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -475,7 +475,7 @@ let selection_range
 let references
       rpc
       (state : State.t)
-      { ReferenceParams.textDocument = { uri }; position; _ }
+      { ReferenceParams.textDocument = { uri }; position; context; _ }
   =
   let doc = Document_store.get state.store uri in
   match Document.kind doc with
@@ -486,6 +486,23 @@ let references
         ~name:"occurrences"
         doc
         (Occurrences (`Ident_at (Position.logical position), `Project))
+    in
+    let* declaration =
+      if context.includeDeclaration
+      then Fiber.return None
+      else
+        Document.Merlin.dispatch_exn
+          ~name:"reference-declaration"
+          doc
+          (Locate (None, `ML, Position.logical position))
+        >>| function
+        | `At_origin -> Some (`At_origin (uri, position))
+        | `Found (path, lexical_position) ->
+          Position.of_lexical_position lexical_position
+          |> Option.map ~f:(fun position ->
+            `Found (Option.value_map path ~default:uri ~f:Uri.of_path, position))
+        | `Builtin _ | `File_not_found _ | `Invalid_context | `Not_found _ | `Not_in_env _
+          -> None
     in
     let+ () =
       match synced with
@@ -506,18 +523,30 @@ let references
          | { loc = _; is_stale = true } -> None
          | { loc; is_stale = false } ->
            let range = Range.of_loc loc in
-           let uri =
+           let occurrence_uri =
              match loc.loc_start.pos_fname with
              | "" -> uri
              | path -> Uri.of_path path
            in
-           Log.log ~section:"debug" (fun () ->
-             Log.msg
-               "merlin returned fname %a"
-               [ "pos_fname", `String loc.loc_start.pos_fname
-               ; "uri", `String (Uri.to_string uri)
-               ]);
-           Some { Location.uri; range }))
+           let is_declaration =
+             Option.value_map declaration ~default:false ~f:(function
+               | `At_origin (declaration_uri, position) ->
+                 Uri.equal occurrence_uri declaration_uri
+                 && Lsp.Range.contains_position range position ~inclusive_end:true
+               | `Found (declaration_uri, position) ->
+                 Uri.equal occurrence_uri declaration_uri
+                 && Lsp.Position.compare range.start position = 0)
+           in
+           if is_declaration
+           then None
+           else (
+             Log.log ~section:"debug" (fun () ->
+               Log.msg
+                 "merlin returned fname %a"
+                 [ "pos_fname", `String loc.loc_start.pos_fname
+                 ; "uri", `String (Uri.to_string occurrence_uri)
+                 ]);
+             Some { Location.uri = occurrence_uri; range })))
 ;;
 
 let highlight

--- a/ocaml-lsp-server/test/e2e-new/references.ml
+++ b/ocaml-lsp-server/test/e2e-new/references.ml
@@ -28,7 +28,7 @@ let check_include_declaration client ~uri position ~print =
   >>| print "without declaration:"
 ;;
 
-let%expect_test "includeDeclaration is ignored" =
+let%expect_test "includeDeclaration filters the declaration" =
   let source =
     {ocaml|let num = 42
 let sum = num + 13
@@ -73,13 +73,6 @@ let sum2 = sum + num
     [
       {
         "range": {
-          "end": { "character": 7, "line": 0 },
-          "start": { "character": 4, "line": 0 }
-        },
-        "uri": "file:///test.ml"
-      },
-      {
-        "range": {
           "end": { "character": 13, "line": 1 },
           "start": { "character": 10, "line": 1 }
         },
@@ -120,7 +113,7 @@ let print_project_references label locations =
     |> List.iter ~f:(fun (path, range) -> Printf.printf "%s: %s\n" path range)
 ;;
 
-let%expect_test "cross-file includeDeclaration is ignored" =
+let%expect_test "cross-file includeDeclaration filters the declaration" =
   let dir = setup_cross_file_workspace () in
   let main_path = Filename.concat dir "main.ml" in
   let main_uri = DocumentUri.of_path main_path in
@@ -160,7 +153,6 @@ let%expect_test "cross-file includeDeclaration is ignored" =
     main.ml: ((0, 17), (0, 22))
     other.ml: ((0, 16), (0, 21))
     without declaration:
-    lib.ml: ((0, 4), (0, 9))
     main.ml: ((0, 17), (0, 22))
     other.ml: ((0, 16), (0, 21))
     |}]


### PR DESCRIPTION
Honor `ReferenceContext.includeDeclaration` instead of always returning every Merlin project occurrence.

When declarations are excluded, use Merlin locate to identify and remove the declaration occurrence. This handles both declarations at the request origin and declarations found in another file, while preserving results when Merlin cannot identify a declaration.

The regressions were added separately in #2161 and #2162.
