### PR TITLE
feat(server): link extracted names with placeholders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Let clients with workspace snippet-edit support rename extracted locals and
+  functions interactively. (#2207, @rgrinberg)
 - Offer parenthesized application snippets for constructors with payloads, with
   independent argument slots, while retaining name-only completions. (#2212, @rgrinberg)
 - Make generated destruct branch bodies interactive for clients with snippet edit

--- a/ocaml-lsp-server/src/code_actions.ml
+++ b/ocaml-lsp-server/src/code_actions.ml
@@ -56,8 +56,8 @@ let compute_ocaml_code_actions (params : CodeActionParams.t) state doc =
       ; (if client_can_resolve_edits state
          then Action_inline.unresolved
          else Action_inline.t)
-      ; Action_extract.local
-      ; Action_extract.function_
+      ; Action_extract.local state
+      ; Action_extract.function_ state
       ]
   in
   let batchable, non_batchable =

--- a/ocaml-lsp-server/src/code_actions/action_extract.ml
+++ b/ocaml-lsp-server/src/code_actions/action_extract.ml
@@ -3,6 +3,53 @@ open Option.O
 module H = Ocaml_parsing.Ast_helper
 module Typedtree_utils = Merlin_analysis.Typedtree_utils
 
+type extraction =
+  { range : Range.t
+  ; insert_range : Range.t
+  ; name : string
+  ; binding_suffix : string
+  ; call_suffix : string
+  }
+
+let workspace_edit state doc { range; insert_range; name; binding_suffix; call_suffix } =
+  let text_document = Document.text_document doc in
+  if State.client_capabilities state |> Capabilities.workspace_edit_snippet_support
+  then
+    (* Only snippet clients need to copy the source between the insertion and
+       replacement. Keep the ordinary-edit fallback independent of this work. *)
+    let+ before_expression =
+      Text_document.substring
+        text_document
+        (Range.create ~start:insert_range.start ~end_:range.start)
+    in
+    let name = Snippet.placeholder ~index:1 (Snippet.text name) in
+    let snippet =
+      Snippet.concat
+        [ Snippet.text "let "
+        ; name
+        ; Snippet.text binding_suffix
+        ; Snippet.text before_expression
+        ; name
+        ; Snippet.text call_suffix
+        ; Snippet.tabstop 0
+        ]
+    in
+    let edit =
+      SnippetTextEdit.create
+        ~range:(Range.create ~start:insert_range.start ~end_:range.end_)
+        ~snippet:(StringValue.create ~value:(Snippet.to_string snippet))
+        ()
+    in
+    Text_document.workspace_edit_of_edits text_document [ `SnippetTextEdit edit ]
+  else
+    Some
+      (Text_document.workspace_edit
+         text_document
+         [ TextEdit.create ~range:insert_range ~newText:("let " ^ name ^ binding_suffix)
+         ; TextEdit.create ~range ~newText:(name ^ call_suffix)
+         ])
+;;
+
 let range_contains_loc range loc =
   match Range.of_loc_opt loc with
   | Some range' -> Range.contains range range'
@@ -169,15 +216,14 @@ let constructors_available (expr : Typedtree.expression) destination_env =
 let extract_local doc typedtree range =
   let* to_extract = largest_enclosed_expression typedtree range in
   let* extract_range = Range.of_loc_opt to_extract.exp_loc in
-  let* edit_pos = tightest_enclosing_binder_position typedtree range in
-  let new_name = "var_name" in
   let* local_text = Text_document.substring (Document.text_document doc) extract_range in
-  let newText = sprintf "let %s = %s in\n" new_name local_text in
-  let insert_range = { Range.start = edit_pos; end_ = edit_pos } in
-  Some
-    [ TextEdit.create ~newText ~range:insert_range
-    ; TextEdit.create ~newText:new_name ~range:extract_range
-    ]
+  let+ edit_pos = tightest_enclosing_binder_position typedtree range in
+  { range = extract_range
+  ; insert_range = Range.create ~start:edit_pos ~end_:edit_pos
+  ; name = "var_name"
+  ; binding_suffix = " = " ^ local_text ^ " in\n"
+  ; call_suffix = ""
+  }
 ;;
 
 let extract_function doc typedtree range =
@@ -186,7 +232,6 @@ let extract_function doc typedtree range =
   let* parent_item = enclosing_structure_item typedtree range in
   let* () = Option.some_if (constructors_available to_extract parent_item.str_env) () in
   let* edit_pos = Position.of_lexical_position parent_item.str_loc.loc_start in
-  let new_name = "fun_name" in
   let* args_str =
     let free_vars = must_pass to_extract parent_item.str_env in
     let+ args =
@@ -198,47 +243,50 @@ let extract_function doc typedtree range =
     let s = String.concat ~sep:" " args in
     if String.is_empty s then "()" else s
   in
-  let* func_text = Text_document.substring (Document.text_document doc) extract_range in
-  let new_function = sprintf "let %s %s = %s\n\n" new_name args_str func_text in
-  let new_call = sprintf "%s %s" new_name args_str in
-  let insert_range = { Range.start = edit_pos; end_ = edit_pos } in
-  Some
-    [ TextEdit.create ~newText:new_function ~range:insert_range
-    ; TextEdit.create ~newText:new_call ~range:extract_range
-    ]
+  let+ func_text = Text_document.substring (Document.text_document doc) extract_range in
+  { range = extract_range
+  ; insert_range = Range.create ~start:edit_pos ~end_:edit_pos
+  ; name = "fun_name"
+  ; binding_suffix = " " ^ args_str ^ " = " ^ func_text ^ "\n\n"
+  ; call_suffix = " " ^ args_str
+  }
 ;;
 
-let run_extract_local pipeline doc (params : CodeActionParams.t) =
-  let typer = Mpipeline.typer_result pipeline in
-  let* typedtree =
-    match Mtyper.get_typedtree typer with
-    | `Interface _ -> None
-    | `Implementation x -> Some x
+let run_extract_local state pipeline doc (params : CodeActionParams.t) =
+  let* extraction =
+    let* typedtree =
+      match Mpipeline.typer_result pipeline |> Mtyper.get_typedtree with
+      | `Interface _ -> None
+      | `Implementation x -> Some x
+    in
+    extract_local doc typedtree params.range
   in
-  let+ edits = extract_local doc typedtree params.range in
+  let+ edit = workspace_edit state doc extraction in
   CodeAction.create
     ~title:"Extract local"
     ~kind:CodeActionKind.RefactorExtract
-    ~edit:(Text_document.workspace_edit (Document.text_document doc) edits)
+    ~edit
     ~isPreferred:false
     ()
 ;;
 
-let run_extract_function pipeline doc (params : CodeActionParams.t) =
-  let typer = Mpipeline.typer_result pipeline in
-  let* typedtree =
-    match Mtyper.get_typedtree typer with
-    | `Interface _ -> None
-    | `Implementation x -> Some x
+let run_extract_function state pipeline doc (params : CodeActionParams.t) =
+  let* extraction =
+    let* typedtree =
+      match Mpipeline.typer_result pipeline |> Mtyper.get_typedtree with
+      | `Interface _ -> None
+      | `Implementation x -> Some x
+    in
+    extract_function doc typedtree params.range
   in
-  let+ edits = extract_function doc typedtree params.range in
+  let+ edit = workspace_edit state doc extraction in
   CodeAction.create
     ~title:"Extract function"
     ~kind:CodeActionKind.RefactorExtract
-    ~edit:(Text_document.workspace_edit (Document.text_document doc) edits)
+    ~edit
     ~isPreferred:false
     ()
 ;;
 
-let local = Code_action.batchable RefactorExtract run_extract_local
-let function_ = Code_action.batchable RefactorExtract run_extract_function
+let local state = Code_action.batchable RefactorExtract (run_extract_local state)
+let function_ state = Code_action.batchable RefactorExtract (run_extract_function state)

--- a/ocaml-lsp-server/src/code_actions/action_extract.mli
+++ b/ocaml-lsp-server/src/code_actions/action_extract.mli
@@ -1,2 +1,2 @@
-val local : Code_action.t
-val function_ : Code_action.t
+val local : State.t -> Code_action.t
+val function_ : State.t -> Code_action.t

--- a/ocaml-lsp-server/test/e2e-new/action_extract.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_extract.ml
@@ -1,5 +1,5 @@
-let extract_local_test = Code_actions.code_action_test ~title:"Extract local"
-let extract_function_test = Code_actions.code_action_test ~title:"Extract function"
+let extract_local_test = Code_actions_extract.test ~kind:`Local
+let extract_function_test = Code_actions_extract.test ~kind:`Function
 
 let%expect_test "extract local constant" =
   extract_local_test

--- a/ocaml-lsp-server/test/e2e-new/code_actions_extract.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_actions_extract.ml
@@ -1,0 +1,430 @@
+open Test.Import
+
+let default_name = function
+  | `Local -> "var_name"
+  | `Function -> "fun_name"
+;;
+
+(* Decode only the grammar emitted by extraction: escaped literal text, two
+   occurrences of placeholder 1, and a final tabstop. This checks protocol text,
+   not a real editor's snippet implementation. *)
+let expand ~default ~name snippet =
+  let placeholder = "${1:" ^ default ^ "}" in
+  let buffer = Buffer.create (String.length snippet) in
+  let names = ref 0
+  and final = ref 0 in
+  let matches pos text =
+    let length = String.length text in
+    pos + length <= String.length snippet
+    && String.equal (String.sub snippet ~pos ~len:length) text
+  in
+  let rec loop pos =
+    if pos < String.length snippet
+    then (
+      match snippet.[pos] with
+      | '\\' ->
+        assert (pos + 1 < String.length snippet);
+        let escaped = snippet.[pos + 1] in
+        assert (List.mem [ '\\'; '$'; '}' ] escaped ~equal:Char.equal);
+        Buffer.add_char buffer escaped;
+        loop (pos + 2)
+      | '$' when matches pos placeholder ->
+        incr names;
+        Buffer.add_string buffer name;
+        loop (pos + String.length placeholder)
+      | '$' when matches pos "$0" ->
+        incr final;
+        assert (pos + 2 = String.length snippet)
+      | '$' -> failwith "unexpected snippet syntax"
+      | char ->
+        Buffer.add_char buffer char;
+        loop (pos + 1))
+  in
+  loop 0;
+  assert (!names = 2 && !final = 1);
+  Buffer.contents buffer
+;;
+
+let request ?path ~capabilities ~kind ~source ~range () =
+  let title =
+    match kind with
+    | `Local -> "Extract local"
+    | `Function -> "Extract function"
+  in
+  let result = ref None in
+  Code_actions.iter_code_actions
+    ?path
+    ~capabilities
+    ~only:[ RefactorExtract ]
+    ~source
+    range
+    (fun actions ->
+       result
+       := Option.bind
+            actions
+            ~f:
+              (List.find_map ~f:(function
+                 | `CodeAction (action : CodeAction.t)
+                   when String.equal action.title title ->
+                   assert (action.kind = Some RefactorExtract);
+                   assert (action.command = None && action.isPreferred = Some false);
+                   let edit = Option.value_exn action.edit in
+                   assert (Option.is_none edit.changes);
+                   (match edit.documentChanges with
+                    | Some [ `TextDocumentEdit { textDocument; edits } ] ->
+                      assert (textDocument.version = Some 0);
+                      Some edits
+                    | _ -> failwith "expected one versioned document edit")
+                 | _ -> None)));
+  !result
+;;
+
+let apply ?(position_encoding = `UTF16) ~source edits =
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:Helpers.uri
+      ~version:0
+      ~languageId:(Other "ocaml")
+      ~text:source
+  in
+  let doc =
+    Lsp.Text_document.make
+      ~position_encoding
+      (DidOpenTextDocumentParams.create ~textDocument)
+  in
+  Lsp.Text_document.apply_text_document_edits doc edits |> Lsp.Text_document.text
+;;
+
+let plain_edits = function
+  | [ `TextEdit a; `TextEdit b ] -> [ a; b ]
+  | _ -> failwith "expected two ordinary edits"
+;;
+
+let check ?path ?name ~kind ~source ~range () =
+  let plain =
+    request ?path ~capabilities:(ClientCapabilities.create ()) ~kind ~source ~range ()
+  in
+  let snippet =
+    request
+      ?path
+      ~capabilities:Code_actions.snippet_edit_capabilities
+      ~kind
+      ~source
+      ~range
+      ()
+  in
+  match plain, snippet with
+  | None, None -> None
+  | Some plain, Some [ `SnippetTextEdit edit ] ->
+    let default = default_name kind in
+    let expand name =
+      let newText = expand ~default ~name edit.snippet.value in
+      apply ~source [ TextEdit.create ~range:edit.range ~newText ]
+    in
+    assert (String.equal (apply ~source (plain_edits plain)) (expand default));
+    Some (expand (Option.value name ~default))
+  | _ -> failwith "plain and snippet extraction availability differs"
+;;
+
+let test ?name ~kind marked_source =
+  let source, range = Test.parse_selection marked_source in
+  check ?name ~kind ~source ~range () |> Option.iter ~f:print_string
+;;
+
+let%expect_test "local name links without touching existing names or surrounding source" =
+  test
+    ~kind:`Local
+    ~name:"chosen"
+    {|let f =
+  0 (* var_name stays in this comment *) +
+  $(1 + 2)$ + String.length "var_name"
+|};
+  [%expect
+    {|
+    let f =
+      let chosen = (1 + 2) in
+    0 (* var_name stays in this comment *) +
+      chosen + String.length "var_name"
+    |}]
+;;
+
+let%expect_test "function name links and the suffix remains outside the edit" =
+  test
+    ~kind:`Function
+    ~name:"chosen"
+    {|let f x =
+  (* fun_name stays in this comment *)
+  $(x * 2)$ + String.length "fun_name"
+|};
+  [%expect
+    {|
+    let chosen x = (x * 2)
+
+    let f x =
+      (* fun_name stays in this comment *)
+      chosen x + String.length "fun_name"
+    |}]
+;;
+
+let%expect_test "snippet metacharacters in the body and intervening source stay literal" =
+  (* Substitute dollar signs after parsing selection markers; both are one
+     UTF-16 code unit, so this does not change the selection's positions. *)
+  let source, range =
+    Test.parse_selection
+      {|let f =
+  0 + (* %0 %{1:var_name} %{1:fun_name} \\ } *)
+  $(String.length "%0 %{1:var_name} %{1:fun_name} \\ }")$ + 1
+|}
+  in
+  let source = String.tr source ~target:'%' ~replacement:'$' in
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    check ~name:"chosen" ~kind ~source ~range () |> Option.value_exn |> print_endline);
+  [%expect
+    {|
+    let f =
+      let chosen = (String.length "$0 ${1:var_name} ${1:fun_name} \\ }") in
+    0 + (* $0 ${1:var_name} ${1:fun_name} \\ } *)
+      chosen + 1
+
+    let chosen () = (String.length "$0 ${1:var_name} ${1:fun_name} \\ }")
+
+    let f =
+      0 + (* $0 ${1:var_name} ${1:fun_name} \\ } *)
+      chosen () + 1
+    |}]
+;;
+
+let%expect_test "nested extraction preserves blank lines, comments, and case suffixes" =
+  let source =
+    {|let f x =
+  match x with
+  | None -> 0
+  | Some y ->
+    let z = y + 1 in
+
+    (* before *)
+    $(z * 2)$ + 3 (* after *)
+|}
+  in
+  test ~kind:`Local source;
+  test ~kind:`Function source;
+  [%expect
+    {|
+    let f x =
+      match x with
+      | None -> 0
+      | Some y ->
+        let z = y + 1 in
+
+        (* before *)
+        let var_name = (z * 2) in
+    var_name + 3 (* after *)
+    let fun_name z = (z * 2)
+
+    let f x =
+      match x with
+      | None -> 0
+      | Some y ->
+        let z = y + 1 in
+
+        (* before *)
+        fun_name z + 3 (* after *)
+    |}]
+;;
+
+(* These CR tests deliberately record the existing position-handling bugs.
+   Fix them with the general position-encoding work, not the snippet feature. *)
+let%expect_test "CR: UTF-16 extraction corrupts source around Unicode" =
+  let source = {|let café = String.length "😀" + $String.length "é😀"$ + 1|} in
+  test ~kind:`Local source;
+  print_newline ();
+  test ~kind:`Function source;
+  [%expect
+    {|
+    let café = Slet var_name = t in
+    tring.length "😀" + Svar_namering.length "é😀" + 1
+    let fun_name () = t
+
+    let café = String.length "😀" + Sfun_name ()ring.length "é😀" + 1
+    |}]
+;;
+
+let%expect_test
+    "CR: UTF-16 extraction selects the wrong expression after a Unicode parameter"
+  =
+  test ~kind:`Function ~name:"chosen" {|let f café = $café + 1$|};
+  [%expect
+    {|
+    let chosen () = 1
+
+    let f café = café + chosen ()
+    |}]
+;;
+
+let%expect_test "CR: extraction depends on the negotiated position encoding" =
+  let source, range =
+    Test.parse_selection {|let café = String.length "😀" + $String.length "é😀"$ + 1|}
+  in
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:Helpers.uri
+      ~version:0
+      ~languageId:(Other "ocaml")
+      ~text:source
+  in
+  let doc =
+    Lsp.Text_document.make
+      ~position_encoding:`UTF16
+      (DidOpenTextDocumentParams.create ~textDocument)
+  in
+  let start_offset, end_offset = Lsp.Text_document.absolute_range doc range in
+  let utf8_doc =
+    Lsp.Text_document.make
+      ~position_encoding:`UTF8
+      (DidOpenTextDocumentParams.create ~textDocument)
+  in
+  let utf8_range =
+    Lsp.Text_document.range_of_utf8_offsets utf8_doc ~start_offset ~end_offset
+  in
+  let general =
+    GeneralClientCapabilities.create ~positionEncodings:[ PositionEncodingKind.UTF8 ] ()
+  in
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    let utf16 = check ~kind ~source ~range () |> Option.value_exn in
+    let results =
+      List.map
+        [ ClientCapabilities.create (); Code_actions.snippet_edit_capabilities ]
+        ~f:(fun capabilities ->
+          let capabilities = { capabilities with general = Some general } in
+          let edits =
+            request ~capabilities ~kind ~source ~range:utf8_range () |> Option.value_exn
+          in
+          let edits =
+            List.map edits ~f:(function
+              | `TextEdit edit -> edit
+              | `SnippetTextEdit edit ->
+                let name = default_name kind in
+                TextEdit.create
+                  ~range:edit.range
+                  ~newText:(expand ~default:name ~name edit.snippet.value)
+              | _ -> assert false)
+          in
+          apply ~position_encoding:`UTF8 ~source edits)
+    in
+    match results with
+    | [ plain; snippet ] ->
+      assert (String.equal plain snippet);
+      Printf.printf "UTF-8 matches UTF-16: %b\n" (String.equal utf16 plain);
+      print_endline plain
+    | _ -> assert false);
+  [%expect
+    {|
+    UTF-8 matches UTF-16: false
+    let café = let var_name = String.length "é😀" in
+    String.length "😀" + var_name + 1
+    UTF-8 matches UTF-16: false
+    let fun_name () = String.length "é😀"
+
+    let café = String.length "😀" + fun_name () + 1
+    |}]
+;;
+
+let%expect_test "CRLF source around the extracted expression is preserved" =
+  let source, range =
+    Test.parse_selection "let f x =\r\n  (* before *)\r\n  $(x + 1)$ + 2\r\n"
+  in
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    let result = check ~kind ~source ~range () |> Option.value_exn in
+    assert (String.is_substring result ~substring:"\r\n  (* before *)\r\n");
+    assert (String.is_suffix result ~suffix:" + 2\r\n"));
+  [%expect {| |}]
+;;
+
+let%expect_test
+    "workspace capability controls edit kind independently of completion snippets"
+  =
+  let completionItem = ClientCompletionItemOptions.create ~snippetSupport:true () in
+  let completion = CompletionClientCapabilities.create ~completionItem () in
+  let textDocument = TextDocumentClientCapabilities.create ~completion () in
+  let caps workspace = ClientCapabilities.create ~textDocument ?workspace () in
+  let workspace snippetEditSupport =
+    let workspaceEdit = WorkspaceEditClientCapabilities.create ?snippetEditSupport () in
+    WorkspaceClientCapabilities.create ~workspaceEdit ()
+  in
+  let source, range = Test.parse_selection {|let f x = $(x * 2)$ + 3|} in
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    let expected =
+      request ~capabilities:(ClientCapabilities.create ()) ~kind ~source ~range ()
+      |> Option.value_exn
+      |> plain_edits
+      |> apply ~source
+    in
+    List.iter
+      [ None
+      ; Some (WorkspaceClientCapabilities.create ())
+      ; Some (workspace None)
+      ; Some (workspace (Some false))
+      ]
+      ~f:(fun workspace ->
+        let edits =
+          request ~capabilities:(caps workspace) ~kind ~source ~range ()
+          |> Option.value_exn
+          |> plain_edits
+        in
+        assert (String.equal expected (apply ~source edits)));
+    match
+      request ~capabilities:(caps (Some (workspace (Some true)))) ~kind ~source ~range ()
+    with
+    | Some [ `SnippetTextEdit _ ] -> ()
+    | _ -> assert false);
+  [%expect {| |}]
+;;
+
+let%expect_test "large intervening source is preserved while plain edits stay small" =
+  let padding = String.make 100_000 'x' in
+  let source, range =
+    Test.parse_selection ("let f = 1 + (* " ^ padding ^ " *)\n  $2$ + 3")
+  in
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    let result = check ~kind ~source ~range () |> Option.value_exn in
+    assert (String.is_substring result ~substring:padding);
+    (match
+       request
+         ~capabilities:Code_actions.snippet_edit_capabilities
+         ~kind
+         ~source
+         ~range
+         ()
+     with
+     | Some [ `SnippetTextEdit edit ] ->
+       assert (String.is_substring edit.snippet.value ~substring:padding)
+     | _ -> assert false);
+    let edits =
+      request ~capabilities:(ClientCapabilities.create ()) ~kind ~source ~range ()
+      |> Option.value_exn
+      |> plain_edits
+    in
+    assert (
+      List.sum
+        (module Int)
+        edits
+        ~f:(fun (edit : TextEdit.t) -> String.length edit.newText)
+      < 100));
+  [%expect {| |}]
+;;
+
+let%expect_test "interfaces and non-expression selections produce no extraction" =
+  List.iter [ `Local; `Function ] ~f:(fun kind ->
+    List.iter
+      [ {|let $value$ = 1|}
+      ; {|type t = $int$|}
+      ; {|let f = 1 (* $comment$ *)|}
+      ; {|let f = function $Some x$ -> x | None -> 0|}
+      ]
+      ~f:(fun marked ->
+        let source, range = Test.parse_selection marked in
+        assert (Option.is_none (check ~kind ~source ~range ())));
+    let source, range = Test.parse_selection {|val f : $int -> int$|} in
+    assert (Option.is_none (check ~path:"foo.mli" ~kind ~source ~range ())));
+  [%expect {| |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -55,6 +55,7 @@
     code_action_resolve
     code_actions_annotations
     code_actions_destruct
+    code_actions_extract
     code_actions_interface
     code_actions_quick_fixes
     code_lens


### PR DESCRIPTION
Let users choose the generated name interactively after **Extract local** or **Extract function**. The new declaration and replacement reference share a snippet placeholder, so editing either updates both; the default names remain `var_name` and `fun_name`.

Snippet clients receive one text edit that preserves the source between the declaration and replacement. They must advertise `workspace.workspaceEdit.snippetEditSupport`; completion snippet support alone is insufficient. Other clients retain the two ordinary text edits, without constructing a snippet or copying the intervening source.

The plain and snippet paths share extraction text, with source-equivalence checks covering both representations. Existing Unicode position-handling bugs are retained as known-bug reproductions only; fixing them is deferred to the broader position-handling work.
