### PR TITLE
test(code-actions): render destruct edits as source

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -2,6 +2,14 @@ open Test.Import
 open Lsp_helpers
 open Code_actions
 
+let destruct = code_action_test ~print_none:true ~title:"Destruct (enumerate cases)"
+
+let destruct_line =
+  code_action_test
+    ~print_none:true
+    ~title:"Destruct-line (enumerate cases, use existing match)"
+;;
+
 let rec censor_backtraces = function
   | `Assoc fields ->
     `Assoc
@@ -65,195 +73,78 @@ let%expect_test "destruct-line rejects a cross-line recovery location" =
 ;;
 
 let%expect_test "can destruct sum types" =
-  let source =
+  destruct
     {ocaml|
 type t = Foo of int | Bar of bool
-let f (x : t) = x
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:16 ~end_line:2 ~end_character:17 in
-  print_code_actions source range ~filter:(find_action "destruct (enumerate cases)");
+let f (x : t) = $x$
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match x with | Foo _ -> _ | Bar _ -> _",
-                "range": {
-                  "end": { "character": 17, "line": 2 },
-                  "start": { "character": 16, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct (enumerate cases)",
-      "title": "Destruct (enumerate cases)"
-    }
+    type t = Foo of int | Bar of bool
+    let f (x : t) = match x with | Foo _ -> _ | Bar _ -> _
     |}]
 ;;
 
 let%expect_test "can destruct match line" =
-  let source =
+  destruct_line
     {ocaml|
 let f (x:bool) =
-  match x
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:5 ~end_line:2 ~end_character:5 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  mat$ch x
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match x with\n  | false -> _\n  | true -> _",
-                "range": {
-                  "end": { "character": 9, "line": 2 },
-                  "start": { "character": 2, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    let f (x:bool) =
+      match x with
+      | false -> _
+      | true -> _
     |}]
 ;;
 
 let%expect_test "destruct-line is available on a whole inline match expression" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
-let x = match A with
-  | A -> _
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:8 ~end_line:3 ~end_character:10 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let x = $match A with
+  | A -> _$
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n  | B -> _\n  | C -> _",
-                "range": {
-                  "end": { "character": 10, "line": 3 },
-                  "start": { "character": 10, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    let x = match A with
+      | A -> _
+      | B -> _
+      | C -> _
     |}]
 ;;
 
 let%expect_test "destruct-line is available when a match case is on the same line" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
-let x = match A with | A -> _
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let x = $match$ A with | A -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n                     | B -> _\n                     | C -> _",
-                "range": {
-                  "end": { "character": 29, "line": 2 },
-                  "start": { "character": 29, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    let x = match A with | A -> _
+                         | B -> _
+                         | C -> _
     |}]
 ;;
 
 let%expect_test "destruct-line expands an inline match without cases" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
-let x = match A with
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let x = $match$ A with
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match A with\n        | A -> _\n        | B -> _\n        | C -> _",
-                "range": {
-                  "end": { "character": 20, "line": 2 },
-                  "start": { "character": 8, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    let x = match A with
+            | A -> _
+            | B -> _
+            | C -> _
     |}]
 ;;
 
@@ -294,123 +185,53 @@ let x = match A with
 ;;
 
 let%expect_test "destruct-line finds a case after a record update" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
 type r = { value : t }
-let f r = match { r with value = A }.value with | A -> _
-|ocaml}
-  in
-  let range = range ~start_line:3 ~start_character:10 ~end_line:3 ~end_character:15 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let f r = $match$ { r with value = A }.value with | A -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n                                                | B -> _\n                                                | C -> _",
-                "range": {
-                  "end": { "character": 56, "line": 3 },
-                  "start": { "character": 56, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    type r = { value : t }
+    let f r = match { r with value = A }.value with | A -> _
+                                                    | B -> _
+                                                    | C -> _
     |}]
 ;;
 
 let%expect_test "destruct-line finds the outer case of a nested match" =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
-let x = match (match A with | A -> B | B -> C | C -> A) with | A -> _
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:8 ~end_line:2 ~end_character:13 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let x = $match$ (match A with | A -> B | B -> C | C -> A) with | A -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n                                                             | B -> _\n                                                             | C -> _",
-                "range": {
-                  "end": { "character": 69, "line": 2 },
-                  "start": { "character": 69, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    let x = match (match A with | A -> B | B -> C | C -> A) with | A -> _
+                                                                 | B -> _
+                                                                 | C -> _
     |}]
 ;;
 
 let%expect_test
     "destruct-line finds the outer case of a nested match containing a record update"
   =
-  let source =
+  destruct_line
     {ocaml|
 type t = A | B | C
 type r = { value : t }
-let f r = match (match { r with value = A } with | A -> B | B -> C | C -> A) with | C -> _
-|ocaml}
-  in
-  let range = range ~start_line:3 ~start_character:10 ~end_line:3 ~end_character:15 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+let f r = $match$ (match { r with value = A } with | A -> B | B -> C | C -> A) with | C -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n                                                                                  | A -> _\n                                                                                  | B -> _",
-                "range": {
-                  "end": { "character": 90, "line": 3 },
-                  "start": { "character": 90, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type t = A | B | C
+    type r = { value : t }
+    let f r = match (match { r with value = A } with | A -> B | B -> C | C -> A) with | C -> _
+                                                                                      | A -> _
+                                                                                      | B -> _
     |}]
 ;;
 
@@ -486,45 +307,20 @@ let f (a : bool) =
 ;;
 
 let%expect_test "can destruct match-with line" =
-  let source =
+  destruct_line
     {ocaml|
-    match (Ok 0) with
-|ocaml}
-  in
-  let range = range ~start_line:1 ~start_character:0 ~end_line:1 ~end_character:0 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+$    match (Ok 0) with
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match Ok 0 with\n    | Ok _ -> _\n    | Error _ -> _",
-                "range": {
-                  "end": { "character": 21, "line": 1 },
-                  "start": { "character": 4, "line": 1 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    match Ok 0 with
+    | Ok _ -> _
+    | Error _ -> _
     |}]
 ;;
 
 let%expect_test "can destruct case line" =
-  let source =
+  destruct_line
     {ocaml|
 type q =
 | A
@@ -533,83 +329,42 @@ type q =
 | D
 let f (x: q) =
   match x with
-  | C -> _
-|ocaml}
-  in
-  let range = range ~start_line:8 ~start_character:0 ~end_line:8 ~end_character:0 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+$  | C -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "\n  | A -> _\n  | B -> _\n  | D -> _",
-                "range": {
-                  "end": { "character": 10, "line": 8 },
-                  "start": { "character": 10, "line": 8 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type q =
+    | A
+    | B
+    | C
+    | D
+    let f (x: q) =
+      match x with
+      | C -> _
+      | A -> _
+      | B -> _
+      | D -> _
     |}]
 ;;
 
 let%expect_test "can destruct hole" =
-  let source =
+  destruct_line
     {ocaml|
 let zip (type a b) (xs : a list) (ys : b list) : (a * b) list =
   match (xs, ys) with
-  | (_, _) -> _
-|ocaml}
-  in
-  let range = range ~start_line:3 ~start_character:5 ~end_line:3 ~end_character:5 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  | ($_, _) -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "([], _) -> _\n  | (_::_, _)",
-                "range": {
-                  "end": { "character": 10, "line": 3 },
-                  "start": { "character": 4, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    let zip (type a b) (xs : a list) (ys : b list) : (a * b) list =
+      match (xs, ys) with
+      | ([], _) -> _
+      | (_::_, _) -> _
     |}]
 ;;
 
 let%expect_test "destruct hole spacing" =
-  let source =
+  destruct_line
     {ocaml|
 type q =
 | A
@@ -618,43 +373,26 @@ type q =
 | D
 let f (x: q) =
   match x with
-  | _ -> _
-|ocaml}
-  in
-  let range = range ~start_line:8 ~start_character:5 ~end_line:8 ~end_character:5 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  | _$ -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "A -> _\n  | B -> _\n  | C -> _\n  | D",
-                "range": {
-                  "end": { "character": 5, "line": 8 },
-                  "start": { "character": 4, "line": 8 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type q =
+    | A
+    | B
+    | C
+    | D
+    let f (x: q) =
+      match x with
+      | A -> _
+      | B -> _
+      | C -> _
+      | D -> _
     |}]
 ;;
 
 let%expect_test "destruct a case with a hole but not on the hole" =
-  let source =
+  destruct_line
     {ocaml|
 type q =
 | A
@@ -663,43 +401,26 @@ type q =
 | D
 let f (x: q) =
   match x with
-  | _ -> _
-|ocaml}
-  in
-  let range = range ~start_line:8 ~start_character:2 ~end_line:8 ~end_character:2 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  $| _ -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "A -> _\n  | B -> _\n  | C -> _\n  | D",
-                "range": {
-                  "end": { "character": 5, "line": 8 },
-                  "start": { "character": 4, "line": 8 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct-line (enumerate cases, use existing match)",
-      "title": "Destruct-line (enumerate cases, use existing match)"
-    }
+    type q =
+    | A
+    | B
+    | C
+    | D
+    let f (x: q) =
+      match x with
+      | A -> _
+      | B -> _
+      | C -> _
+      | D -> _
     |}]
 ;;
 
 let%expect_test "destruct uses the right number of newlines" =
-  let source =
+  destruct_line
     {ocaml|
 type t =
   | Very_long_name_for_for_the_first_case_so_that_merlin_will_use_multiple_lines
@@ -707,43 +428,25 @@ type t =
   | Another_long_name_for_for_the_third_case
 ;;
 let f (x: t) =
-  match x with
-  |ocaml}
-  in
-  let range = range ~start_line:7 ~start_character:7 ~end_line:7 ~end_character:7 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  match$ x with
+  |ocaml};
   [%expect
     {|
-      Code actions:
-      {
-        "edit": {
-          "documentChanges": [
-            {
-              "edits": [
-                {
-                  "newText": "match x with\n  | Very_long_name_for_for_the_first_case_so_that_merlin_will_use_multiple_lines -> _\n  | Almost_as_long_name_for_for_the_second_case -> _\n  | Another_long_name_for_for_the_third_case -> _",
-                  "range": {
-                    "end": { "character": 14, "line": 7 },
-                    "start": { "character": 2, "line": 7 }
-                  }
-                }
-              ],
-              "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-            }
-          ]
-        },
-        "isPreferred": false,
-        "kind": "destruct-line (enumerate cases, use existing match)",
-        "title": "Destruct-line (enumerate cases, use existing match)"
-      }
-      |}]
+    type t =
+      | Very_long_name_for_for_the_first_case_so_that_merlin_will_use_multiple_lines
+      | Almost_as_long_name_for_for_the_second_case
+      | Another_long_name_for_for_the_third_case
+    ;;
+    let f (x: t) =
+      match x with
+      | Very_long_name_for_for_the_first_case_so_that_merlin_will_use_multiple_lines -> _
+      | Almost_as_long_name_for_for_the_second_case -> _
+      | Another_long_name_for_for_the_third_case -> _
+    |}]
 ;;
 
 let%expect_test "destruct strips parentheses even on long lines" =
-  let source =
+  destruct_line
     {ocaml|
 type q =
   | Very_long_name_for_for_the_first_case_so_that_merlin_will_be_forced_to_use_multiple_lines
@@ -753,113 +456,56 @@ type q =
 ;;
 let f (x: q) =
   match x with
-  | Almost_as_long_name_for_for_the_second_case -> _
-|ocaml}
-  in
-  let range = range ~start_line:9 ~start_character:22 ~end_line:9 ~end_character:22 in
-  print_code_actions
-    source
-    range
-    ~filter:(find_action "destruct-line (enumerate cases, use existing match)");
+  | Almost_as_long_nam$e_for_for_the_second_case -> _
+|ocaml};
   [%expect
     {|
-      Code actions:
-      {
-        "edit": {
-          "documentChanges": [
-            {
-              "edits": [
-                {
-                  "newText": "\n  | Very_long_name_for_for_the_first_case_so_that_merlin_will_be_forced_to_use_multiple_lines -> _\n  | Another_long_name_for_for_the_third_case -> _\n  | Very_long_name_for_for_the_last_case_so_that_we_can_make_sure_we_handle_both_parens_and_line_breaks\n     _ -> _",
-                  "range": {
-                    "end": { "character": 52, "line": 9 },
-                    "start": { "character": 52, "line": 9 }
-                  }
-                }
-              ],
-              "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-            }
-          ]
-        },
-        "isPreferred": false,
-        "kind": "destruct-line (enumerate cases, use existing match)",
-        "title": "Destruct-line (enumerate cases, use existing match)"
-      }
-      |}]
+    type q =
+      | Very_long_name_for_for_the_first_case_so_that_merlin_will_be_forced_to_use_multiple_lines
+      | Almost_as_long_name_for_for_the_second_case
+      | Another_long_name_for_for_the_third_case
+      | Very_long_name_for_for_the_last_case_so_that_we_can_make_sure_we_handle_both_parens_and_line_breaks of int
+    ;;
+    let f (x: q) =
+      match x with
+      | Almost_as_long_name_for_for_the_second_case -> _
+      | Very_long_name_for_for_the_first_case_so_that_merlin_will_be_forced_to_use_multiple_lines -> _
+      | Another_long_name_for_for_the_third_case -> _
+      | Very_long_name_for_for_the_last_case_so_that_we_can_make_sure_we_handle_both_parens_and_line_breaks
+         _ -> _
+    |}]
 ;;
 
 let%expect_test "can destruct on sub-expression" =
-  let source =
+  destruct
     {ocaml|
 let defered_peek x = if x >= 0 then Some (`Foo x) else None
 let job_reader = 10
 
-let _ = defered_peek job_reader
-|ocaml}
-  in
-  let range = range ~start_line:4 ~start_character:8 ~end_line:4 ~end_character:31 in
-  print_code_actions source range ~filter:(find_action "destruct (enumerate cases)");
+let _ = $defered_peek job_reader$
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "match defered_peek job_reader with | None -> _ | Some _ -> _",
-                "range": {
-                  "end": { "character": 31, "line": 4 },
-                  "start": { "character": 8, "line": 4 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct (enumerate cases)",
-      "title": "Destruct (enumerate cases)"
-    }
+    let defered_peek x = if x >= 0 then Some (`Foo x) else None
+    let job_reader = 10
+
+    let _ = match defered_peek job_reader with | None -> _ | Some _ -> _
     |}]
 ;;
 
 let%expect_test "can destruct on sub-expression that need parenthesis" =
-  let source =
+  destruct
     {ocaml|
 let defered_peek x = if x >= 0 then Some (`Foo x) else None
 let job_reader = 10
 
-let _ = defered_peek job_reader
-|ocaml}
-  in
-  let range = range ~start_line:4 ~start_character:21 ~end_line:4 ~end_character:31 in
-  print_code_actions source range ~filter:(find_action "destruct (enumerate cases)");
+let _ = defered_peek $job_reader$
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "(match job_reader with | 0 -> _ | _ -> _)",
-                "range": {
-                  "end": { "character": 31, "line": 4 },
-                  "start": { "character": 21, "line": 4 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "destruct (enumerate cases)",
-      "title": "Destruct (enumerate cases)"
-    }
+    let defered_peek x = if x >= 0 then Some (`Foo x) else None
+    let job_reader = 10
+
+    let _ = defered_peek (match job_reader with | 0 -> _ | _ -> _)
     |}]
 ;;


### PR DESCRIPTION
Render successful destruct actions as transformed source with their requested selections marked inline. The expectations now show inserted cases, indentation, parentheses, and multiline placement in context rather than as serialized edits.

The UTF-16 regression remains a raw action snapshot because its exact wire range is the behavior under test. Error and unavailable-action cases also remain structural.
