### PR TITLE
feat(server): offer constructor application completions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Offer parenthesized application snippets for constructors with payloads, with
+  independent argument slots, while retaining name-only completions. (#2212, @rgrinberg)
 - Make generated destruct branch bodies interactive for clients with snippet edit
   support. (#2204, @rgrinberg)
 - Offer whole-call completions for OCaml functions with multiple labelled or

--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -183,7 +183,62 @@ module Complete_by_prefix = struct
     Query_commands.dispatch pipeline complete
   ;;
 
+  let constructor_qualifier pipeline doc range =
+    let text_document = Document.Merlin.to_doc doc |> Document.text_document in
+    let start_offset, end_offset = Text_document.absolute_range text_document range in
+    let exception Found of Loc.t in
+    match
+      let reference name (loc : Loc.t) =
+        (* The primary edit must replace exactly the final identifier, not part of
+           it or its qualifier. In particular, do not move a partial name into the
+           qualifier when an existing position-encoding bug misplaces the edit. *)
+        if
+          loc.loc_start.pos_cnum <= start_offset
+          && loc.loc_end.pos_cnum = end_offset
+          && end_offset - String.length name = start_offset
+          && loc.loc_start.pos_lnum = loc.loc_end.pos_lnum
+        then raise_notrace (Found loc)
+      in
+      let iterator =
+        { Ast_iterator.default_iterator with
+          expr =
+            (fun iter expr ->
+              (match expr.pexp_desc with
+               (* Merlin inserts a zero-width value identifier for empty prefixes
+                  such as [M.], which can also complete to a constructor. *)
+               | Pexp_construct (name, _) | Pexp_ident name ->
+                 reference (Longident.last name.txt) name.loc
+               | _ -> ());
+              Ast_iterator.default_iterator.expr iter expr)
+        ; pat =
+            (fun iter pat ->
+              (match pat.ppat_desc with
+               | Ppat_construct (name, _) -> reference (Longident.last name.txt) name.loc
+               | Ppat_var name -> reference name.txt name.loc
+               | _ -> ());
+              Ast_iterator.default_iterator.pat iter pat)
+        }
+      in
+      match Mpipeline.reader_parsetree pipeline with
+      | `Implementation structure -> iterator.structure iterator structure
+      | `Interface signature -> iterator.signature iterator signature
+    with
+    | () -> None
+    | exception Found loc when loc.loc_start.pos_cnum = start_offset -> Some ("", None)
+    | exception Found loc ->
+      let range =
+        Text_document.range_of_utf8_offsets
+          text_document
+          ~start_offset:loc.loc_start.pos_cnum
+          ~end_offset:start_offset
+      in
+      let open Option.O in
+      let+ prefix = Text_document.substring text_document range in
+      prefix, Some [ TextEdit.create ~range ~newText:"" ]
+  ;;
+
   let process_dispatch_resp
+        ~pipeline
         ~supports_deprecated_field
         ~supports_deprecated_tag
         ~supports_enum_member
@@ -195,6 +250,15 @@ module Complete_by_prefix = struct
         (completion : Query_protocol.completions)
     =
     let range = edit_range doc pos in
+    (* Only inspect constructor syntax when a snippet-capable client receives a
+       constructor candidate. Function and plain completions do not need it. *)
+    let constructor_qualifier =
+      lazy
+        (constructor_qualifier
+           (Mpipeline.for_completion (Position.logical pos) pipeline)
+           doc
+           range)
+    in
     let supports_snippets =
       supports_snippets && Document.syntax (Document.Merlin.to_doc doc) = Ocaml
     in
@@ -247,18 +311,30 @@ module Complete_by_prefix = struct
           | false -> []
           | true ->
             (match entry.kind with
-             | `Label
-             | `Constructor
-             | `Keyword
-             | `MethodCall
-             | `Module
-             | `Modtype
-             | `Type
-             | `Variant -> []
-             | `Value ->
-               (match Snippet_builder.application ~name:entry.name ~typ:entry.desc with
-                | None -> []
-                | Some snippet -> [ snippet_completion_item plain ~range snippet ]))
+             | `Label | `Keyword | `MethodCall | `Module | `Modtype | `Type | `Variant ->
+               []
+             | (`Value | `Constructor) as kind ->
+               let application =
+                 let open Option.O in
+                 let* kind, name, additionalTextEdits =
+                   match kind with
+                   | `Value -> Some (`Function, entry.name, None)
+                   | `Constructor ->
+                     let+ prefix, edits = Lazy.force constructor_qualifier in
+                     `Constructor, prefix ^ entry.name, edits
+                 in
+                 let+ item =
+                   let+ snippet =
+                     Snippet_builder.application ~kind ~name ~typ:entry.desc
+                   in
+                   snippet_completion_item plain ~range snippet
+                 in
+                 (* Keep filtering and the primary edit on the ordinary name.
+                    Move the complete qualifier, including comments, inside the
+                    parentheses rather than opening its scope over the payload. *)
+                 { item with additionalTextEdits }
+               in
+               Option.to_list application)
         in
         plain :: snippets)
     in
@@ -298,12 +374,21 @@ module Complete_by_prefix = struct
         ~supports_snippets
         ~resolve
     =
-    let+ (completion : Query_protocol.completions) =
-      let logical_pos = Position.logical pos in
-      Document.Merlin.with_pipeline_exn
-        ~name:"completion-prefix"
-        doc
-        (dispatch_cmd ~prefix logical_pos)
+    let+ items =
+      let position = Position.logical pos in
+      Document.Merlin.with_pipeline_exn ~name:"completion-prefix" doc (fun pipeline ->
+        let completion = dispatch_cmd ~prefix position pipeline in
+        process_dispatch_resp
+          ~pipeline
+          ~supports_deprecated_field
+          ~supports_deprecated_tag
+          ~supports_enum_member
+          ~supports_snippets
+          ~resolve
+          ~prefix
+          doc
+          pos
+          completion)
     in
     let keyword_completionItems =
       (* we complete only keyword 'in' for now *)
@@ -311,18 +396,7 @@ module Complete_by_prefix = struct
       | Intf -> []
       | Impl -> complete_keywords pos prefix
     in
-    keyword_completionItems
-    @ process_dispatch_resp
-        ~supports_deprecated_field
-        ~supports_deprecated_tag
-        ~supports_enum_member
-        ~supports_snippets
-        ~resolve
-        ~prefix
-        doc
-        pos
-        completion
-    |> reindex_sortText
+    keyword_completionItems @ items |> reindex_sortText
   ;;
 end
 
@@ -489,7 +563,7 @@ let complete
                  | ci :: rest -> { ci with CompletionItem.preselect = Some true } :: rest
                else fun x -> x
              in
-             let+ construct_cmd_resp, compl_by_prefix_resp =
+             let+ construct_cmd_resp, compl_by_prefix_completionItems =
                Document.Merlin.with_pipeline_exn
                  ~name:"completion"
                  merlin
@@ -497,10 +571,20 @@ let complete
                     let construct_cmd_resp =
                       Complete_with_construct.dispatch_cmd position pipeline
                     in
-                    let compl_by_prefix_resp =
+                    let compl_by_prefix_completionItems =
                       Complete_by_prefix.dispatch_cmd ~prefix position pipeline
+                      |> Complete_by_prefix.process_dispatch_resp
+                           ~pipeline
+                           ~resolve
+                           ~supports_deprecated_field
+                           ~supports_deprecated_tag
+                           ~supports_enum_member
+                           ~supports_snippets
+                           ~prefix
+                           merlin
+                           pos
                     in
-                    construct_cmd_resp, compl_by_prefix_resp)
+                    construct_cmd_resp, compl_by_prefix_completionItems)
              in
              let construct_completionItems =
                let supportsJumpToNextHole =
@@ -514,18 +598,6 @@ let complete
                  ~fallback_range:(edit_range merlin pos)
                  ~position:pos
                  construct_cmd_resp
-             in
-             let compl_by_prefix_completionItems =
-               Complete_by_prefix.process_dispatch_resp
-                 ~resolve
-                 ~supports_deprecated_field
-                 ~supports_deprecated_tag
-                 ~supports_enum_member
-                 ~supports_snippets
-                 ~prefix
-                 merlin
-                 pos
-                 compl_by_prefix_resp
              in
              construct_completionItems @ compl_by_prefix_completionItems
              |> reindex_sortText

--- a/ocaml-lsp-server/src/snippet_builder.ml
+++ b/ocaml-lsp-server/src/snippet_builder.ml
@@ -135,40 +135,121 @@ let argument_labels typ =
     Some (loop [] typ)
 ;;
 
-let valid_application_name name =
-  String.split name ~on:'.'
-  |> List.for_all ~f:(fun segment ->
-    (not (String.is_empty segment))
-    && (match segment.[0] with
-        | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
-        | _ -> false)
-    && String.for_all segment ~f:(function
-      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'' -> true
-      | _ -> false))
+let valid_application_name ~kind name =
+  let lexbuf = Lexing.from_string name in
+  let lexer = Lexer.make (Lexer.keywords []) in
+  let rec path () =
+    match lexer_token lexer lexbuf with
+    | Parser.UIDENT _ ->
+      (match lexer_token lexer lexbuf with
+       | Parser.DOT -> path ()
+       | EOF -> kind = `Constructor
+       | _ -> false)
+    | Parser.LIDENT _ -> kind = `Function && lexer_token lexer lexbuf = Parser.EOF
+    | _ -> false
+  in
+  match path () with
+  | result -> result
+  | exception Parser.Error -> false
 ;;
 
-let application ~name ~typ =
-  match valid_application_name name with
+let constructor_arity typ =
+  match
+    let lexbuf = Lexing.from_string typ in
+    let lexer = Lexer.make (Lexer.keywords []) in
+    let rec tokens () =
+      match lexer_token lexer lexbuf with
+      | Parser.EOF -> [ Parser.EOF ]
+      | token -> token :: tokens ()
+    in
+    let rec normalize = function
+      (* Merlin renders an inline-record payload as [t.Constructor], which is not
+         an OCaml type path. Use an opaque type while preserving its arity. *)
+      | Parser.LIDENT _ :: Parser.DOT :: Parser.UIDENT _ :: rest ->
+        Parser.UIDENT "Inline_record" :: Parser.DOT :: Parser.LIDENT "t" :: normalize rest
+      | token :: rest -> token :: normalize rest
+      | [] -> []
+    in
+    (* Parse a constructor signature, not a function type: parentheses distinguish
+       [int * bool -> t] from [(int * bool) -> t]. *)
+    let tokens =
+      Queue.of_list
+        ([ Parser.TYPE; Parser.LIDENT "t"; Parser.EQUAL; Parser.UIDENT "C"; Parser.COLON ]
+         @ normalize (tokens ()))
+    in
+    Parser.implementation
+      (fun _ -> Option.value (Queue.dequeue tokens) ~default:Parser.EOF)
+      lexbuf
+  with
+  | [ { pstr_desc =
+          Pstr_type (_, [ { ptype_kind = Ptype_variant [ { pcd_args; _ } ]; _ } ])
+      ; _
+      }
+    ] ->
+    Some
+      (match pcd_args with
+       | Pcstr_tuple arguments -> List.length arguments
+       | Pcstr_record _ -> 1)
+  | _ -> None
+  | exception Parser.Error -> None
+;;
+
+type application_kind =
+  [ `Function
+  | `Constructor
+  ]
+
+let application ~kind ~name ~typ =
+  match valid_application_name ~kind name with
   | false -> None
   | true ->
     let open Option.O in
-    let* labels = argument_labels typ in
-    if
-      List.count labels ~f:(function
-        | Asttypes.Nolabel -> false
-        | Labelled _ | Optional _ -> true)
-      < 2
-    then None
-    else (
-      let arguments =
-        let placeholder = [ Snippet.placeholder (Snippet.text "_") ] in
-        List.concat_map labels ~f:(fun (label : Asttypes.arg_label) ->
-          Snippet.text
-            (match label with
-             | Nolabel -> " "
-             | Labelled label -> " ~" ^ label ^ ":"
-             | Optional label -> " ?" ^ label ^ ":")
-          :: placeholder)
-      in
-      Some (Snippet.concat ((Snippet.text name :: arguments) @ [ Snippet.tabstop 0 ])))
+    let placeholder = Snippet.placeholder (Snippet.text "_") in
+    let* arguments =
+      match kind with
+      | `Constructor ->
+        let* arity = constructor_arity typ in
+        if arity = 0
+        then None
+        else (
+          let payload =
+            if arity = 1
+            then placeholder
+            else
+              Snippet.concat
+                [ Snippet.text "("
+                ; Snippet.concat
+                    (List.init arity ~f:(fun _ -> placeholder)
+                     |> List.intersperse ~sep:(Snippet.text ", "))
+                ; Snippet.text ")"
+                ]
+          in
+          Some [ Snippet.text " "; payload ])
+      | `Function ->
+        let* labels = argument_labels typ in
+        if
+          List.count labels ~f:(function
+            | Asttypes.Nolabel -> false
+            | Labelled _ | Optional _ -> true)
+          < 2
+        then None
+        else
+          Some
+            (List.concat_map labels ~f:(fun (label : Asttypes.arg_label) ->
+               [ Snippet.text
+                   (match label with
+                    | Nolabel -> " "
+                    | Labelled label -> " ~" ^ label ^ ":"
+                    | Optional label -> " ?" ^ label ^ ":")
+               ; placeholder
+               ]))
+    in
+    let prefix, suffix =
+      match kind with
+      | `Function -> name, ""
+      | `Constructor -> "(" ^ name, ")"
+    in
+    Some
+      (Snippet.concat
+         ((Snippet.text prefix :: arguments) @ [ Snippet.text suffix; Snippet.tabstop 0 ]))
 ;;

--- a/ocaml-lsp-server/src/snippet_builder.mli
+++ b/ocaml-lsp-server/src/snippet_builder.mli
@@ -19,8 +19,15 @@ type hole_kind =
     is always appended. *)
 val source : holes:hole_kind -> source:string -> t
 
-(** A whole-call snippet with one hole per top-level function argument, derived
-    by parsing a rendered OCaml core type. Requires at least two labelled or
-    optional arguments; positional arguments do not count toward this threshold.
-    Returns [None] for other types, unsafe names, or unparseable types. *)
-val application : name:string -> typ:string -> Snippet.t option
+type application_kind =
+  [ `Function
+  | `Constructor
+  ]
+
+(** An application snippet derived from a rendered type. Functions require at
+    least two labelled or optional arguments and get one hole per argument.
+    Constructor applications are parenthesized and get one hole per argument,
+    including one for a tuple-valued or inline-record argument. Nullary
+    constructors are excluded. Names must be identifier paths, not operators.
+    Returns [None] for unsuitable types, unsafe names, or unparseable types. *)
+val application : kind:application_kind -> name:string -> typ:string -> Snippet.t option

--- a/ocaml-lsp-server/test/e2e-new/completion.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion.ml
@@ -133,7 +133,8 @@ let snippet_capabilities =
   ClientCapabilities.create ~textDocument ()
 ;;
 
-let%expect_test "completion converts UTF-16 positions before querying Merlin" =
+(* CR: Keep these known position bugs until the coordinated encoding fixes. *)
+let%expect_test "CR: completion queries use byte columns for UTF-16 positions" =
   let source = "let café = List.ma" in
   let position = Position.create ~line:0 ~character:18 in
   let only_map =
@@ -769,6 +770,21 @@ let y = 1 >$
   |}]
 ;;
 
+let%expect_test "a dot in a symbolic prefix does not shorten its replacement range" =
+  let source, position = Test.parse_cursor "let x = 1. +.$" in
+  iter_completions ~source ~position (function
+    | Some (`CompletionList { items; _ }) ->
+      assert (not (List.is_empty items));
+      List.iter items ~f:(fun (item : CompletionItem.t) ->
+        match item.textEdit with
+        | Some (`TextEdit { range; _ }) ->
+          assert (range.start = Position.create ~line:0 ~character:11);
+          assert (range.end_ = position)
+        | _ -> assert false)
+    | _ -> assert false);
+  [%expect {| |}]
+;;
+
 let%expect_test "completes without prefix" =
   let source =
     {ocaml|
@@ -779,7 +795,7 @@ let plus_42 (x:int) (y:int) =
   somenum +
 |ocaml}
   in
-  let position = Position.create ~line:5 ~character:12 in
+  let position = Position.create ~line:5 ~character:11 in
   print_completions source position;
   [%expect
     {|
@@ -792,8 +808,8 @@ let plus_42 (x:int) (y:int) =
     "textEdit": {
       "newText": "+",
       "range": {
-        "end": { "character": 12, "line": 5 },
-        "start": { "character": 11, "line": 5 }
+        "end": { "character": 11, "line": 5 },
+        "start": { "character": 10, "line": 5 }
       }
     }
   }
@@ -805,8 +821,8 @@ let plus_42 (x:int) (y:int) =
     "textEdit": {
       "newText": "+.",
       "range": {
-        "end": { "character": 12, "line": 5 },
-        "start": { "character": 11, "line": 5 }
+        "end": { "character": 11, "line": 5 },
+        "start": { "character": 10, "line": 5 }
       }
     }
   }
@@ -954,7 +970,7 @@ type t = [ `Int | `String ]
 let x : t = `I
   |ocaml}
   in
-  let position = Position.create ~line:3 ~character:15 in
+  let position = Position.create ~line:3 ~character:14 in
   print_completions source position;
   [%expect
     {|
@@ -967,8 +983,8 @@ let x : t = `I
       "textEdit": {
         "newText": "`Int",
         "range": {
-          "end": { "character": 15, "line": 3 },
-          "start": { "character": 13, "line": 3 }
+          "end": { "character": 14, "line": 3 },
+          "start": { "character": 12, "line": 3 }
         }
       }
     }
@@ -989,7 +1005,7 @@ type t = [ `Int | `String ]
 let x : t = `I
   |ocaml}
   in
-  let position = Position.create ~line:3 ~character:15 in
+  let position = Position.create ~line:3 ~character:14 in
   let only_int =
     List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "`Int")
   in
@@ -1008,8 +1024,8 @@ let x : t = `I
       "textEdit": {
         "newText": "`Int",
         "range": {
-          "end": { "character": 15, "line": 3 },
-          "start": { "character": 13, "line": 3 }
+          "end": { "character": 14, "line": 3 },
+          "start": { "character": 12, "line": 3 }
         }
       }
     }
@@ -1475,7 +1491,38 @@ let%expect_test "whole-call snippets preserve deprecation without symbol resolve
     |}]
 ;;
 
-let%expect_test "construct completion converts Merlin ranges to UTF-16" =
+let%expect_test "constructor completions offer application skeletons" =
+  let source, position = Test.parse_cursor "type t = C of int\nlet value = C$" in
+  let only_constructor_skeleton =
+    List.filter ~f:(fun (item : CompletionItem.t) -> String.equal item.label "C (call)")
+  in
+  print_completions
+    ~capabilities:snippet_capabilities
+    ~pre_print:only_constructor_skeleton
+    source
+    position;
+  [%expect
+    {|
+    Completions:
+    {
+      "detail": "int -> t",
+      "filterText": "C",
+      "insertTextFormat": 2,
+      "kind": 15,
+      "label": "C (call)",
+      "sortText": "0011",
+      "textEdit": {
+        "newText": "(C ${1:_})$0",
+        "range": {
+          "end": { "character": 13, "line": 1 },
+          "start": { "character": 12, "line": 1 }
+        }
+      }
+    }
+    |}]
+;;
+
+let%expect_test "CR: construct completion misses the hole after Unicode" =
   let source = "let café : int = _" in
   let position = Position.create ~line:0 ~character:18 in
   let only_zero =
@@ -2197,7 +2244,7 @@ let%expect_test "completion for object methods" =
 
 let%expect_test "completion for object methods" =
   let source = {ocaml|let f (x : < a_method : 'a; ab_m : 'b >) = x#ab|ocaml} in
-  let position = Position.create ~line:0 ~character:49 in
+  let position = Position.create ~line:0 ~character:47 in
   print_completions ~limit:3 source position;
   [%expect
     {|
@@ -2210,8 +2257,8 @@ let%expect_test "completion for object methods" =
       "textEdit": {
         "newText": "ab_m",
         "range": {
-          "end": { "character": 49, "line": 0 },
-          "start": { "character": 47, "line": 0 }
+          "end": { "character": 47, "line": 0 },
+          "start": { "character": 45, "line": 0 }
         }
       }
     } |}]

--- a/ocaml-lsp-server/test/e2e-new/completion_constructors.ml
+++ b/ocaml-lsp-server/test/e2e-new/completion_constructors.ml
@@ -1,0 +1,381 @@
+open Test.Import
+open Completion
+
+let definitions =
+  "type t = Ctor_empty | Ctor_one of int | Ctor_pair of int * bool\n\
+   | Ctor_tuple of (int * bool) | Ctor_record of { x : int; y : bool }\n\
+   | Ctor_fn of (int -> int)\n"
+;;
+
+let iter ?path ?(capabilities = snippet_capabilities) source f =
+  let source, position = Test.parse_cursor source in
+  iter_completions ?path ~capabilities ~source ~position (function
+    | Some (`CompletionList { isIncomplete; items; _ }) ->
+      assert (not isIncomplete);
+      List.iteri items ~f:(fun index (item : CompletionItem.t) ->
+        assert (item.sortText = Some (Printf.sprintf "%04d" index)));
+      f source items
+    | _ -> failwith "expected a complete completion list")
+;;
+
+let apply source (item : CompletionItem.t) =
+  let edit =
+    match item.textEdit with
+    | Some (`TextEdit edit) -> edit
+    | _ -> failwith "expected a text edit"
+  in
+  let textDocument =
+    TextDocumentItem.create
+      ~uri:Helpers.uri
+      ~version:0
+      ~languageId:(Other "ocaml")
+      ~text:source
+  in
+  let doc =
+    Lsp.Text_document.make
+      ~position_encoding:`UTF16
+      (DidOpenTextDocumentParams.create ~textDocument)
+  in
+  Lsp.Text_document.apply_text_document_edits
+    doc
+    (edit :: Option.value item.additionalTextEdits ~default:[])
+  |> Lsp.Text_document.text
+;;
+
+let%expect_test "constructor payload shapes retain ordinary completions" =
+  iter (definitions ^ "let value = Ctor$") (fun _ items ->
+    List.iter items ~f:(fun (item : CompletionItem.t) ->
+      if String.is_prefix item.label ~prefix:"Ctor"
+      then (
+        let text =
+          match item.textEdit with
+          | Some (`TextEdit edit) -> edit.newText
+          | _ -> failwith "expected a text edit"
+        in
+        Printf.printf "%s: %s => %s\n" item.label (Option.value_exn item.detail) text)));
+  [%expect
+    {|
+    Ctor_empty: t => Ctor_empty
+    Ctor_fn: (int -> int) -> t => Ctor_fn
+    Ctor_one: int -> t => Ctor_one
+    Ctor_pair: int * bool -> t => Ctor_pair
+    Ctor_record: t.Ctor_record -> t => Ctor_record
+    Ctor_tuple: (int * bool) -> t => Ctor_tuple
+    Ctor_fn (call): (int -> int) -> t => (Ctor_fn ${1:_})$0
+    Ctor_one (call): int -> t => (Ctor_one ${1:_})$0
+    Ctor_pair (call): int * bool -> t => (Ctor_pair (${1:_}, ${2:_}))$0
+    Ctor_record (call): t.Ctor_record -> t => (Ctor_record ${1:_})$0
+    Ctor_tuple (call): (int * bool) -> t => (Ctor_tuple ${1:_})$0
+    |}]
+;;
+
+let%expect_test "constructor calls in function arguments and qualified paths" =
+  List.iter
+    [ "type t = Ctor of int\nlet consume (_ : t) = ()\nlet _ = consume Ct$"
+    ; "module M = struct type t = Ctor of int end\nlet _ = M.Ct$"
+    ; "module M = struct type t = Ctor of int end\nlet _ = M . Ct$"
+    ; "type t = Ctor of int\nlet f = function Ct$ -> ()"
+    ]
+    ~f:(fun source ->
+      iter source (fun source items ->
+        List.iter items ~f:(fun (item : CompletionItem.t) ->
+          if String.equal item.label "Ctor (call)" then print_endline (apply source item))));
+  [%expect
+    {|
+    type t = Ctor of int
+    let consume (_ : t) = ()
+    let _ = consume (Ctor ${1:_})$0
+    module M = struct type t = Ctor of int end
+    let _ = (M.Ctor ${1:_})$0
+    module M = struct type t = Ctor of int end
+    let _ = (M . Ctor ${1:_})$0
+    type t = Ctor of int
+    let f = function (Ctor ${1:_})$0 -> ()
+    |}]
+;;
+
+let%expect_test "constructor snippet capabilities and ordering" =
+  List.iter [ None; Some false; Some true ] ~f:(fun snippetSupport ->
+    let completionItem = ClientCompletionItemOptions.create ?snippetSupport () in
+    let completion = CompletionClientCapabilities.create ~completionItem () in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    let capabilities = ClientCapabilities.create ~textDocument () in
+    iter
+      ~capabilities
+      "type t = Ctor_a of int | Ctor_b | Ctor_c of bool\nlet value = Ctor$"
+      (fun _ items ->
+         Printf.printf
+           "%s: %s\n"
+           (Option.value_map snippetSupport ~default:"absent" ~f:string_of_bool)
+           (List.filter_map items ~f:(fun (item : CompletionItem.t) ->
+              Option.some_if (String.is_prefix item.label ~prefix:"Ctor") item.label)
+            |> String.concat ~sep:", ")));
+  [%expect
+    {|
+    absent: Ctor_a, Ctor_b, Ctor_c
+    false: Ctor_a, Ctor_b, Ctor_c
+    true: Ctor_a, Ctor_b, Ctor_c, Ctor_a (call), Ctor_c (call)
+    |}]
+;;
+
+let%expect_test "workspace snippet support alone does not enable constructor completions" =
+  let capabilities = Code_actions.snippet_edit_capabilities in
+  iter ~capabilities "type t = Ctor of int\nlet value = Ct$" (fun _ items ->
+    assert (List.exists items ~f:(fun (item : CompletionItem.t) -> item.label = "Ctor"));
+    assert (
+      not
+        (List.exists items ~f:(fun (item : CompletionItem.t) -> item.kind = Some Snippet))));
+  [%expect {| |}]
+;;
+
+let%expect_test "constructor completion replaces suffixes" =
+  List.iter [ "Ct$"; "Ct$or_typo"; "Ctor$" ] ~f:(fun prefix ->
+    iter ("type t = Ctor of int\nlet value : t = " ^ prefix) (fun source items ->
+      let item =
+        List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+          item.label = "Ctor (call)")
+      in
+      print_endline (apply source item)));
+  [%expect
+    {|
+    type t = Ctor of int
+    let value : t = (Ctor ${1:_})$0
+    type t = Ctor of int
+    let value : t = (Ctor ${1:_})$0
+    type t = Ctor of int
+    let value : t = (Ctor ${1:_})$0
+    |}]
+;;
+
+(* CR: These position bugs are shared with ordinary completions. Fix them with
+   the general position-encoding work, not the constructor snippet feature. *)
+let%expect_test "CR: constructor completion after Unicode uses the wrong prefix" =
+  List.iter [ "Ct$"; "Ct$or_typo"; "Ctor$" ] ~f:(fun prefix ->
+    iter
+      ("type t = Ctor of int\nlet café : t = let _ = \"😀\" in " ^ prefix)
+      (fun source items ->
+         let items =
+           List.filter items ~f:(fun (item : CompletionItem.t) ->
+             String.is_prefix item.label ~prefix:"Ctor")
+         in
+         Printf.printf "%s: %d constructor completions\n" prefix (List.length items);
+         List.iter items ~f:(fun item ->
+           print_endline (List.last_exn (String.split_lines (apply source item))))));
+  [%expect
+    {|
+    Ct$: 0 constructor completions
+    Ct$or_typo: 0 constructor completions
+    Ctor$: 1 constructor completions
+    let café : t = let _ = "😀" in CtoCtor
+    |}]
+;;
+
+let%expect_test "constructor names may contain Unicode" =
+  iter "type t = Café of int\nlet value = Caf$" (fun source items ->
+    let item =
+      List.find_exn items ~f:(fun (item : CompletionItem.t) -> item.label = "Café (call)")
+    in
+    print_endline (apply source item));
+  [%expect
+    {|
+    type t = Café of int
+    let value = (Café ${1:_})$0
+    |}]
+;;
+
+let%expect_test "exception and GADT constructors with payloads" =
+  List.iter
+    [ "exception Ctor of string\nlet value = Ct$"
+    ; "type _ t = Ctor : int -> int t\nlet value = Ct$"
+    ]
+    ~f:(fun source ->
+      iter source (fun source items ->
+        let item =
+          List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+            item.label = "Ctor (call)")
+        in
+        print_endline (apply source item)));
+  [%expect
+    {|
+    exception Ctor of string
+    let value = (Ctor ${1:_})$0
+    type _ t = Ctor : int -> int t
+    let value = (Ctor ${1:_})$0
+    |}]
+;;
+
+let%expect_test "constructor snippets preserve metadata but disable symbol resolution" =
+  List.iter [ false; true ] ~f:(fun tags ->
+    let tagSupport =
+      Option.some_if tags (CompletionItemTagOptions.create ~valueSet:[ Deprecated ])
+    in
+    let resolveSupport =
+      ClientCompletionItemResolveOptions.create ~properties:[ "documentation" ]
+    in
+    let completionItem =
+      ClientCompletionItemOptions.create
+        ~snippetSupport:true
+        ~deprecatedSupport:true
+        ?tagSupport
+        ~resolveSupport
+        ()
+    in
+    let completionItemKind =
+      ClientCompletionItemOptionsKind.create
+        ~valueSet:[ Constructor; EnumMember; Snippet ]
+        ()
+    in
+    let completion =
+      CompletionClientCapabilities.create ~completionItem ~completionItemKind ()
+    in
+    let textDocument = TextDocumentClientCapabilities.create ~completion () in
+    let capabilities = ClientCapabilities.create ~textDocument () in
+    iter
+      ~capabilities
+      "module M : sig type t = Ctor of int [@deprecated] end = struct type t = Ctor of \
+       int end\n\
+       let value = M.Ct$"
+      (fun _ items ->
+         let find label =
+           List.find_exn items ~f:(fun (item : CompletionItem.t) -> item.label = label)
+         in
+         let plain = find "Ctor"
+         and call = find "Ctor (call)" in
+         assert (plain.kind = Some Constructor);
+         assert (call.kind = Some Snippet && call.insertTextFormat = Some Snippet);
+         assert (Option.is_some plain.data && Option.is_none call.data);
+         assert (
+           call.detail = plain.detail
+           && call.deprecated = plain.deprecated
+           && call.tags = plain.tags);
+         assert (call.filterText = Some "Ctor");
+         assert (Option.is_none call.command);
+         assert (call.insertTextMode = None);
+         (match call.additionalTextEdits with
+          | Some [ edit ] -> assert (String.is_empty edit.newText)
+          | _ -> assert false);
+         assert (
+           if tags then call.tags = Some [ Deprecated ] else call.deprecated = Some true)));
+  [%expect {| |}]
+;;
+
+let%expect_test "constructor calls are disabled outside OCaml" =
+  let source, position = Test.parse_cursor "type t = Ctor of int\nlet value = Ct$" in
+  List.iter [ "reason"; "ocaml.mlx" ] ~f:(fun language_id ->
+    Helpers.test ~language_id ~capabilities:snippet_capabilities source (fun client ->
+      let+ response = request_completions client position in
+      let items =
+        match Option.value_exn response with
+        | `CompletionList list -> list.items
+        | `List items -> items
+      in
+      assert (List.exists items ~f:(fun (item : CompletionItem.t) -> item.label = "Ctor"));
+      assert (
+        not
+          (List.exists items ~f:(fun (item : CompletionItem.t) ->
+             item.kind = Some Snippet)))));
+  [%expect {| |}]
+;;
+
+let%expect_test "constructor declarations stay name-only" =
+  List.iter [ "test.ml"; "test.mli" ] ~f:(fun path ->
+    List.iter
+      [ "type t = Ctor of int\ntype u = Ct$"
+      ; "type t = Ctor of int\ntype u = A | Ct$"
+      ; "type t = Ctor of int\ntype u = ..\ntype u += Ct$"
+      ; "exception Ctor of int\nexception Ct$"
+      ]
+      ~f:(fun source ->
+        iter ~path source (fun _ items ->
+          if
+            not
+              (List.exists items ~f:(fun (item : CompletionItem.t) -> item.label = "Ctor"))
+          then failwith (path ^ ": " ^ source);
+          assert (
+            not
+              (List.exists items ~f:(fun (item : CompletionItem.t) ->
+                 item.label = "Ctor (call)"))))));
+  [%expect {| |}]
+;;
+
+let%expect_test "qualified constructor calls preserve comments and payload scope" =
+  List.iter
+    [ "M.(* comment *)Ct$"
+    ; "M (* outer (* nested *) *). Ct$"
+    ; "M. (* \"quoted\" *) Ct$or_typo"
+    ]
+    ~f:(fun reference ->
+      iter
+        ("module M = struct type t = Ctor of int let payload = false end\n\
+          open M\n\
+          let payload = 42\n\
+          let value = "
+         ^ reference)
+        (fun source items ->
+           let item =
+             List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+               item.label = "Ctor (call)")
+           in
+           let source = apply source item in
+           let source =
+             String.substr_replace_all source ~pattern:"${1:_}" ~with_:"payload"
+           in
+           let source = String.substr_replace_all source ~pattern:"$0" ~with_:"" in
+           print_endline (List.last_exn (String.split_lines source))));
+  [%expect
+    {|
+    let value = (M.(* comment *)Ctor payload)
+    let value = (M (* outer (* nested *) *). Ctor payload)
+    let value = (M. (* "quoted" *) Ctor payload)
+    |}]
+;;
+
+let%expect_test "constructor reference contexts include empty prefixes and patterns" =
+  List.iter
+    [ "let value = M.$"
+    ; "let value = Ct$"
+    ; "let f = function M.Ct$ -> ()"
+    ; "let f = function M.(* comment *)Ct$ -> ()"
+    ; "let f = function Ct$ -> ()"
+    ; "let f (M.Ct$) = ()"
+    ; "let value = M.(Ct$)"
+    ]
+    ~f:(fun expression ->
+      iter
+        ("module M = struct type t = Ctor of int end\nopen M\n" ^ expression)
+        (fun source items ->
+           let item =
+             List.find_exn items ~f:(fun (item : CompletionItem.t) ->
+               item.label = "Ctor (call)")
+           in
+           print_endline (List.last_exn (String.split_lines (apply source item)))));
+  [%expect
+    {|
+    let value = (M.Ctor ${1:_})$0
+    let value = (Ctor ${1:_})$0
+    let f = function (M.Ctor ${1:_})$0 -> ()
+    let f = function (M.(* comment *)Ctor ${1:_})$0 -> ()
+    let f = function (Ctor ${1:_})$0 -> ()
+    let f ((M.Ctor ${1:_})$0) = ()
+    let value = M.((Ctor ${1:_})$0)
+    |}]
+;;
+
+let%expect_test "multiline qualified paths and polymorphic variants stay name-only" =
+  List.iter
+    [ "module M = struct type t = Ctor of int end\nlet value = M.\nCt$"
+    ; "module M = struct type t = Ctor of int end\n\
+       open M\n\
+       let value = M.(*\n\
+       comment *)Ct$"
+    ; "type t = [ `Ctor of int ]\nlet value : t = `Ct$"
+    ]
+    ~f:(fun source ->
+      iter source (fun _ items ->
+        assert (not (List.is_empty items));
+        assert (
+          not
+            (List.exists items ~f:(fun (item : CompletionItem.t) ->
+               item.kind = Some Snippet)))));
+  [%expect {| |}]
+;;

--- a/ocaml-lsp-server/test/e2e-new/dune
+++ b/ocaml-lsp-server/test/e2e-new/dune
@@ -59,6 +59,7 @@
     code_actions_quick_fixes
     code_lens
     completion
+    completion_constructors
     completion_resolve
     completions
     formatting

--- a/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
+++ b/ocaml-lsp-server/test/snippet_builder_quickcheck_tests.ml
@@ -392,7 +392,7 @@ let check_application arguments =
       | Labelled | Optional -> true
       | _ -> false)
   in
-  match Builder.application ~name:"f" ~typ, label_count >= 2 with
+  match Builder.application ~kind:`Function ~name:"f" ~typ, label_count >= 2 with
   | None, false -> ()
   | Some snippet, true ->
     let rendered = Snippet.to_string snippet in
@@ -439,9 +439,86 @@ let%test_unit "whole-call snippets require multiple labels and preserve arity" =
     ~f:check_application
 ;;
 
+let%test_unit "constructor signatures preserve arity across nested payload types" =
+  Test.run_exn
+    (module Application_case)
+    ~examples:[ []; [ Tuple ]; [ Tuple; Nested_arrow ]; List.init 12 ~f:(fun _ -> Tuple) ]
+    ~f:(fun arguments ->
+      let typ =
+        match arguments with
+        | [] -> "t"
+        | arguments ->
+          List.map arguments ~f:(fun arg ->
+            let typ =
+              match arg with
+              | Labelled | Optional -> "f:int -> ?limit:int -> unit"
+              | _ -> argument arg
+            in
+            "(" ^ typ ^ ")")
+          |> String.concat ~sep:" * "
+          |> fun payload -> payload ^ " -> t"
+      in
+      match Builder.application ~kind:`Constructor ~name:"M.C" ~typ with
+      | None -> assert (List.is_empty arguments)
+      | Some snippet ->
+        let arity = List.length arguments in
+        let payload =
+          match arity with
+          | 1 -> "_"
+          | _ -> "(" ^ String.concat ~sep:", " (List.init arity ~f:(fun _ -> "_")) ^ ")"
+        in
+        let rendered = Snippet.to_string snippet in
+        assert (String.equal (defaults rendered) ("(M.C " ^ payload ^ ")"));
+        let { Builder.placeholders; _ } =
+          Builder.source ~holes:`Expression ~source:(defaults rendered)
+        in
+        assert (placeholders = arity))
+;;
+
+let%expect_test "constructor application snippets" =
+  let print name typ =
+    match Builder.application ~kind:`Constructor ~name ~typ with
+    | None -> Stdlib.print_endline "none"
+    | Some snippet -> Snippet.to_string snippet |> Stdlib.print_endline
+  in
+  print "Some" "'a -> 'a option";
+  print "None" "'a option";
+  print "Pair" "int * bool -> t";
+  print "Tuple" "(int * bool) -> t";
+  print "Function" "(int -> int) -> t";
+  print "Record" "t.Record -> t";
+  print "M.Record" "M.t.Record -> M.t";
+  print "Record" "{ x : int; y : bool } -> t";
+  print "Gadt" "'a -> 'a t";
+  print "M.Café" "int -> M.t";
+  List.iter [ ""; "Some$"; "C🚀"; "Some _"; "(::)" ] ~f:(fun name -> print name "int -> t");
+  List.iter [ ""; "int ->"; "(*" ] ~f:(print "C");
+  [%expect
+    {|
+    (Some ${1:_})$0
+    none
+    (Pair (${1:_}, ${2:_}))$0
+    (Tuple ${1:_})$0
+    (Function ${1:_})$0
+    (Record ${1:_})$0
+    (M.Record ${1:_})$0
+    (Record ${1:_})$0
+    (Gadt ${1:_})$0
+    (M.Café ${1:_})$0
+    none
+    none
+    none
+    none
+    none
+    none
+    none
+    none
+    |}]
+;;
+
 let%expect_test "whole-call snippets" =
   let print name typ =
-    match Builder.application ~name ~typ with
+    match Builder.application ~kind:`Function ~name ~typ with
     | None -> Stdlib.print_endline "none"
     | Some snippet -> Snippet.to_string snippet |> Stdlib.print_endline
   in


### PR DESCRIPTION
Adds optional `Ctor (call)` completions for OCaml constructors with payloads. Ordinary name-only entries remain available and appear before the application variants, with complete lists and name-based filtering.

- Generate parenthesized applications with independent `_` placeholders. `Pair of int * bool` gets two slots; `Tuple of (int * bool)` gets one. Inline-record and function-valued payloads also get one slot.
- Offer applications in expression and pattern references, not constructor declarations. Preserve qualified paths, including comments, without introducing a local open that changes payload scope.
- Retain type and deprecation metadata, avoid symbol resolution on snippets, and defer constructor syntax analysis until it is needed by a snippet-capable client.