### PR TITLE
test(inline): cover annotated mutable arguments and object self

### DIFF
--- a/ocaml-lsp-server/test/e2e-new/action_inline.ml
+++ b/ocaml-lsp-server/test/e2e-new/action_inline.ml
@@ -22,6 +22,62 @@ let inline_runtime_test source =
        print_string result)
 ;;
 
+let%expect_test "partial inlining snapshots mutable arguments for annotated parameters" =
+  inline_runtime_test
+    {|
+let $f (x : int) y = x + y
+class counter = object
+  val mutable x = 1
+  method set n = x <- n
+  method callback = let callback = f x in callback
+end
+let counter = new counter
+let callback = counter#callback
+let () = counter#set 10; assert (callback 2 = 3)
+|};
+  [%expect
+    {|
+    let f (x : int) y = x + y
+    class counter = object
+      val mutable x = 1
+      method set n = x <- n
+      method callback = let callback = ((fun (x : int) y -> x + y) x) in callback
+    end
+    let counter = new counter
+    let callback = counter#callback
+    let () = counter#set 10; assert (callback 2 = 3)
+    |}]
+;;
+
+let%expect_test "partial inlining preserves object self bindings" =
+  inline_runtime_test
+    {|
+let $f self (ignored : unit) = self#get
+class counter = object (self)
+  val mutable x = 1
+  method set n = x <- n
+  method get = x
+  method callback = let callback = f self in callback
+end
+let counter = new counter
+let callback = counter#callback
+let () = counter#set 10; assert (callback () = 10)
+|};
+  [%expect
+    {|
+    let f self (ignored : unit) = self#get
+    class counter = object (self)
+      val mutable x = 1
+      method set n = x <- n
+      method get = x
+      method callback = let callback = ((fun self (ignored : unit) -> self#get) self) in callback
+    end
+    let counter = new counter
+    let callback = counter#callback
+    let () = counter#set 10; assert (callback () = 10)
+    |}]
+;;
+
 let%expect_test "partial inlining snapshots mutable instance variables" =
   inline_runtime_test
     {|


### PR DESCRIPTION
Complements #2213 with two focused **Inline into uses** cases:

- A mutable instance variable passed to an annotated parameter: the callback must retain the argument's original value.
- An object `self` argument: the callback must retain the object reference and observe later field updates.

Both fixtures compile and execute assertions before and after the edit. Snapshots record current `master` behavior so this coverage can land independently of #2214. No production changes.
