### PR TITLE
test(inline): cover partial application of mutable instance variables

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -22,6 +22,33 @@ let inline_runtime_test source =
        print_string result)
 ;;
 
+let%expect_test "partial inlining snapshots mutable instance variables" =
+  inline_runtime_test
+    {|
+let $f x y = x + y
+class counter = object
+  val mutable x = 1
+  method set n = x <- n
+  method callback = let callback = f x in callback
+end
+let counter = new counter
+let callback = counter#callback
+let () = counter#set 10; assert (callback 2 = 3)
+|};
+  [%expect
+    {|
+    let f x y = x + y
+    class counter = object
+      val mutable x = 1
+      method set n = x <- n
+      method callback = let callback = ((fun x y -> x + y) x) in callback
+    end
+    let counter = new counter
+    let callback = counter#callback
+    let () = counter#set 10; assert (callback 2 = 3)
+    |}]
+;;
+
 (* Repro: the partial application retains a redundant [self] parameter instead
    of becoming [fun (case : int) -> self.visit self case]. The fully applied use
    below is reduced correctly. *)


### PR DESCRIPTION
Extends #2209 with a partial application whose argument is a mutable instance variable. The callback must retain the value read at creation, even if the instance variable changes before invocation.

The test snapshots today's inline edit and compiles and executes assertions before and after applying it. It guards against simplifying `f x` to `fun y -> x + y`: unlike an ordinary immutable binding, the instance variable `x` would then be read too late.

Test-only and passes on `master`; no production changes.
