### PR TITLE
fix(code-actions): reject extraction of scoped constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Suppress function extraction when a constructor would move out of scope or
+  resolve to a shadowing declaration. (#2169, @rgrinberg)
 - Exclude symbol declarations from reference results when requested by the
   client. (#2164, @rgrinberg)
 - Convert related locations parsed from Merlin diagnostic messages to zero-based

--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -132,6 +132,40 @@ let must_pass expr env =
   |> List.map ~f:fst
 ;;
 
+let constructors_available (expr : Typedtree.expression) destination_env =
+  let module I = Ocaml_typing.Tast_iterator in
+  let exception Unavailable in
+  let resolves_to env lid uid =
+    match Env.find_constructor_by_name lid env with
+    | constructor -> Types.Uid.equal uid constructor.cstr_uid
+    | exception Not_found -> false
+  in
+  let check lid uid =
+    (* If this constructor does not resolve before entering the selected expression,
+       its scope is contained in the expression and moves with it. *)
+    if resolves_to expr.exp_env lid uid && not (resolves_to destination_env lid uid)
+    then raise_notrace Unavailable
+  in
+  let expr_iter (iter : I.iterator) (expr : Typedtree.expression) =
+    (match expr.exp_desc with
+     | Texp_construct (lid, constructor, _) -> check lid.txt constructor.cstr_uid
+     | _ -> ());
+    I.default_iterator.expr iter expr
+  in
+  let pat_iter (type k) (iter : I.iterator) (pat : k Typedtree.general_pattern) =
+    (match pat.pat_desc with
+     | Tpat_construct (lid, constructor, _, _) -> check lid.txt constructor.cstr_uid
+     | _ -> ());
+    I.default_iterator.pat iter pat
+  in
+  let iterator = { I.default_iterator with expr = expr_iter; pat = pat_iter } in
+  try
+    iterator.expr iterator expr;
+    true
+  with
+  | Unavailable -> false
+;;
+
 let extract_local doc typedtree range =
   let* to_extract = largest_enclosed_expression typedtree range in
   let* extract_range = Range.of_loc_opt to_extract.exp_loc in
@@ -150,6 +184,7 @@ let extract_function doc typedtree range =
   let* to_extract = largest_enclosed_expression typedtree range in
   let* extract_range = Range.of_loc_opt to_extract.exp_loc in
   let* parent_item = enclosing_structure_item typedtree range in
+  let* () = Option.some_if (constructors_available to_extract parent_item.str_env) () in
   let* edit_pos = Position.of_lexical_position parent_item.str_loc.loc_start in
   let new_name = "fun_name" in
   let* args_str =

--- a/ocaml-lsp-server/test/e2e-new/action_extract.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_extract.ml
@@ -71,21 +71,14 @@ let f x =
   [%expect {||}]
 ;;
 
-(* TODO: This extraction shouldn't be allowed. *)
-let%expect_test "extract function with local exception" =
+let%expect_test "does not extract a function that uses a local exception" =
   extract_function_test
     {|
 let f x =
   let exception Local in
   $raise Local$
 |};
-  [%expect
-    {|
-    let fun_name () = raise Local
-
-    let f x =
-      let exception Local in
-      fun_name () |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "extract function with local exception in a pattern" =
@@ -95,14 +88,7 @@ let f x =
   let exception Local in
   $match x with Local -> true | _ -> false$
 |};
-  [%expect
-    {|
-    let fun_name x = match x with Local -> true | _ -> false
-
-    let f x =
-      let exception Local in
-      fun_name x
-    |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "extract function with a self-contained local exception" =
@@ -128,15 +114,7 @@ let f () =
   let exception Local in
   $raise Local$
 |};
-  [%expect
-    {|
-    exception Local
-    let fun_name () = raise Local
-
-    let f () =
-      let exception Local in
-      fun_name ()
-    |}]
+  [%expect {| |}]
 ;;
 
 let%expect_test "extract function with shadowed parameter" =


### PR DESCRIPTION
Function extraction can move constructor references outside their scope, producing invalid code or changing meaning when a local constructor shadows another declaration.

Check constructor references in expressions and patterns against the selection and destination environments. Extraction is suppressed unless each free constructor resolves to the same UID at the destination; constructor scopes contained entirely within the selection remain supported.

Follows the regression coverage added in #2167.
