### PR TITLE
test(code-actions): refresh package-constraint snapshot

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -164,7 +164,7 @@ let f (x : t) =
     let f (x : t) =
       match (x, ((module M) : (module S with
       | type u = int))) with -> _
-      | _, _ -> _
+      | (_, _) -> _
     |}]
 ;;
 


### PR DESCRIPTION
Refresh the package-constraint regression snapshot after #2191 and #2194 landed together. The formatter now retains tuple parentheses, so the expected `| _, _ -> _` becomes `| (_, _) -> _`.

This fixes the new destruct-line test failure on master without changing server behavior. The underlying separator bug remains captured by the test.
