### PR TITLE
test(e2e): share marked-source edit helpers

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -64,81 +64,27 @@ let find_action action_name action =
 
 let find_annotate_action action = find_action "type-annotate" action
 let find_remove_annotation_action action = find_action "remove type annotation" action
+let parse_selection = Test.parse_selection
 
-let position_of_offset src target =
-  assert (0 <= target && target < String.length src);
-  let rec loop offset line character =
-    if offset = target
-    then Position.create ~line ~character
-    else (
-      let decoded = Stdlib.String.get_utf_8_uchar src offset in
-      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
-      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
-      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
-      assert (offset + byte_length <= target);
-      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
-      then loop (offset + byte_length) (line + 1) 0
-      else
-        loop
-          (offset + byte_length)
-          line
-          (character + (Stdlib.Uchar.utf_16_byte_length uchar / 2)))
-  in
-  loop 0 0 0
-;;
-
-let parse_selection src =
-  let start_pos =
-    match String.index src '$' with
-    | Some x -> x
-    | None -> failwith "expected a selection opening mark"
-  in
-  let end_pos =
-    match String.index_from src (start_pos + 1) '$' with
-    | Some x ->
-      if Option.is_some (String.index_from src (x + 1) '$')
-      then failwith "unexpected third selection mark";
-      x - 1 (* account for opening mark *)
-    | None -> start_pos
-  in
-  let start = position_of_offset src start_pos in
-  let end_ = position_of_offset src end_pos in
-  let src' =
-    String.filter_map src ~f:(function
-      | '$' -> None
-      | c -> Some c)
-  in
-  src', Range.create ~start ~end_
-;;
-
-let apply_code_action ?diagnostics title source range =
+let apply_code_action ?prep ?path ?diagnostics title source range =
   let open Option.O in
   (* collect code action results *)
   let code_actions = ref None in
-  iter_code_actions ?diagnostics ~source range (fun ca -> code_actions := Some ca);
+  iter_code_actions ?prep ?path ?diagnostics ~source range (fun ca ->
+    code_actions := Some ca);
   let* m_code_actions = !code_actions in
   let* code_actions = m_code_actions in
-  let* edit =
+  let+ edit =
     List.find_map code_actions ~f:(function
       | `CodeAction { title = t; edit = Some edit; _ } when t = title -> Some edit
       | _ -> None)
   in
-  let+ changes = edit.documentChanges in
-  List.concat_map changes ~f:(function
-    | `TextDocumentEdit x ->
-      List.map x.edits ~f:(function
-        | `AnnotatedTextEdit (a : AnnotatedTextEdit.t) ->
-          TextEdit.create ~newText:a.newText ~range:a.range
-        | `SnippetTextEdit (s : SnippetTextEdit.t) ->
-          TextEdit.create ~newText:s.snippet.value ~range:s.range
-        | `TextEdit e -> e)
-    | `CreateFile _ | `DeleteFile _ | `RenameFile _ -> [])
-  |> Test.apply_edits source
+  Test.apply_workspace_edit source edit
 ;;
 
-let code_action_test ?(print_none = false) ~title source =
+let code_action_test ?prep ?path ?diagnostics ?(print_none = false) ~title source =
   let src, range = parse_selection source in
-  match apply_code_action title src range with
+  match apply_code_action ?prep ?path ?diagnostics title src range with
   | None -> if print_none then print_endline "None"
   | Some result -> print_string result
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -48,7 +48,9 @@ val find_remove_annotation_action
 val parse_selection : string -> string * Range.t
 
 val apply_code_action
-  :  ?diagnostics:Diagnostic.t list
+  :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
+  -> ?path:string
+  -> ?diagnostics:Diagnostic.t list
   -> string
   -> string
   -> Range.t
@@ -57,4 +59,11 @@ val apply_code_action
 (** [code_action_test title source] runs the code action with title [title] and
     prints the resulting source. When [print_none] is set, it explicitly prints
     when the action is unavailable. *)
-val code_action_test : ?print_none:bool -> title:string -> string -> unit
+val code_action_test
+  :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
+  -> ?path:string
+  -> ?diagnostics:Diagnostic.t list
+  -> ?print_none:bool
+  -> title:string
+  -> string
+  -> unit

--- a/ocaml-lsp-server/test/e2e-new/test.ml
+++ b/ocaml-lsp-server/test/e2e-new/test.ml
@@ -317,6 +317,52 @@ let open_document ?(language_id = "ocaml") ~client ~uri ~source () =
     (TextDocumentDidOpen (DidOpenTextDocumentParams.create ~textDocument))
 ;;
 
+let position_of_offset src target =
+  assert (0 <= target && target <= String.length src);
+  let rec loop offset line character =
+    if offset = target
+    then Position.create ~line ~character
+    else (
+      let decoded = Stdlib.String.get_utf_8_uchar src offset in
+      assert (Stdlib.Uchar.utf_decode_is_valid decoded);
+      let uchar = Stdlib.Uchar.utf_decode_uchar decoded in
+      let byte_length = Stdlib.Uchar.utf_decode_length decoded in
+      assert (offset + byte_length <= target);
+      if Stdlib.Uchar.equal uchar (Stdlib.Uchar.of_char '\n')
+      then loop (offset + byte_length) (line + 1) 0
+      else
+        loop
+          (offset + byte_length)
+          line
+          (character + (Stdlib.Uchar.utf_16_byte_length uchar / 2)))
+  in
+  loop 0 0 0
+;;
+
+let parse_selection src =
+  let start_pos =
+    match String.index src '$' with
+    | Some x -> x
+    | None -> failwith "expected a selection opening mark"
+  in
+  let end_pos =
+    match String.index_from src (start_pos + 1) '$' with
+    | Some x ->
+      if Option.is_some (String.index_from src (x + 1) '$')
+      then failwith "unexpected third selection mark";
+      x - 1 (* account for opening mark *)
+    | None -> start_pos
+  in
+  let src' =
+    String.filter_map src ~f:(function
+      | '$' -> None
+      | c -> Some c)
+  in
+  let start = position_of_offset src' start_pos in
+  let end_ = position_of_offset src' end_pos in
+  src', Range.create ~start ~end_
+;;
+
 let offset_of_position src (pos : Position.t) =
   let line_offset =
     String.split_lines src
@@ -352,6 +398,25 @@ let apply_edits src edits =
   (* apply edits *)
   List.fold_left edits ~init:src ~f:(fun src (new_text, start, end_) ->
     String.prefix src start ^ new_text ^ String.drop_prefix src end_)
+;;
+
+let apply_workspace_edit source (edit : WorkspaceEdit.t) =
+  let text_edits =
+    match edit.changes, edit.documentChanges with
+    | Some [ (_, edits) ], None -> edits
+    | None, Some [ `TextDocumentEdit { edits; _ } ] ->
+      List.map edits ~f:(function
+        | `TextEdit edit -> edit
+        | `AnnotatedTextEdit (edit : AnnotatedTextEdit.t) ->
+          TextEdit.create ~newText:edit.newText ~range:edit.range
+        | `SnippetTextEdit (edit : SnippetTextEdit.t) ->
+          TextEdit.create ~newText:edit.snippet.value ~range:edit.range)
+    | Some _, Some _ -> failwith "workspace edit contains both edit representations"
+    | Some _, None | None, Some _ ->
+      failwith "expected workspace edits for exactly one document"
+    | None, None -> failwith "workspace edit contains no edits"
+  in
+  apply_edits source text_edits
 ;;
 
 let print_result result =


### PR DESCRIPTION
Centralize marked-selection parsing and source rendering for E2E tests so request tests can show both where an action is invoked and the resulting document.

The workspace-edit helper supports the two LSP representations used by single-document tests: `changes` and `documentChanges`, including annotated and snippet edits. It intentionally rejects multi-document and resource-operation shapes, which should remain protocol-level assertions.

Marker positions are now computed after removing the marker bytes, avoiding a one-column-short endpoint for multiline selections.
