### PR TITLE
feat(server): make destruct bodies interactive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Make generated destruct branch bodies interactive for clients with snippet edit
+  support. (#2204, @rgrinberg)
 - Offer whole-call completions for OCaml functions with multiple labelled or
   optional arguments, with editable slots for all arguments. (#2199, @rgrinberg)
 - Make generated construct completions interactive for clients with snippet support.

--- a/lsp/src/capabilities.ml
+++ b/lsp/src/capabilities.ml
@@ -164,6 +164,11 @@ let workspace_symbol_tag_support (t : t) =
 
 let workspace_edit (t : t) = Option.bind t.workspace (fun w -> w.workspaceEdit)
 
+let workspace_edit_snippet_support t =
+  Option.bind (workspace_edit t) (fun edit -> edit.snippetEditSupport)
+  |> Option.value ~default:false
+;;
+
 let workspace_edit_document_changes t =
   Option.bind (workspace_edit t) (fun edit -> edit.documentChanges)
   |> Option.value ~default:false

--- a/lsp/src/capabilities.mli
+++ b/lsp/src/capabilities.mli
@@ -108,6 +108,9 @@ val text_document_sync_dynamic_registration : t -> bool
 (** The set of workspace-symbol tags the client supports. *)
 val workspace_symbol_tag_support : t -> SymbolTag.t list option
 
+(** Whether the client supports snippet edits in workspace edits. *)
+val workspace_edit_snippet_support : t -> bool
+
 (** Whether the client supports document changes in workspace edits. *)
 val workspace_edit_document_changes : t -> bool
 

--- a/lsp/src/text_document.ml
+++ b/lsp/src/text_document.ml
@@ -123,13 +123,18 @@ let apply_text_document_edits t (edits : TextEdit.t list) =
   { t with text = Some text; zipper }
 ;;
 
-let workspace_edit t text_edits =
-  let textDocument =
-    OptionalVersionedTextDocumentIdentifier.create ~uri:t.uri ~version:t.version ()
+let workspace_edit_of_edits t edits =
+  let edit =
+    let textDocument =
+      OptionalVersionedTextDocumentIdentifier.create ~uri:t.uri ~version:t.version ()
+    in
+    TextDocumentEdit.create ~textDocument ~edits
   in
-  let edits = List.map text_edits ~f:(fun edit -> `TextEdit edit) in
-  let edit = TextDocumentEdit.create ~textDocument ~edits in
   WorkspaceEdit.create ~documentChanges:[ `TextDocumentEdit edit ] ()
+;;
+
+let workspace_edit t text_edits =
+  List.map text_edits ~f:(fun edit -> `TextEdit edit) |> workspace_edit_of_edits t
 ;;
 
 let absolute_position t pos =

--- a/lsp/src/text_document.mli
+++ b/lsp/src/text_document.mli
@@ -33,8 +33,19 @@ val set_version : t -> version:int -> t
     interpreted relative to the original document. *)
 val apply_text_document_edits : t -> TextEdit.t list -> t
 
+(** [workspace_edit_of_edits t edits] creates a versioned workspace edit that
+    applies ordinary, annotated, or snippet edits to [t]. *)
+val workspace_edit_of_edits
+  :  t
+  -> [ `TextEdit of TextEdit.t
+     | `AnnotatedTextEdit of AnnotatedTextEdit.t
+     | `SnippetTextEdit of SnippetTextEdit.t
+     ]
+       list
+  -> WorkspaceEdit.t
+
 (** [workspace_edit t edits] creates a versioned workspace edit that applies
-    [edits] to [t]. *)
+    ordinary text [edits] to [t]. *)
 val workspace_edit : t -> TextEdit.t list -> WorkspaceEdit.t
 
 (** [absolute_position t pos] returns the absolute position of [pos] inside

--- a/lsp/test/capabilities_tests.ml
+++ b/lsp/test/capabilities_tests.ml
@@ -30,6 +30,33 @@ let%expect_test "completion snippet support is opt-in" =
     |}]
 ;;
 
+let%expect_test "workspace snippet edit support is opt-in" =
+  List.iter
+    [ "no workspace", {|{}|}
+    ; "no workspace edit", {|{"workspace":{}}|}
+    ; "absent", {|{"workspace":{"workspaceEdit":{}}}|}
+    ; "false", {|{"workspace":{"workspaceEdit":{"snippetEditSupport":false}}}|}
+    ; "true", {|{"workspace":{"workspaceEdit":{"snippetEditSupport":true}}}|}
+    ; ( "completion snippets only"
+      , {|{"textDocument":{"completion":{"completionItem":{"snippetSupport":true}}}}|} )
+    ]
+    ~f:(fun (name, json) ->
+      let capabilities = Yojson.Safe.from_string json |> ClientCapabilities.t_of_yojson in
+      Stdlib.Printf.printf
+        "%s: %b\n"
+        name
+        (Capabilities.workspace_edit_snippet_support capabilities));
+  [%expect
+    {|
+    no workspace: false
+    no workspace edit: false
+    absent: false
+    false: false
+    true: true
+    completion snippets only: false
+    |}]
+;;
+
 let capabilities ?folding_range () =
   let textDocument =
     TextDocumentClientCapabilities.create ?foldingRange:folding_range ()

--- a/ocaml-lsp-server/src/code_actions/action_destruct.ml
+++ b/ocaml-lsp-server/src/code_actions/action_destruct.ml
@@ -4,13 +4,41 @@ open Fiber.O
 let action_kind = "destruct (enumerate cases)"
 let kind = CodeActionKind.Other action_kind
 
-let code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc (loc, newText) =
+let code_action_of_case_analysis
+      ~action_kind
+      ~supportsJumpToNextHole
+      ~supportsSnippetEdits
+      doc
+      (loc, newText)
+  =
   let range : Range.t = Range.of_loc loc in
   let textedit : TextEdit.t = { range; newText } in
-  let edit = Text_document.workspace_edit (Document.text_document doc) [ textedit ] in
+  let snippet =
+    match supportsSnippetEdits with
+    | false -> None
+    | true ->
+      let { Snippet_builder.snippet; placeholders } =
+        Snippet_builder.source ~holes:`After_arrow ~source:newText
+      in
+      Option.some_if (placeholders > 0) snippet
+  in
+  let edit =
+    let edits =
+      match snippet with
+      | None -> [ `TextEdit textedit ]
+      | Some snippet ->
+        [ `SnippetTextEdit
+            (SnippetTextEdit.create
+               ~range
+               ~snippet:(StringValue.create ~value:(Snippet.to_string snippet))
+               ())
+        ]
+    in
+    Text_document.workspace_edit_of_edits (Document.text_document doc) edits
+  in
   let title = String.capitalize action_kind in
   let command =
-    if supportsJumpToNextHole
+    if Option.is_none snippet && supportsJumpToNextHole
     then
       Some
         (Client.Custom_commands.next_hole
@@ -61,7 +89,15 @@ let run state doc ~(dispatch : dispatch) ~action_kind ~(range : Range.t) ~postpr
       let supportsJumpToNextHole =
         Experimental.bool (State.experimental_client_capabilities state) "jumpToNextHole"
       in
-      code_action_of_case_analysis ~action_kind ~supportsJumpToNextHole doc reply)
+      let supportsSnippetEdits =
+        State.client_capabilities state |> Capabilities.workspace_edit_snippet_support
+      in
+      code_action_of_case_analysis
+        ~action_kind
+        ~supportsJumpToNextHole
+        ~supportsSnippetEdits
+        doc
+        reply)
   | Error
       { exn =
           ( Merlin_analysis.Destruct.Wrong_parent _

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -373,7 +373,7 @@ module Complete_with_construct = struct
           | false -> None
           | true ->
             let { Snippet_builder.snippet; placeholders } =
-              Snippet_builder.source ~source:expr
+              Snippet_builder.source ~holes:`Expression ~source:expr
             in
             Option.some_if (placeholders > 0) snippet
         in

--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -273,6 +273,8 @@ include struct
   module Server_notification = Lsp.Server_notification
   module SetTraceParams = SetTraceParams
   module Snippet = Lsp.Snippet
+  module SnippetTextEdit = SnippetTextEdit
+  module StringValue = StringValue
   module ShowDocumentClientCapabilities = ShowDocumentClientCapabilities
   module ShowDocumentParams = ShowDocumentParams
   module ShowDocumentResult = ShowDocumentResult

--- a/ocaml-lsp-server/src/snippet_builder.ml
+++ b/ocaml-lsp-server/src/snippet_builder.ml
@@ -7,6 +7,11 @@ type t =
   ; placeholders : int
   }
 
+type hole_kind =
+  [ `Expression
+  | `After_arrow
+  ]
+
 let rec lexer_result = function
   | Lexer.Return token -> token
   | Refill refill -> lexer_result (refill ())
@@ -15,11 +20,44 @@ let rec lexer_result = function
 
 let lexer_token lexer lexbuf = lexer_result (Lexer.token_without_comments lexer lexbuf)
 
-let expression_hole_ranges source =
+let expression_hole_ranges ~context ~holes source =
+  let arrow_holes = ref (Set.empty (module Int)) in
   match
-    let lexbuf = Lexing.from_string source in
-    let lexer = Lexer.make (Lexer.keywords []) in
-    Parser.parse_expression (lexer_token lexer) lexbuf
+    let next_source_token =
+      let lexer = Lexer.make (Lexer.keywords []) in
+      match holes with
+      | `Expression -> lexer_token lexer
+      | `After_arrow ->
+        let previous = ref Parser.EOF in
+        fun lexbuf ->
+          let token = lexer_token lexer lexbuf in
+          (match token, !previous with
+           | Parser.UNDERSCORE, Parser.MINUSGREATER ->
+             arrow_holes := Set.add !arrow_holes (Lexing.lexeme_start lexbuf)
+           | _ -> ());
+          previous := token;
+          token
+    in
+    let prefix, suffix =
+      match context with
+      | `Expression -> [], []
+      | `Cases -> [ Parser.FUNCTION ], []
+      | `Cases_with_final_pattern ->
+        [ Parser.FUNCTION ], [ Parser.MINUSGREATER; Parser.LPAREN; Parser.RPAREN ]
+    in
+    let prefix = Queue.of_list prefix in
+    let suffix = Queue.of_list suffix in
+    (* Synthetic tokens have zero-width locations at the start or EOF. Lexing
+       the original source keeps every real token's location unchanged. *)
+    let next lexbuf =
+      match Queue.dequeue prefix with
+      | Some token -> token
+      | None ->
+        (match next_source_token lexbuf with
+         | Parser.EOF -> Option.value (Queue.dequeue suffix) ~default:Parser.EOF
+         | token -> token)
+    in
+    Parser.parse_expression next (Lexing.from_string source)
   with
   | exception Parser.Error -> Error ()
   | expression ->
@@ -44,16 +82,31 @@ let expression_hole_ranges source =
     in
     let iterator = { Ocaml_parsing.Ast_iterator.default_iterator with expr } in
     iterator.expr iterator expression;
+    let ranges =
+      List.dedup_and_sort !ranges ~compare:(fun (start, _) (start', _) ->
+        Int.compare start start')
+    in
     Ok
-      (List.dedup_and_sort !ranges ~compare:(fun (start, _) (start', _) ->
-         Int.compare start start'))
+      (match holes with
+       | `Expression -> ranges
+       | `After_arrow ->
+         (* An underscore after an arrow can also be a type wildcard. Retain only
+            candidates confirmed to be expression holes by the parser. *)
+         List.filter ranges ~f:(fun (start, _) -> Set.mem !arrow_holes start))
 ;;
 
-let source ~source =
+let source ~holes ~source =
   let ranges =
-    match expression_hole_ranges source with
-    | Ok ranges -> ranges
-    | Error () -> []
+    let contexts =
+      match holes with
+      | `Expression -> [ `Expression ]
+      | `After_arrow -> [ `Expression; `Cases; `Cases_with_final_pattern ]
+    in
+    List.find_map contexts ~f:(fun context ->
+      match expression_hole_ranges ~context ~holes source with
+      | Error () -> None
+      | Ok ranges -> Some ranges)
+    |> Option.value ~default:[]
   in
   let rec snippets offset = function
     | [] -> [ Snippet.text (String.drop_prefix source offset); Snippet.tabstop 0 ]

--- a/ocaml-lsp-server/src/snippet_builder.mli
+++ b/ocaml-lsp-server/src/snippet_builder.mli
@@ -5,11 +5,19 @@ type t =
   ; placeholders : int
   }
 
-(** Convert expression holes in OCaml source to snippet placeholders while
-    leaving wildcard patterns unchanged. [placeholders] counts the generated
-    placeholders. If parsing fails, the source is preserved without placeholders
-    and [placeholders] is zero. A final tab stop is always appended. *)
-val source : source:string -> t
+type hole_kind =
+  [ `Expression
+  | `After_arrow
+  ]
+
+(** Convert OCaml holes to snippet placeholders. [`Expression] converts
+    expression holes while leaving wildcard patterns unchanged. [`After_arrow]
+    converts only expression holes immediately following [->], including in
+    generated case fragments. Type wildcards are left unchanged. [placeholders]
+    counts the generated placeholders. If parsing or lexing fails, the source is
+    preserved without placeholders and [placeholders] is zero. A final tab stop
+    is always appended. *)
+val source : holes:hole_kind -> source:string -> t
 
 (** A whole-call snippet with one hole per top-level function argument, derived
     by parsing a rendered OCaml core type. Requires at least two labelled or

--- a/ocaml-lsp-server/test/e2e-new/code_actions.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.ml
@@ -7,13 +7,13 @@ let range ~start_line ~start_character ~end_line ~end_character =
   Range.create ~start ~end_
 ;;
 
-let iter_code_actions ?prep ?path ?capabilities ?(diagnostics = []) ?only ~source range =
+let iter_code_actions ?prep ?path ?capabilities ?(diagnostics = []) ?only ~source range k =
   let makeRequest textDocument =
     let context = CodeActionContext.create ~diagnostics ?only () in
     Lsp.Client_request.CodeAction
       (CodeActionParams.create ~textDocument ~range ~context ())
   in
-  iter_lsp_response ?prep ?path ?capabilities ~language_id:"ocaml" ~makeRequest ~source
+  iter_lsp_response ?prep ?path ?capabilities ~language_id:"ocaml" ~makeRequest ~source k
 ;;
 
 let print_code_action_result ?(filter = fun _ -> true) = function
@@ -55,6 +55,16 @@ let print_code_actions
     (print_code_action_result ?filter)
 ;;
 
+let snippet_edit_capabilities =
+  let workspace =
+    let workspaceEdit =
+      WorkspaceEditClientCapabilities.create ~snippetEditSupport:true ()
+    in
+    WorkspaceClientCapabilities.create ~workspaceEdit ()
+  in
+  ClientCapabilities.create ~workspace ()
+;;
+
 let find_action action_name action =
   match action with
   | `CodeAction { CodeAction.kind = Some (Other name); _ } ->
@@ -69,6 +79,7 @@ let parse_selection = Test.parse_selection
 let apply_code_action
       ?prep
       ?path
+      ?capabilities
       ?diagnostics
       ?(filter = fun _ -> true)
       title
@@ -78,7 +89,7 @@ let apply_code_action
   let open Option.O in
   (* collect code action results *)
   let code_actions = ref None in
-  iter_code_actions ?prep ?path ?diagnostics ~source range (fun ca ->
+  iter_code_actions ?prep ?path ?capabilities ?diagnostics ~source range (fun ca ->
     code_actions := Some ca);
   let* m_code_actions = !code_actions in
   let* code_actions = m_code_actions in
@@ -94,9 +105,20 @@ let apply_code_action
   Test.apply_workspace_edit source edit
 ;;
 
-let code_action_test ?prep ?path ?diagnostics ?filter ?(print_none = false) ~title source =
+let code_action_test
+      ?prep
+      ?path
+      ?capabilities
+      ?diagnostics
+      ?filter
+      ?(print_none = false)
+      ~title
+      source
+  =
   let src, range = parse_selection source in
-  match apply_code_action ?prep ?path ?diagnostics ?filter title src range with
+  match
+    apply_code_action ?prep ?path ?capabilities ?diagnostics ?filter title src range
+  with
   | None -> if print_none then print_endline "None"
   | Some result -> print_string result
 ;;

--- a/ocaml-lsp-server/test/e2e-new/code_actions.mli
+++ b/ocaml-lsp-server/test/e2e-new/code_actions.mli
@@ -34,6 +34,8 @@ val print_code_actions
   -> Range.t
   -> unit
 
+val snippet_edit_capabilities : ClientCapabilities.t
+
 val find_action
   :  string
   -> [ `Command of Command.t | `CodeAction of CodeAction.t ]
@@ -50,6 +52,7 @@ val parse_selection : string -> string * Range.t
 val apply_code_action
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string
+  -> ?capabilities:ClientCapabilities.t
   -> ?diagnostics:Diagnostic.t list
   -> ?filter:([ `Command of Command.t | `CodeAction of CodeAction.t ] -> bool)
   -> string
@@ -63,6 +66,7 @@ val apply_code_action
 val code_action_test
   :  ?prep:(unit Test.Import.Client.t -> unit Fiber.t)
   -> ?path:string
+  -> ?capabilities:ClientCapabilities.t
   -> ?diagnostics:Diagnostic.t list
   -> ?filter:([ `Command of Command.t | `CodeAction of CodeAction.t ] -> bool)
   -> ?print_none:bool

--- a/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_destruct.ml
@@ -10,6 +10,23 @@ let destruct_line =
     ~title:"Destruct-line (enumerate cases, use existing match)"
 ;;
 
+let has_edit ~snippet ~jump_to_next_hole = function
+  | `CodeAction { CodeAction.edit = Some edit; command; _ } ->
+    let command_matches =
+      match command with
+      | None -> not jump_to_next_hole
+      | Some { command = "ocaml.next-hole"; _ } -> jump_to_next_hole
+      | Some _ -> false
+    in
+    command_matches
+    &&
+      (match edit.documentChanges with
+      | Some [ `TextDocumentEdit { edits = [ `SnippetTextEdit _ ]; _ } ] -> snippet
+      | Some [ `TextDocumentEdit { edits = [ `TextEdit _ ]; _ } ] -> not snippet
+      | _ -> false)
+  | _ -> false
+;;
+
 let rec censor_backtraces = function
   | `Assoc fields ->
     `Assoc
@@ -103,6 +120,151 @@ let f (x : t) = $x$
     {|
     type t = Foo of int | Bar of bool
     let f (x : t) = match x with | Foo _ -> _ | Bar _ -> _
+    |}]
+;;
+
+let%expect_test "destruct uses snippet edits for branch bodies when supported" =
+  destruct
+    ~capabilities:snippet_edit_capabilities
+    ~filter:(has_edit ~snippet:true ~jump_to_next_hole:false)
+    {ocaml|
+type t = Foo of int | Bar of bool
+let f (x : t) = $x$
+|ocaml};
+  [%expect
+    {|
+    type t = Foo of int | Bar of bool
+    let f (x : t) = match x with | Foo _ -> ${1:_} | Bar _ -> ${2:_}$0
+    |}]
+;;
+
+let%expect_test "destruct snippet edits and next-hole fallbacks" =
+  List.iter [ None; Some false; Some true ] ~f:(fun snippetEditSupport ->
+    List.iter [ false; true ] ~f:(fun jumpToNextHole ->
+      let workspaceEdit = WorkspaceEditClientCapabilities.create ?snippetEditSupport () in
+      let workspace = WorkspaceClientCapabilities.create ~workspaceEdit () in
+      let capabilities =
+        ClientCapabilities.create
+          ~workspace
+          ~experimental:(`Assoc [ "jumpToNextHole", `Bool jumpToNextHole ])
+          ()
+      in
+      Printf.printf
+        "snippetEditSupport=%s jumpToNextHole=%b\n"
+        (Option.value_map snippetEditSupport ~default:"absent" ~f:Bool.to_string)
+        jumpToNextHole;
+      let snippet = Option.value snippetEditSupport ~default:false in
+      destruct
+        ~capabilities
+        ~filter:(has_edit ~snippet ~jump_to_next_hole:(jumpToNextHole && not snippet))
+        {ocaml|let f (x : bool) = $x$
+|ocaml};
+      (* Refining a pattern generates no branch bodies: even a snippet-capable
+         client must receive a plain edit, retaining its next-hole fallback. *)
+      destruct
+        ~capabilities
+        ~filter:(has_edit ~snippet:false ~jump_to_next_hole:jumpToNextHole)
+        {ocaml|let f (x : bool) = match x with | $_$ -> ()
+|ocaml}));
+  [%expect
+    {|
+    snippetEditSupport=absent jumpToNextHole=false
+    let f (x : bool) = match x with | false -> _ | true -> _
+    let f (x : bool) = match x with | false | true -> ()
+    snippetEditSupport=absent jumpToNextHole=true
+    let f (x : bool) = match x with | false -> _ | true -> _
+    let f (x : bool) = match x with | false | true -> ()
+    snippetEditSupport=false jumpToNextHole=false
+    let f (x : bool) = match x with | false -> _ | true -> _
+    let f (x : bool) = match x with | false | true -> ()
+    snippetEditSupport=false jumpToNextHole=true
+    let f (x : bool) = match x with | false -> _ | true -> _
+    let f (x : bool) = match x with | false | true -> ()
+    snippetEditSupport=true jumpToNextHole=false
+    let f (x : bool) = match x with | false -> ${1:_} | true -> ${2:_}$0
+    let f (x : bool) = match x with | false | true -> ()
+    snippetEditSupport=true jumpToNextHole=true
+    let f (x : bool) = match x with | false -> ${1:_} | true -> ${2:_}$0
+    let f (x : bool) = match x with | false | true -> ()
+    |}]
+;;
+
+let%expect_test "destruct-line snippets expand a multiline match" =
+  destruct_line
+    ~capabilities:snippet_edit_capabilities
+    ~filter:(has_edit ~snippet:true ~jump_to_next_hole:false)
+    {ocaml|
+type t = Foo of int | Bar of bool
+let f (x : t) =
+  mat$ch x
+|ocaml};
+  [%expect
+    {|
+    type t = Foo of int | Bar of bool
+    let f (x : t) =
+      match x with
+      | Foo _ -> ${1:_}
+      | Bar _ -> ${2:_}$0
+    |}]
+;;
+
+let%expect_test
+    "destruct-line snippets append missing cases without changing existing bodies"
+  =
+  destruct_line
+    ~capabilities:snippet_edit_capabilities
+    ~filter:(has_edit ~snippet:true ~jump_to_next_hole:false)
+    {ocaml|
+type t = A | B | C
+let f (x : t) =
+  match x with
+$  | C -> 42
+|ocaml};
+  [%expect
+    {|
+    type t = A | B | C
+    let f (x : t) =
+      match x with
+      | C -> 42
+      | A -> ${1:_}
+      | B -> ${2:_}$0
+    |}]
+;;
+
+let%expect_test
+    "destruct-line snippets refine a pattern while retaining its existing body"
+  =
+  destruct_line
+    ~capabilities:snippet_edit_capabilities
+    ~filter:(has_edit ~snippet:true ~jump_to_next_hole:false)
+    {ocaml|
+let f (x : bool) =
+  match x with
+  | $_$ -> 42
+|ocaml};
+  [%expect
+    {|
+    let f (x : bool) =
+      match x with
+      | false -> ${1:_}
+      | true$0 -> 42
+    |}]
+;;
+
+let%expect_test
+    "destruct snippets do not turn scrutinee type wildcards into expression slots"
+  =
+  destruct
+    ~capabilities:snippet_edit_capabilities
+    ~filter:(has_edit ~snippet:true ~jump_to_next_hole:false)
+    {ocaml|
+let get _ = true
+let value = $((get : int -> _) 0)$
+|ocaml};
+  [%expect
+    {|
+    let get _ = true
+    let value = match (get : int -> _) 0 with | false -> ${1:_} | true -> ${2:_}$0
     |}]
 ;;
 

--- a/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
@@ -18,6 +18,7 @@ type fragment =
   | Function_with_wildcard
   | Match_with_wildcards
   | Tuple_holes
+  | Function_type_wildcard
 [@@deriving quickcheck, sexp_of]
 
 module Source_case = struct
@@ -31,14 +32,15 @@ let fragment = function
   | String_backslash -> "\"\\\\\""
   | Expression_hole -> "_"
   | Hole_identifier -> "_value"
-  | String_hole -> "\"_\""
+  | String_hole -> "\"-> _\""
   | Character_hole -> "'_'"
-  | Comment_hole -> "((* _ *) x)"
-  | Nested_comment_hole -> "((* outer (* _ *) *) x)"
-  | Quoted_string_hole -> "{tag|_ $}\\|tag}"
+  | Comment_hole -> "((* -> _ *) x)"
+  | Nested_comment_hole -> "((* -> (* -> _ *) _ *) x)"
+  | Quoted_string_hole -> "{tag|-> _ $}\\|tag}"
   | Function_with_wildcard -> "(fun _ -> _)"
   | Match_with_wildcards -> "(match _ with | Some _ -> _ | None -> _)"
   | Tuple_holes -> "(_, _)"
+  | Function_type_wildcard -> "(fun (f : int -> _) -> f)"
 ;;
 
 let placeholder_count = function
@@ -55,7 +57,8 @@ let placeholder_count = function
   | Character_hole
   | Comment_hole
   | Nested_comment_hole
-  | Quoted_string_hole -> 0
+  | Quoted_string_hole
+  | Function_type_wildcard -> 0
 ;;
 
 let source fragments =
@@ -99,7 +102,9 @@ let defaults snippet =
 
 let check_source fragments =
   let source = source fragments in
-  let { Builder.snippet; placeholders = actual_count } = Builder.source ~source in
+  let { Builder.snippet; placeholders = actual_count } =
+    Builder.source ~holes:`Expression ~source
+  in
   let expected_count = List.sum (module Int) fragments ~f:placeholder_count in
   if actual_count <> expected_count
   then
@@ -127,6 +132,7 @@ let source_examples =
   ; [ Match_with_wildcards ]
   ; [ String_hole; Comment_hole; Quoted_string_hole; Hole_identifier ]
   ; [ String_dollar; String_close_brace; String_backslash; Tuple_holes ]
+  ; [ Function_type_wildcard ]
   ]
 ;;
 
@@ -134,8 +140,8 @@ let%test_unit "only expression holes become placeholders without changing source
   Test.run_exn (module Source_case) ~examples:source_examples ~f:check_source
 ;;
 
-let print_source source =
-  let { Builder.snippet; placeholders } = Builder.source ~source in
+let print_source ?(holes = `Expression) source =
+  let { Builder.snippet; placeholders } = Builder.source ~holes ~source in
   Stdlib.Printf.printf "%d: %s\n" placeholders (Snippet.to_string snippet)
 ;;
 
@@ -180,7 +186,7 @@ let%expect_test "attributes on holes retain wildcard patterns and visit expressi
 let%expect_test "parse failures preserve source without placeholders" =
   List.iter
     [ ""; "(_"; "\"unterminated"; "(* unterminated"; {ocaml|("$}", _|ocaml} ]
-    ~f:print_source;
+    ~f:(print_source ~holes:`Expression);
   [%expect
     {|
     0: $0
@@ -188,6 +194,162 @@ let%expect_test "parse failures preserve source without placeholders" =
     0: "unterminated$0
     0: (* unterminated$0
     0: ("\$\}", _$0
+    |}]
+;;
+
+let after_arrow_placeholder_count = function
+  | Function_with_wildcard -> 1
+  | Match_with_wildcards -> 2
+  | Variable
+  | String_dollar
+  | String_close_brace
+  | String_backslash
+  | Expression_hole
+  | Hole_identifier
+  | String_hole
+  | Character_hole
+  | Comment_hole
+  | Nested_comment_hole
+  | Quoted_string_hole
+  | Tuple_holes
+  | Function_type_wildcard -> 0
+;;
+
+let check_after_arrow fragments =
+  let source = source fragments in
+  let { Builder.snippet; placeholders = actual_count } =
+    Builder.source ~holes:`After_arrow ~source
+  in
+  let expected_count = List.sum (module Int) fragments ~f:after_arrow_placeholder_count in
+  if actual_count <> expected_count
+  then
+    failwith
+      (Printf.sprintf
+         "branch-body placeholder count for %S: expected %d, got %d"
+         source
+         expected_count
+         actual_count);
+  let rendered = Snippet.to_string snippet in
+  let round_trip = defaults rendered in
+  if not (String.equal source round_trip)
+  then
+    failwith
+      (Printf.sprintf
+         "branch-body round trip: expected %S, got %S via %S"
+         source
+         round_trip
+         rendered)
+;;
+
+let%test_unit "only branch-body holes become placeholders in destruct output" =
+  Test.run_exn (module Source_case) ~examples:source_examples ~f:check_after_arrow
+;;
+
+let%expect_test "after-arrow holes ignore comments, strings, and non-body underscores" =
+  List.iter
+    [ "function | Some _ -> (* -> _ (* -> _ *) *) _ | None ->\n _"
+    ; {ocaml|function | _ when "-> _ $}\\" = {tag|-> _|tag} -> _|ocaml}
+    ; {ocaml|function | _ -> _value | _ -> "-> _"|ocaml}
+    ; "function | _ -> (_ : _) | _ -> [%merlin.hole]"
+    ; "fun _ -> _ [@foo? _]"
+    ; "fun _ -> _ [@foo (fun _ -> _)]"
+    ; "fun _ -> _ + 1"
+    ; "function _ when (fun _ -> _) () -> _"
+    ; "match (let café = \"😀\" in _) with | Some _ -> _ | None -> _"
+    ]
+    ~f:(print_source ~holes:`After_arrow);
+  [%expect
+    {|
+    2: function | Some _ -> (* -> _ (* -> _ *) *) ${1:_} | None ->
+     ${2:_}$0
+    1: function | _ when "-> _ \$\}\\\\" = {tag|-> _|tag\} -> ${1:_}$0
+    0: function | _ -> _value | _ -> "-> _"$0
+    0: function | _ -> (_ : _) | _ -> [%merlin.hole]$0
+    1: fun _ -> ${1:_} [@foo? _]$0
+    2: fun _ -> ${1:_} [@foo (fun _ -> ${2:_})]$0
+    1: fun _ -> ${1:_} + 1$0
+    2: function _ when (fun _ -> ${1:_}) () -> ${2:_}$0
+    2: match (let café = "😀" in _) with | Some _ -> ${1:_} | None -> ${2:_}$0
+    |}]
+;;
+
+let%expect_test "after-arrow holes work in complete and partial case fragments" =
+  List.iter
+    [ "| Some _ -> _ | None -> _"
+    ; "false -> _ | true"
+    ; "| (Some _ | None) -> _"
+    ; "Some _ | None"
+    ; "None -> (_)"
+    ; "| Some \"😀\" -> _ | None"
+    ]
+    ~f:(print_source ~holes:`After_arrow);
+  [%expect
+    {|
+    2: | Some _ -> ${1:_} | None -> ${2:_}$0
+    1: false -> ${1:_} | true$0
+    1: | (Some _ | None) -> ${1:_}$0
+    0: Some _ | None$0
+    0: None -> (_)$0
+    1: | Some "😀" -> ${1:_} | None$0
+    |}]
+;;
+
+let%expect_test "case context preserves holes at source boundaries and around comments" =
+  List.iter
+    [ "_ -> _"
+    ; "_ -> _ | _"
+    ; "| Some \"😀\" -> _ | None (* -> _ *)"
+    ; "(* 😀 *)\n| Some _ -> _\n| None (* end *)"
+    ; "_ | _"
+    ]
+    ~f:(print_source ~holes:`After_arrow);
+  [%expect
+    {|
+    1: _ -> ${1:_}$0
+    1: _ -> ${1:_} | _$0
+    1: | Some "😀" -> ${1:_} | None (* -> _ *)$0
+    1: (* 😀 *)
+    | Some _ -> ${1:_}
+    | None (* end *)$0
+    0: _ | _$0
+    |}]
+;;
+
+let%expect_test "after-arrow parse and lexing failures preserve the entire source" =
+  List.iter
+    [ ""
+    ; "| A -> _ | B -> \"unterminated"
+    ; "| A -> _ (* unterminated"
+    ; "| A -> _ | B -> {tag|unterminated"
+    ; "function | A -> _ |"
+    ; "fun -> _"
+    ]
+    ~f:(print_source ~holes:`After_arrow);
+  [%expect
+    {|
+    0: $0
+    0: | A -> _ | B -> "unterminated$0
+    0: | A -> _ (* unterminated$0
+    0: | A -> _ | B -> {tag|unterminated$0
+    0: function | A -> _ |$0
+    0: fun -> _$0
+    |}]
+;;
+
+let%expect_test
+    "after-arrow holes exclude type wildcards in expressions and case fragments"
+  =
+  List.iter
+    [ "match (f : int -> _) 0 with | Some _ -> _ | None -> _"
+    ; "| (Some (_ : int -> _)) -> _ | None -> _"
+    ; "| Some _ -> _ | Some (_ : int -> _)"
+    ]
+    ~f:(print_source ~holes:`After_arrow);
+  [%expect
+    {|
+    2: match (f : int -> _) 0 with | Some _ -> ${1:_} | None -> ${2:_}$0
+    2: | (Some (_ : int -> _)) -> ${1:_} | None -> ${2:_}$0
+    1: | Some _ -> ${1:_} | Some (_ : int -> _)$0
     |}]
 ;;
 
@@ -236,7 +398,7 @@ let check_application arguments =
     let rendered = Snippet.to_string snippet in
     let expected_placeholders = List.length arguments in
     let { Builder.placeholders = actual_placeholders; _ } =
-      Builder.source ~source:(defaults rendered)
+      Builder.source ~holes:`Expression ~source:(defaults rendered)
     in
     if actual_placeholders <> expected_placeholders
     then


### PR DESCRIPTION
Make the generated branch bodies from `destruct` and `destruct-line` independently editable snippet placeholders, so users can navigate between them without moving through pattern wildcards.

- Require `workspace.workspaceEdit.snippetEditSupport`; completion snippet support alone is insufficient.
- Handle complete expressions and partial case fragments, leaving pattern and type wildcards unchanged. Supply parser context using synthetic tokens rather than source-string wrappers, preserving original source locations.
- Prefer snippet navigation over `ocaml.next-hole` when both are supported. Preserve plain edits and the existing next-hole fallback when snippets are unsupported or no branch-body holes are generated.

The interactive path is covered by protocol and property tests. Real-editor validation currently covers only the plain-edit fallback: the available Neovim build does not support snippet workspace edits.
