### PR TITLE
test(code-actions): expose nested or-pattern corruption

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -378,6 +378,25 @@ $  | C -> _
     |}]
 ;;
 
+let%expect_test "destruct-line corrupts a nested or-pattern" =
+  destruct_line
+    {ocaml|
+type t = A | B | C
+let f (x : t) =
+  match (x, true) with
+$  | A, _ -> _
+|ocaml};
+  [%expect
+    {|
+    type t = A | B | C
+    let f (x : t) =
+      match (x, true) with
+      | A, _ -> _
+      | (B -> _
+      | C), _ -> _
+    |}]
+;;
+
 let%expect_test "can destruct hole" =
   destruct_line
     {ocaml|


### PR DESCRIPTION
Adds an end-to-end reproduction for destruct-line splitting a nested or-pattern as if each bar introduced a separate match case.

The snapshot captures the resulting syntactically invalid edit before case formatting is fixed.
