### PR TITLE
test(selection-range): expose non-enclosing recovery range

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/selection_range.ml
+++ b/ocaml-lsp-server/test/e2e-new/selection_range.ml
@@ -232,6 +232,21 @@ let%expect_test "comment-only document without a trailing newline" =
     |}]
 ;;
 
+let%expect_test "selection range does not contain the requested position during recovery" =
+  test "\nx" [ Position.create ~line:1 ~character:1 ];
+  [%expect
+    {|
+    [
+      [
+        {
+          "end": { "character": 0, "line": 1 },
+          "start": { "character": 0, "line": 0 }
+        }
+      ]
+    ]
+    |}]
+;;
+
 let%expect_test "returns a reasonable selection range in the presence of syntax errors" =
   let source =
     {ocaml|module M = struct


### PR DESCRIPTION
Add a regression for a recovery case where `textDocument/selectionRange` returns a range ending at `(1, 0)` for a request at `(1, 1)`. The snapshot records the current non-enclosing result without changing server behavior.

A follow-up fix will discard recovered ranges that do not contain the requested position and return a cursor fallback when none remain.
