### PR TITLE
test(code-actions): render interface edits as source

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_interface.ml
@@ -11,38 +11,18 @@ let f (x : t) = x
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source = "" in
-  let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "inferred_intf");
+    ~print_none:true
+    ~title:"Insert inferred interface"
+    {ocaml|$|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "type t = Foo of int | Bar of bool\n\nval f : t -> t\n",
-                "range": {
-                  "end": { "character": 0, "line": 0 },
-                  "start": { "character": 0, "line": 0 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "inferred_intf",
-      "title": "Insert inferred interface"
-    } |}]
+    type t = Foo of int | Bar of bool
+
+    val f : t -> t
+    |}]
 ;;
 
 let%expect_test "inferred interface excludes existing names" =
@@ -54,42 +34,19 @@ let f (x : t) = x
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
-    {ocaml|
-val f : t -> t
-|ocaml}
-  in
-  let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "inferred_intf");
+    ~print_none:true
+    ~title:"Insert inferred interface"
+    {ocaml|$
+val f : t -> t
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "type t = Foo of int | Bar of bool\n",
-                "range": {
-                  "end": { "character": 0, "line": 0 },
-                  "start": { "character": 0, "line": 0 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "inferred_intf",
-      "title": "Insert inferred interface"
-    }
+    type t = Foo of int | Bar of bool
+
+    val f : t -> t
     |}]
 ;;
 
@@ -130,43 +87,19 @@ let f (x : t) (d : bool) =
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
-    {ocaml|
-type t = Foo of int | Bar of bool
-val f : t -> bool
-|ocaml}
-  in
-  let range = range ~start_line:2 ~start_character:0 ~end_line:2 ~end_character:0 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "update_intf");
+    ~print_none:true
+    ~title:"Update signature(s) to match implementation"
+    {ocaml|
+type t = Foo of int | Bar of bool
+$val f : t -> bool
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "val f : t -> bool -> bool\n",
-                "range": {
-                  "end": { "character": 17, "line": 2 },
-                  "start": { "character": 0, "line": 2 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "update_intf",
-      "title": "Update signature(s) to match implementation"
-    }
+    type t = Foo of int | Bar of bool
+    val f : t -> bool -> bool
     |}]
 ;;
 
@@ -179,43 +112,15 @@ let f i s b =
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
-    {ocaml|
-val f : int -> string -> 'a list -> bool -> bool
-|ocaml}
-  in
-  let range = range ~start_line:1 ~start_character:10 ~end_line:1 ~end_character:10 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "update_intf");
-  [%expect
-    {|
-  Code actions:
-  {
-    "edit": {
-      "documentChanges": [
-        {
-          "edits": [
-            {
-              "newText": "val f : int -> string -> bool -> bool\n",
-              "range": {
-                "end": { "character": 48, "line": 1 },
-                "start": { "character": 0, "line": 1 }
-              }
-            }
-          ],
-          "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-        }
-      ]
-    },
-    "isPreferred": false,
-    "kind": "update_intf",
-    "title": "Update signature(s) to match implementation"
-  }
-  |}]
+    ~print_none:true
+    ~title:"Update signature(s) to match implementation"
+    {ocaml|
+val f : in$t -> string -> 'a list -> bool -> bool
+|ocaml};
+  [%expect {| val f : int -> string -> bool -> bool |}]
 ;;
 
 let%expect_test "update-signatures updates parameter types" =
@@ -227,43 +132,15 @@ let f i s l b =
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
-    {ocaml|
-val f : int -> string -> 'a list -> bool -> bool
-|ocaml}
-  in
-  let range = range ~start_line:1 ~start_character:1 ~end_line:1 ~end_character:12 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "update_intf");
-  [%expect
-    {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "val f : int -> 'a list -> 'b list -> bool -> bool\n",
-                "range": {
-                  "end": { "character": 48, "line": 1 },
-                  "start": { "character": 0, "line": 1 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "update_intf",
-      "title": "Update signature(s) to match implementation"
-    }
-    |}]
+    ~print_none:true
+    ~title:"Update signature(s) to match implementation"
+    {ocaml|
+v$al f : int $-> string -> 'a list -> bool -> bool
+|ocaml};
+  [%expect {| val f : int -> 'a list -> 'b list -> bool -> bool |}]
 ;;
 
 let%expect_test "update-signatures preserves functions and their comments" =
@@ -278,9 +155,13 @@ let h x = x *. 2.0;;
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
+  code_action_test
+    ~prep
+    ~path:"foo.mli"
+    ~print_none:true
+    ~title:"Update signature(s) to match implementation"
     {ocaml|
-val f :
+$val f :
     int  (* This comment should stay. *)
     -> int
 
@@ -289,47 +170,23 @@ val g : int
     -> int
 
 (* This comment should stay even though the function changes. *)
-val h : int -> bool
-|ocaml}
-  in
-  let range = range ~start_line:1 ~start_character:0 ~end_line:10 ~end_character:19 in
-  print_code_actions
-    intf_source
-    range
-    ~prep
-    ~path:"foo.mli"
-    ~filter:(find_action "update_intf");
+val h : int -> bool$
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "val g :\n  int ->\n  int ->\n  int ->\n  another_arg:int -> yet_another_arg:int -> keep_them_coming:int -> int\n",
-                "range": {
-                  "end": { "character": 10, "line": 7 },
-                  "start": { "character": 0, "line": 5 }
-                }
-              },
-              {
-                "newText": "val h : float -> float\n",
-                "range": {
-                  "end": { "character": 19, "line": 10 },
-                  "start": { "character": 0, "line": 10 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "update_intf",
-      "title": "Update signature(s) to match implementation"
-    }
+    val f :
+        int  (* This comment should stay. *)
+        -> int
+
+    val g :
+      int ->
+      int ->
+      int ->
+      another_arg:int -> yet_another_arg:int -> keep_them_coming:int -> int
+
+
+    (* This comment should stay even though the function changes. *)
+    val h : float -> float
     |}]
 ;;
 
@@ -351,42 +208,21 @@ end
   in
   let uri = DocumentUri.of_path "foo.ml" in
   let prep client = Test.open_document ~client ~uri ~source:impl_source () in
-  let intf_source =
-    {ocaml|
-module M : sig type t = I of int | B of bool end
-|ocaml}
-  in
-  let range = range ~start_line:1 ~start_character:0 ~end_line:1 ~end_character:0 in
-  print_code_actions
-    intf_source
-    range
+  code_action_test
     ~prep
     ~path:"foo.mli"
-    ~filter:(find_action "update_intf");
+    ~print_none:true
+    ~title:"Update signature(s) to match implementation"
+    {ocaml|
+$module M : sig type t = I of int | B of bool end
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "module M :\n  sig\n    type t = I of int | F of float\n    val f : t -> long_name_for_an_integer_argument:int -> int\n  end\n",
-                "range": {
-                  "end": { "character": 48, "line": 1 },
-                  "start": { "character": 0, "line": 1 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.mli", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "update_intf",
-      "title": "Update signature(s) to match implementation"
-    }
+    module M :
+      sig
+        type t = I of int | F of float
+        val f : t -> long_name_for_an_integer_argument:int -> int
+      end
     |}]
 ;;
 
@@ -686,81 +522,43 @@ let%expect_test "shouldn't find the jump target on the same line" =
 ;;
 
 let%expect_test "can combine cases with multiple RHSes" =
-  let source =
+  code_action_test
+    ~print_none:true
+    ~title:"Combine-cases"
     {ocaml|
     match card with
     | Ace -> _
-    | King -> _
+   $ | King -> _
     | Queen -> "Face card!"
     | Jack -> "Face card?"
-    | Number _ -> _
-|ocaml}
-  in
-  let range = range ~start_line:3 ~start_character:3 ~end_line:6 ~end_character:6 in
-  print_code_actions source range ~filter:(find_action "combine-cases");
+    | $Number _ -> _
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "    | King | Queen | Jack | Number _ -> _\n",
-                "range": {
-                  "end": { "character": 0, "line": 7 },
-                  "start": { "character": 0, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "combine-cases",
-      "title": "Combine-cases"
-    }
+    match card with
+    | Ace -> _
+    | King | Queen | Jack | Number _ -> _
     |}]
 ;;
 
 let%expect_test "can combine cases with one unique RHS" =
-  let source =
+  code_action_test
+    ~print_none:true
+    ~title:"Combine-cases"
     {ocaml|
     match card with
     | Ace -> _
-    | King -> _
-    | Queen -> "Face card!"
+   $ | King -> _
+    $| Queen -> "Face card!"
     | Jack -> "Face card?"
     | Number _ -> _
-|ocaml}
-  in
-  let range = range ~start_line:3 ~start_character:3 ~end_line:4 ~end_character:4 in
-  print_code_actions source range ~filter:(find_action "combine-cases");
+|ocaml};
   [%expect
     {|
-    Code actions:
-    {
-      "edit": {
-        "documentChanges": [
-          {
-            "edits": [
-              {
-                "newText": "    | King | Queen -> \"Face card!\"\n",
-                "range": {
-                  "end": { "character": 0, "line": 5 },
-                  "start": { "character": 0, "line": 3 }
-                }
-              }
-            ],
-            "textDocument": { "uri": "file:///foo.ml", "version": 0 }
-          }
-        ]
-      },
-      "isPreferred": false,
-      "kind": "combine-cases",
-      "title": "Combine-cases"
-    }
+    match card with
+    | Ace -> _
+    | King | Queen -> "Face card!"
+    | Jack -> "Face card?"
+    | Number _ -> _
     |}]
 ;;


### PR DESCRIPTION
Render inferred-interface, signature-update, and combine-cases actions as transformed source with their request ranges marked inline. The expectations now show how declarations and adjacent cases change in context instead of requiring readers to apply workspace-edit JSON manually.

Merlin jump actions remain protocol snapshots because their command arguments and target ranges are the behavior under test.
