### PR TITLE
test: cover URI escaping and operator documentation

### DIFF
--- a/lsp/test/uri_tests.ml
+++ b/lsp/test/uri_tests.ml
@@ -130,6 +130,32 @@ let%expect_test "JSON URI serialization normalizes wire spelling" =
     |}]
 ;;
 
+(* FIXME: serialization should preserve both literal query separators and
+   escapes within values. It currently encodes the separators as well. *)
+let%expect_test "query separators and escaped values" =
+  List.iter
+    (fun source ->
+       let serialized = Uri.of_string source |> Uri.to_string in
+       assert (Uri.yojson_of_t (Uri.t_of_yojson (`String source)) = `String serialized);
+       Printf.printf "%s -> %s\n" source serialized)
+    [ "https://ocaml.org/search?q=a+b&page=1"
+    ; "https://example.org/?q=%26"
+    ; "https://example.org/?q=a%2Bb"
+    ; "https://example.org/?q=a%26admin%3Dtrue"
+    ; "https://ocaml.org/?q=%23tag"
+    ; "file:///foo.ml#L3,4"
+    ];
+  [%expect
+    {|
+    https://ocaml.org/search?q=a+b&page=1 -> https://ocaml.org/search?q%3Da%2Bb%26page%3D1
+    https://example.org/?q=%26 -> https://example.org/?q%3D%26
+    https://example.org/?q=a%2Bb -> https://example.org/?q%3Da%2Bb
+    https://example.org/?q=a%26admin%3Dtrue -> https://example.org/?q%3Da%26admin%3Dtrue
+    https://ocaml.org/?q=%23tag -> https://ocaml.org/?q%3D%23tag
+    file:///foo.ml#L3,4 -> file:///foo.ml#L3%2C4
+    |}]
+;;
+
 let%expect_test "an unescaped Unicode URI query is preserved" =
   let uri = Uri.of_string "file:///foo.ml?search=😀&limit=1" in
   Printf.printf

--- a/ocaml-lsp-server/test/e2e-new/doc_to_md.ml
+++ b/ocaml-lsp-server/test/e2e-new/doc_to_md.ml
@@ -5,6 +5,11 @@ let print_doc = function
   | Markdown s -> print_endline s
 ;;
 
+let%expect_test "operator cross-reference labels" =
+  translate "Use {!Stdlib.(+)} or {!Stdlib.(-)} or {!val:(--)}." |> print_doc;
+  [%expect {| Use `Stdlib.(+)` or `Stdlib.(-)` or `val:(--)`. |}]
+;;
+
 let%expect_test "superscript" =
   let doc = {| 2{^30} |} in
   translate doc |> print_doc;


### PR DESCRIPTION
Add baseline coverage on master for URI query separators, escaped query values, position fragments, and operator cross-reference labels, independently of #2139.

The URI expectations record the existing over-encoding that #2023 addresses. The documentation test protects the current rendering of operators containing hyphens. No implementation changes.
