### PR TITLE
test(dune): expose late cleanup after RPC errors

### DIFF
--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -696,38 +696,45 @@ let uri_dune_overlap =
     || List.is_prefix dune_root ~prefix:path ~equal:equal_path_component
 ;;
 
-let make_finalizer active (instance : Instance.t) =
-  Lazy_fiber.create (fun () ->
-    active.instances
-    <- Map.remove active.instances (Registry.Dune.root (Instance.source instance));
-    let to_unregister =
-      Instance.promotions instance
-      |> Map.data
-      |> List.map ~f:(fun promotion ->
-        let path = Drpc.Diagnostic.Promotion.in_source promotion in
-        Uri.of_path path)
-    in
-    Document_store.unregister_promotions active.config.document_store to_unregister)
-;;
-
-let run_instance active (instance : Instance.t) =
-  let cleanup = make_finalizer active instance in
+let run_with_cleanup ~run ~cleanup ~on_error =
+  let cleanup = Lazy_fiber.create cleanup in
   let* (_ : (unit, unit) result) =
     Fiber.map_reduce_errors
       (module Monoid.Unit)
-      (fun () -> Instance.run instance)
+      run
       ~on_error:(fun exn ->
-        let message =
-          Format.asprintf
-            "disconnected %s:@.%a"
-            (Registry.Dune.root (Instance.source instance))
-            Exn_with_backtrace.pp_uncaught
-            exn
-        in
-        let* () = active.config.log ~type_:Error ~message in
+        let* () = on_error exn in
         Lazy_fiber.force cleanup)
   in
   Lazy_fiber.force cleanup
+;;
+
+let cleanup_instance active (instance : Instance.t) =
+  active.instances
+  <- Map.remove active.instances (Registry.Dune.root (Instance.source instance));
+  let to_unregister =
+    Instance.promotions instance
+    |> Map.data
+    |> List.map ~f:(fun promotion ->
+      let path = Drpc.Diagnostic.Promotion.in_source promotion in
+      Uri.of_path path)
+  in
+  Document_store.unregister_promotions active.config.document_store to_unregister
+;;
+
+let run_instance active (instance : Instance.t) =
+  run_with_cleanup
+    ~run:(fun () -> Instance.run instance)
+    ~cleanup:(fun () -> cleanup_instance active instance)
+    ~on_error:(fun exn ->
+      let message =
+        Format.asprintf
+          "disconnected %s:@.%a"
+          (Registry.Dune.root (Instance.source instance))
+          Exn_with_backtrace.pp_uncaught
+          exn
+      in
+      active.config.log ~type_:Error ~message)
 ;;
 
 let poll active last_error =
@@ -1064,3 +1071,7 @@ let for_doc t doc =
   | Closed -> []
   | Active active -> instances_for_uri active (Document.Dune.uri doc)
 ;;
+
+module For_tests = struct
+  let run_with_cleanup = run_with_cleanup
+end

--- a/ocaml-lsp-server/src/dune.mli
+++ b/ocaml-lsp-server/src/dune.mli
@@ -27,3 +27,11 @@ val commands : string list
 val on_command : t -> ExecuteCommandParams.t -> Json.t Fiber.t
 val code_actions : t -> Uri.t -> CodeAction.t list
 val for_doc : t -> Document.Dune.t -> Instance.t list
+
+module For_tests : sig
+  val run_with_cleanup
+    :  run:(unit -> unit Fiber.t)
+    -> cleanup:(unit -> unit Fiber.t)
+    -> on_error:(Exn_with_backtrace.t -> unit Fiber.t)
+    -> unit Fiber.t
+end

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -4,6 +4,11 @@ module Diagnostics = Diagnostics
 module Position = Position
 module Doc_to_md = Doc_to_md
 module Diff = Diff
+
+module For_tests = struct
+  module Dune = Dune.For_tests
+end
+
 module Testing = Testing
 open Fiber.O
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.mli
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.mli
@@ -4,5 +4,10 @@ module Diagnostics = Diagnostics
 module Version = Version
 module Position = Position
 module Doc_to_md = Doc_to_md
+
+module For_tests : sig
+  module Dune : module type of Dune.For_tests
+end
+
 module Testing = Testing
 module Custom_request = Custom_request

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -1,6 +1,7 @@
 (library
  (modules
   destruct_line_quickcheck_tests
+  dune_tests
   ocaml_lsp_tests
   position_prefix_tests
   semantic_tokens_quickcheck_tests)
@@ -9,6 +10,8 @@
   (>= %{ocaml_version} 4.08))
  (inline_tests)
  (libraries
+  fiber
+  lev_fiber
   ordering
   ocaml_lsp_server
   merlin-lib.kernel

--- a/ocaml-lsp-server/test/dune_tests.ml
+++ b/ocaml-lsp-server/test/dune_tests.ml
@@ -1,0 +1,22 @@
+module Dune = Ocaml_lsp_server.For_tests.Dune
+
+let run fiber = Lev_fiber.run (fun () -> fiber) |> Lev_fiber.Error.ok_exn
+
+let%expect_test "cleanup runs after reporting an RPC error" =
+  let cleanups = ref 0 in
+  run
+    (Dune.run_with_cleanup
+       ~run:(fun () -> Fiber.of_thunk (fun () -> raise Exit))
+       ~cleanup:(fun () ->
+         incr cleanups;
+         Fiber.return ())
+       ~on_error:(fun _ ->
+         Printf.printf "cleanups while reporting: %d\n" !cleanups;
+         Fiber.return ()));
+  Printf.printf "total cleanups: %d\n" !cleanups;
+  [%expect
+    {|
+    cleanups while reporting: 0
+    total cleanups: 1
+    |}]
+;;


### PR DESCRIPTION
Factor the existing disconnected-instance finalization into a testable helper without changing its behavior. The regression test records that an RPC failure is currently reported before cleanup runs, while confirming that cleanup eventually runs exactly once.

A follow-up change will move cleanup ahead of error reporting and use the same finalizer to clear exceptional-exit state.
