### PR TITLE
fix(lsp): generate notebook synchronization contracts

### DIFF
--- a/lsp/bin/ocaml/ocaml.ml
+++ b/lsp/bin/ocaml/ocaml.ml
@@ -21,9 +21,6 @@ let skipped_ts_decls =
   ; "LSPObject"
   ; "LSPArray"
   ; "LSPErrorCodes"
-  ; "NotebookDocumentSyncOptions"
-  ; "NotebookDocumentFilter"
-  ; "NotebookDocumentSyncRegistrationOptions"
   ; "URI"
   ]
 ;;

--- a/lsp/src/types.ml
+++ b/lsp/src/types.ml
@@ -1,42 +1,6 @@
 open! Import
 open Json.Conv
 
-module NotebookDocumentSyncOptions = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
-module NotebookDocumentSyncRegistrationOptions = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
-module NotebookDocumentFilter = struct
-  type t = unit [@@deriving_inline yojson]
-
-  let _ = fun (_ : t) -> ()
-  let t_of_yojson = (unit_of_yojson : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
-  let _ = t_of_yojson
-  let yojson_of_t = (yojson_of_unit : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
-  let _ = yojson_of_t
-
-  [@@@end]
-end
-
 module MarkedString = struct
   type t =
     { value : string
@@ -6024,6 +5988,36 @@ module NotebookDocumentFilterNotebookType = struct
     : t
     =
     { notebookType; pattern; scheme }
+  ;;
+end
+
+module NotebookDocumentFilter = struct
+  type t =
+    [ `NotebookDocumentFilterNotebookType of NotebookDocumentFilterNotebookType.t
+    | `NotebookDocumentFilterScheme of NotebookDocumentFilterScheme.t
+    | `NotebookDocumentFilterPattern of NotebookDocumentFilterPattern.t
+    ]
+
+  let t_of_yojson (json : Json.t) : t =
+    Json.Of.untagged_union
+      "t"
+      [ (fun json ->
+          `NotebookDocumentFilterNotebookType
+            (NotebookDocumentFilterNotebookType.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterScheme (NotebookDocumentFilterScheme.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterPattern (NotebookDocumentFilterPattern.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_t (t : t) : Json.t =
+    match t with
+    | `NotebookDocumentFilterNotebookType s ->
+      NotebookDocumentFilterNotebookType.yojson_of_t s
+    | `NotebookDocumentFilterScheme s -> NotebookDocumentFilterScheme.yojson_of_t s
+    | `NotebookDocumentFilterPattern s -> NotebookDocumentFilterPattern.yojson_of_t s
   ;;
 end
 
@@ -41613,6 +41607,323 @@ module NotebookDocumentFilterWithNotebook = struct
     : t
     =
     { cells; notebook }
+  ;;
+end
+
+module NotebookDocumentSyncRegistrationOptions = struct
+  type notebookSelector_pvar =
+    [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+    | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+    ]
+
+  let notebookSelector_pvar_of_yojson (json : Json.t) : notebookSelector_pvar =
+    Json.Of.untagged_union
+      "notebookSelector_pvar"
+      [ (fun json ->
+          `NotebookDocumentFilterWithNotebook
+            (NotebookDocumentFilterWithNotebook.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterWithCells
+            (NotebookDocumentFilterWithCells.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_notebookSelector_pvar (notebookSelector_pvar : notebookSelector_pvar)
+    : Json.t
+    =
+    match notebookSelector_pvar with
+    | `NotebookDocumentFilterWithNotebook s ->
+      NotebookDocumentFilterWithNotebook.yojson_of_t s
+    | `NotebookDocumentFilterWithCells s -> NotebookDocumentFilterWithCells.yojson_of_t s
+  ;;
+
+  type t =
+    { id : string Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    ; notebookSelector : notebookSelector_pvar list
+    ; save : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentSyncRegistrationOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let id_field = ref Ppx_yojson_conv_lib.Option.None
+       and notebookSelector_field = ref Ppx_yojson_conv_lib.Option.None
+       and save_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "id" ->
+              (match Ppx_yojson_conv_lib.( ! ) id_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson string_of_yojson _field_yojson
+                 in
+                 id_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "notebookSelector" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookSelector_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson notebookSelector_pvar_of_yojson _field_yojson
+                 in
+                 notebookSelector_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "save" ->
+              (match Ppx_yojson_conv_lib.( ! ) save_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 save_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) id_field
+                , Ppx_yojson_conv_lib.( ! ) notebookSelector_field
+                , Ppx_yojson_conv_lib.( ! ) save_field )
+              with
+              | ( id_value
+                , Ppx_yojson_conv_lib.Option.Some notebookSelector_value
+                , save_value ) ->
+                { id =
+                    (match id_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                ; notebookSelector = notebookSelector_value
+                ; save =
+                    (match save_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebookSelector_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebookSelector" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { id = v_id; notebookSelector = v_notebookSelector; save = v_save } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_save
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_save in
+           let bnd = "save", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_list yojson_of_notebookSelector_pvar v_notebookSelector in
+         ("notebookSelector", arg) :: bnds
+       in
+       let bnds =
+         if None = v_id
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_string) v_id in
+           let bnd = "id", arg in
+           bnd :: bnds)
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ?(id : string option)
+        ~(notebookSelector : notebookSelector_pvar list)
+        ?(save : bool option)
+        (() : unit)
+    : t
+    =
+    { id; notebookSelector; save }
+  ;;
+end
+
+module NotebookDocumentSyncOptions = struct
+  type notebookSelector_pvar =
+    [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+    | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+    ]
+
+  let notebookSelector_pvar_of_yojson (json : Json.t) : notebookSelector_pvar =
+    Json.Of.untagged_union
+      "notebookSelector_pvar"
+      [ (fun json ->
+          `NotebookDocumentFilterWithNotebook
+            (NotebookDocumentFilterWithNotebook.t_of_yojson json))
+      ; (fun json ->
+          `NotebookDocumentFilterWithCells
+            (NotebookDocumentFilterWithCells.t_of_yojson json))
+      ]
+      json
+  ;;
+
+  let yojson_of_notebookSelector_pvar (notebookSelector_pvar : notebookSelector_pvar)
+    : Json.t
+    =
+    match notebookSelector_pvar with
+    | `NotebookDocumentFilterWithNotebook s ->
+      NotebookDocumentFilterWithNotebook.yojson_of_t s
+    | `NotebookDocumentFilterWithCells s -> NotebookDocumentFilterWithCells.yojson_of_t s
+  ;;
+
+  type t =
+    { notebookSelector : notebookSelector_pvar list
+    ; save : bool Json.Nullable_option.t [@default None] [@yojson_drop_default ( = )]
+    }
+  [@@deriving_inline yojson] [@@yojson.allow_extra_fields]
+
+  let _ = fun (_ : t) -> ()
+
+  let t_of_yojson =
+    (let _tp_loc = "lsp/src/types.ml.NotebookDocumentSyncOptions.t" in
+     function
+     | `Assoc field_yojsons as yojson ->
+       let notebookSelector_field = ref Ppx_yojson_conv_lib.Option.None
+       and save_field = ref Ppx_yojson_conv_lib.Option.None
+       and duplicates = ref []
+       and extra = ref [] in
+       let rec iter = function
+         | (field_name, _field_yojson) :: tail ->
+           (match field_name with
+            | "notebookSelector" ->
+              (match Ppx_yojson_conv_lib.( ! ) notebookSelector_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   list_of_yojson notebookSelector_pvar_of_yojson _field_yojson
+                 in
+                 notebookSelector_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | "save" ->
+              (match Ppx_yojson_conv_lib.( ! ) save_field with
+               | Ppx_yojson_conv_lib.Option.None ->
+                 let fvalue =
+                   Json.Nullable_option.t_of_yojson bool_of_yojson _field_yojson
+                 in
+                 save_field := Ppx_yojson_conv_lib.Option.Some fvalue
+               | Ppx_yojson_conv_lib.Option.Some _ ->
+                 duplicates := field_name :: Ppx_yojson_conv_lib.( ! ) duplicates)
+            | _ -> ());
+           iter tail
+         | [] -> ()
+       in
+       iter field_yojsons;
+       (match Ppx_yojson_conv_lib.( ! ) duplicates with
+        | _ :: _ ->
+          Ppx_yojson_conv_lib.Yojson_conv_error.record_duplicate_fields
+            _tp_loc
+            (Ppx_yojson_conv_lib.( ! ) duplicates)
+            yojson
+        | [] ->
+          (match Ppx_yojson_conv_lib.( ! ) extra with
+           | _ :: _ ->
+             Ppx_yojson_conv_lib.Yojson_conv_error.record_extra_fields
+               _tp_loc
+               (Ppx_yojson_conv_lib.( ! ) extra)
+               yojson
+           | [] ->
+             (match
+                ( Ppx_yojson_conv_lib.( ! ) notebookSelector_field
+                , Ppx_yojson_conv_lib.( ! ) save_field )
+              with
+              | Ppx_yojson_conv_lib.Option.Some notebookSelector_value, save_value ->
+                { notebookSelector = notebookSelector_value
+                ; save =
+                    (match save_value with
+                     | Ppx_yojson_conv_lib.Option.None -> None
+                     | Ppx_yojson_conv_lib.Option.Some v -> v)
+                }
+              | _ ->
+                Ppx_yojson_conv_lib.Yojson_conv_error.record_undefined_elements
+                  _tp_loc
+                  yojson
+                  [ ( Ppx_yojson_conv_lib.poly_equal
+                        (Ppx_yojson_conv_lib.( ! ) notebookSelector_field)
+                        Ppx_yojson_conv_lib.Option.None
+                    , "notebookSelector" )
+                  ])))
+     | _ as yojson ->
+       Ppx_yojson_conv_lib.Yojson_conv_error.record_list_instead_atom _tp_loc yojson
+     : Ppx_yojson_conv_lib.Yojson.Safe.t -> t)
+  ;;
+
+  let _ = t_of_yojson
+
+  let yojson_of_t =
+    (function
+     | { notebookSelector = v_notebookSelector; save = v_save } ->
+       let bnds : (string * Ppx_yojson_conv_lib.Yojson.Safe.t) list = [] in
+       let bnds =
+         if None = v_save
+         then bnds
+         else (
+           let arg = (Json.Nullable_option.yojson_of_t yojson_of_bool) v_save in
+           let bnd = "save", arg in
+           bnd :: bnds)
+       in
+       let bnds =
+         let arg = yojson_of_list yojson_of_notebookSelector_pvar v_notebookSelector in
+         ("notebookSelector", arg) :: bnds
+       in
+       `Assoc bnds
+     : t -> Ppx_yojson_conv_lib.Yojson.Safe.t)
+  ;;
+
+  let _ = yojson_of_t
+
+  [@@@end]
+
+  let create
+        ~(notebookSelector : notebookSelector_pvar list)
+        ?(save : bool option)
+        (() : unit)
+    : t
+    =
+    { notebookSelector; save }
   ;;
 end
 

--- a/lsp/src/types.mli
+++ b/lsp/src/types.mli
@@ -31,24 +31,6 @@ module ProgressParams : sig
   include Json.Jsonable.S1 with type 'a t := 'a t
 end
 
-module NotebookDocumentSyncOptions : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
-module NotebookDocumentSyncRegistrationOptions : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
-module NotebookDocumentFilter : sig
-  type t = unit
-
-  include Json.Jsonable.S with type t := t
-end
-
 (*$ Lsp_gen.print_mli () *)
 module ApplyKind : sig
   type t =
@@ -1029,6 +1011,16 @@ module NotebookDocumentFilterNotebookType : sig
     -> ?scheme:string
     -> unit
     -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentFilter : sig
+  type t =
+    [ `NotebookDocumentFilterNotebookType of NotebookDocumentFilterNotebookType.t
+    | `NotebookDocumentFilterScheme of NotebookDocumentFilterScheme.t
+    | `NotebookDocumentFilterPattern of NotebookDocumentFilterPattern.t
+    ]
 
   include Json.Jsonable.S with type t := t
 end
@@ -4594,6 +4586,54 @@ module NotebookDocumentFilterWithNotebook : sig
     :  ?cells:NotebookCellLanguage.t list
     -> notebook:
          [ `String of string | `NotebookDocumentFilter of NotebookDocumentFilter.t ]
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentSyncRegistrationOptions : sig
+  type t =
+    { id : string option
+    ; notebookSelector :
+        [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+        | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+        ]
+          list
+    ; save : bool option
+    }
+
+  val create
+    :  ?id:string
+    -> notebookSelector:
+         [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+         | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+         ]
+           list
+    -> ?save:bool
+    -> unit
+    -> t
+
+  include Json.Jsonable.S with type t := t
+end
+
+module NotebookDocumentSyncOptions : sig
+  type t =
+    { notebookSelector :
+        [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+        | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+        ]
+          list
+    ; save : bool option
+    }
+
+  val create
+    :  notebookSelector:
+         [ `NotebookDocumentFilterWithNotebook of NotebookDocumentFilterWithNotebook.t
+         | `NotebookDocumentFilterWithCells of NotebookDocumentFilterWithCells.t
+         ]
+           list
+    -> ?save:bool
     -> unit
     -> t
 

--- a/lsp/test/contract_tests.ml
+++ b/lsp/test/contract_tests.ml
@@ -3,13 +3,6 @@ open Types
 
 let print_json json = Yojson.Safe.pretty_to_string json |> Stdlib.print_endline
 
-let check_decode label decode json =
-  Stdlib.Printf.printf "%s: " label;
-  match decode json with
-  | _ -> Stdlib.print_endline "accepted"
-  | exception _ -> Stdlib.print_endline "rejected"
-;;
-
 let print_decoded label decode encode json =
   Stdlib.Printf.printf "%s:\n" label;
   decode json |> encode |> print_json
@@ -44,24 +37,32 @@ let%expect_test "document filter wire contract" =
 ;;
 
 let%expect_test "notebook sync wire contract" =
-  print_json (NotebookDocumentSyncOptions.yojson_of_t ());
-  check_decode
+  print_json
+    (NotebookDocumentSyncOptions.yojson_of_t
+       (NotebookDocumentSyncOptions.create ~notebookSelector:[] ()));
+  print_decoded
     "sync options"
     NotebookDocumentSyncOptions.t_of_yojson
+    NotebookDocumentSyncOptions.yojson_of_t
     (`Assoc [ "notebookSelector", `List [] ]);
-  check_decode
+  print_decoded
     "registration options"
     NotebookDocumentSyncRegistrationOptions.t_of_yojson
+    NotebookDocumentSyncRegistrationOptions.yojson_of_t
     (`Assoc [ "id", `String "notebook-registration"; "notebookSelector", `List [] ]);
-  check_decode
+  print_decoded
     "notebook filter"
     NotebookDocumentFilter.t_of_yojson
+    NotebookDocumentFilter.yojson_of_t
     (`Assoc [ "notebookType", `String "jupyter-notebook" ]);
   [%expect
     {|
-    null
-    sync options: rejected
-    registration options: rejected
-    notebook filter: rejected
+    { "notebookSelector": [] }
+    sync options:
+    { "notebookSelector": [] }
+    registration options:
+    { "id": "notebook-registration", "notebookSelector": [] }
+    notebook filter:
+    { "notebookType": "jupyter-notebook" }
     |}]
 ;;


### PR DESCRIPTION
Remove the notebook synchronization declarations from the generator skip list and replace their handwritten `unit` placeholders with the LSP 3.18 metamodel-generated contracts. Valid notebook filters, synchronization options, and registration options now decode and round-trip instead of encoding as `null` or being rejected.

This completes the notebook-contract portion of #1996. It corrects the public `lsp` data model and JSON representation; it does not add notebook handling to ocamllsp itself.
