### PR TITLE
feat(server): add tab stops to construct completions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Make generated construct completions interactive for clients with snippet support.
+  (#2198, @rgrinberg)
 - Support `ocp-indent` as an alternative for document and range formatting.
   (#2148, @rgrinberg)
 - Support `textDocument/onTypeFormatting` through the optional, persistent

--- a/lsp/src/capabilities.ml
+++ b/lsp/src/capabilities.ml
@@ -27,6 +27,11 @@ let completion_preselect_support (t : t) =
   |> Option.value ~default:false
 ;;
 
+let completion_snippet_support (t : t) =
+  Option.bind (completion_item t) (fun item -> item.snippetSupport)
+  |> Option.value ~default:false
+;;
+
 let completion_resolve_properties (t : t) =
   Option.bind (completion_item t) (fun item ->
     map item.resolveSupport (fun resolve -> resolve.properties))

--- a/lsp/src/capabilities.mli
+++ b/lsp/src/capabilities.mli
@@ -19,6 +19,9 @@ val completion_deprecated_support : t -> bool
 (** Whether the client supports preselecting a completion item. *)
 val completion_preselect_support : t -> bool
 
+(** Whether the client supports snippets in completion items. *)
+val completion_snippet_support : t -> bool
+
 (** The properties the client supports resolving for completion items. *)
 val completion_resolve_properties : t -> string list option
 

--- a/lsp/test/capabilities_tests.ml
+++ b/lsp/test/capabilities_tests.ml
@@ -1,5 +1,34 @@
 open Base
 open Lsp.Types
+module Capabilities = Lsp.Capabilities
+
+let%expect_test "completion snippet support is opt-in" =
+  List.iter
+    [ "no text document", {|{}|}
+    ; "no completion", {|{"textDocument":{}}|}
+    ; "no completion item", {|{"textDocument":{"completion":{}}}|}
+    ; "absent", {|{"textDocument":{"completion":{"completionItem":{}}}}|}
+    ; ( "false"
+      , {|{"textDocument":{"completion":{"completionItem":{"snippetSupport":false}}}}|} )
+    ; ( "true"
+      , {|{"textDocument":{"completion":{"completionItem":{"snippetSupport":true}}}}|} )
+    ]
+    ~f:(fun (name, json) ->
+      let capabilities = Yojson.Safe.from_string json |> ClientCapabilities.t_of_yojson in
+      Stdlib.Printf.printf
+        "%s: %b\n"
+        name
+        (Capabilities.completion_snippet_support capabilities));
+  [%expect
+    {|
+    no text document: false
+    no completion: false
+    no completion item: false
+    absent: false
+    false: false
+    true: true
+    |}]
+;;
 
 let capabilities ?folding_range () =
   let textDocument =
@@ -9,9 +38,9 @@ let capabilities ?folding_range () =
 ;;
 
 let print_folding_range (t : ClientCapabilities.t) =
-  let line_folding_only = Lsp.Capabilities.folding_range_line_folding_only t in
+  let line_folding_only = Capabilities.folding_range_line_folding_only t in
   let kinds =
-    match Lsp.Capabilities.folding_range_kinds t with
+    match Capabilities.folding_range_kinds t with
     | None -> "none"
     | Some kinds ->
       let kind_to_string = function
@@ -23,7 +52,7 @@ let print_folding_range (t : ClientCapabilities.t) =
       kinds |> List.map ~f:kind_to_string |> String.concat ~sep:","
   in
   let limit =
-    match Lsp.Capabilities.folding_range_limit t with
+    match Capabilities.folding_range_limit t with
     | None -> "none"
     | Some limit -> Int.to_string limit
   in

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -299,7 +299,12 @@ module Complete_with_construct = struct
     | Error exn -> Exn_with_backtrace.reraise exn
   ;;
 
-  let process_dispatch_resp ~supportsJumpToNextHole ~fallback_range ~position = function
+  let process_dispatch_resp
+        ~supportsJumpToNextHole
+        ~supports_snippets
+        ~fallback_range
+        ~position
+    = function
     | None -> []
     | Some (loc, constructed_exprs) ->
       let range =
@@ -324,9 +329,22 @@ module Complete_with_construct = struct
       in
       let completionItem_of_constructed_expr idx expr =
         let expr_wo_parens = deparen_constr_expr expr in
-        let edit = { TextEdit.range; newText = expr } in
+        let snippet =
+          match supports_snippets with
+          | false -> None
+          | true ->
+            let { Snippet_builder.snippet; placeholders } =
+              Snippet_builder.source ~source:expr
+            in
+            Option.some_if (placeholders > 0) snippet
+        in
+        let use_snippet = Option.is_some snippet in
+        let edit =
+          let newText = Option.value_map snippet ~default:expr ~f:Snippet.to_string in
+          { TextEdit.range; newText }
+        in
         let command =
-          if supportsJumpToNextHole
+          if (not use_snippet) && supportsJumpToNextHole
           then
             Some
               (Client.Custom_commands.next_hole
@@ -339,6 +357,7 @@ module Complete_with_construct = struct
           ~label:expr_wo_parens
           ~textEdit:(`TextEdit edit)
           ~filterText:("_" ^ expr)
+          ?insertTextFormat:(Option.some_if use_snippet InsertTextFormat.Snippet)
           ~kind:CompletionItemKind.Text
           ~sortText:(sortText_of_index ~width:sort_text_width idx)
           ?command
@@ -358,6 +377,7 @@ let complete
     | `Other -> Fiber.return None
     | `Merlin merlin ->
       let capabilities = State.client_capabilities state in
+      let supports_snippets = Capabilities.completion_snippet_support capabilities in
       let resolve =
         match Capabilities.completion_resolve_properties capabilities with
         | None -> false
@@ -450,6 +470,7 @@ let complete
                in
                Complete_with_construct.process_dispatch_resp
                  ~supportsJumpToNextHole
+                 ~supports_snippets
                  ~fallback_range:(edit_range merlin pos)
                  ~position:pos
                  construct_cmd_resp

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -232,6 +232,7 @@ include struct
   module InlayHintParams = InlayHintParams
   module InitializeParams = InitializeParams
   module InitializeResult = InitializeResult
+  module InsertTextFormat = InsertTextFormat
   module LanguageKind = LanguageKind
   module Location = Location
   module LogMessageParams = LogMessageParams
@@ -271,6 +272,7 @@ include struct
   module ServerInfo = ServerInfo
   module Server_notification = Lsp.Server_notification
   module SetTraceParams = SetTraceParams
+  module Snippet = Lsp.Snippet
   module ShowDocumentClientCapabilities = ShowDocumentClientCapabilities
   module ShowDocumentParams = ShowDocumentParams
   module ShowDocumentResult = ShowDocumentResult

--- a/ocaml-lsp-server/src/snippet_builder.ml
+++ b/ocaml-lsp-server/src/snippet_builder.ml
@@ -1,0 +1,67 @@
+open Import
+module Lexer = Ocaml_preprocess.Lexer_raw
+module Parser = Ocaml_preprocess.Parser_raw
+
+type t =
+  { snippet : Snippet.t
+  ; placeholders : int
+  }
+
+let rec lexer_result = function
+  | Lexer.Return token -> token
+  | Refill refill -> lexer_result (refill ())
+  | Fail _ -> raise Parser.Error
+;;
+
+let lexer_token lexer lexbuf = lexer_result (Lexer.token_without_comments lexer lexbuf)
+
+let expression_hole_ranges source =
+  let lexbuf = Lexing.from_string source in
+  let lexer = Lexer.make (Lexer.keywords []) in
+  match Parser.parse_expression (lexer_token lexer) lexbuf with
+  | exception Parser.Error -> Error ()
+  | expression ->
+    let ranges = ref [] in
+    let expr iterator (expression : Parsetree.expression) =
+      (match expression.pexp_desc with
+       | Pexp_extension ({ txt; loc }, PStr [])
+         when String.equal txt Ocaml_parsing.Ast_helper.hole_txt ->
+         (* The identifier location covers just the hole, whereas [pexp_loc]
+            can include parentheses and attributes. Check the source to exclude
+            explicit [%merlin.hole] extensions. *)
+         let start = loc.loc_start.pos_cnum in
+         let stop = loc.loc_end.pos_cnum in
+         if
+           start >= 0
+           && stop = start + 1
+           && stop <= String.length source
+           && Char.equal source.[start] '_'
+         then ranges := (start, stop) :: !ranges
+       | _ -> ());
+      Ocaml_parsing.Ast_iterator.default_iterator.expr iterator expression
+    in
+    let iterator = { Ocaml_parsing.Ast_iterator.default_iterator with expr } in
+    iterator.expr iterator expression;
+    Ok
+      (List.dedup_and_sort !ranges ~compare:(fun (start, _) (start', _) ->
+         Int.compare start start'))
+;;
+
+let source ~source =
+  let ranges =
+    match expression_hole_ranges source with
+    | Ok ranges -> ranges
+    | Error () -> []
+  in
+  let rec snippets offset = function
+    | [] ->
+      [ Snippet.text (String.sub source ~pos:offset ~len:(String.length source - offset))
+      ; Snippet.tabstop 0
+      ]
+    | (start, stop) :: ranges ->
+      Snippet.text (String.sub source ~pos:offset ~len:(start - offset))
+      :: Snippet.placeholder (Snippet.text "_")
+      :: snippets stop ranges
+  in
+  { snippet = Snippet.concat (snippets 0 ranges); placeholders = List.length ranges }
+;;

--- a/ocaml-lsp-server/src/snippet_builder.mli
+++ b/ocaml-lsp-server/src/snippet_builder.mli
@@ -1,0 +1,12 @@
+open Import
+
+type t =
+  { snippet : Snippet.t
+  ; placeholders : int
+  }
+
+(** Convert expression holes in OCaml source to snippet placeholders while
+    leaving wildcard patterns unchanged. [placeholders] counts the generated
+    placeholders. If parsing fails, the source is preserved without placeholders
+    and [placeholders] is zero. A final tab stop is always appended. *)
+val source : source:string -> t

--- a/ocaml-lsp-server/src/testing.ml
+++ b/ocaml-lsp-server/src/testing.ml
@@ -9,3 +9,4 @@ module Prefix_parser = Prefix_parser
 module Position = Position
 module Range = Range
 module Semantic_tokens = Semantic_highlighting.For_tests
+module Snippet_builder = Snippet_builder

--- a/ocaml-lsp-server/test/dune
+++ b/ocaml-lsp-server/test/dune
@@ -4,7 +4,8 @@
   dune_tests
   ocaml_lsp_tests
   position_prefix_tests
-  semantic_tokens_quickcheck_tests)
+  semantic_tokens_quickcheck_tests
+  snippet_builder_quickcheck_tests)
  (name ocaml_lsp_tests)
  (enabled_if
   (>= %{ocaml_version} 4.08))

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -3,6 +3,7 @@ open Test.Import
 let iter_completions
       ?prep
       ?path
+      ?capabilities
       ?(triggerCharacter = "")
       ?(triggerKind = CompletionTriggerKind.Invoked)
       ~position
@@ -12,7 +13,12 @@ let iter_completions
     Lsp.Client_request.TextDocumentCompletion
       (CompletionParams.create ~textDocument ~position ~context ())
   in
-  Lsp_helpers.iter_lsp_response ?prep ?path ~language_id:"ocaml" ~makeRequest
+  Lsp_helpers.iter_lsp_response
+    ?prep
+    ?path
+    ?capabilities
+    ~language_id:"ocaml"
+    ~makeRequest
 ;;
 
 let print_completion_response
@@ -50,6 +56,7 @@ let print_completion_response
 let print_completions
       ?(prep = fun _ -> Fiber.return ())
       ?(path = "foo.ml")
+      ?capabilities
       ?limit
       ?pre_print
       source
@@ -58,6 +65,7 @@ let print_completions
   iter_completions
     ~prep
     ~path
+    ?capabilities
     ~source
     ~position
     (print_completion_response ?limit ?pre_print)
@@ -106,6 +114,23 @@ let%expect_test "triggered completion inside a comment after Unicode" =
     ~position
     (print_completion_response ~limit:1);
   [%expect {| No completion Items |}]
+;;
+
+let snippet_capabilities =
+  let textDocument =
+    let completion =
+      let completionItem =
+        let insertTextModeSupport =
+          ClientCompletionItemInsertTextModeOptions.create
+            ~valueSet:[ InsertTextMode.AsIs; AdjustIndentation ]
+        in
+        ClientCompletionItemOptions.create ~snippetSupport:true ~insertTextModeSupport ()
+      in
+      CompletionClientCapabilities.create ~completionItem ()
+    in
+    TextDocumentClientCapabilities.create ~completion ()
+  in
+  ClientCapabilities.create ~textDocument ()
 ;;
 
 let%expect_test "completion converts UTF-16 positions before querying Merlin" =
@@ -1017,6 +1042,131 @@ let x : t = `$|ocaml}
 let%expect_test "completion for holes" =
   apply_completion ~label:"0" {ocaml|let u : int = _$|ocaml};
   [%expect {| let u : int = 0 |}]
+;;
+
+let%expect_test "construct completions stay plain without snippet support" =
+  let source = "type t = A | B of int\nlet value : t = _" in
+  let position = Position.create ~line:1 ~character:17 in
+  let only_b =
+    List.filter ~f:(fun (item : CompletionItem.t) ->
+      String.is_prefix item.label ~prefix:"B")
+  in
+  print_completions ~pre_print:only_b source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "filterText": "_(B _)",
+      "kind": 1,
+      "label": "B _",
+      "sortText": "0001",
+      "textEdit": {
+        "newText": "(B _)",
+        "range": {
+          "end": { "character": 17, "line": 1 },
+          "start": { "character": 16, "line": 1 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "construct completions use snippets for generated holes" =
+  let source = "type t = A | B of int\nlet value : t = _" in
+  let position = Position.create ~line:1 ~character:17 in
+  let only_b =
+    List.filter ~f:(fun (item : CompletionItem.t) ->
+      String.is_prefix item.label ~prefix:"B")
+  in
+  print_completions ~capabilities:snippet_capabilities ~pre_print:only_b source position;
+  [%expect
+    {|
+    Completions:
+    {
+      "filterText": "_(B _)",
+      "insertTextFormat": 2,
+      "kind": 1,
+      "label": "B _",
+      "sortText": "0001",
+      "textEdit": {
+        "newText": "(B ${1:_})$0",
+        "range": {
+          "end": { "character": 17, "line": 1 },
+          "start": { "character": 16, "line": 1 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "construct snippets respect capabilities and next-hole commands" =
+  let source = "type t = A | B of int\nlet value : t = _" in
+  let position = Position.create ~line:1 ~character:17 in
+  List.iter [ None; Some false; Some true ] ~f:(fun snippetSupport ->
+    List.iter [ false; true ] ~f:(fun jumpToNextHole ->
+      let completionItem = ClientCompletionItemOptions.create ?snippetSupport () in
+      let completion = CompletionClientCapabilities.create ~completionItem () in
+      let textDocument = TextDocumentClientCapabilities.create ~completion () in
+      let capabilities =
+        ClientCapabilities.create
+          ~textDocument
+          ~experimental:(`Assoc [ "jumpToNextHole", `Bool jumpToNextHole ])
+          ()
+      in
+      Printf.printf
+        "snippetSupport=%s jumpToNextHole=%b\n"
+        (Option.value_map snippetSupport ~default:"absent" ~f:string_of_bool)
+        jumpToNextHole;
+      iter_completions ~capabilities ~source ~position (fun response ->
+        let items =
+          match Option.value_exn response with
+          | `CompletionList completions -> completions.items
+          | `List items -> items
+        in
+        List.iter [ "A"; "B _" ] ~f:(fun label ->
+          let item =
+            List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+              String.equal item.label label)
+          in
+          let newText =
+            match item.textEdit with
+            | Some (`TextEdit edit) -> edit.newText
+            | _ -> failwith "expected a text edit"
+          in
+          let format =
+            match item.insertTextFormat with
+            | None -> "absent"
+            | Some PlainText -> "plain"
+            | Some Snippet -> "snippet"
+          in
+          Printf.printf
+            "%s: format=%s text=%S command=%s\n"
+            label
+            format
+            newText
+            (Option.value_map item.command ~default:"none" ~f:(fun command ->
+               command.command))))));
+  [%expect
+    {|
+    snippetSupport=absent jumpToNextHole=false
+    A: format=absent text="A" command=none
+    B _: format=absent text="(B _)" command=none
+    snippetSupport=absent jumpToNextHole=true
+    A: format=absent text="A" command=ocaml.next-hole
+    B _: format=absent text="(B _)" command=ocaml.next-hole
+    snippetSupport=false jumpToNextHole=false
+    A: format=absent text="A" command=none
+    B _: format=absent text="(B _)" command=none
+    snippetSupport=false jumpToNextHole=true
+    A: format=absent text="A" command=ocaml.next-hole
+    B _: format=absent text="(B _)" command=ocaml.next-hole
+    snippetSupport=true jumpToNextHole=false
+    A: format=absent text="A" command=none
+    B _: format=snippet text="(B ${1:_})$0" command=none
+    snippetSupport=true jumpToNextHole=true
+    A: format=absent text="A" command=ocaml.next-hole
+    B _: format=snippet text="(B ${1:_})$0" command=none
+    |}]
 ;;
 
 let%expect_test "construct completion converts Merlin ranges to UTF-16" =

--- a/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
@@ -1,0 +1,192 @@
+open Base
+open Base_quickcheck
+module Builder = Ocaml_lsp_server.Testing.Snippet_builder
+module Snippet = Lsp.Snippet
+
+type fragment =
+  | Variable
+  | String_dollar
+  | String_close_brace
+  | String_backslash
+  | Expression_hole
+  | Hole_identifier
+  | String_hole
+  | Character_hole
+  | Comment_hole
+  | Nested_comment_hole
+  | Quoted_string_hole
+  | Function_with_wildcard
+  | Match_with_wildcards
+  | Tuple_holes
+[@@deriving quickcheck, sexp_of]
+
+module Source_case = struct
+  type t = fragment list [@@deriving quickcheck, sexp_of]
+end
+
+let fragment = function
+  | Variable -> "x"
+  | String_dollar -> "\"$\""
+  | String_close_brace -> "\"}\""
+  | String_backslash -> "\"\\\\\""
+  | Expression_hole -> "_"
+  | Hole_identifier -> "_value"
+  | String_hole -> "\"_\""
+  | Character_hole -> "'_'"
+  | Comment_hole -> "((* _ *) x)"
+  | Nested_comment_hole -> "((* outer (* _ *) *) x)"
+  | Quoted_string_hole -> "{tag|_ $}\\|tag}"
+  | Function_with_wildcard -> "(fun _ -> _)"
+  | Match_with_wildcards -> "(match _ with | Some _ -> _ | None -> _)"
+  | Tuple_holes -> "(_, _)"
+;;
+
+let placeholder_count = function
+  | Expression_hole -> 1
+  | Function_with_wildcard -> 1
+  | Match_with_wildcards -> 3
+  | Tuple_holes -> 2
+  | Variable
+  | String_dollar
+  | String_close_brace
+  | String_backslash
+  | Hole_identifier
+  | String_hole
+  | Character_hole
+  | Comment_hole
+  | Nested_comment_hole
+  | Quoted_string_hole -> 0
+;;
+
+let source fragments =
+  match fragments with
+  | [] -> "()"
+  | _ -> "(" ^ (List.map fragments ~f:fragment |> String.concat ~sep:", ") ^ ")"
+;;
+
+let defaults snippet =
+  let length = String.length snippet in
+  let buffer = Buffer.create length in
+  let rec digits index =
+    if index < length && Char.is_digit snippet.[index] then digits (index + 1) else index
+  in
+  let rec loop index =
+    if index = length
+    then Buffer.contents buffer
+    else (
+      match snippet.[index] with
+      | '\\' when index + 1 < length ->
+        Buffer.add_char buffer snippet.[index + 1];
+        loop (index + 2)
+      | '$' when index + 1 < length && Char.equal snippet.[index + 1] '0' ->
+        loop (index + 2)
+      | '$' when index + 1 < length && Char.equal snippet.[index + 1] '{' ->
+        let after_index = digits (index + 2) in
+        if
+          after_index + 2 >= length
+          || (not (Char.equal snippet.[after_index] ':'))
+          || (not (Char.equal snippet.[after_index + 1] '_'))
+          || not (Char.equal snippet.[after_index + 2] '}')
+        then failwith (Printf.sprintf "unexpected snippet form: %S" snippet);
+        Buffer.add_char buffer '_';
+        loop (after_index + 3)
+      | char ->
+        Buffer.add_char buffer char;
+        loop (index + 1))
+  in
+  loop 0
+;;
+
+let check_source fragments =
+  let source = source fragments in
+  let { Builder.snippet; placeholders = actual_count } = Builder.source ~source in
+  let expected_count = List.sum (module Int) fragments ~f:placeholder_count in
+  if actual_count <> expected_count
+  then
+    failwith
+      (Printf.sprintf
+         "placeholder count for %S: expected %d, got %d"
+         source
+         expected_count
+         actual_count);
+  let rendered = Snippet.to_string snippet in
+  let round_trip = defaults rendered in
+  if not (String.equal source round_trip)
+  then
+    failwith
+      (Printf.sprintf
+         "source round trip: expected %S, got %S via %S"
+         source
+         round_trip
+         rendered)
+;;
+
+let source_examples =
+  [ [ Expression_hole ]
+  ; [ Function_with_wildcard ]
+  ; [ Match_with_wildcards ]
+  ; [ String_hole; Comment_hole; Quoted_string_hole; Hole_identifier ]
+  ; [ String_dollar; String_close_brace; String_backslash; Tuple_holes ]
+  ]
+;;
+
+let%test_unit "only expression holes become placeholders without changing source" =
+  Test.run_exn (module Source_case) ~examples:source_examples ~f:check_source
+;;
+
+let print_source source =
+  let { Builder.snippet; placeholders } = Builder.source ~source in
+  Stdlib.Printf.printf "%d: %s\n" placeholders (Snippet.to_string snippet)
+;;
+
+let%expect_test "only expression holes are numbered, in source order" =
+  print_source "(fun _ -> (_, _))";
+  print_source "(match _ with | Some _ -> _ | None -> _)";
+  print_source "(let _ = _ in _)";
+  print_source "(_, _, _, _, _, _, _, _, _, _, _, _)";
+  [%expect
+    {|
+    2: (fun _ -> (${1:_}, ${2:_}))$0
+    3: (match ${1:_} with | Some _ -> ${2:_} | None -> ${3:_})$0
+    2: (let _ = ${1:_} in ${2:_})$0
+    12: (${1:_}, ${2:_}, ${3:_}, ${4:_}, ${5:_}, ${6:_}, ${7:_}, ${8:_}, ${9:_}, ${10:_}, ${11:_}, ${12:_})$0
+    |}]
+;;
+
+let%expect_test "hole locations exclude surrounding syntax and type wildcards" =
+  print_source "(( _ (* _ *) ))";
+  print_source "(_ : _)";
+  print_source "(let café = \"😀\" in (_, _))";
+  print_source "[%merlin.hole]";
+  [%expect
+    {|
+    1: (( ${1:_} (* _ *) ))$0
+    1: (${1:_} : _)$0
+    2: (let café = "😀" in (${1:_}, ${2:_}))$0
+    0: [%merlin.hole]$0
+    |}]
+;;
+
+let%expect_test "attributes on holes retain wildcard patterns and visit expression holes" =
+  print_source "(_ [@foo? _])";
+  print_source "_ [@foo _]";
+  [%expect
+    {|
+    1: (${1:_} [@foo? _])$0
+    2: ${1:_} [@foo ${2:_}]$0
+    |}]
+;;
+
+let%expect_test "parse failures preserve source without placeholders" =
+  List.iter
+    [ ""; "(_"; "\"unterminated"; "(* unterminated"; {ocaml|("$}", _|ocaml} ]
+    ~f:print_source;
+  [%expect
+    {|
+    0: $0
+    0: (_$0
+    0: "unterminated$0
+    0: (* unterminated$0
+    0: ("\$\}", _$0
+    |}]
+;;


### PR DESCRIPTION
Make generated construct completions interactive for clients with snippet support: expression holes become ordered placeholders, followed by a final tab stop. For example, `(B _)` becomes `(B ${1:_})$0`.

Use precise parser locations so wildcard patterns, type wildcards, comments, and quoted underscores remain untouched. Preserve plain completions when snippets are unsupported, no holes are present, or parsing fails. Snippet completions omit the competing `ocaml.next-hole` command.

Includes property tests for source preservation and escaping, exact placeholder regressions, and completion capability/command coverage.
