### PR TITLE
test(dune): cover location-free diagnostics and unknown promotion removal

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_fake_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_fake_diagnostics.ml
@@ -203,3 +203,152 @@ let%expect_test "removes a Dune diagnostic published earlier" =
     { "diagnostics": [], "uri": "<root>/main.ml" }
     |}]
 ;;
+
+let%expect_test "Dune diagnostic without a location uses the workspace root" =
+  let fake =
+    Fake.start "no-loc" ~diagnostics:(fun _root ->
+      [ [ D.Event.Add
+            { (fake_diagnostic
+                 ~fname:"unused"
+                 ~diagnostic_id:1
+                 ~diagnostic_message:"build failed"
+                 ~line:1
+                 ~start_char:0
+                 ~end_char:1)
+              with
+              loc = None
+            }
+        ]
+      ])
+  in
+  Fun.protect
+    ~finally:(fun () -> Fake.stop fake)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run_with_workspace
+         ~capabilities
+         ~root:(Fake.root fake)
+         ~runtime_dir:(Fake.runtime_dir fake)
+         events
+         ~f:(fun client _workspace ->
+           let uri = source_uri fake in
+           let* () = open_document client ~uri ~text:"let value = 1\n" in
+           let+ published =
+             Events.wait_for_diagnostics events.dune ~f:(fun params ->
+               for_uri (Uri.of_path (Fake.root fake)) params && has_dune_diagnostic params)
+           in
+           print_publication fake "root diagnostic:" published));
+  [%expect
+    {|
+    root diagnostic:
+    {
+      "diagnostics": [
+        {
+          "message": "build\nfailed",
+          "range": {
+            "end": { "character": 0, "line": 1 },
+            "start": { "character": 0, "line": 0 }
+          },
+          "severity": 1,
+          "source": "dune"
+        }
+      ],
+      "uri": "<root>"
+    }
+    |}]
+;;
+
+let%expect_test "removing an unknown promotion is a no-op" =
+  let fake =
+    Fake.start "unknown-promotion" ~diagnostics:(fun root ->
+      let promotion_diagnostic file diagnostic_id =
+        let source = Filename.concat root file in
+        let promotion =
+          D.Promotion.
+            { in_build = Filename.concat (Filename.concat root "_build/default") file
+            ; in_source = source
+            }
+        in
+        { (fake_diagnostic
+             ~fname:source
+             ~diagnostic_id
+             ~diagnostic_message:"promotion"
+             ~line:1
+             ~start_char:0
+             ~end_char:1)
+          with
+          promotion = [ promotion ]
+        }
+      in
+      let diagnostic = promotion_diagnostic "main.ml" 1 in
+      let unknown = { diagnostic with id = D.Id.create 2 } in
+      (* Ignore unknown removals both before and after a promotion exists,
+         even when the unknown diagnostic names the same promotion source. *)
+      [ [ D.Event.Remove unknown ]
+      ; [ D.Event.Add diagnostic ]
+      ; [ D.Event.Remove unknown ]
+      ; [ D.Event.Add (promotion_diagnostic "marker.ml" 3) ]
+      ])
+  in
+  Fun.protect
+    ~finally:(fun () -> Fake.stop fake)
+    (fun () ->
+       let events = Lifecycle_events.create () in
+       run_with_workspace
+         ~capabilities
+         ~root:(Fake.root fake)
+         ~runtime_dir:(Fake.runtime_dir fake)
+         events
+         ~f:(fun client _workspace ->
+           let* registration = Mailbox.wait events.registrations in
+           Printf.printf
+             "initial registrations: %d\n"
+             (List.length registration.registrations);
+           (* The later diagnostic proves removal processing has finished.
+              Its registration also drains the preceding queued registration
+              updates before we check for unexpected requests. *)
+           let marker_uri = Uri.of_path (Filename.concat (Fake.root fake) "marker.ml") in
+           let* (_ : PublishDiagnosticsParams.t) =
+             Events.wait_for_diagnostics events.dune ~f:(fun params ->
+               for_uri marker_uri params && has_dune_diagnostic params)
+           in
+           let* marker_registration = Mailbox.wait events.registrations in
+           (match marker_registration.registrations with
+            | [ registration ]
+              when String.equal
+                     registration.id
+                     ("ocamllsp-promote/" ^ Uri.to_string marker_uri) -> ()
+            | _ -> failwith "expected only the marker promotion registration");
+           print_endline "removal processed";
+           let textDocument = TextDocumentIdentifier.create ~uri:(source_uri fake) in
+           let context =
+             CodeActionContext.create ~diagnostics:[] ~only:[ CodeActionKind.QuickFix ] ()
+           in
+           let params =
+             CodeActionParams.create ~textDocument ~range:Range.first_line ~context ()
+           in
+           let* actions = Client.request client (CodeAction params) in
+           let commands =
+             List.map (Option.value actions ~default:[]) ~f:(function
+               | `CodeAction { command = Some command; _ } -> `String command.command
+               | _ -> failwith "expected a promotion command")
+           in
+           print_endline "remaining promotion commands:";
+           Test.print_result (`List commands);
+           Printf.printf
+             "Dune errors: %d\nextra registrations: %d\nunregistrations: %d\n"
+             (List.length (Mailbox.take_pending (Events.errors events.dune)))
+             (List.length (Mailbox.take_pending events.registrations))
+             (List.length (Mailbox.take_pending events.unregistrations));
+           Fiber.return ()));
+  [%expect
+    {|
+    initial registrations: 1
+    removal processed
+    remaining promotion commands:
+    [ "dune/promote" ]
+    Dune errors: 0
+    extra registrations: 0
+    unregistrations: 0
+    |}]
+;;


### PR DESCRIPTION
Add fake-Dune end-to-end coverage for diagnostics without locations and removal of unknown promotions.

Verify that location-free diagnostics use the workspace-root URI and fallback range. For unknown removals, synchronize on a later diagnostic and its registration, then check that an existing promotion for the same source remains available without Dune errors or unexpected registration changes.