### PR TITLE
test(formatting): mark ranges and render formatted source

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/range_formatting.ml
+++ b/ocaml-lsp-server/test/e2e-new/range_formatting.ml
@@ -36,60 +36,56 @@ let iter_range_formatting ?language_id source path range =
 ;;
 
 let print_formatting ?language_id source path range =
-  iter_range_formatting ?language_id source path range print_formatting_textedits
+  iter_range_formatting
+    ?language_id
+    source
+    path
+    range
+    (print_formatting_textedits ~source)
 ;;
 
 let%expect_test "can format part of an ocaml impl file" =
-  let source =
-    {ocaml|let () =
-  let rec gcd a b =
+  let source, range =
+    Test.parse_selection
+      {ocaml|let () =
+  $let rec gcd a b =
   match (a, b) with
     | 0, n
     | n, 0 ->
       n
-    | _, _ -> gcd a (b mod a)
+    | _, _ -> gcd a (b mod a)$
   in print_endline (string_of_int (gcd 48 18))
 |ocaml}
-  in
-  let range =
-    (* range selects entire definition of `gcd` *)
-    Range.create
-      ~start:(Position.create ~line:1 ~character:2)
-      ~end_:(Position.create ~line:6 ~character:29)
   in
   let path = Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml" in
   print_formatting source path range;
   [%expect
     {|
-    [
-      {
-        "newText": "    match (a, b) with\n",
-        "range": {
-          "end": { "character": 0, "line": 3 },
-          "start": { "character": 0, "line": 2 }
-        }
-      }
-    ]
+    edit: ((2, 0), (3, 0))
+    result:
+    let () =
+      let rec gcd a b =
+        match (a, b) with
+        | 0, n
+        | n, 0 ->
+          n
+        | _, _ -> gcd a (b mod a)
+      in print_endline (string_of_int (gcd 48 18))
     |}]
 ;;
 
 let%expect_test "leaves formatted snippets alone" =
-  let source =
-    {ocaml|let () =
-  let rec gcd a b =
+  let source, range =
+    Test.parse_selection
+      {ocaml|let () =
+  $let rec gcd a b =
     match (a, b) with
     | 0, n
     | n, 0 ->
       n
-    | _, _ -> gcd a (b mod a)
+    | _, _ -> gcd a (b mod a)$
   in print_endline (string_of_int (gcd 48 18))
 |ocaml}
-  in
-  let range =
-    (* range selects entire definition of `gcd` *)
-    Range.create
-      ~start:(Position.create ~line:1 ~character:2)
-      ~end_:(Position.create ~line:6 ~character:29)
   in
   let path = Filename.concat (setup_ocamlformat ocamlformat_config) "format_me.ml" in
   print_formatting source path range;
@@ -97,25 +93,20 @@ let%expect_test "leaves formatted snippets alone" =
 ;;
 
 let%expect_test "formats semantic actions in ocamllex files" =
-  let source =
-    {ocamllex|{
+  let source, range =
+    Test.parse_selection
+      {ocamllex|{
   type Token = Char of char | Censored | EOF
 }
 
 rule censor = parse
-  | "super secret"  { print_string "redacting input! it's too secretive"; Censored
+  | "super secret"  { $print_string "redacting input! it's too secretive"; Censored$
                     }
   | _ as c          { Char c }
   | eof             { EOF }
 
 {}
 |ocamllex}
-  in
-  let range =
-    (* range is selecting from `p` in `print_string` to `d` in `Censored` *)
-    Range.create
-      ~start:(Position.create ~line:5 ~character:22)
-      ~end_:(Position.create ~line:5 ~character:82)
   in
   let path = Filename.concat (setup_ocamlformat ocamlformat_config) "lexer.mll" in
   print_formatting ~language_id:"ocaml.ocamllex" source path range;
@@ -124,45 +115,46 @@ rule censor = parse
     string would not be split across two lines *)
   [%expect
     {|
-    [
-      {
-        "newText": "  | \"super secret\"  { print_string\n                        \"redacting input! it's too \\\n                         secretive\";\n                      Censored\n",
-        "range": {
-          "end": { "character": 0, "line": 6 },
-          "start": { "character": 0, "line": 5 }
-        }
-      }
-    ]
+    edit: ((5, 0), (6, 0))
+    result:
+    {
+      type Token = Char of char | Censored | EOF
+    }
+
+    rule censor = parse
+      | "super secret"  { print_string
+                            "redacting input! it's too \
+                             secretive";
+                          Censored
+                        }
+      | _ as c          { Char c }
+      | eof             { EOF }
+
+    {}
     |}]
 ;;
 
 let%expect_test "formats semantic actions in menhir files" =
-  let source =
-    {menhir|%token <int> INT
+  let source, range =
+    Test.parse_selection
+      {menhir|%token <int> INT
 %start <int> main
 %%
 main:
-  | value = INT { value+1 }
+  | value = INT { $value+1$ }
 |menhir}
-  in
-  let range =
-    Range.create
-      ~start:(Position.create ~line:4 ~character:18)
-      ~end_:(Position.create ~line:4 ~character:25)
   in
   let path = Filename.concat (setup_ocamlformat ocamlformat_config) "parser.mly" in
   print_formatting ~language_id:"ocaml.menhir" source path range;
   [%expect
     {|
-    [
-      {
-        "newText": "  | value = INT { value + 1 }\n",
-        "range": {
-          "end": { "character": 0, "line": 5 },
-          "start": { "character": 0, "line": 4 }
-        }
-      }
-    ]
+    edit: ((4, 0), (5, 0))
+    result:
+    %token <int> INT
+    %start <int> main
+    %%
+    main:
+      | value = INT { value + 1 }
     |}]
 ;;
 
@@ -186,21 +178,17 @@ let%expect_test "does not range format unsupported documents" =
 ;;
 
 let%expect_test "does not format ignored files" =
-  let source =
-    {ocaml|let () =
-  let rec gcd a b =
+  let source, range =
+    Test.parse_selection
+      {ocaml|let () =
+  $let rec gcd a b =
   match (a, b) with
     | 0, n
     | n, 0 ->
       n
-    | _, _ -> gcd a (b mod a)
+    | _, _ -> gcd a (b mod a)$
   in print_endline (string_of_int (gcd 48 18))
 |ocaml}
-  in
-  let range =
-    Range.create
-      ~start:(Position.create ~line:1 ~character:2)
-      ~end_:(Position.create ~line:6 ~character:29)
   in
   let tmpdir = setup_ocamlformat ocamlformat_config in
   let name = "dont_format_me.ml" in


### PR DESCRIPTION
Replace numeric range construction with inline selection markers in range-formatting tests, then show each compact edit range alongside the resulting source. This makes OCaml, ocamllex, and Menhir formatting effects readable in their surrounding document while retaining minimal-edit coverage.

Unsupported and ignored-document cases remain focused on the absence of a formatting result.
