### PR TITLE
fix(inline): reduce partial applications of unlabelled functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 
 ## Fixes
 
+- Simplify partially applied functions when inlining, preserving argument scope
+  and evaluation. (#2214, @rgrinberg)
 - Avoid overlapping semantic tokens in `with type` constraints and destructive
   substitutions. (#2206, @rgrinberg)
 - Preserve nested or-patterns when formatting destruct-line case-analysis

--- a/ocaml-lsp-server/src/code_actions/action_inline.ml
+++ b/ocaml-lsp-server/src/code_actions/action_inline.ml
@@ -207,7 +207,64 @@ let same_path paths (id : _ H.with_loc) (id' : _ H.with_loc) =
   Paths.same_path paths id.loc id'.loc
 ;;
 
-let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
+let bind_partial_args ~env pats args body =
+  let open Option.O in
+  (* Refutable patterns must still be matched when the remaining arguments
+     arrive. Restrict the supplied parameters to distinct variables. *)
+  let* names =
+    List.map pats ~f:(fun (pat : Parsetree.pattern) ->
+      match pat.ppat_desc with
+      | Ppat_var name | Ppat_constraint ({ ppat_desc = Ppat_var name; _ }, _) ->
+        Some name.txt
+      | _ -> None)
+    |> Option.all
+  in
+  if List.length (List.dedup_and_sort names ~compare:String.compare) <> List.length names
+  then None
+  else (
+    let bindings =
+      let can_capture id =
+        (* Instance variables also parse as identifiers. Bind their reads eagerly
+           rather than letting the residual function read them after mutation. *)
+        match Ocaml_typing.Env.find_value_by_name (Lident id) env with
+        | _, { val_kind = Val_reg | Val_prim _ | Val_self _; _ } -> true
+        | _ | (exception Not_found) -> false
+      in
+      List.map2_exn
+        (List.zip_exn names pats)
+        args
+        ~f:(fun (name, pat) (_, (arg : Parsetree.expression)) ->
+          match arg.pexp_desc, pat.ppat_desc with
+          | Pexp_ident { txt = Lident id; _ }, Ppat_var _
+            when String.equal name id && can_capture id ->
+            (* The residual function can capture the caller's binding directly. *)
+            None
+          | Pexp_ident { txt = Lident id; _ }, Ppat_constraint (var, typ)
+            when String.equal name id && can_capture id ->
+            (* Keep the type constraint: without it, record fields in the body
+               might resolve differently. No new binding for [name] is needed. *)
+            let var = { var with ppat_desc = Ppat_any } in
+            Some ({ pat with ppat_desc = Ppat_constraint (var, typ) }, arg)
+          | _ -> Some (pat, arg))
+      |> List.filter_opt
+    in
+    match bindings with
+    | [] -> Some body
+    | bindings ->
+      (* Evaluate arguments once, before creating the closure. A tuple keeps
+         right-to-left evaluation without capturing other argument expressions. *)
+      let pat, arg =
+        match bindings with
+        | [ binding ] -> binding
+        | _ ->
+          let pats, args = List.unzip bindings in
+          ( H.Pat.tuple (List.map pats ~f:(fun pat -> None, pat)) Closed
+          , H.Exp.tuple (List.map args ~f:(fun arg -> None, arg)) )
+      in
+      Some (H.Exp.let_ Nonrecursive [ H.Vb.mk pat arg ] body))
+;;
+
+let beta_reduce ~env (paths : Paths.t) (app : Parsetree.expression) =
   let rec beta_reduce_arg body (pat : Parsetree.pattern) arg =
     let with_let () = H.Exp.let_ Nonrecursive [ H.Vb.mk pat arg ] body in
     let with_subst param = subst (same_path paths) arg param body in
@@ -225,21 +282,30 @@ let beta_reduce (paths : Paths.t) (app : Parsetree.expression) =
        | _ -> with_let ())
     | _ -> with_let ()
   in
-  let extract_param_pats params =
-    List.map params ~f:(fun p ->
-      match p.Parsetree.pparam_desc with
-      | Pparam_val (Nolabel, _, pat) -> Some pat
-      | _ -> None)
-    |> Option.all
-  in
   match app.pexp_desc with
-  | Pexp_apply ({ pexp_desc = Pexp_function (params, None, Pfunction_body body); _ }, args)
-    when List.length params = List.length args && all_unlabeled_params params ->
-    (match extract_param_pats params with
+  | Pexp_apply
+      (({ pexp_desc = Pexp_function (params, None, Pfunction_body body); _ } as fn), args)
+    when List.length args <= List.length params && all_unlabeled_params params ->
+    let supplied, remaining = List.split_n params (List.length args) in
+    let pats =
+      List.map supplied ~f:(fun p ->
+        match p.Parsetree.pparam_desc with
+        | Pparam_val (Nolabel, _, pat) -> Some pat
+        | _ -> None)
+      |> Option.all
+    in
+    (match pats with
+     | None -> app
      | Some pats ->
-       List.fold2_exn pats args ~init:body ~f:(fun body pat (_, arg) ->
-         beta_reduce_arg body pat arg)
-     | None -> app)
+       (match remaining with
+        | [] ->
+          List.fold2_exn pats args ~init:body ~f:(fun body pat (_, arg) ->
+            beta_reduce_arg body pat arg)
+        | _ ->
+          let body =
+            { fn with pexp_desc = Pexp_function (remaining, None, Pfunction_body body) }
+          in
+          bind_partial_args ~env pats args body |> Option.value ~default:app))
   | _ -> app
 ;;
 
@@ -365,7 +431,7 @@ let inline_edits pipeline task =
              let app_pexpr = find_parsetree_loc_exn pipeline expr.exp_loc in
              match app_pexpr.pexp_desc with
              | Pexp_apply ({ pexp_desc = Pexp_ident _; _ }, args) ->
-               beta_reduce paths (H.Exp.apply inlined_pexpr args)
+               beta_reduce ~env paths (H.Exp.apply inlined_pexpr args)
              | _ -> app_pexpr
            in
            Format.asprintf "(%a)" Pprintast.expression

--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -41,7 +41,7 @@ let () = counter#set 10; assert (callback 2 = 3)
     class counter = object
       val mutable x = 1
       method set n = x <- n
-      method callback = let callback = ((fun (x : int) y -> x + y) x) in callback
+      method callback = let callback = (let (x : int) = x in fun y -> x + y) in callback
     end
     let counter = new counter
     let callback = counter#callback
@@ -70,7 +70,7 @@ let () = counter#set 10; assert (callback () = 10)
       val mutable x = 1
       method set n = x <- n
       method get = x
-      method callback = let callback = ((fun self (ignored : unit) -> self#get) self) in callback
+      method callback = let callback = (fun (ignored : unit) -> self#get) in callback
     end
     let counter = new counter
     let callback = counter#callback
@@ -97,7 +97,7 @@ let () = counter#set 10; assert (callback 2 = 3)
     class counter = object
       val mutable x = 1
       method set n = x <- n
-      method callback = let callback = ((fun x y -> x + y) x) in callback
+      method callback = let callback = (let x = x in fun y -> x + y) in callback
     end
     let counter = new counter
     let callback = counter#callback
@@ -105,10 +105,7 @@ let () = counter#set 10; assert (callback 2 = 3)
     |}]
 ;;
 
-(* Repro: the partial application retains a redundant [self] parameter instead
-   of becoming [fun (case : int) -> self.visit self case]. The fully applied use
-   below is reduced correctly. *)
-let%expect_test "inline partial application retains a redundant parameter" =
+let%expect_test "inline partial application captures the supplied argument" =
   inline_test
     {|
 type iterator = { visit : iterator -> int -> unit }
@@ -124,7 +121,7 @@ let direct self case = function_case self case
     let iter cases ~f = List.iter f cases
     let function_case (self : iterator) (case : int) = self.visit self case
     let function_body (self : iterator) cases =
-      iter cases ~f:((fun (self : iterator) (case : int) -> self.visit self case) self)
+      iter cases ~f:(let (_ : iterator) = self in fun (case : int) -> self.visit self case)
     let direct self case = (self.visit self case)
     |}]
 ;;
@@ -139,8 +136,8 @@ let two x y = f x y
   [%expect
     {|
     let f x y z = x + y + z
-    let one x = ((fun x y z -> (x + y) + z) x)
-    let two x y = ((fun x y z -> (x + y) + z) x y)
+    let one x = (fun y z -> (x + y) + z)
+    let two x y = (fun z -> (x + y) + z)
     |}]
 ;;
 
@@ -158,7 +155,7 @@ let () = assert (g ({ value = 3 } : first) () = 3)
     type first = { value : int }
     type second = { value : int; extra : unit }
     let f (self : first) ignored = self.value
-    let g self = ((fun (self : first) ignored -> self.value) self)
+    let g self = (let (_ : first) = self in fun ignored -> self.value)
     let () = assert (g ({ value = 3 } : first) () = 3)
     |}]
 ;;
@@ -194,13 +191,13 @@ let () =
     let f x y = let outer = y + 1 in x - outer
     let y = 10
     let outer = 20
-    let captured = ((fun x y -> let outer = y + 1 in x - outer) y)
-    let nested = ((fun x y -> let outer = y + 1 in x - outer) outer)
+    let captured = (let x = y in fun y -> let outer = y + 1 in x - outer)
+    let nested = (let x = outer in fun y -> let outer = y + 1 in x - outer)
     let calls = ref 0
-    let effectful = ((fun x y -> let outer = y + 1 in x - outer) (incr calls; 30))
+    let effectful = (let x = incr calls; 30 in fun y -> let outer = y + 1 in x - outer)
     let cell = { value = 40 }
-    let snapshot = ((fun x y -> let outer = y + 1 in x - outer) cell.value)
-    let raised = try ignore ((fun x y -> let outer = y + 1 in x - outer) (failwith "argument")); false with Failure _ -> true
+    let snapshot = (let x = cell.value in fun y -> let outer = y + 1 in x - outer)
+    let raised = try ignore (let x = failwith "argument" in fun y -> let outer = y + 1 in x - outer); false with Failure _ -> true
     let () =
       assert (!calls = 1);
       cell.value <- 100;
@@ -236,10 +233,10 @@ let () =
     let f x y z = x - y + z
     let x = 3
     let y = 10
-    let swapped = ((fun x y z -> (x - y) + z) y x)
+    let swapped = (let (x, y) = (y, x) in fun z -> (x - y) + z)
     let log = ref []
     let argument tag value = log := !log @ [tag]; value
-    let effectful = ((fun x y z -> (x - y) + z) (argument 1 10) (argument 2 3))
+    let effectful = (let (x, y) = ((argument 1 10), (argument 2 3)) in fun z -> (x - y) + z)
     let () =
       assert (swapped 0 = 7);
       assert (!log = [2; 1]);
@@ -610,7 +607,8 @@ let _ =
     {|
     let _ =
       let f x y = x + y in
-      ((fun x y -> x + y) 0) |}]
+      (let x = 0 in fun y -> x + y)
+    |}]
 ;;
 
 let%expect_test "" =

--- a/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
+++ b/ocaml-lsp-server/test/e2e-new/code_action_resolve.ml
@@ -69,7 +69,7 @@ let caller self = f self
   [%expect
     {|
     let f self case = self + case
-    let caller self = ((fun self case -> self + case) self)
+    let caller self = (fun case -> self + case)
     |}]
 ;;
 


### PR DESCRIPTION
Reduce partial applications in **Inline into uses**, keeping a function for the remaining parameters instead of a redundant application such as `(fun x y -> x + y) x`.

Capture matching ordinary bindings directly; evaluate other supplied arguments once before creating the closure. This preserves scope and evaluation order, including mutable instance-variable reads. Parameter annotations are retained so record-field resolution does not change.

Labelled parameters, refutable supplied patterns, and duplicate supplied names remain unreduced. Fully applied reduction is unchanged.

Updates snapshots from the merged coverage in #2208, #2209, and #2213; runtime assertions remain unchanged. No new tests are included.
