### PR TITLE
test(diagnostics): expect cleared errors after Dune builds

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
+++ b/ocaml-lsp-server/test/e2e-new/dune_diagnostics.ml
@@ -373,8 +373,6 @@ let%expect_test "Dune success refreshes load paths in every Merlin state" =
     {|
     Dune trace: Connected to Dune RPC
     Dune trace: Dune build finished (verbose details present)
-    Unbound module Bar
-    Unbound value x
     Dune trace: Merlin configuration process started
     Dune trace: Merlin configuration request completed
     Dune trace: Merlin configuration process stopped and exited


### PR DESCRIPTION
Update the Dune diagnostics regression to expect no stale errors after a successful build. Merlin 5.8.1 fixed per-typer load-path invalidation in ocaml/merlin#2109, but the snapshot from #1854 still recorded the bug.

Opam CI already uses fixed Merlin; the `ocaml-overlays` update in #2144 brought Nix's check shell to the same release, exposing the obsolete expectation in both jobs (including #2209).

Test-only: no dependency constraints or production behavior changes.
