### PR TITLE
fix(dune): clean up disconnected RPC instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+- Clear stale Dune diagnostics and promotion actions when an RPC instance exits,
+  without removing a replacement instance for the same root. (#2189, @rgrinberg)
 - Ensure recovered selection ranges contain the requested position. (#2170,
   @rgrinberg)
 - Suppress function extraction when a constructor would move out of scope or

--- a/ocaml-lsp-server/src/dune.ml
+++ b/ocaml-lsp-server/src/dune.ml
@@ -203,6 +203,7 @@ module Instance : sig
 
   val format_dune_file : t -> Document.Dune.t -> string Fiber.t
   val stop : t -> unit Fiber.t
+  val disconnect : t -> unit Fiber.t
   val run : t -> unit Fiber.t
   val connect : t -> (unit, unit) result Fiber.t
   val source : t -> Registry.Dune.t
@@ -543,6 +544,15 @@ end = struct
       Fiber.return (Ok ())
   ;;
 
+  let disconnect t =
+    match t.state with
+    | Running running ->
+      t.state <- Finished running.promotions;
+      Diagnostics.disconnect t.config.diagnostics running.diagnostics_id;
+      Diagnostics.send t.config.diagnostics `All
+    | Connected _ | Idle | Finished _ -> Fiber.return ()
+  ;;
+
   let run ({ config; source; _ } as t) =
     let* () = Fiber.return () in
     let session, where =
@@ -703,15 +713,13 @@ let run_with_cleanup ~run ~cleanup ~on_error =
       (module Monoid.Unit)
       run
       ~on_error:(fun exn ->
-        let* () = on_error exn in
-        Lazy_fiber.force cleanup)
+        let* () = Lazy_fiber.force cleanup in
+        on_error exn)
   in
   Lazy_fiber.force cleanup
 ;;
 
 let cleanup_instance active (instance : Instance.t) =
-  active.instances
-  <- Map.remove active.instances (Registry.Dune.root (Instance.source instance));
   let to_unregister =
     Instance.promotions instance
     |> Map.data
@@ -719,6 +727,12 @@ let cleanup_instance active (instance : Instance.t) =
       let path = Drpc.Diagnostic.Promotion.in_source promotion in
       Uri.of_path path)
   in
+  let* () = Instance.disconnect instance in
+  let root = Registry.Dune.root (Instance.source instance) in
+  active.instances
+  <- (match Map.find active.instances root with
+      | Some current when current == instance -> Map.remove active.instances root
+      | None | Some _ -> active.instances);
   Document_store.unregister_promotions active.config.document_store to_unregister
 ;;
 

--- a/ocaml-lsp-server/test/dune_tests.ml
+++ b/ocaml-lsp-server/test/dune_tests.ml
@@ -2,7 +2,7 @@ module Dune = Ocaml_lsp_server.For_tests.Dune
 
 let run fiber = Lev_fiber.run (fun () -> fiber) |> Lev_fiber.Error.ok_exn
 
-let%expect_test "cleanup runs after reporting an RPC error" =
+let%expect_test "cleanup runs once before reporting an RPC error" =
   let cleanups = ref 0 in
   run
     (Dune.run_with_cleanup
@@ -16,7 +16,7 @@ let%expect_test "cleanup runs after reporting an RPC error" =
   Printf.printf "total cleanups: %d\n" !cleanups;
   [%expect
     {|
-    cleanups while reporting: 0
+    cleanups while reporting: 1
     total cleanups: 1
     |}]
 ;;


### PR DESCRIPTION
Finalize a running Dune RPC instance before reporting an exceptional exit. Disconnection now clears that instance's diagnostics and promotion registrations, while map removal is guarded by physical identity so a delayed finalizer cannot discard a replacement connection for the same root.

This updates the regression merged in #2165: cleanup is now visible during error reporting and still runs exactly once.
