### PR TITLE
test(code-actions): expose destruct-line separator bugs

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -131,6 +131,43 @@ let f (x:bool) =
     |}]
 ;;
 
+let%expect_test "destruct-line mistakes with in the scrutinee for the separator" =
+  destruct_line
+    {ocaml|
+let f (xwith : bool) =
+  mat$ch xwith
+|ocaml};
+  [%expect
+    {|
+    let f (xwith : bool) =
+      match xwith
+      | with -> _
+      | false -> _
+      | true -> _
+    |}]
+;;
+
+let%expect_test "destruct-line mistakes a package constraint for the match separator" =
+  destruct_line
+    {ocaml|
+type t = A | B
+module type S = sig type u end
+module M : S with type u = int = struct type u = int end
+let f (x : t) =
+  mat$ch (x, (module M : S with type u = int))
+|ocaml};
+  [%expect
+    {|
+    type t = A | B
+    module type S = sig type u end
+    module M : S with type u = int = struct type u = int end
+    let f (x : t) =
+      match (x, ((module M) : (module S with
+      | type u = int))) with -> _
+      | _, _ -> _
+    |}]
+;;
+
 let%expect_test "destruct-line is available on a whole inline match expression" =
   destruct_line
     {ocaml|


### PR DESCRIPTION
Adds end-to-end reproductions for destruct-line selecting the wrong `with` while formatting generated matches.

The snapshots capture the corrupt edits produced when `with` appears inside a scrutinee identifier or package constraint rather than at the outer match separator.
