### PR TITLE
feat(server): offer whole-call completions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Offer whole-call completions for OCaml functions with multiple labelled or
+  optional arguments, with editable slots for all arguments. (#2199, @rgrinberg)
 - Make generated construct completions interactive for clients with snippet support.
   (#2198, @rgrinberg)
 - Support `ocp-indent` as an alternative for document and range formatting.

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -139,14 +139,12 @@ let reindex_sortText completion_items =
 
 module Complete_by_prefix = struct
   let completionItem_of_completion_entry
-        idx
         (entry : Query_protocol.Compl.entry)
         ~compl_params
         ~range
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
-        ~sort_text_width
     =
     let kind = completion_kind ~supports_enum_member entry.kind in
     let { Deprecation.deprecated; tags } =
@@ -163,12 +161,21 @@ module Complete_by_prefix = struct
       ~detail:entry.desc
       ?deprecated
       ?tags
-        (* Without this field the client is not forced to respect the order
-           provided by merlin. *)
-      ~sortText:(sortText_of_index ~width:sort_text_width idx)
       ?data:compl_params
       ~textEdit
       ()
+  ;;
+
+  let snippet_completion_item (plain : CompletionItem.t) ~range snippet =
+    { plain with
+      label = plain.label ^ " (call)"
+    ; filterText = Some plain.label
+    ; insertTextFormat = Some Snippet
+    ; kind = Some Snippet
+    ; textEdit =
+        Some (`TextEdit (TextEdit.create ~range ~newText:(Snippet.to_string snippet)))
+    ; data = None
+    }
   ;;
 
   let dispatch_cmd ~prefix position pipeline =
@@ -180,6 +187,7 @@ module Complete_by_prefix = struct
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
+        ~supports_snippets
         ~resolve
         ~prefix
         doc
@@ -187,6 +195,9 @@ module Complete_by_prefix = struct
         (completion : Query_protocol.completions)
     =
     let range = edit_range doc pos in
+    let supports_snippets =
+      supports_snippets && Document.syntax (Document.Merlin.to_doc doc) = Ocaml
+    in
     let completion_entries =
       match completion.context with
       | `Unknown -> completion.entries
@@ -202,7 +213,7 @@ module Complete_by_prefix = struct
           ; kind = `Label
           ; desc = typ
           ; info = ""
-          ; deprecated = false (* TODO this is wrong *)
+          ; deprecated = false
           })
     in
     (* we need to json-ify completion params to put them in completion item's
@@ -220,17 +231,43 @@ module Complete_by_prefix = struct
            CompletionParams.create ~textDocument ~position:pos ()
            |> CompletionParams.yojson_of_t)
     in
-    let sort_text_width = sortText_width (List.length completion_entries) in
-    List.mapi
-      completion_entries
-      ~f:
-        (completionItem_of_completion_entry
-           ~supports_deprecated_field
-           ~supports_deprecated_tag
-           ~supports_enum_member
-           ~range
-           ~compl_params
-           ~sort_text_width)
+    let items =
+      List.concat_map completion_entries ~f:(fun (entry : Query_protocol.Compl.entry) ->
+        let plain =
+          completionItem_of_completion_entry
+            entry
+            ~supports_deprecated_field
+            ~supports_deprecated_tag
+            ~supports_enum_member
+            ~range
+            ~compl_params
+        in
+        let snippets =
+          match supports_snippets with
+          | false -> []
+          | true ->
+            (match entry.kind with
+             | `Label
+             | `Constructor
+             | `Keyword
+             | `MethodCall
+             | `Module
+             | `Modtype
+             | `Type
+             | `Variant -> []
+             | `Value ->
+               (match Snippet_builder.application ~name:entry.name ~typ:entry.desc with
+                | None -> []
+                | Some snippet -> [ snippet_completion_item plain ~range snippet ]))
+        in
+        plain :: snippets)
+    in
+    let plain, calls =
+      List.partition_tf items ~f:(fun (item : CompletionItem.t) ->
+        item.kind <> Some Snippet)
+    in
+    (* [calls] are last on purpose so that the user doesn't see duplication *)
+    plain @ calls
   ;;
 
   let complete_keywords completion_position prefix =
@@ -258,6 +295,7 @@ module Complete_by_prefix = struct
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
+        ~supports_snippets
         ~resolve
     =
     let+ (completion : Query_protocol.completions) =
@@ -278,6 +316,7 @@ module Complete_by_prefix = struct
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
+        ~supports_snippets
         ~resolve
         ~prefix
         doc
@@ -358,7 +397,7 @@ module Complete_with_construct = struct
           ~textEdit:(`TextEdit edit)
           ~filterText:("_" ^ expr)
           ?insertTextFormat:(Option.some_if use_snippet InsertTextFormat.Snippet)
-          ~kind:CompletionItemKind.Text
+          ~kind:Text
           ~sortText:(sortText_of_index ~width:sort_text_width idx)
           ?command
           ()
@@ -439,6 +478,7 @@ let complete
                ~supports_deprecated_field
                ~supports_deprecated_tag
                ~supports_enum_member
+               ~supports_snippets
                ~resolve
            else (
              let preselect_first =
@@ -481,6 +521,7 @@ let complete
                  ~supports_deprecated_field
                  ~supports_deprecated_tag
                  ~supports_enum_member
+                 ~supports_snippets
                  ~prefix
                  merlin
                  pos

--- a/ocaml-lsp-server/src/snippet_builder.ml
+++ b/ocaml-lsp-server/src/snippet_builder.ml
@@ -16,9 +16,11 @@ let rec lexer_result = function
 let lexer_token lexer lexbuf = lexer_result (Lexer.token_without_comments lexer lexbuf)
 
 let expression_hole_ranges source =
-  let lexbuf = Lexing.from_string source in
-  let lexer = Lexer.make (Lexer.keywords []) in
-  match Parser.parse_expression (lexer_token lexer) lexbuf with
+  match
+    let lexbuf = Lexing.from_string source in
+    let lexer = Lexer.make (Lexer.keywords []) in
+    Parser.parse_expression (lexer_token lexer) lexbuf
+  with
   | exception Parser.Error -> Error ()
   | expression ->
     let ranges = ref [] in
@@ -54,14 +56,66 @@ let source ~source =
     | Error () -> []
   in
   let rec snippets offset = function
-    | [] ->
-      [ Snippet.text (String.sub source ~pos:offset ~len:(String.length source - offset))
-      ; Snippet.tabstop 0
-      ]
+    | [] -> [ Snippet.text (String.drop_prefix source offset); Snippet.tabstop 0 ]
     | (start, stop) :: ranges ->
       Snippet.text (String.sub source ~pos:offset ~len:(start - offset))
       :: Snippet.placeholder (Snippet.text "_")
       :: snippets stop ranges
   in
   { snippet = Snippet.concat (snippets 0 ranges); placeholders = List.length ranges }
+;;
+
+let argument_labels typ =
+  match
+    let lexbuf = Lexing.from_string typ in
+    let lexer = Lexer.make (Lexer.keywords []) in
+    Parser.parse_core_type (lexer_token lexer) lexbuf
+  with
+  | exception Parser.Error -> None
+  | typ ->
+    let rec loop labels (typ : Parsetree.core_type) =
+      match typ.ptyp_desc with
+      | Ptyp_arrow (label, _argument, result) -> loop (label :: labels) result
+      | Ptyp_alias (typ, _) | Ptyp_poly (_, typ) -> loop labels typ
+      | _ -> List.rev labels
+    in
+    Some (loop [] typ)
+;;
+
+let valid_application_name name =
+  String.split name ~on:'.'
+  |> List.for_all ~f:(fun segment ->
+    (not (String.is_empty segment))
+    && (match segment.[0] with
+        | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
+        | _ -> false)
+    && String.for_all segment ~f:(function
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'' -> true
+      | _ -> false))
+;;
+
+let application ~name ~typ =
+  match valid_application_name name with
+  | false -> None
+  | true ->
+    let open Option.O in
+    let* labels = argument_labels typ in
+    if
+      List.count labels ~f:(function
+        | Asttypes.Nolabel -> false
+        | Labelled _ | Optional _ -> true)
+      < 2
+    then None
+    else (
+      let arguments =
+        let placeholder = [ Snippet.placeholder (Snippet.text "_") ] in
+        List.concat_map labels ~f:(fun (label : Asttypes.arg_label) ->
+          Snippet.text
+            (match label with
+             | Nolabel -> " "
+             | Labelled label -> " ~" ^ label ^ ":"
+             | Optional label -> " ?" ^ label ^ ":")
+          :: placeholder)
+      in
+      Some (Snippet.concat ((Snippet.text name :: arguments) @ [ Snippet.tabstop 0 ])))
 ;;

--- a/ocaml-lsp-server/src/snippet_builder.mli
+++ b/ocaml-lsp-server/src/snippet_builder.mli
@@ -10,3 +10,9 @@ type t =
     placeholders. If parsing fails, the source is preserved without placeholders
     and [placeholders] is zero. A final tab stop is always appended. *)
 val source : source:string -> t
+
+(** A whole-call snippet with one hole per top-level function argument, derived
+    by parsing a rendered OCaml core type. Requires at least two labelled or
+    optional arguments; positional arguments do not count toward this threshold.
+    Returns [None] for other types, unsafe names, or unparseable types. *)
+val application : name:string -> typ:string -> Snippet.t option

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -1169,6 +1169,312 @@ let%expect_test "construct snippets respect capabilities and next-hole commands"
     |}]
 ;;
 
+let%expect_test "whole-call variants follow all ordinary candidates in complete lists" =
+  List.iter [ None; Some false; Some true ] ~f:(fun snippetSupport ->
+    let completionItem = ClientCompletionItemOptions.create ?snippetSupport () in
+    let completion = CompletionClientCapabilities.create ~completionItem () in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    let capabilities = ClientCapabilities.create ~textDocument () in
+    List.iter [ "wholec_"; "wholec_al"; "wholec_alpha" ] ~f:(fun prefix ->
+      let source, position =
+        Test.parse_cursor
+          ("let wholec_alpha ~a ~b = a + b\n\
+            let wholec_alpine ~a ?b () = a, b\n\
+            let wholec_value = 42\n\
+            let value = "
+           ^ prefix
+           ^ "$")
+      in
+      iter_completions ~capabilities ~source ~position (function
+        | Some (`CompletionList { isIncomplete; items; _ }) ->
+          assert (not isIncomplete);
+          List.iteri items ~f:(fun i (item : CompletionItem.t) ->
+            assert (item.sortText = Some (Printf.sprintf "%04d" i)));
+          Printf.printf
+            "snippets=%s %s: %s\n"
+            (Option.value_map snippetSupport ~default:"absent" ~f:string_of_bool)
+            prefix
+            (List.map items ~f:(fun (item : CompletionItem.t) -> item.label)
+             |> String.concat ~sep:", ")
+        | _ -> failwith "expected a completion list")));
+  [%expect
+    {|
+    snippets=absent wholec_: wholec_alpha, wholec_alpine, wholec_value
+    snippets=absent wholec_al: wholec_alpha, wholec_alpine
+    snippets=absent wholec_alpha: wholec_alpha
+    snippets=false wholec_: wholec_alpha, wholec_alpine, wholec_value
+    snippets=false wholec_al: wholec_alpha, wholec_alpine
+    snippets=false wholec_alpha: wholec_alpha
+    snippets=true wholec_: wholec_alpha, wholec_alpine, wholec_value, wholec_alpha (call), wholec_alpine (call)
+    snippets=true wholec_al: wholec_alpha, wholec_alpine, wholec_alpha (call), wholec_alpine (call)
+    snippets=true wholec_alpha: wholec_alpha, wholec_alpha (call)
+    |}]
+;;
+
+let%expect_test "value completions offer whole-call snippets" =
+  let source, position = Test.parse_cursor "let f = ListLabels.fo$" in
+  let only_fold_snippet =
+    List.filter ~f:(fun (item : CompletionItem.t) ->
+      String.equal item.label "fold_left (call)")
+  in
+  print_completions
+    ~capabilities:snippet_capabilities
+    ~pre_print:only_fold_snippet
+    source
+    position;
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "f:('acc -> 'a -> 'acc) -> init:'acc -> 'a list -> 'acc",
+      "filterText": "fold_left",
+      "insertTextFormat": 2,
+      "kind": 15,
+      "label": "fold_left (call)",
+      "sortText": "0007",
+      "textEdit": {
+        "newText": "fold_left ~f:${1:_} ~init:${2:_} ${3:_}$0",
+        "range": {
+          "end": { "character": 21, "line": 0 },
+          "start": { "character": 19, "line": 0 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "whole-call snippets require multiple labelled or optional arguments" =
+  List.iter
+    [ "x = x"
+    ; "x y = x, y"
+    ; "~a = a"
+    ; "?a () = a"
+    ; "~a x = a, x"
+    ; "?a x = a, x"
+    ; "~a ~b = a, b"
+    ; "~a ?b () = a, b"
+    ; "?a ?b () = a, b"
+    ]
+    ~f:(fun definition ->
+      let source, position =
+        Test.parse_cursor ("let target " ^ definition ^ "\nlet value = tar$")
+      in
+      iter_completions
+        ~capabilities:snippet_capabilities
+        ~source
+        ~position
+        (fun response ->
+           let items =
+             match Option.value_exn response with
+             | `CompletionList list -> list.items
+             | `List items -> items
+           in
+           assert (
+             List.exists items ~f:(fun (item : CompletionItem.t) ->
+               String.equal item.label "target" && item.kind = Some Value));
+           let snippets =
+             List.count items ~f:(fun (item : CompletionItem.t) ->
+               item.kind = Some Snippet)
+           in
+           Printf.printf "%s: %d snippets\n" definition snippets));
+  [%expect
+    {|
+    x = x: 0 snippets
+    x y = x, y: 0 snippets
+    ~a = a: 0 snippets
+    ?a () = a: 0 snippets
+    ~a x = a, x: 0 snippets
+    ?a x = a, x: 0 snippets
+    ~a ~b = a, b: 1 snippets
+    ~a ?b () = a, b: 1 snippets
+    ?a ?b () = a, b: 1 snippets
+    |}]
+;;
+
+let%expect_test "completing existing label values does not add snippets" =
+  List.iter
+    [ "let f = ListLabels.map ~f$:Fun.id"
+    ; "let f = ListLabels.map ~$f:Fun.id"
+    ; "let f ?limit () = ()\nlet _ = f ?limit$:None ()"
+    ; "let f ?limit () = ()\nlet _ = f ?li$mit:None ()"
+    ]
+    ~f:(fun marked_source ->
+      let source, position = Test.parse_cursor marked_source in
+      print_endline marked_source;
+      iter_completions
+        ~capabilities:snippet_capabilities
+        ~source
+        ~position
+        (fun response ->
+           let items =
+             match Option.value_exn response with
+             | `CompletionList list -> list.items
+             | `List items -> items
+           in
+           let snippets =
+             List.filter items ~f:(fun (item : CompletionItem.t) ->
+               item.kind = Some CompletionItemKind.Snippet)
+           in
+           List.iter snippets ~f:(fun (item : CompletionItem.t) ->
+             match item.textEdit with
+             | Some (`TextEdit edit) ->
+               Printf.printf "%s -> %s\n" item.label (Test.apply_edits source [ edit ])
+             | _ -> failwith "expected a text edit")));
+  [%expect
+    {|
+    let f = ListLabels.map ~f$:Fun.id
+    let f = ListLabels.map ~$f:Fun.id
+    let f ?limit () = ()
+    let _ = f ?limit$:None ()
+    let f ?limit () = ()
+    let _ = f ?li$mit:None ()
+    |}]
+;;
+
+let%expect_test "whole-call snippet capabilities optional arguments and ordering" =
+  List.iter [ None; Some false; Some true ] ~f:(fun snippetSupport ->
+    let capabilities =
+      let completionItem = ClientCompletionItemOptions.create ?snippetSupport () in
+      let completion = CompletionClientCapabilities.create ~completionItem () in
+      let textDocument = TextDocumentClientCapabilities.create ~completion () in
+      ClientCapabilities.create ~textDocument ()
+    in
+    List.iter [ "tar$"; "tar$get_typo"; "targ$et" ] ~f:(fun prefix ->
+      let source, position =
+        Test.parse_cursor
+          ("let target ~name ?limit count = name, limit, count\nlet value = " ^ prefix)
+      in
+      Printf.printf
+        "snippets=%s prefix=%s:"
+        (Option.value_map snippetSupport ~default:"absent" ~f:string_of_bool)
+        prefix;
+      iter_completions ~capabilities ~source ~position (fun response ->
+        let items =
+          match Option.value_exn response with
+          | `CompletionList list -> list.items
+          | `List items -> items
+        in
+        List.iteri items ~f:(fun idx (item : CompletionItem.t) ->
+          assert (item.sortText = Some (Printf.sprintf "%04d" idx)));
+        List.iter items ~f:(fun (item : CompletionItem.t) ->
+          if String.is_prefix item.label ~prefix:"target"
+          then (
+            match item.textEdit with
+            | Some (`TextEdit edit) ->
+              assert (
+                String.equal
+                  (Test.apply_edits source [ edit ])
+                  ("let target ~name ?limit count = name, limit, count\nlet value = "
+                   ^ edit.newText));
+              Printf.printf " %s" edit.newText
+            | _ -> failwith "expected a text edit"));
+        print_newline ())));
+  [%expect
+    {|
+    snippets=absent prefix=tar$: target
+    snippets=absent prefix=tar$get_typo: target
+    snippets=absent prefix=targ$et: target
+    snippets=false prefix=tar$: target
+    snippets=false prefix=tar$get_typo: target
+    snippets=false prefix=targ$et: target
+    snippets=true prefix=tar$: target target ~name:${1:_} ?limit:${2:_} ${3:_}$0
+    snippets=true prefix=tar$get_typo: target target ~name:${1:_} ?limit:${2:_} ${3:_}$0
+    snippets=true prefix=targ$et: target target ~name:${1:_} ?limit:${2:_} ${3:_}$0
+    |}]
+;;
+
+let%expect_test "whole-call snippets exclude labels record fields and non-functions" =
+  List.iter
+    [ "let f = ListLabels.map ~$"
+    ; "let f ?limit () = ()\nlet value = f ?$"
+    ; "type t = { field : int }\nlet f (x : t) = x.fi$"
+    ; "let number = 42\nlet value = num$"
+    ]
+    ~f:(fun source ->
+      let source, position = Test.parse_cursor source in
+      print_completions
+        ~capabilities:snippet_capabilities
+        ~pre_print:
+          (List.filter ~f:(fun (item : CompletionItem.t) -> item.kind = Some Snippet))
+        source
+        position);
+  [%expect
+    {|
+    No completions
+    No completions
+    No completions
+    No completions
+    |}]
+;;
+
+let%expect_test "whole-call snippets are disabled for non-OCaml documents" =
+  (* Keep the .ml URI and OCaml source so this exercises the language-id guard
+     without depending on an external Reason or MLX reader. *)
+  let source, position = Test.parse_cursor "let f = ListLabels.fo$" in
+  List.iter [ "reason"; "ocaml.mlx" ] ~f:(fun language_id ->
+    Helpers.test ~language_id ~capabilities:snippet_capabilities source (fun client ->
+      let+ response = request_completions client position in
+      let items =
+        match Option.value_exn response with
+        | `CompletionList list -> list.items
+        | `List items -> items
+      in
+      assert (
+        List.exists items ~f:(fun (item : CompletionItem.t) ->
+          String.equal item.label "fold_left" && item.kind = Some Value));
+      print_completion_response
+        ~pre_print:
+          (List.filter ~f:(fun (item : CompletionItem.t) -> item.kind = Some Snippet))
+        response));
+  [%expect
+    {|
+    No completions
+    No completions
+    |}]
+;;
+
+let%expect_test "whole-call snippets preserve deprecation without symbol resolve data" =
+  let tagSupport =
+    CompletionItemTagOptions.create ~valueSet:[ CompletionItemTag.Deprecated ]
+  in
+  let resolveSupport =
+    ClientCompletionItemResolveOptions.create ~properties:[ "documentation" ]
+  in
+  let completionItem =
+    ClientCompletionItemOptions.create ~snippetSupport:true ~tagSupport ~resolveSupport ()
+  in
+  let completion = CompletionClientCapabilities.create ~completionItem () in
+  let textDocument = TextDocumentClientCapabilities.create ~completion () in
+  let capabilities = ClientCapabilities.create ~textDocument () in
+  let source, position =
+    Test.parse_cursor
+      "module M : sig val old : a:int -> b:int -> int [@@deprecated] end = struct\n\
+       let old ~a ~b = a + b end\n\
+       let value = M.ol$"
+  in
+  iter_completions ~capabilities ~source ~position (fun response ->
+    let items =
+      match Option.value_exn response with
+      | `CompletionList list -> list.items
+      | `List items -> items
+    in
+    List.iter [ "old"; "old (call)" ] ~f:(fun label ->
+      let item =
+        List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+          String.equal item.label label)
+      in
+      Printf.printf
+        "%s: deprecated=%b resolve=%b\n"
+        label
+        (item.tags = Some [ CompletionItemTag.Deprecated ])
+        (Option.is_some item.data)));
+  [%expect
+    {|
+    old: deprecated=true resolve=true
+    old (call): deprecated=true resolve=false
+    |}]
+;;
+
 let%expect_test "construct completion converts Merlin ranges to UTF-16" =
   let source = "let café : int = _" in
   let position = Position.create ~line:0 ~character:18 in

--- a/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
@@ -190,3 +190,119 @@ let%expect_test "parse failures preserve source without placeholders" =
     0: ("\$\}", _$0
     |}]
 ;;
+
+type argument =
+  | Unlabelled
+  | Labelled
+  | Optional
+  | Nested_arrow
+  | Tuple
+  | Object
+  | Polymorphic_variant
+  | Alias
+  | Package
+[@@deriving quickcheck, sexp_of]
+
+module Application_case = struct
+  type t = argument list [@@deriving quickcheck, sexp_of]
+end
+
+let argument = function
+  | Unlabelled -> "int"
+  | Labelled -> "f:(int -> int)"
+  | Optional -> "?limit:int"
+  | Nested_arrow -> "(string -> bool)"
+  | Tuple -> "int * string"
+  | Object -> "< m : int -> int >"
+  | Polymorphic_variant -> "[ `A of (int -> int) | `B ]"
+  | Alias -> "((int -> int) as 'fn)"
+  | Package -> "(module S with type t = int)"
+;;
+
+let check_application arguments =
+  let typ =
+    match arguments with
+    | [] -> "result"
+    | _ -> String.concat ~sep:" -> " (List.map arguments ~f:argument @ [ "result" ])
+  in
+  let label_count =
+    List.count arguments ~f:(function
+      | Labelled | Optional -> true
+      | _ -> false)
+  in
+  match Builder.application ~name:"f" ~typ, label_count >= 2 with
+  | None, false -> ()
+  | Some snippet, true ->
+    let rendered = Snippet.to_string snippet in
+    let expected_placeholders = List.length arguments in
+    let { Builder.placeholders = actual_placeholders; _ } =
+      Builder.source ~source:(defaults rendered)
+    in
+    if actual_placeholders <> expected_placeholders
+    then
+      failwith
+        (Printf.sprintf
+           "application %S: expected %d placeholders, got %d in %S"
+           typ
+           expected_placeholders
+           actual_placeholders
+           rendered)
+  | None, true -> failwith (Printf.sprintf "missing application snippet for %S" typ)
+  | Some snippet, false ->
+    failwith
+      (Printf.sprintf "unexpected application snippet %S" (Snippet.to_string snippet))
+;;
+
+let%test_unit "whole-call snippets require multiple labels and preserve arity" =
+  Test.run_exn
+    (module Application_case)
+    ~examples:
+      [ []
+      ; [ Unlabelled ]
+      ; [ Labelled ]
+      ; [ Optional; Unlabelled ]
+      ; [ Nested_arrow; Tuple ]
+      ; [ Labelled; Optional ]
+      ; [ Optional; Optional ]
+      ; [ Nested_arrow
+        ; Labelled
+        ; Optional
+        ; Tuple
+        ; Object
+        ; Polymorphic_variant
+        ; Alias
+        ; Package
+        ]
+      ]
+    ~f:check_application
+;;
+
+let%expect_test "whole-call snippets" =
+  let print name typ =
+    match Builder.application ~name ~typ with
+    | None -> Stdlib.print_endline "none"
+    | Some snippet -> Snippet.to_string snippet |> Stdlib.print_endline
+  in
+  print "ListLabels.fold_left" "f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a";
+  print "f" "name:string -> ?limit:int -> int -> string";
+  print "f" "(int -> int) -> (int * string) -> result";
+  print "f" "(a:int -> b:int -> int) as 'fn";
+  print "f" "int";
+  List.iter [ ""; "+"; "f..g"; "f$"; "~f" ] ~f:(fun name ->
+    print name "a:int -> b:int -> int");
+  print "f" "a:int -> b:int ->";
+  [%expect
+    {|
+    ListLabels.fold_left ~f:${1:_} ~init:${2:_} ${3:_}$0
+    f ~name:${1:_} ?limit:${2:_} ${3:_}$0
+    none
+    f ~a:${1:_} ~b:${2:_}$0
+    none
+    none
+    none
+    none
+    none
+    none
+    none
+    |}]
+;;


### PR DESCRIPTION
Offer secondary whole-call completions for OCaml functions with at least two labelled or optional arguments. Positional arguments do not count toward that threshold, but all arguments receive independent placeholders in declaration order.

For example, completing `target (call)` inserts:

```ocaml
target ~name:_ ?limit:_ _
```

Tab through each argument value, then exit the snippet after the call. Defaults are expression holes rather than guessed variable names.

List all ordinary completions first, followed by the `(call)` variants, preserving Merlin's order within each group. Return complete lists so clients can narrow both groups locally without extra requests. Leave individual label completions plain. Generate snippets only for snippet-capable clients in OCaml documents; derive the argument list by parsing the rendered function type, falling back to ordinary completion for unsupported names or unparseable types.
