### PR TITLE
test(code-actions): filter rendered edits by action

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -66,7 +66,15 @@ let find_annotate_action action = find_action "type-annotate" action
 let find_remove_annotation_action action = find_action "remove type annotation" action
 let parse_selection = Test.parse_selection
 
-let apply_code_action ?prep ?path ?diagnostics title source range =
+let apply_code_action
+      ?prep
+      ?path
+      ?diagnostics
+      ?(filter = fun _ -> true)
+      title
+      source
+      range
+  =
   let open Option.O in
   (* collect code action results *)
   let code_actions = ref None in
@@ -75,16 +83,20 @@ let apply_code_action ?prep ?path ?diagnostics title source range =
   let* m_code_actions = !code_actions in
   let* code_actions = m_code_actions in
   let+ edit =
-    List.find_map code_actions ~f:(function
-      | `CodeAction { title = t; edit = Some edit; _ } when t = title -> Some edit
-      | _ -> None)
+    List.find_map code_actions ~f:(fun action ->
+      if not (filter action)
+      then None
+      else (
+        match action with
+        | `CodeAction { title = t; edit = Some edit; _ } when t = title -> Some edit
+        | `CodeAction _ | `Command _ -> None))
   in
   Test.apply_workspace_edit source edit
 ;;
 
-let code_action_test ?prep ?path ?diagnostics ?(print_none = false) ~title source =
+let code_action_test ?prep ?path ?diagnostics ?filter ?(print_none = false) ~title source =
   let src, range = parse_selection source in
-  match apply_code_action ?prep ?path ?diagnostics title src range with
+  match apply_code_action ?prep ?path ?diagnostics ?filter title src range with
   | None -> if print_none then print_endline "None"
   | Some result -> print_string result
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -51,18 +51,20 @@ val apply_code_action
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string
   -> ?diagnostics:Diagnostic.t list
+  -> ?filter:([ `Command of Command.t | `CodeAction of CodeAction.t ] -> bool)
   -> string
   -> string
   -> Range.t
   -> string option
 
 (** [code_action_test title source] runs the code action with title [title] and
-    prints the resulting source. When [print_none] is set, it explicitly prints
-    when the action is unavailable. *)
+    prints the resulting source. [filter] can further identify the intended
+    action, and [print_none] explicitly prints when it is unavailable. *)
 val code_action_test
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string
   -> ?diagnostics:Diagnostic.t list
+  -> ?filter:([ `Command of Command.t | `CodeAction of CodeAction.t ] -> bool)
   -> ?print_none:bool
   -> title:string
   -> string

--- a/ocaml-lsp-server/test/e2e-new/code_actions_quick_fixes.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_quick_fixes.ml
@@ -27,29 +27,22 @@ let diagnostic ?(severity = DiagnosticSeverity.Error) message range =
   Diagnostic.create ~message:(`String message) ~range ~severity ~source:"ocamllsp" ()
 ;;
 
-let print_applied_action ?diagnostics ~title source range =
-  match apply_code_action ~path:"test.ml" ?diagnostics title source range with
+let print_applied_action ?(path = "test.ml") ?diagnostics ?filter ~title source range =
+  match apply_code_action ~path ?diagnostics ?filter title source range with
   | None -> print_endline "None"
   | Some source -> print_string source
-;;
-
-let print_inferred_intf_edits source path range =
-  iter_code_actions ~path ~source range (function
-    | None -> print_endline "No code actions"
-    | Some code_actions ->
-      (match List.find code_actions ~f:(find_action "inferred_intf") with
-       | None -> print_endline "No inferred interface action"
-       | Some (`Command _) -> print_endline "Inferred interface action was a command"
-       | Some (`CodeAction { edit = None; _ }) -> print_endline "No edit"
-       | Some (`CodeAction { edit = Some edit; _ }) ->
-         Test.apply_workspace_edit source edit |> print_string))
 ;;
 
 let%expect_test "opens the implementation if not in store" =
   let dir = setup_inferred_intf_workspace () in
   let path = Filename.concat dir "lib.mli" in
   let range = range ~start_line:0 ~start_character:0 ~end_line:0 ~end_character:0 in
-  print_inferred_intf_edits "" path range;
+  print_applied_action
+    ~path
+    ~filter:(find_action "inferred_intf")
+    ~title:"Insert inferred interface"
+    ""
+    range;
   [%expect {| val x : int |}]
 ;;
 


### PR DESCRIPTION
Allow source-rendering code-action helpers to identify an action with both its title and an optional predicate. This supports cases where the protocol kind is the stable discriminator while preserving title-based behavior for existing callers.

Use the predicate-aware helper for inferred-interface quick fixes, removing duplicated response traversal and workspace-edit application.
